### PR TITLE
Adding image tag annotations

### DIFF
--- a/adapters/mocksbom.go
+++ b/adapters/mocksbom.go
@@ -35,7 +35,7 @@ func NewMockSBOMAdapter(error, timeout, toomanyrequests bool) *MockSBOMAdapter {
 }
 
 // CreateSBOM returns a dummy SBOM for the given imageID
-func (m MockSBOMAdapter) CreateSBOM(_ context.Context, name, imageID string, _ domain.RegistryOptions) (domain.SBOM, error) {
+func (m MockSBOMAdapter) CreateSBOM(_ context.Context, name, imageID, imageTag string, _ domain.RegistryOptions) (domain.SBOM, error) {
 	logger.L().Info("CreateSBOM")
 	if m.error {
 		return domain.SBOM{}, domain.ErrMockError
@@ -51,7 +51,8 @@ func (m MockSBOMAdapter) CreateSBOM(_ context.Context, name, imageID string, _ d
 		Name:               name,
 		SBOMCreatorVersion: m.Version(),
 		Annotations: map[string]string{
-			helpersv1.ImageIDMetadataKey: imageID,
+			helpersv1.ImageIDMetadataKey:  imageID,
+			helpersv1.ImageTagMetadataKey: imageTag,
 		},
 		Labels:  tools.LabelsFromImageID(imageID),
 		Content: &v1beta1.SyftDocument{},

--- a/adapters/mocksbom_test.go
+++ b/adapters/mocksbom_test.go
@@ -12,19 +12,19 @@ import (
 
 func TestMockSBOMAdapter_CreateSBOM(t *testing.T) {
 	m := NewMockSBOMAdapter(false, false, false)
-	sbom, _ := m.CreateSBOM(context.TODO(), "name", "image", domain.RegistryOptions{})
+	sbom, _ := m.CreateSBOM(context.TODO(), "name", "image", "", domain.RegistryOptions{})
 	assert.NotNil(t, sbom.Content)
 }
 
 func TestMockSBOMAdapter_CreateSBOM_Error(t *testing.T) {
 	m := NewMockSBOMAdapter(true, false, false)
-	_, err := m.CreateSBOM(context.TODO(), "name", "image", domain.RegistryOptions{})
+	_, err := m.CreateSBOM(context.TODO(), "name", "image", "", domain.RegistryOptions{})
 	assert.Error(t, err)
 }
 
 func TestMockSBOMAdapter_CreateSBOM_Timeout(t *testing.T) {
 	m := NewMockSBOMAdapter(false, true, false)
-	sbom, _ := m.CreateSBOM(context.TODO(), "name", "image", domain.RegistryOptions{})
+	sbom, _ := m.CreateSBOM(context.TODO(), "name", "image", "", domain.RegistryOptions{})
 	assert.Equal(t, helpersv1.Incomplete, sbom.Status)
 }
 

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -197,6 +197,11 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 	finalReport.Designators.Attributes[identifiers.AttributeContainerName] = workload.ContainerName
 	finalReport.Designators.Attributes[identifiers.AttributeWorkloadHash] = cs.GenerateWorkloadHash(finalReport.Designators.Attributes)
 	finalReport.Designators.Attributes[identifiers.AttributeCustomerGUID] = a.clusterConfig.AccountID
+
+	// FIXME: use identifiers.AttributeSBOMToolVersion instead of "sbomToolVersion"
+	finalReport.Designators.Attributes["sbomToolVersion"] = cve.SBOMCreatorVersion
+	finalReport.Designators.Attributes["sbomToolName"] = cve.SBOMCreatorName
+
 	if val, ok := workload.Args[identifiers.AttributeRegistryName]; ok {
 		finalReport.Designators.Attributes[identifiers.AttributeRegistryName] = val.(string)
 	}

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -45,7 +45,7 @@ func NewSyftAdapter(scanTimeout time.Duration, maxImageSize int64) *SyftAdapter 
 // CreateSBOM creates an SBOM for a given imageID, restrict parallelism to prevent disk space issues,
 // a timeout prevents the process from hanging for too long.
 // Format is syft JSON and the resulting SBOM is tagged with the Syft version.
-func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID string, options domain.RegistryOptions) (domain.SBOM, error) {
+func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag string, options domain.RegistryOptions) (domain.SBOM, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "SyftAdapter.CreateSBOM")
 	defer span.End()
 
@@ -58,6 +58,9 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID string, opti
 			helpersv1.ImageIDMetadataKey: imageID,
 		},
 		Labels: tools.LabelsFromImageID(imageID),
+	}
+	if imageTag != "" {
+		domainSBOM.Annotations[helpersv1.ImageTagMetadataKey] = imageTag
 	}
 	// translate business models into Syft models
 	if options.Platform == "" {

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -81,7 +81,7 @@ func Test_syftAdapter_CreateSBOM(t *testing.T) {
 				maxImageSize = tt.maxImageSize
 			}
 			s := NewSyftAdapter(5*time.Minute, maxImageSize)
-			got, err := s.CreateSBOM(context.TODO(), "name", tt.imageID, tt.options)
+			got, err := s.CreateSBOM(context.TODO(), "name", tt.imageID, "", tt.options)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateSBOM() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/adapters/v1/testdata/cve-body-with-exception.json
+++ b/adapters/v1/testdata/cve-body-with-exception.json
@@ -76,7 +76,8 @@
       }
     ],
     "jobIDs": null,
-    "vulnerabilities": ["<<UNORDERED>>",
+    "vulnerabilities": [
+      "<<UNORDERED>>",
       {
         "name": "CVE-2005-2541"
       },
@@ -84,7 +85,8 @@
         "name": "CVE-2007-6755"
       }
     ],
-    "context": ["<<UNORDERED>>",
+    "context": [
+      "<<UNORDERED>>",
       {
         "attribute": "containerName",
         "value": "",
@@ -93,6 +95,16 @@
       {
         "attribute": "workloadHash",
         "value": "14695981039346656037",
+        "source": "designators.attributes"
+      },
+      {
+        "attribute": "sbomToolVersion",
+        "value": "Mock SBOM 1.0",
+        "source": "designators.attributes"
+      },
+      {
+        "attribute": "sbomToolName",
+        "value": "",
         "source": "designators.attributes"
       },
       {
@@ -106,7 +118,8 @@
     "hasRelevancyData": false
   },
   "containersScanID": "<<PRESENCE>>",
-  "vulnerabilities": ["<<UNORDERED>>",
+  "vulnerabilities": [
+    "<<UNORDERED>>",
     {
       "clusterShortName": "",
       "designators": {
@@ -114,7 +127,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -150,7 +165,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -167,7 +183,8 @@
           "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
         "https://security-tracker.debian.org/tracker/CVE-2005-2541"
       ],
@@ -183,7 +200,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -236,7 +255,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -253,7 +273,8 @@
           "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
         "https://security-tracker.debian.org/tracker/CVE-2007-5686"
       ],
@@ -269,7 +290,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -322,7 +345,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -339,7 +363,8 @@
           "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
         "https://security-tracker.debian.org/tracker/CVE-2007-5686"
       ],
@@ -355,7 +380,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -391,7 +418,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -408,7 +436,8 @@
           "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
         "https://security-tracker.debian.org/tracker/CVE-2007-6755"
       ],

--- a/adapters/v1/testdata/cve-body-with-exception.json
+++ b/adapters/v1/testdata/cve-body-with-exception.json
@@ -181,6 +181,16 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "source": "designators.attributes",
+          "value": "Mock SBOM 1.0"
+        },
+        {
+          "attribute": "sbomToolName",
+          "source": "designators.attributes",
+          "value": ""
         }
       ],
       "links": [
@@ -271,6 +281,16 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "source": "designators.attributes",
+          "value": "Mock SBOM 1.0"
+        },
+        {
+          "attribute": "sbomToolName",
+          "source": "designators.attributes",
+          "value": ""
         }
       ],
       "links": [
@@ -361,6 +381,16 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "source": "designators.attributes",
+          "value": "Mock SBOM 1.0"
+        },
+        {
+          "attribute": "sbomToolName",
+          "source": "designators.attributes",
+          "value": ""
         }
       ],
       "links": [
@@ -434,6 +464,16 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "source": "designators.attributes",
+          "value": "Mock SBOM 1.0"
+        },
+        {
+          "attribute": "sbomToolName",
+          "source": "designators.attributes",
+          "value": ""
         }
       ],
       "links": [

--- a/adapters/v1/testdata/cve-body-with-exception.json
+++ b/adapters/v1/testdata/cve-body-with-exception.json
@@ -4,7 +4,9 @@
     "attributes": {
       "containerName": "",
       "customerGUID": "",
-      "workloadHash": "14695981039346656037"
+      "workloadHash": "14695981039346656037",
+      "sbomToolVersion": "Mock SBOM 1.0",
+      "sbomToolName": ""
     }
   },
   "summary": {

--- a/adapters/v1/testdata/cve-body-with-exception.json
+++ b/adapters/v1/testdata/cve-body-with-exception.json
@@ -15,7 +15,9 @@
       "attributes": {
         "containerName": "",
         "customerGUID": "",
-        "workloadHash": "14695981039346656037"
+        "workloadHash": "14695981039346656037",
+        "sbomToolVersion": "Mock SBOM 1.0",
+        "sbomToolName": ""
       }
     },
     "healthStatus": "",

