### PR TITLE
env var for config file added

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -26,7 +26,12 @@ import (
 func main() {
 	ctx := context.Background()
 
-	c, err := config.LoadConfig("/etc/config")
+	configPath := os.Getenv("CONFIG")
+	if configPath == "" {
+		configPath = "/etc/config"
+	}
+
+	c, err := config.LoadConfig(configPath)
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("load config error", helpers.Error(err))
 	}


### PR DESCRIPTION
## Overview
Use the CONFIG environment variable to load the config file, but it currently doesn't allow custom file paths. Kubevuln always defaults to searching for the config file in the /etc/config path, regardless of the CONFIG env value.

## How to Test

Build kubevuln using ```make```
Load config file using the CONFIG environment variable
```export CONFIG=path/to/clusterData.json```

Set the PORT environment variable to 8081
```export PORT=8080```

## Related issues/PRs:
Resolved #129 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


 