### PR TITLE
cannot convert 0 (untyped int constant) to struct{ExitCode uint32}

### DIFF
--- a/scanner/anchorescan.go
+++ b/scanner/anchorescan.go
@@ -409,7 +409,7 @@ func anchoreErrorHandler(out *bytes.Buffer, out_err *bytes.Buffer, err error) (s
 	}
 	exit_code := "unknown"
 	if werr, ok := err.(*exec.ExitError); ok {
-		if s := werr.Sys().(syscall.WaitStatus); s != 0 {
+		if s := werr.Sys().(syscall.WaitStatus); s.ExitStatus() != 0 {
 			exit_code = fmt.Sprintf("%d", s)
 		}
 	}
@@ -653,7 +653,7 @@ func StartUpdateDB(payload interface{}, config *pkgcautils.ClusterConfig) (inter
 		}
 		exit_code := "unknown"
 		if werr, ok := err.(*exec.ExitError); ok {
-			if s := werr.Sys().(syscall.WaitStatus); s != 0 {
+			if s := werr.Sys().(syscall.WaitStatus); s.ExitStatus() != 0 {
 				exit_code = fmt.Sprintf("%d", s)
 			}
 		}


### PR DESCRIPTION
Compile time error while compiling project

# github.com/kubescape/kubevuln/scanner
scanner\anchorescan.go:412:49: cannot convert 0 (untyped int constant) to struct{ExitCode uint32}
scanner\anchorescan.go:656:50: cannot convert 0 (untyped int constant) to struct{ExitCode uint32}
