### PR TITLE
add option to useDefaultMatchers in grype

### DIFF
--- a/adapters/mockcve.go
+++ b/adapters/mockcve.go
@@ -39,7 +39,7 @@ func (m MockCVEAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.
 	return domain.CVEManifest{
 		Name:               sbom.Name,
 		SBOMCreatorVersion: sbom.SBOMCreatorVersion,
-		CVEScannerVersion:  m.Version(ctx),
+		CVEScannerVersion:  m.Version(),
 		CVEDBVersion:       m.DBVersion(ctx),
 		Annotations:        sbom.Annotations,
 		Labels:             sbom.Labels,
@@ -57,7 +57,7 @@ func (m MockCVEAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.
 }
 
 // Version returns a static version
-func (m MockCVEAdapter) Version(_ context.Context) string {
+func (m MockCVEAdapter) Version() string {
 	logger.L().Info("MockCVEAdapter.Version")
 	return "Mock CVE 1.0"
 }

--- a/adapters/mockcve_test.go
+++ b/adapters/mockcve_test.go
@@ -26,5 +26,5 @@ func TestMockCVEAdapter_ScanSBOM(t *testing.T) {
 
 func TestMockCVEAdapter_Version(t *testing.T) {
 	m := NewMockCVEAdapter()
-	assert.Equal(t, "Mock CVE 1.0", m.Version(context.TODO()))
+	assert.Equal(t, "Mock CVE 1.0", m.Version())
 }

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -174,7 +174,7 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 	return domain.CVEManifest{
 		Name:               sbom.Name,
 		SBOMCreatorVersion: sbom.SBOMCreatorVersion,
-		CVEScannerVersion:  g.Version(ctx),
+		CVEScannerVersion:  g.Version(),
 		CVEDBVersion:       g.DBVersion(ctx),
 		Annotations:        sbom.Annotations,
 		Labels:             sbom.Labels,
@@ -222,12 +222,10 @@ func defaultMatcherConfig() matcher.Config {
 }
 
 // Version returns Grype's version which is used to tag CVE manifests
-func (g *GrypeAdapter) Version(context.Context) string {
+func (g *GrypeAdapter) Version() string {
 	v := tools.PackageVersion("github.com/anchore/grype")
-	if v == "unknown" || v == "" {
-		return v
+	if g.useDefaultMatchers {
+		v += "-default-matchers"
 	}
-	// we added a hotfix in the storage, so we need to append it to the version so the SBOM will be re-created
-	// remove the hotfix suffix next upgrade of the syft version
 	return v
 }

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -33,24 +33,26 @@ import (
 
 // GrypeAdapter implements CVEScanner from ports using Grype's API
 type GrypeAdapter struct {
-	lastDbUpdate time.Time
-	dbCloser     *db.Closer
-	dbStatus     *db.Status
-	store        *store.Store
-	dbConfig     db.Config
-	mu           sync.RWMutex
+	lastDbUpdate       time.Time
+	dbCloser           *db.Closer
+	dbStatus           *db.Status
+	store              *store.Store
+	dbConfig           db.Config
+	mu                 sync.RWMutex
+	useDefaultMatchers bool
 }
 
 var _ ports.CVEScanner = (*GrypeAdapter)(nil)
 
 // NewGrypeAdapter initializes the GrypeAdapter structure
 // DB loading is done via readiness probes
-func NewGrypeAdapter(listingURL string) *GrypeAdapter {
+func NewGrypeAdapter(listingURL string, useDefaultMatchers bool) *GrypeAdapter {
 	g := &GrypeAdapter{
 		dbConfig: db.Config{
 			DBRootDir:  path.Join(xdg.CacheHome, "grype", "db"),
 			ListingURL: listingURL,
 		},
+		useDefaultMatchers: useDefaultMatchers,
 	}
 	return g
 }
@@ -137,7 +139,7 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 	}
 	vulnMatcher := grype.VulnerabilityMatcher{
 		Store:          *g.store,
-		Matchers:       getMatchers(),
+		Matchers:       getMatchers(g.useDefaultMatchers),
 		NormalizeByCVE: true,
 	}
 
@@ -180,7 +182,10 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 	}, nil
 }
 
-func getMatchers() []matcher.Matcher {
+func getMatchers(useDefaultMatchers bool) []matcher.Matcher {
+	if useDefaultMatchers {
+		return matcher.NewDefaultMatchers(defaultMatcherConfig())
+	}
 	return matcher.NewDefaultMatchers(
 		matcher.Config{
 			Java: java.MatcherConfig{
@@ -195,6 +200,25 @@ func getMatchers() []matcher.Matcher {
 			Stock:      stock.MatcherConfig{UseCPEs: true},
 		},
 	)
+}
+
+func defaultMatcherConfig() matcher.Config {
+	return matcher.Config{
+		Java: java.MatcherConfig{
+			ExternalSearchConfig: java.ExternalSearchConfig{MavenBaseURL: "https://search.maven.org/solrsearch/select"},
+			UseCPEs:              false,
+		},
+		Ruby:       ruby.MatcherConfig{UseCPEs: false},
+		Python:     python.MatcherConfig{UseCPEs: false},
+		Dotnet:     dotnet.MatcherConfig{UseCPEs: false},
+		Javascript: javascript.MatcherConfig{UseCPEs: false},
+		Golang: golang.MatcherConfig{
+			UseCPEs:                                false,
+			AlwaysUseCPEForStdlib:                  true,
+			AllowMainModulePseudoVersionComparison: false,
+		},
+		Stock: stock.MatcherConfig{UseCPEs: true},
+	}
 }
 
 // Version returns Grype's version which is used to tag CVE manifests

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -84,8 +84,7 @@ func Test_grypeAdapter_ScanSBOM(t *testing.T) {
 }
 
 func Test_grypeAdapter_Version(t *testing.T) {
-	ctx := context.TODO()
 	g := NewGrypeAdapter("", false)
-	version := g.Version(ctx)
+	version := g.Version()
 	assert.NotEqual(t, version, "")
 }

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -85,7 +85,7 @@ func Test_grypeAdapter_ScanSBOM(t *testing.T) {
 
 func Test_grypeAdapter_Version(t *testing.T) {
 	ctx := context.TODO()
-	g := NewGrypeAdapter("")
+	g := NewGrypeAdapter("", false)
 	version := g.Version(ctx)
 	assert.NotEqual(t, version, "")
 }

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -233,10 +233,6 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 // Version returns Syft's version which is used to tag SBOMs
 func (s *SyftAdapter) Version() string {
 	v := tools.PackageVersion("github.com/anchore/syft")
-	if v == "unknown" || v == "" {
-		return v
-	}
-	// we added a hotfix in the storage, so we need to append it to the version so the SBOM will be re-created
-	// remove the hotfix suffix next upgrade of the syft version
+	// no more processing needed
 	return v
 }

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -63,7 +63,7 @@ func main() {
 		}
 	}
 	sbomAdapter := v1.NewSyftAdapter(c.ScanTimeout, c.MaxImageSize, c.MaxSBOMSize)
-	cveAdapter := v1.NewGrypeAdapter(c.ListingURL)
+	cveAdapter := v1.NewGrypeAdapter(c.ListingURL, c.UseDefaultMatchers)
 	var platform ports.Platform
 	if c.KeepLocal {
 		platform = adapters.NewMockPlatform(true)

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Storage            bool          `mapstructure:"storage"`
 	VexGeneration      bool          `mapstructure:"vexGeneration"`
 	NodeSbomGeneration bool          `mapstructure:"nodeSbomGeneration"`
+	UseDefaultMatchers bool          `mapstructure:"useDefaultMatchers"`
 }
 
 // LoadConfig reads configuration from file or environment variables.

--- a/core/ports/providers.go
+++ b/core/ports/providers.go
@@ -13,7 +13,7 @@ type CVEScanner interface {
 	DBVersion(ctx context.Context) string
 	Ready(ctx context.Context) bool
 	ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.CVEManifest, error)
-	Version(ctx context.Context) string
+	Version() string
 }
 
 // SBOMCreator is the port implemented by adapters to be used in ScanService to generate SBOM

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -297,7 +297,7 @@ func TestScanService_ScanAP(t *testing.T) {
 				t.Errorf("ScanAP() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantCvep {
-				cvep, err := storageCVE.GetCVE(ctx, tt.slug, sbomAdapter.Version(), cveAdapter.Version(ctx), cveAdapter.DBVersion(ctx))
+				cvep, err := storageCVE.GetCVE(ctx, tt.slug, sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx))
 				require.NoError(t, err)
 				assert.NotNil(t, cvep.Labels)
 			}
@@ -525,7 +525,7 @@ func TestScanService_NginxTest(t *testing.T) {
 	require.NoError(t, err)
 	err = s.ScanAP(ctx)
 	require.NoError(t, err)
-	cvep, err := storageCVE.GetCVE(ctx, slug, sbomAdapter.Version(), cveAdapter.Version(ctx), cveAdapter.DBVersion(ctx))
+	cvep, err := storageCVE.GetCVE(ctx, slug, sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx))
 	require.NoError(t, err)
 	assert.NotNil(t, cvep.Content)
 }


### PR DESCRIPTION
Currently we are detecting CVE’s by CPE matching in kubevuln. To some customers (such as ESET) it causes more FP’s so we want them to be able to match CVE’s by stock screener (other mechanism of Grype).
 We need to add an option in the helm chart to let the user choose which mechanism he want to use.