### PR TITLE
add top level permissions: read-all for openssf

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -1,9 +1,10 @@
 name: pull_request_created
+permissions: read-all
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
-      - '*.md' 
+      - '*.md'
       - '*.yaml'
       - '.github/workflows/*'
 

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -1,21 +1,22 @@
 name: pr-merged
+permissions: read-all
 on:
   pull_request_target:
     types: [closed]
-    branches: 
+    branches:
     - 'main'
     paths-ignore:
-      - '*.md' 
+      - '*.md'
       - '*.yaml'
       - '.github/workflows/*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-    
+
 jobs:
   pr-merged:
-    if: ${{ github.event.pull_request.merged == true }} ## Skip if not merged 
+    if: ${{ github.event.pull_request.merged == true }} ## Skip if not merged
     uses: kubescape/workflows/.github/workflows/incluster-comp-pr-merged.yaml@main
     with:
       IMAGE_NAME: quay.io/${{ github.repository_owner }}/kubevuln


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new top-level permission, 'read-all', for OpenSSF. This permission has been added to the workflows for when a pull request is created and when a pull request is merged. The changes aim to enhance the security and control over the repository by specifying the level of access required for these workflows.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`.github/workflows/pr-created.yaml`: Added 'read-all' permission at the top level. Also, some formatting changes have been made.
`.github/workflows/pr-merged.yaml`: Added 'read-all' permission at the top level. Some formatting changes have been made and the condition for the 'pr-merged' job has been updated to skip if not merged.
</details>
