### PR TITLE
add debug print of full HttpPost and logs

### DIFF
--- a/adapters/mockcve.go
+++ b/adapters/mockcve.go
@@ -43,7 +43,16 @@ func (m MockCVEAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.
 		CVEDBVersion:       m.DBVersion(ctx),
 		Annotations:        sbom.Annotations,
 		Labels:             sbom.Labels,
-		Content:            &v1beta1.GrypeDocument{},
+		Content: &v1beta1.GrypeDocument{
+			Matches: []v1beta1.Match{
+				{
+					Vulnerability:          v1beta1.Vulnerability{},
+					RelatedVulnerabilities: nil,
+					MatchDetails:           nil,
+					Artifact:               v1beta1.GrypePackage{},
+				},
+			},
+		},
 	}, nil
 }
 

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	backendClientV1 "github.com/kubescape/backend/pkg/client/v1"
 	sysreport "github.com/kubescape/backend/pkg/server/v1/systemreports"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"go.opentelemetry.io/otel"
@@ -248,4 +250,10 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 		err = multierror.Append(err, e)
 	}
 	return err
+}
+
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+func httpPostDebug(httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte) (*http.Response, error) {
+	logger.L().Debug("httpPostDebug", helpers.String("fullURL", fullURL), helpers.Interface("headers", headers), helpers.String("body", string(body)))
+	return httputils.HttpPostWithContext(context.Background(), httpClient, fullURL, headers, body)
 }

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -163,7 +163,8 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 	}
 
 	logger.L().Debug("returning CVE manifest",
-		helpers.String("name", sbom.Name))
+		helpers.String("name", sbom.Name),
+		helpers.Int("vulnerabilities", len(vulnerabilityResults.Matches)))
 	return domain.CVEManifest{
 		Name:               sbom.Name,
 		SBOMCreatorVersion: sbom.SBOMCreatorVersion,

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -167,7 +167,8 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID string, opti
 	domainSBOM.Content, err = s.syftToDomain(syftSBOM)
 	// return SBOM
 	logger.L().Debug("returning SBOM",
-		helpers.String("imageID", imageID))
+		helpers.String("imageID", imageID),
+		helpers.Int("packages", len(domainSBOM.Content.Packages)))
 	return domainSBOM, err
 }
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR enhances the debugging capabilities by adding debug logs to various functions. It also adds mock vulnerability data to the `MockCVEAdapter` for testing purposes.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`adapters/mockcve.go`: Added mock vulnerability data to the `ScanSBOM` function of the `MockCVEAdapter`.
`adapters/v1/backend.go`: Added a new function `httpPostDebug` that logs the full URL, headers, and body of an HTTP post request.
`adapters/v1/grype.go`: Enhanced the debug log in the `ScanSBOM` function to include the number of vulnerabilities.
`adapters/v1/syft.go`: Enhanced the debug log in the `CreateSBOM` function to include the number of packages.
</details>
