### PR TITLE
Update `dev` and `master` to `main` branch in `CONTRIBUTING.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# Built Kubevuln binary
+kubevuln
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Please note we have a code of conduct, please follow it in all your interactions
    build.
 2. Update the README.md with details of changes to the interface, this includes new environment 
    variables, exposed ports, useful file locations and container parameters.
-3. Open Pull Request to `dev` branch - we test the component before merging into the `master` branch
+3. Open Pull Request to `main` branch - we test the component before merging it into the `main` branch.
 4. We will merge the Pull Request in once you have the sign-off.
 
 ## Code of Conduct


### PR DESCRIPTION
- This PR fixes a [line](https://github.com/kubescape/kubevuln/blob/main/CONTRIBUTING.md#pull-request-process) in the `CONTRIBUTING.md`, changing `dev` and `master` to `main`.

- Current line:
             3. Open Pull Request to `dev` branch - we test the component before merging into the `master` branch
- Updated line:
             3. Open Pull Request to `main` branch - we test the component before merging it into the `main` branch.