--- a/adapters/v1/testdata/cve-body.json
+++ b/adapters/v1/testdata/cve-body.json
@@ -61,7 +61,8 @@
       }
     ],
     "jobIDs": null,
-    "vulnerabilities": ["<<UNORDERED>>",
+    "vulnerabilities": [
+      "<<UNORDERED>>",
       {
         "name": "CVE-2005-2541"
       },
@@ -75,7 +76,8 @@
         "name": "CVE-2007-6755"
       }
     ],
-    "context": ["<<UNORDERED>>",
+    "context": [
+      "<<UNORDERED>>",
       {
         "attribute": "containerName",
         "value": "",
@@ -84,6 +86,16 @@
       {
         "attribute": "workloadHash",
         "value": "14695981039346656037",
+        "source": "designators.attributes"
+      },
+      {
+        "attribute": "sbomToolVersion",
+        "value": "Mock SBOM 1.0",
+        "source": "designators.attributes"
+      },
+      {
+        "attribute": "sbomToolName",
+        "value": "",
         "source": "designators.attributes"
       },
       {
@@ -97,7 +109,8 @@
     "hasRelevancyData": false
   },
   "containersScanID": "<<PRESENCE>>",
-  "vulnerabilities": ["<<UNORDERED>>",
+  "vulnerabilities": [
+    "<<UNORDERED>>",
     {
       "clusterShortName": "",
       "designators": {
@@ -105,7 +118,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -141,7 +156,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -156,9 +172,20 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "value": "Mock SBOM 1.0",
+          "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolName",
+          "value": "",
+          "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
         "https://security-tracker.debian.org/tracker/CVE-2005-2541"
       ],
@@ -174,7 +201,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -210,7 +239,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -225,9 +255,20 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "value": "Mock SBOM 1.0",
+          "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolName",
+          "value": "",
+          "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
         "https://security-tracker.debian.org/tracker/CVE-2007-5686"
       ],
@@ -243,7 +284,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -279,7 +322,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -294,9 +338,20 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "value": "Mock SBOM 1.0",
+          "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolName",
+          "value": "",
+          "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
         "https://security-tracker.debian.org/tracker/CVE-2007-5686"
       ],
@@ -312,7 +367,9 @@
         "attributes": {
           "containerName": "",
           "customerGUID": "",
-          "workloadHash": "14695981039346656037"
+          "workloadHash": "14695981039346656037",
+          "sbomToolVersion": "Mock SBOM 1.0",
+          "sbomToolName": ""
         }
       },
       "layerHash": "generatedlayer",
@@ -348,7 +405,8 @@
         }
       ],
       "layersNested": null,
-      "context": ["<<UNORDERED>>",
+      "context": [
+        "<<UNORDERED>>",
         {
           "attribute": "containerName",
           "value": "",
@@ -363,9 +421,20 @@
           "attribute": "customerGUID",
           "value": "",
           "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolVersion",
+          "value": "Mock SBOM 1.0",
+          "source": "designators.attributes"
+        },
+        {
+          "attribute": "sbomToolName",
+          "value": "",
+          "source": "designators.attributes"
         }
       ],
-      "links": ["<<UNORDERED>>",
+      "links": [
+        "<<UNORDERED>>",
         "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
         "https://security-tracker.debian.org/tracker/CVE-2007-6755"
       ],

--- a/adapters/v1/testdata/cve-body.json
+++ b/adapters/v1/testdata/cve-body.json
@@ -4,7 +4,9 @@
     "attributes": {
       "containerName": "",
       "customerGUID": "",
-      "workloadHash": "14695981039346656037"
+      "workloadHash": "14695981039346656037",
+      "sbomToolVersion": "Mock SBOM 1.0",
+      "sbomToolName": ""
     }
   },
   "summary": {

--- a/adapters/v1/testdata/cve-body.json
+++ b/adapters/v1/testdata/cve-body.json
@@ -15,7 +15,9 @@
       "attributes": {
         "containerName": "",
         "customerGUID": "",
-        "workloadHash": "14695981039346656037"
+        "workloadHash": "14695981039346656037",
+        "sbomToolVersion": "Mock SBOM 1.0",
+        "sbomToolName": ""
       }
     },
     "healthStatus": "",

--- a/adapters/v1/testdata/cve-chunk-with-relevant-summary.json
+++ b/adapters/v1/testdata/cve-chunk-with-relevant-summary.json
@@ -60,6 +60,16 @@
         "source": "designators.attributes"
       },
       {
+        "attribute": "sbomToolVersion",
+        "value": "Mock SBOM 1.0",
+        "source": "designators.attributes"
+      },
+      {
+        "attribute": "sbomToolName",
+        "value": "",
+        "source": "designators.attributes"
+      },
+      {
         "attribute": "customerGUID",
         "value": "",
         "source": "designators.attributes"

--- a/adapters/v1/testdata/cve-chunk-with-relevant-summary.json
+++ b/adapters/v1/testdata/cve-chunk-with-relevant-summary.json
@@ -4,7 +4,9 @@
     "attributes": {
       "containerName": "",
       "customerGUID": "",
-      "workloadHash": "14695981039346656037"
+      "workloadHash": "14695981039346656037",
+      "sbomToolVersion": "Mock SBOM 1.0",
+      "sbomToolName": ""
     }
   },
   "summary": {

--- a/adapters/v1/testdata/cve-chunk-with-relevant-summary.json
+++ b/adapters/v1/testdata/cve-chunk-with-relevant-summary.json
@@ -15,7 +15,9 @@
       "attributes": {
         "containerName": "",
         "customerGUID": "",
-        "workloadHash": "14695981039346656037"
+        "workloadHash": "14695981039346656037",
+        "sbomToolVersion": "Mock SBOM 1.0",
+        "sbomToolName": ""
       }
     },
     "healthStatus": "",

--- a/adapters/v1/testdata/cve-chunk-with-summary.json
+++ b/adapters/v1/testdata/cve-chunk-with-summary.json
@@ -48,7 +48,8 @@
     "severitiesStats": "<<PRESENCE>>",
     "jobIDs": null,
     "vulnerabilities": "<<PRESENCE>>",
-    "context": ["<<UNORDERED>>",
+    "context": [
+      "<<UNORDERED>>",
       {
         "attribute": "containerName",
         "value": "",
@@ -57,6 +58,16 @@
       {
         "attribute": "workloadHash",
         "value": "14695981039346656037",
+        "source": "designators.attributes"
+      },
+      {
+        "attribute": "sbomToolVersion",
+        "value": "Mock SBOM 1.0",
+        "source": "designators.attributes"
+      },
+      {
+        "attribute": "sbomToolName",
+        "value": "",
         "source": "designators.attributes"
       },
       {

--- a/adapters/v1/testdata/cve-chunk-with-summary.json
+++ b/adapters/v1/testdata/cve-chunk-with-summary.json
@@ -15,7 +15,9 @@
       "attributes": {
         "containerName": "",
         "customerGUID": "",
-        "workloadHash": "14695981039346656037"
+        "workloadHash": "14695981039346656037",
+        "sbomToolVersion": "Mock SBOM 1.0",
+        "sbomToolName": ""
       }
     },
     "clusterShortName": "",

--- a/adapters/v1/testdata/cve-chunk-with-summary.json
+++ b/adapters/v1/testdata/cve-chunk-with-summary.json
@@ -4,7 +4,9 @@
     "attributes": {
       "containerName": "",
       "customerGUID": "",
-      "workloadHash": "14695981039346656037"
+      "workloadHash": "14695981039346656037",
+      "sbomToolVersion": "Mock SBOM 1.0",
+      "sbomToolName": ""
     }
   },
   "summary": {

--- a/adapters/v1/testdata/cve-chunk.json
+++ b/adapters/v1/testdata/cve-chunk.json
@@ -4,7 +4,9 @@
     "attributes": {
       "containerName": "",
       "customerGUID": "",
-      "workloadHash": "14695981039346656037"
+      "workloadHash": "14695981039346656037",
+      "sbomToolVersion": "Mock SBOM 1.0",
+      "sbomToolName": ""
     }
   },
   "containersScanID": "<<PRESENCE>>",

--- a/core/ports/providers.go
+++ b/core/ports/providers.go
@@ -16,7 +16,7 @@ type CVEScanner interface {
 
 // SBOMCreator is the port implemented by adapters to be used in ScanService to generate SBOM
 type SBOMCreator interface {
-	CreateSBOM(ctx context.Context, name, imageID string, options domain.RegistryOptions) (domain.SBOM, error)
+	CreateSBOM(ctx context.Context, name, imageID, imageTag string, options domain.RegistryOptions) (domain.SBOM, error)
 	Version() string
 }
 

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -97,7 +97,7 @@ func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 	// if SBOM is not available, create it
 	if sbom.Content == nil {
 		// create SBOM
-		sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, optionsFromWorkload(workload))
+		sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTag, optionsFromWorkload(workload))
 		s.checkCreateSBOM(err, workload.ImageHash)
 		if err != nil {
 			return err
@@ -170,7 +170,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 		// if SBOM is not available, create it
 		if sbom.Content == nil {
 			// create SBOM
-			sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, optionsFromWorkload(workload))
+			sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTag, optionsFromWorkload(workload))
 			s.checkCreateSBOM(err, workload.ImageHash)
 			if err != nil {
 				return fmt.Errorf("error creating SBOM: %w", err)
@@ -311,7 +311,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	}
 
 	// create SBOM
-	sbom, err := s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageTag, optionsFromWorkload(workload))
+	sbom, err := s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageTag, workload.ImageTag, optionsFromWorkload(workload))
 	s.checkCreateSBOM(err, workload.ImageTag)
 	if err != nil {
 		return err

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -271,7 +271,7 @@ func TestScanService_ScanCVE(t *testing.T) {
 				tools.EnsureSetup(t, err == nil)
 			}
 			if tt.sbom {
-				sbom, err := sbomAdapter.CreateSBOM(ctx, "imageSlug", imageHash, domain.RegistryOptions{})
+				sbom, err := sbomAdapter.CreateSBOM(ctx, "imageSlug", imageHash, "", domain.RegistryOptions{})
 				tools.EnsureSetup(t, err == nil)
 				_ = storageSBOM.StoreSBOM(ctx, sbom)
 				if tt.cveManifest {
@@ -283,7 +283,7 @@ func TestScanService_ScanCVE(t *testing.T) {
 			var sbomp domain.SBOM
 			if tt.instanceID != "" {
 				var err error
-				sbomp, err = sbomAdapter.CreateSBOM(ctx, tt.instanceID, tt.instanceID, domain.RegistryOptions{})
+				sbomp, err = sbomAdapter.CreateSBOM(ctx, tt.instanceID, tt.instanceID, "", domain.RegistryOptions{})
 				tools.EnsureSetup(t, err == nil)
 				sbomp.Labels = map[string]string{"foo": "bar"}
 				_ = storageSBOM.StoreSBOM(ctx, sbomp)


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
Enhancement


___

## **Description**
- The pull request mainly focuses on including the `imageTag` in the Software Bill of Materials (SBOM) creation process.
- The `CreateSBOM` function in both `MockSBOMAdapter` and `SyftAdapter` now includes an `imageTag` parameter, and the `imageTag` is included in the `Annotations` of the `sbom` object.
- The `CreateSBOM` function signature in the `SBOMCreator` interface has been updated to include the `imageTag` parameter.
- The `CreateSBOM` function calls in `GenerateSBOM`, `ScanCVE`, and `ScanRegistry` methods of the `ScanService` have been updated to include `workload.ImageTag`.
- Corresponding test cases have been updated to accommodate these changes.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mocksbom.go</strong><dd><code>Added image tag annotations in mock SBOM creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/mocksbom.go
- Added `imageTag` as a parameter to `CreateSBOM` function.
- Included `imageTag` in the `Annotations` of the `sbom` object.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/208/files#diff-6e38ef77727c8b71cc3535335be36ede25f09463924b19da2ffcc576791b9848">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>syft.go</strong><dd><code>Added image tag annotations in Syft SBOM creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/v1/syft.go
- Added `imageTag` as a parameter to `CreateSBOM` function.
- Included `imageTag` in the `Annotations` of the `sbom` object if <br>  `imageTag` is not empty.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/208/files#diff-59cc1c76e75b8cc3f401be82a7ad03494324118b3eb21cb247c7b7f0ade69515">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>providers.go</strong><dd><code>Updated SBOMCreator interface to include image tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/ports/providers.go
- Updated the `CreateSBOM` function signature in the `SBOMCreator` <br>  interface to include `imageTag` parameter.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/208/files#diff-b7680bf53120bc227c3b581687513cff80c469f2eb0ee44eeda6a373c76c100a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scan.go</strong><dd><code>Updated SBOM creation calls in scan service to include image tag</code>&nbsp; </dd></summary>
<hr>

core/services/scan.go
- Updated the `CreateSBOM` function calls in `GenerateSBOM`, `ScanCVE`, `<br>  `and `<br>  ``ScanRegistry` <br>  methods to include `workload.ImageTag`.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/208/files#diff-85deac1fd3ad15a30ddc8a15245049faf294923a8058adfb7c47994034b662d8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mocksbom_test.go</strong><dd><code>Updated tests for mock SBOM creation with image tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/mocksbom_test.go
- Updated the `CreateSBOM` function calls in the tests to include the <br>  new `imageTag` parameter.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/208/files#diff-b6524a7ecc6b056eaa66ae082ed91157d7c3f40289db8fed98aa18e9fbef3ce0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>syft_test.go</strong><dd><code>Updated tests for Syft SBOM creation with image tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/v1/syft_test.go
- Updated the `CreateSBOM` function calls in the tests to include the <br>  new `imageTag` parameter.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/208/files#diff-58134a5183879fd2da27ae7458a485bf76579b87e7269f07d7f440086178b470">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scan_test.go</strong><dd><code>Updated tests for SBOM creation in scan service with image tag</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/services/scan_test.go
- Updated the `CreateSBOM` function calls in the tests to include the <br>  new `imageTag` parameter.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/208/files#diff-d56b03ebd7c08629490de62e8320ae4efa2c430b065f8ffc327e0763fd7c3a41">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
