### PR TITLE
Add built `kubevuln` binary file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# Built Kubevuln binary
+kubevuln
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
- The built `kubevuln` binary file is generated during the build process and should not be tracked by Git.
- This pull request adds the entry for the `kubevuln` binary to the .gitignore file.

**Signed Commits?**
- [x]  Yes, I signed my commits.