### PR TITLE
fix id

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -2,11 +2,13 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/instanceidhandler/v1"
@@ -276,13 +278,12 @@ func enrichContext(ctx context.Context, workload domain.ScanCommand) context.Con
 }
 
 func generateScanID(workload domain.ScanCommand) string {
-	if workload.InstanceID != "" {
-		return workload.InstanceID
-	}
-	if workload.ImageTag != "" && workload.ImageHash != "" {
-		return workload.ImageTag + workload.ImageHash
-	}
-	return uuid.New().String()
+	// ID is wlid/containerName/imageTag hashed
+	id := fmt.Sprintf("%s/%s/%s", workload.Wlid, workload.ContainerName, workload.ImageTag)
+	hash := sha256.Sum256([]byte(id))
+	idHashed := hex.EncodeToString(hash[:])
+
+	return idHashed
 }
 
 func optionsFromWorkload(workload domain.ScanCommand) domain.RegistryOptions {

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -518,7 +518,7 @@ func Test_generateScanID(t *testing.T) {
 					ImageHash: "sha256:6f9c1c5b5b1b2b3b4b5b6b7b8b9b0b1b2b3b4b5b6b7b8b9b0b1b2b3b4b5b6b7b",
 				},
 			},
-			want: "k8s.gcr.io/kube-proxy:v1.24.3sha256:6f9c1c5b5b1b2b3b4b5b6b7b8b9b0b1b2b3b4b5b6b7b8b9b0b1b2b3b4b5b6b7b",
+			want: "f21dc043dab98dc4b4f2971a803434fddd83be9eb1074511f0dcfa2fbe1b25d1",
 		},
 		{
 			name: "generate scanID with instanceID",
@@ -527,15 +527,8 @@ func Test_generateScanID(t *testing.T) {
 					InstanceID: "InstanceID",
 				},
 			},
-			want: "InstanceID",
+			want: "a2c2339691fc48fbd14fb307292dff3e21222712d9240810742d7df0c6d74dfb",
 		},
-		// {
-		// 	name: "generate scanID with UUID",
-		// 	args: args{
-		// 		workload: domain.ScanCommand{},
-		// 	},
-		// 	want: "",
-		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This change will fix the bug where we have two rows for the same workload. The reason was that we had two different instanceIDs, and the instanceID was being used as the ID.