### PR TITLE
fix image load in registry scanning

### DIFF
--- a/adapters/mockplatform.go
+++ b/adapters/mockplatform.go
@@ -31,6 +31,12 @@ func (m MockPlatform) GetCVEExceptions(ctx context.Context) (domain.CVEException
 	return domain.CVEExceptions{}, nil
 }
 
+func (m MockPlatform) ReportError(ctx context.Context, _ error) error {
+	_, span := otel.Tracer("").Start(ctx, "MockPlatform.ReportError")
+	defer span.End()
+	return nil
+}
+
 // SendStatus logs the given status and details
 func (m MockPlatform) SendStatus(ctx context.Context, _ int) error {
 	_, span := otel.Tracer("").Start(ctx, "MockPlatform.SendStatus")
@@ -39,7 +45,7 @@ func (m MockPlatform) SendStatus(ctx context.Context, _ int) error {
 }
 
 // SubmitCVE logs the given ID for CVE calculation
-func (m MockPlatform) SubmitCVE(ctx context.Context, cve domain.CVEManifest, _ domain.CVEManifest) error {
+func (m MockPlatform) SubmitCVE(ctx context.Context, _ domain.CVEManifest, _ domain.CVEManifest) error {
 	_, span := otel.Tracer("").Start(ctx, "MockPlatform.SubmitCVE")
 	defer span.End()
 	return nil

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -47,6 +47,10 @@ func NewSyftAdapter(scanTimeout time.Duration, maxImageSize int64) *SyftAdapter 
 const digestDelim = "@"
 
 func normalizeImageID(imageID, imageTag string) string {
+	// registry scanning doesn't provide imageID, so we use imageTag as a reference
+	if imageID == "" {
+		return imageTag
+	}
 	// try to parse imageID as a full digest
 	if newDigest, err := name.NewDigest(imageID); err == nil {
 		return newDigest.String()

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -86,6 +86,12 @@ func Test_syftAdapter_CreateSBOM(t *testing.T) {
 			imageTag: "registry.k8s.io/kube-scheduler:v1.28.4",
 			wantErr:  false,
 		},
+		{
+			name:     "registry scan",
+			imageID:  "",
+			imageTag: "quay.io/matthiasb_1/kubevuln:latest",
+			wantErr:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/ports/providers.go
+++ b/core/ports/providers.go
@@ -23,6 +23,7 @@ type SBOMCreator interface {
 // Platform is the port implemented by adapters to be used in ScanService to report scan results and send telemetry data
 type Platform interface {
 	GetCVEExceptions(ctx context.Context) (domain.CVEExceptions, error)
+	ReportError(ctx context.Context, err error) error
 	SendStatus(ctx context.Context, step int) error
 	SubmitCVE(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest) error
 }

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -311,7 +311,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	}
 
 	// create SBOM
-	sbom, err := s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageTag, workload.ImageTag, optionsFromWorkload(workload))
+	sbom, err := s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTag, optionsFromWorkload(workload))
 	s.checkCreateSBOM(err, workload.ImageTag)
 	if err != nil {
 		return err

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -314,6 +314,11 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	sbom, err := s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTag, optionsFromWorkload(workload))
 	s.checkCreateSBOM(err, workload.ImageTag)
 	if err != nil {
+		repErr := s.platform.ReportError(ctx, err)
+		if repErr != nil {
+			logger.L().Ctx(ctx).Warning("telemetry error", helpers.Error(repErr),
+				helpers.String("imageSlug", workload.ImageSlug))
+		}
 		return err
 	}
 
@@ -325,6 +330,11 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	// scan for CVE
 	cve, err := s.cveScanner.ScanSBOM(ctx, sbom)
 	if err != nil {
+		repErr := s.platform.ReportError(ctx, err)
+		if repErr != nil {
+			logger.L().Ctx(ctx).Warning("telemetry error", helpers.Error(repErr),
+				helpers.String("imageSlug", workload.ImageSlug))
+		}
 		return err
 	}
 


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Enhanced registry scanning by allowing the use of `imageTag` as a reference when `imageID` is not provided.
- Added a test case to ensure registry scanning works correctly without an `imageID`.
- Fixed an incorrect parameter in the `CreateSBOM` call to correctly use `workload.ImageHash`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>syft.go</strong><dd><code>Support for Registry Scanning without ImageID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/v1/syft.go
<li>Added handling for cases where <code>imageID</code> is empty, using <code>imageTag</code> as a <br>reference instead.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/213/files#diff-59cc1c76e75b8cc3f401be82a7ad03494324118b3eb21cb247c7b7f0ade69515">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>syft_test.go</strong><dd><code>Test Case for Registry Scan without ImageID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/v1/syft_test.go
<li>Introduced a new test case for registry scanning without an <code>imageID</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/213/files#diff-58134a5183879fd2da27ae7458a485bf76579b87e7269f07d7f440086178b470">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scan.go</strong><dd><code>Correct Parameter in CreateSBOM Call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/services/scan.go
<li>Modified <code>CreateSBOM</code> call to use <code>workload.ImageHash</code> instead of <br>repeating <code>workload.ImageTag</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/213/files#diff-85deac1fd3ad15a30ddc8a15245049faf294923a8058adfb7c47994034b662d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

