### PR TITLE
Adding hotfix to syft version

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/opencontainers/go-digest"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/opencontainers/go-digest"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 
@@ -260,5 +261,11 @@ func detectSource(userInput string, opts *packagesOptions, registryOptions *imag
 
 // Version returns Syft's version which is used to tag SBOMs
 func (s *SyftAdapter) Version() string {
-	return tools.PackageVersion("github.com/anchore/syft")
+	v := tools.PackageVersion("github.com/anchore/syft")
+	if v == "unknown" || v == "" {
+		return v
+	}
+	// we added a hotfix in the storage, so we need to append it to the version so the SBOM will be re-created
+	// remove the hotfix suffix next upgrade of the syft version
+	return v + "-hotfix"
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/kubescape/backend v0.0.18-0.20231228073313-741ad2d0a7ad
 	github.com/kubescape/go-logger v0.0.22
 	github.com/kubescape/k8s-interface v0.0.162
-	github.com/kubescape/storage v0.0.74
+	github.com/kubescape/storage v0.0.79
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openvex/go-vex v0.2.5
 	github.com/spf13/viper v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -880,8 +880,8 @@ github.com/kubescape/opa-utils v0.0.268 h1:mIsAbpIW0aIk8xr0ECuf8q9gUntGQqJQIJACt
 github.com/kubescape/opa-utils v0.0.268/go.mod h1:95JkuIOfClgLc+DyGb2mDvefRW0STkZe4L2z6AaZJlQ=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=
 github.com/kubescape/rbac-utils v0.0.20/go.mod h1:t57AhSrjuNGQ+mpZWQM/hBzrCOeKBDHegFoVo4tbikQ=
-github.com/kubescape/storage v0.0.74 h1:Fdogm2799K6koPKezmcbimDa3+X9rm92BuLvOiJkKP8=
-github.com/kubescape/storage v0.0.74/go.mod h1:ttwWSuxDyckuB014uPHBs23zSdFZx6TMD0MZHlwuw+0=
+github.com/kubescape/storage v0.0.79 h1:APvBd00/OYjNMvMgOhdiiIFSUzy/wUyLzb92xjcmuqw=
+github.com/kubescape/storage v0.0.79/go.mod h1:ttwWSuxDyckuB014uPHBs23zSdFZx6TMD0MZHlwuw+0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Added a hotfix to the Syft versioning in `adapters/v1/syft.go` to ensure SBOMs are re-created with the hotfix version.
- Updated `github.com/kubescape/storage` dependency from `v0.0.74` to `v0.0.79` in `go.mod`.
- Updated checksums in `go.sum` for the new storage version.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>syft.go</strong><dd><code>Append "-hotfix" to Syft Version for SBOM Recreation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/v1/syft.go
<li>Added a conditional check to append "-hotfix" to the version if it's <br>not "unknown" or empty.<br> <li> This change ensures that the SBOM will be re-created with the hotfix <br>version.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/222/files#diff-59cc1c76e75b8cc3f401be82a7ad03494324118b3eb21cb247c7b7f0ade69515">+10/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update Kubescape Storage Dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod
- Updated `github.com/kubescape/storage` from `v0.0.74` to `v0.0.79`.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/222/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update Checksums for Storage Dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.sum
- Updated checksums for `github.com/kubescape/storage` to `v0.0.79`.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/222/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

