### PR TITLE
summary objects - move to lower case

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/armosec/utils-k8s-go/wlid"
@@ -297,7 +298,7 @@ func enrichSummaryManifestObjectLabels(ctx context.Context, labels map[string]st
 
 	enrichedLabels[v1.ApiGroupMetadataKey] = groupVersionScheme.Group
 	enrichedLabels[v1.ApiVersionMetadataKey] = groupVersionScheme.Version
-	enrichedLabels[v1.KindMetadataKey] = workloadKind
+	enrichedLabels[v1.KindMetadataKey] = strings.ToLower(workloadKind)
 	enrichedLabels[v1.NameMetadataKey] = wlid.GetNameFromWlid(workload.Wlid)
 	enrichedLabels[v1.NamespaceMetadataKey] = wlid.GetNamespaceFromWlid(workload.Wlid)
 	enrichedLabels[v1.ContainerNameMetadataKey] = workload.ContainerName
@@ -310,9 +311,9 @@ func GetCVESummaryK8sResourceName(ctx context.Context) (string, error) {
 	if !ok {
 		return "", domain.ErrCastingWorkload
 	}
-	kind := wlid.GetKindFromWlid(workload.Wlid)
-	name := wlid.GetNameFromWlid(workload.Wlid)
-	contName := workload.ContainerName
+	kind := strings.ToLower(wlid.GetKindFromWlid(workload.Wlid))
+	name := strings.ToLower(wlid.GetNameFromWlid(workload.Wlid))
+	contName := strings.ToLower(workload.ContainerName)
 
 	return fmt.Sprintf(vulnSummaryContNameFormat, kind, name, contName), nil
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -474,7 +474,7 @@ func TestAPIServerStore_enrichSummaryManifestObjectLabels(t *testing.T) {
 		workload             domain.ScanCommand
 	}{
 		{
-			k8sResourceType:      "Deployment",
+			k8sResourceType:      "deployment",
 			k8sResourceGroup:     "apps",
 			k8sResourceVersion:   "v1",
 			k8sResourceName:      "ccc",
@@ -489,7 +489,7 @@ func TestAPIServerStore_enrichSummaryManifestObjectLabels(t *testing.T) {
 			},
 		},
 		{
-			k8sResourceType:      "CronJob",
+			k8sResourceType:      "cronjob",
 			k8sResourceGroup:     "batch",
 			k8sResourceVersion:   "v1",
 			k8sResourceName:      "123",
@@ -504,7 +504,7 @@ func TestAPIServerStore_enrichSummaryManifestObjectLabels(t *testing.T) {
 			},
 		},
 		{
-			k8sResourceType:      "Job",
+			k8sResourceType:      "job",
 			k8sResourceGroup:     "batch",
 			k8sResourceVersion:   "v1",
 			k8sResourceName:      "anyJob",
@@ -617,42 +617,42 @@ func TestAPIServerStore_getCVESummaryK8sResourceName(t *testing.T) {
 				Wlid:          "wlid://cluster-aaa/deployment-default/deployment-nginx",
 				ContainerName: "nginx",
 			},
-			expRes: "Deployment-nginx-nginx",
+			expRes: "deployment-nginx-nginx",
 		},
 		{
 			workload: domain.ScanCommand{
 				Wlid:          "wlid://cluster-aaa/deployment-default/deployment-nginx",
 				ContainerName: "nginx",
 			},
-			expRes: "Deployment-nginx-nginx",
+			expRes: "deployment-nginx-nginx",
 		},
 		{
 			workload: domain.ScanCommand{
 				Wlid:          "wlid://cluster-aaa/deployment-kubescape/deployment-kubescape",
 				ContainerName: "kubescape",
 			},
-			expRes: "Deployment-kubescape-kubescape",
+			expRes: "deployment-kubescape-kubescape",
 		},
 		{
 			workload: domain.ScanCommand{
 				Wlid:          "wlid://cluster-aaa/namespace-kubescape/deployment-kubevuln",
 				ContainerName: "kubevuln",
 			},
-			expRes: "Deployment-kubevuln-kubevuln",
+			expRes: "deployment-kubevuln-kubevuln",
 		},
 		{
 			workload: domain.ScanCommand{
 				Wlid:          "wlid://cluster-aaa/namespace-kubescape/deployment-operator",
 				ContainerName: "operator",
 			},
-			expRes: "Deployment-operator-operator",
+			expRes: "deployment-operator-operator",
 		},
 		{
 			workload: domain.ScanCommand{
 				Wlid:          "wlid://cluster-aaa/namespace-kube-system/pod-etcd-control-plane",
 				ContainerName: "etcd-control-plane",
 			},
-			expRes: "Pod-etcd-control-plane-etcd-control-plane",
+			expRes: "pod-etcd-control-plane-etcd-control-plane",
 		},
 	}
 


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR includes changes to convert Kubernetes resource names to lowercase in the summary objects. This is done to maintain consistency and avoid potential issues due to case sensitivity. The changes are made in the 'apiserver.go' file and corresponding changes are also made in the 'apiserver_test.go' file to ensure the tests are aligned with the changes.

___
## PR Main Files Walkthrough:
`repositories/apiserver.go`: The 'enrichSummaryManifestObjectLabels' and 'GetCVESummaryK8sResourceName' functions have been updated to convert various Kubernetes resource names to lowercase using the 'strings.ToLower' function.
`repositories/apiserver_test.go`: The test cases in 'TestAPIServerStore_enrichSummaryManifestObjectLabels' and 'TestAPIServerStore_getCVESummaryK8sResourceName' have been updated to use lowercase Kubernetes resource names, aligning with the changes made in 'apiserver.go'.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
