### PR TITLE
Prevent DB update cancellation on readiness probe

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -136,7 +136,8 @@ func (g *GrypeAdapter) Ready(ctx context.Context) bool {
 	if g.dbStatus == nil || now.Sub(g.lastDbUpdate) > 24*time.Hour {
 		g.mu.Lock()
 		defer g.mu.Unlock()
-		ctx, span := otel.Tracer("").Start(ctx, "GrypeAdapter.UpdateDB")
+		// Use context.WithoutCancel to prevent the update from being cancelled if the request context (e.g. readiness probe) is cancelled
+		ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "GrypeAdapter.UpdateDB")
 		defer span.End()
 		logger.L().Info("updating grype DB",
 			helpers.String("listingURL", g.distCfg.LatestURL))


### PR DESCRIPTION
Use context.WithoutCancel when starting the OpenTelemetry span for GrypeAdapter.UpdateDB so the DB update won't be cancelled if the request context (e.g. a readiness probe) is cancelled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of vulnerability database updates by preventing update operations from being interrupted by other system requests. This ensures the scanning database remains current and continuously available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->