### PR TITLE
use new ImageIDMetadataKey in metadata

### DIFF
--- a/adapters/mocksbom.go
+++ b/adapters/mocksbom.go
@@ -40,7 +40,7 @@ func (m MockSBOMAdapter) CreateSBOM(ctx context.Context, imageID string, _ domai
 		ID:                 imageID,
 		SBOMCreatorVersion: m.Version(),
 		Annotations: map[string]string{
-			instanceidhandler.ImageTagMetadataKey: imageID,
+			instanceidhandler.ImageIDMetadataKey: imageID,
 		},
 		Labels: tools.LabelsFromImageID(imageID),
 		Content: &v1beta1.Document{

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -61,7 +61,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, imageID string, options do
 		ID:                 imageID,
 		SBOMCreatorVersion: s.Version(),
 		Annotations: map[string]string{
-			instanceidhandler.ImageTagMetadataKey: imageID,
+			instanceidhandler.ImageIDMetadataKey: imageID,
 		},
 		Labels: tools.LabelsFromImageID(imageID),
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kinbiko/jsonassert v1.1.1
 	github.com/kubescape/go-logger v0.0.11
-	github.com/kubescape/k8s-interface v0.0.121
+	github.com/kubescape/k8s-interface v0.0.122
 	github.com/kubescape/storage v0.2.0
 	github.com/spdx/tools-golang v0.5.0-rc1
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -679,6 +679,8 @@ github.com/kubescape/go-logger v0.0.11 h1:oucpq2S7+DT7O+UclG5IrmHado/tj6+IkYf9cz
 github.com/kubescape/go-logger v0.0.11/go.mod h1:yGiKBJ2lhq/kxzY/MVYDREL9fLV3RGD6gv+UFjslaew=
 github.com/kubescape/k8s-interface v0.0.121 h1:nk9NDuVPo4lWcVU7WDvJCfH6ZM4dE9gTNSr4gZHA6V4=
 github.com/kubescape/k8s-interface v0.0.121/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
+github.com/kubescape/k8s-interface v0.0.122 h1:Aq6xf1wq+nl2UtLX6rjFaGULZxES8OlzvXNLQcZk9+0=
+github.com/kubescape/k8s-interface v0.0.122/go.mod h1:ENpA9SkkS6E3PIT+AaMu/JGkuyE04aUamY+a7WLqsJQ=
 github.com/kubescape/storage v0.2.0 h1:WZXy4Dyjf5ltEMtk0SOD9RFL1haS9ffFPGfs1gUV1aM=
 github.com/kubescape/storage v0.2.0/go.mod h1:sPE749pFNoxoskBn6JTpNQyguF2rv/u2kYqzRd3MvXw=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -39,6 +39,7 @@ func sanitize(s string) string {
 func LabelsFromImageID(imageID string) map[string]string {
 	labels := map[string]string{}
 	match := reference.ReferenceRegexp.FindStringSubmatch(imageID)
+	labels[instanceidhandler.ImageIDMetadataKey] = sanitize(match[0])
 	labels[instanceidhandler.ImageNameMetadataKey] = sanitize(match[1])
 	labels[instanceidhandler.ImageTagMetadataKey] = sanitize(match[2])
 	// prune invalid labels

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -23,23 +23,23 @@ func TestLabelsFromImageID(t *testing.T) {
 	}{
 		{
 			imageID: "myapp",
-			want:    map[string]string{instanceidhandler.ImageNameMetadataKey: "myapp"},
+			want:    map[string]string{instanceidhandler.ImageIDMetadataKey: "myapp", instanceidhandler.ImageNameMetadataKey: "myapp"},
 		},
 		{
 			imageID: "registry.com:8080/myapp",
-			want:    map[string]string{instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp"},
+			want:    map[string]string{instanceidhandler.ImageIDMetadataKey: "registry-com-8080-myapp", instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp"},
 		},
 		{
 			imageID: "registry.com:8080/myapp:tag",
-			want:    map[string]string{instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp", instanceidhandler.ImageTagMetadataKey: "tag"},
+			want:    map[string]string{instanceidhandler.ImageIDMetadataKey: "registry-com-8080-myapp-tag", instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp", instanceidhandler.ImageTagMetadataKey: "tag"},
 		},
 		{
 			imageID: "registry.com:8080/myapp@sha256:be178c0543eb17f5f3043021c9e5fcf30285e557a4fc309cce97ff9ca6182912",
-			want:    map[string]string{instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp"},
+			want:    map[string]string{instanceidhandler.ImageIDMetadataKey: "registry-com-8080-myapp-sha256-be178c0543eb17f5f3043021c9e5fcf3", instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp"},
 		},
 		{
 			imageID: "registry.com:8080/myapp:tag2@sha256:be178c0543eb17f5f3043021c9e5fcf30285e557a4fc309cce97ff9ca6182912",
-			want:    map[string]string{instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp", instanceidhandler.ImageTagMetadataKey: "tag2"},
+			want:    map[string]string{instanceidhandler.ImageIDMetadataKey: "registry-com-8080-myapp-tag2-sha256-be178c0543eb17f5f3043021c9e", instanceidhandler.ImageNameMetadataKey: "registry-com-8080-myapp", instanceidhandler.ImageTagMetadataKey: "tag2"},
 		},
 	}
 	for _, tt := range tests {
@@ -48,7 +48,7 @@ func TestLabelsFromImageID(t *testing.T) {
 			diff := deep.Equal(got, tt.want)
 			if diff != nil {
 				t.Errorf("compare failed: %v", diff)
-			}	
+			}
 		})
 	}
 }


### PR DESCRIPTION
@rcohencyberarmor you will have a new label with the whole ImageID sanitized (invalid chars replaced with `-` and truncated to 64 chars)

the original ImageID was already in the `image-tag` annotation, it is now in `image-id`
**IMPORTANT**: as a migration path, do you want me to keep ImageID in both annotations?