### PR TITLE
docs: comment the Anchore glob

### DIFF
--- a/scanner/anchorescan.go
+++ b/scanner/anchorescan.go
@@ -44,6 +44,7 @@ const (
 
 	anchoreConfigFileName      = "config.yaml"
 	anchoreConfigDirectoryName = ".grype"
+	// A pattern for artifacts that Grype produces during its scans
 	anchoreScanArtifactsGlob   = "/tmp/stereoscope-*"
 )
 


### PR DESCRIPTION
# What this PR changes?

This PR adds a comment to the Grype artifacts glob pattern used. This commit is mostly used to trigger a recently re-enabled workflow run.