### PR TITLE
Check content is not nil

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -228,11 +228,13 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 			if errors.Is(err, domain.ErrSBOMWithPartialArtifacts) {
 				// sometimes the SBOM' is not complete, so we need to update it
 				// this is a workaround so users will not need to restart
-				for i := range sbomp.Content.Artifacts {
-					for j := range sbom.Content.Artifacts {
-						if sbomp.Content.Artifacts[i].ID == sbom.Content.Artifacts[j].ID {
-							sbomp.Content.Artifacts[i] = sbom.Content.Artifacts[j]
-							break
+				if sbomp.Content != nil && sbom.Content != nil {
+					for i := range sbomp.Content.Artifacts {
+						for j := range sbom.Content.Artifacts {
+							if sbomp.Content.Artifacts[i].ID == sbom.Content.Artifacts[j].ID {
+								sbomp.Content.Artifacts[i] = sbom.Content.Artifacts[j]
+								break
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
bug_fix


___

## **Description**
- Added checks to ensure `sbomp.Content` and `sbom.Content` are not nil before iterating over their artifacts in `ScanCVE` method.
- This change prevents runtime errors that could occur when these objects are nil, enhancing the robustness of the SBOM update logic.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scan.go</strong><dd><code>Add nil checks before accessing SBOM content artifacts</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/services/scan.go
<li>Added nil checks for <code>sbomp.Content</code> and <code>sbom.Content</code> before iterating <br>over artifacts.<br> <li> Ensures that the code does not attempt to access properties of nil <br>objects, preventing potential runtime panics.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/kubevuln/pull/225/files#diff-85deac1fd3ad15a30ddc8a15245049faf294923a8058adfb7c47994034b662d8">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

