### PR TITLE
fix(panic): Enhanced Support for Diverse Image ID Formats in Hash Extraction

### DIFF
--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -357,6 +357,7 @@ func Test_extractHashFromImageID(t *testing.T) {
 		name    string
 		imageID string
 		want    string
+		err     bool
 	}{
 		{
 			name:    "no tag",
@@ -373,10 +374,26 @@ func Test_extractHashFromImageID(t *testing.T) {
 			imageID: "c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
 			want:    "c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
 		},
+		{
+			name:    "sha256 hash",
+			imageID: "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+			want:    "c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+		},
+		{
+			name:    "docker imageID",
+			imageID: "docker://sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+			want:    "c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+		},
+		{
+			name:    "empty imageID",
+			imageID: "",
+			want:    "",
+			err:     true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := hashFromImageID(tt.imageID); got != tt.want {
+			if got, e := hashFromImageID(tt.imageID); got != tt.want || (e != nil) != tt.err {
 				t.Errorf("hashFromImageID() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Pull Request Description

Title: **Handling of Various Image ID Formats in Hash Extraction**
Resolves: #111 

### Background:
The current implementation of hash extraction from Image IDs assumes a certain pattern and does not account for all variations of Image IDs, specifically formats like:
- "docker://sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
- "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"

There are instances where the Image ID doesn't have enough submatches (less than 3) leading to panic as the existing code tries to access an index that does not exist.

### Changes:
This PR provides a robust mechanism to extract the SHA256 hash from Image IDs that can handle varying formats. The key changes include:

1. **Adding a check for plain SHA256 hashes:** If the Image ID is a plain SHA256 hash, the function will now directly return it as the hash.

2. **Improved Error Handling:** An error is now returned when there is an issue with the hash extraction, instead of the function panicking. 

3. **Fallback Mechanism:** In cases where the Image ID doesn't match the usual pattern, a fallback mechanism has been implemented to parse and extract the hash using a regular expression.

### Impact:
This change will make the hash extraction from Image IDs more robust and prevent unexpected panics. It also improves error handling and provides more detailed error messages to help with troubleshooting.
