### PR TITLE
moved scanID to annotations, add timestamp annotation to summary

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -162,9 +162,9 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 		return domain.CVEManifest{}, err
 	}
 
-	// retrieve scanID from context and add it to the labels
+	// retrieve scanID from context and add it to the annotations
 	scanID, _ := ctx.Value(domain.ScanIDKey{}).(string)
-	sbom.Labels[helpersv1.ScanIdMetadataKey] = tools.SanitizeLabel(scanID)
+	sbom.Annotations[helpersv1.ScanIdMetadataKey] = scanID
 
 	logger.L().Debug("returning CVE manifest",
 		helpers.String("name", sbom.Name),

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -325,6 +325,11 @@ func enrichSummaryManifestObjectAnnotations(ctx context.Context, annotations map
 	if !ok {
 		return nil, domain.ErrCastingWorkload
 	}
+	timestamp, ok := ctx.Value(domain.TimestampKey{}).(int64)
+	if !ok {
+		return nil, domain.ErrMissingTimestamp
+	}
+	enrichedAnnotations["kubescape.io/timestamp"] = strconv.FormatInt(timestamp, 10) // TODO: use a constant
 	enrichedAnnotations[helpersv1.WlidMetadataKey] = workload.Wlid
 	enrichedAnnotations[helpersv1.ContainerNameMetadataKey] = workload.ContainerName
 

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -478,7 +478,9 @@ func TestAPIServerStore_enrichSummaryManifestObjectAnnotations(t *testing.T) {
 	}
 
 	for i := range tests {
+		var timestamp int64 = 1734957372
 		ctx = context.WithValue(ctx, domain.WorkloadKey{}, tests[i].workload)
+		ctx = context.WithValue(ctx, domain.TimestampKey{}, timestamp)
 		enrichedAnnotations, err := enrichSummaryManifestObjectAnnotations(ctx, tests[i].annotations)
 		assert.Equal(t, err, nil)
 
@@ -489,6 +491,10 @@ func TestAPIServerStore_enrichSummaryManifestObjectAnnotations(t *testing.T) {
 		val, exist = enrichedAnnotations[helpersv1.ContainerNameMetadataKey]
 		assert.Equal(t, exist, true)
 		assert.Equal(t, val, tests[i].workload.ContainerName)
+
+		val, exist = enrichedAnnotations["kubescape.io/timestamp"]
+		assert.Equal(t, exist, true)
+		assert.Equal(t, val, "1734957372")
 	}
 
 }


### PR DESCRIPTION
# Overview

This PR changes the behavior so that:
1. Scan ID will be saved in the annotations instead of labels (label value is limited to 63 chars)
2. Add timestamp annotation to the summary, so that it will get updated on every scan request