### PR TITLE
fix: Use os.TempDir() for creating temporary anchore/grype config

### DIFF
--- a/scanner/anchorescan.go
+++ b/scanner/anchorescan.go
@@ -282,7 +282,7 @@ func cleanupScanArtifacts() {
 func GetAnchoreScanRes(scanCmd *wssc.WebsocketScanCommand) (*models.Document, error) {
 
 	configFileName := randomstring.HumanFriendlyEnglishString(rand.Intn(100)) + ".yaml"
-	anchoreConfigPath := path.Join(anchoreDirectoryPath, anchoreConfigDirectoryName, configFileName)
+	anchoreConfigPath := path.Join(os.TempDir(), configFileName)
 	err := copyFileData(anchoreConfigPath)
 	if err != nil {
 		log.Printf("failed to copy default file config to %v with err %v\n", anchoreConfigPath, err)


### PR DESCRIPTION
I prepare a contribution to use read-only root filesystem in every kubescape component. Unfortunately, kubevuln writes the temporary grype config to the same directory where the bundled config is living and therefore there is no option to mount a temporary filesystem below this folder.

By moving the temporary config to /tmp (`os.TempDir()`) we can mount a kuberentes `emptyDir` volume to /tmp and we're done :-)

/cc: @dwertent 