### PR TITLE
Add SecurityException CRD design doc and review

### DIFF
--- a/docs/security-exception-design-review.md
+++ b/docs/security-exception-design-review.md
@@ -1,0 +1,103 @@
+# SecurityException CRD — Design Review
+
+**Design document**: [security-exception-design.md](security-exception-design.md)
+**Date**: 2026-04-09
+
+---
+
+## Summary
+
+The core model — CRD-to-armotypes bridge, dual-scope kinds (namespaced + cluster), and OpenVEX alignment — is sound. The major gaps are in the **security and operational boundary**: authorization, blast radius control, conflict semantics, and observability. For a feature that suppresses security findings, these are table stakes, not nice-to-haves.
+
+---
+
+## Major Review Points
+
+### 1. No Authorization / Admission Control Story — ADDRESSED
+
+The design has no discussion of **who is allowed to create exceptions** and how to prevent abuse. A malicious or careless actor with RBAC access to the CRD could suppress all vulnerability findings cluster-wide. The design needs:
+
+- A validating admission webhook (or CEL validation rules) to enforce invariants (e.g., `expiresAt` must be in the future, `justification` is required when `status: not_affected`)
+- Guidance on RBAC lockdown — which roles should get `create`/`update` on these CRDs
+- Consideration of an approval workflow or annotation (e.g., `approved-by`) for high-blast-radius exceptions
+
+> **Resolution**: Added "Authorization & Validation" section to design doc with RBAC guidance table (security team full access, developers read-only) and CEL validation rules (justification required for `not_affected`, future `expiresAt`, enum validation). Approval workflow deferred as out of scope for v1.
+
+### 2. `expiredOnFix` Is Undefined and Has Deep Implications — ADDRESSED
+
+The field appears in examples but is **never specified** in the schema section. This is a significant feature that requires its own design:
+
+- How does the system determine a fix is available? Grype feed? Image rescan?
+- What is the lifecycle — does it flip a status condition? Delete the entry? Trigger a notification?
+- This effectively requires continuous reconciliation against vulnerability databases, which is a different operational model than the rest of the CRD
+
+> **Resolution**: Added "`expiredOnFix` Behavior" section to design doc. No external DB access needed — fix availability comes from Grype's scan output, which is already present at exception matching time. kubevuln's `getCVEExceptionMatchCVENameFromList` already supports this via the `filterFixed` parameter. The CRD is not mutated; the exception is simply skipped when a fix is detected, and reapplies if the fix is retracted.
+
+### 3. `products` Field Is Described but Never Specified — ADDRESSED
+
+The "Identifier Bridging" section describes purl-based product matching, but `products` never appears in the CRD spec table or the YAML examples. Either spec it fully (type, validation, matching semantics) or cut it from v1alpha1 and add it later. Half-specified fields in a CRD are a compatibility hazard.
+
+> **Resolution**: Cut `products` from v1. CVE ID + `match.images` glob patterns cover the common use cases. Purl-based package-level matching is noted as a future extension in the "Identifier Bridging" and "OpenVEX Compatibility" sections.
+
+### 4. Conflict Resolution and Precedence Are Undefined — ADDRESSED
+
+The migration section says cloud and CRD exceptions "work simultaneously" but does not define:
+
+- What happens when a CRD says `not_affected` and the cloud says `under_investigation` for the same CVE on the same workload?
+- Is the merge union (most permissive wins) or does one source take precedence?
+- This matters for compliance audits — you need deterministic, documentable behavior
+
+> **Resolution**: Added "Conflict Resolution & Precedence" section. Cloud exceptions take precedence on overlap — if both sources define an exception for the same CVE on the same workload, the cloud exception wins. Non-overlapping exceptions from both sources are merged normally.
+
+### 5. Unbounded Blast Radius on Cluster-Scoped Exceptions — ADDRESSED
+
+A `ClusterSecurityException` with **no `namespaceSelector`** and **no `resources`** matches every workload in every namespace, including `kube-system`. The design should:
+
+- Require at least one non-empty match constraint, or explicitly document and warn about "match-all" exceptions
+- Consider a `maxScope` safety net or annotation that forces the author to acknowledge cluster-wide intent
+- The `CooldownQueue` debounce is not sufficient — a single broad CRD change could trigger rescans across every namespace
+
+> **Resolution**: This is by design — cluster-wide exceptions without match constraints are a valid use case (e.g., "this CVE is not exploitable anywhere"). Added a note in the RBAC section explicitly documenting this behavior and pointing to RBAC as the appropriate control. No schema constraints added — consistent with how other cluster-scoped K8s resources (e.g., ClusterRole) handle broad access.
+
+### 6. Status Subresource Is Underspecified — ADDRESSED
+
+The example shows `status.matchedVulnerabilities`, `status.conditions`, etc., but there is no spec for:
+
+- Which controller owns the status (kubevuln? operator? both?)
+- Update frequency and what triggers a status refresh
+- What the conditions represent (e.g., `Expired`, `MatchError`, `Applied`)
+- Status is the primary observability surface — operators will build alerts on it
+
+> **Resolution**: Status subresource is not used. Observability is provided through Kubernetes Events emitted by the scanners (kubevuln/kubescape) when exceptions match during scans. Expiry is evaluated at scan time — no controller writes to status. Removed status block from YAML examples. This keeps the operator as a pure trigger mechanism and avoids controller ownership conflicts.
+
+### 7. Posture `action` Semantics Need Compliance Scoring Definition — ADDRESSED
+
+`alert_only` says "keep the finding but mark as acknowledged" — but does the control still **fail** in compliance scoring? If a framework requires C-0034 to pass and you set `alert_only`, does the cluster report as compliant or not? This distinction is critical for regulatory use cases (SOC2, PCI-DSS). `ignore` vs `alert_only` must be defined in terms of their effect on `ComplianceScore` and `ResourceResult.Status`.
+
+> **Resolution**: Defined explicitly in design doc. `ignore` removes the finding from results and compliance scoring entirely (not counted as pass or fail). `alert_only` keeps the control as a **failure** in compliance scoring but annotates it as acknowledged — the compliance score reflects reality, the annotation signals accepted risk.
+
+### 8. No Audit Trail Beyond Git — ADDRESSED
+
+The document cites Git history as the audit mechanism, but in-cluster mutations (direct `kubectl edit`, controller reconciliation) bypass Git. Consider:
+
+- An audit annotation recording the last human modifier
+- Integration with Kubernetes audit logging guidance
+- Whether the CRD should have an immutable phase after creation (update-only via delete+recreate)
+
+> **Resolution**: Added "Audit Trail" note in the Observability section. Git history is the primary audit mechanism for GitOps workflows. For in-cluster mutations, Kubernetes API server audit logging already captures all changes. No custom audit annotations or immutability constraints needed.
+
+### 9. Image Glob Matching Is Underspecified and Risky — ADDRESSED
+
+`images: ["docker.io/library/nginx:*"]` — what matching library is used? Does `*` match path separators? Is `**` supported? Does it match the normalized or raw image reference? (`nginx:latest` vs `docker.io/library/nginx:latest` are the same image). Ambiguous glob semantics in a security-suppression context is a vulnerability — an overly broad pattern could silently suppress findings for unintended images.
+
+> **Resolution**: Added "Image Matching" section to design doc. Uses Go's `path.Match` — `*` does not match `/` (prevents accidental over-matching), `**` is not supported, patterns match against the fully qualified normalized image reference (e.g., `nginx` is normalized to `docker.io/library/nginx:latest` before matching). Includes examples of correct pattern usage.
+
+### 10. Missing: Observability and Dry-Run Mode — PARTIALLY ADDRESSED
+
+There is no way for a user to **preview** what an exception would match before applying it. For a security-critical CRD, this is a significant operational gap. Consider:
+
+- A `dryRun: true` field or a status endpoint that shows matched workloads without suppressing findings
+- Events emitted when an exception matches (or stops matching) a workload
+- Metrics (Prometheus) for number of active exceptions, matched findings, expired exceptions
+
+> **Resolution**: Events are covered — scanners emit Kubernetes Events on SecurityException resources when exceptions match during scans (see point 6). Dry-run preview and Prometheus metrics are deferred as future enhancements. Users can validate CRD schema via `kubectl apply --dry-run=server` and observe matching behavior through Events after the next scan.

--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -1,0 +1,384 @@
+# SecurityException CRD — Design Document
+
+## Background & Problem Statement
+
+Kubescape currently has **no in-cluster, declarative exception mechanism**. All vulnerability exceptions come from the Armo cloud API (`BackendAdapter.GetCVEExceptions()` in kubevuln), and posture exceptions come from JSON files or cloud API (`IExceptionsGetter` in kubescape). This means:
+
+- **No GitOps-native workflow** — exceptions don't live alongside app code
+- **Cloud dependency** — users without an external backend (like ARMO) and air-gapped clusters can't use exceptions
+- **No audit trail** via Git history
+- **CI and runtime scanning** have different exception mechanisms
+
+## Solution
+
+Introduce a **SecurityException CRD** (`kubescape.io/v1`) that teams deploy via GitOps alongside their applications. It covers both vulnerability exceptions (OpenVEX-compatible) and posture/compliance exceptions in a single resource.
+
+## CRD Specification
+
+### API Group & Versioning
+
+| Field | Value |
+|-------|-------|
+| Group | `kubescape.io` |
+| Version | `v1` |
+| Kinds | `SecurityException` (namespaced), `ClusterSecurityException` (cluster-scoped) |
+| Short names | `se`, `cse` |
+
+### Workload Matching
+
+SecurityException uses standard Kubernetes matching patterns to determine which workloads an exception applies to. Matching is defined at the top-level `spec.match` field and applies to all vulnerability and posture entries within the resource.
+
+#### Match fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `namespaceSelector` | `metav1.LabelSelector` | Selects namespaces by label. Standard K8s label selector supporting `matchLabels` and `matchExpressions`. Only meaningful on `ClusterSecurityException`. |
+| `objectSelector` | `metav1.LabelSelector` | Selects workloads by their labels. Standard K8s label selector. |
+| `resources` | `[]ResourceMatch` | Explicit list of workloads by kind/name. |
+| `images` | `[]string` | Glob patterns matched against container image references (see "Image Matching" below). Applies only to vulnerability entries (posture controls are about workload configuration, not image contents). |
+
+`ResourceMatch` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `apiGroup` | `string` | API group (e.g., `apps`, empty string for core). Optional — defaults to all groups. |
+| `kind` | `string` | Resource kind (e.g., `Deployment`, `StatefulSet`). Required. |
+| `name` | `string` | Exact resource name. Optional — omit to match all of this kind. |
+
+#### Matching semantics
+
+- **`namespaceSelector` AND `objectSelector` AND `resources` AND `images`**: all specified selectors must match (standard K8s convention, consistent with ValidatingWebhookConfiguration)
+- **Within `resources` list**: OR — any entry can match
+- **Within `images` list**: OR — any pattern can match
+- **Within `matchExpressions`**: AND (standard K8s `LabelSelector` behavior)
+- **Omitted selectors**: match everything (e.g., no `objectSelector` = all workloads). Only specified selectors constrain the match.
+- **`images`**: only applies to vulnerability entries. Ignored for posture entries.
+- **Namespaced `SecurityException`**: implicitly scoped to its own namespace; `namespaceSelector` is not available
+- **Cluster-scoped `ClusterSecurityException`**: uses `namespaceSelector` to target namespaces
+
+#### Image Matching
+
+Image patterns in `match.images` use Go's `path.Match` glob syntax:
+
+- `*` matches any sequence of characters **except** `/` (path separators)
+- `?` matches any single character except `/`
+- `**` is **not** supported — use multiple patterns instead
+- Character classes like `[abc]` are supported
+
+Patterns are matched against the **fully qualified, normalized** image reference. The scanner normalizes images before matching:
+- `nginx` → `docker.io/library/nginx:latest`
+- `nginx:1.25` → `docker.io/library/nginx:1.25`
+- `my-registry.io/app:v1` → `my-registry.io/app:v1` (already qualified)
+
+This means patterns should always be written against the full form:
+- `docker.io/library/nginx:*` — matches any nginx tag
+- `my-registry.io/team/*:*` — matches any image under `my-registry.io/team/` (one level deep)
+- `docker.io/library/nginx:1.25` — matches exact image reference
+
+### Full YAML Examples
+
+#### Namespaced — target specific workloads by label and name
+
+```yaml
+apiVersion: kubescape.io/v1
+kind: SecurityException
+metadata:
+  name: nginx-exceptions
+  namespace: production
+spec:
+  author: "team-platform@example.com"
+  reason: "Accepted risks for Q2 2026 release"
+  expiresAt: "2026-07-01T00:00:00Z"
+
+  match:
+    objectSelector:
+      matchLabels:
+        app: nginx
+    resources:
+      - kind: Deployment
+        name: nginx-frontend
+
+  vulnerabilities:
+    - vulnerability:
+        id: "CVE-2021-44228"
+        aliases: ["GHSA-jfh8-c2jp-5v3q"]
+      status: "not_affected"
+      justification: "component_not_present"
+      impactStatement: "No Java runtime in this container"
+      expiredOnFix: true
+
+    - vulnerability:
+        id: "CVE-2023-44487"
+      status: "not_affected"
+      justification: "inline_mitigations_already_exist"
+      impactStatement: "WAF mitigates HTTP/2 rapid reset"
+
+  posture:
+    - controlID: "C-0034"
+      frameworkName: "NSA"
+      action: "alert_only"
+```
+
+#### Namespaced — apply to all workloads in namespace (no match selector)
+
+```yaml
+apiVersion: kubescape.io/v1
+kind: SecurityException
+metadata:
+  name: namespace-wide-log4j
+  namespace: production
+spec:
+  reason: "Log4j not exploitable — no Java in any container"
+
+  vulnerabilities:
+    - vulnerability:
+        id: "CVE-2021-44228"
+      status: "not_affected"
+      justification: "component_not_present"
+```
+
+#### Cluster-scoped — target namespaces by label
+
+```yaml
+apiVersion: kubescape.io/v1
+kind: ClusterSecurityException
+metadata:
+  name: staging-relaxed-posture
+spec:
+  author: "platform-team@example.com"
+  reason: "Relaxed posture checks for non-production"
+
+  match:
+    namespaceSelector:
+      matchLabels:
+        env: staging
+
+  posture:
+    - controlID: "C-0034"
+      action: "ignore"
+    - controlID: "C-0017"
+      action: "alert_only"
+```
+
+#### Cluster-scoped — target by image pattern
+
+```yaml
+apiVersion: kubescape.io/v1
+kind: ClusterSecurityException
+metadata:
+  name: nginx-http2-exception
+spec:
+  reason: "HTTP/2 rapid reset mitigated by WAF for all nginx images"
+
+  match:
+    images:
+      - "docker.io/library/nginx:*"
+      - "my-registry.io/custom-nginx:*"
+
+  vulnerabilities:
+    - vulnerability:
+        id: "CVE-2023-44487"
+      status: "not_affected"
+      justification: "inline_mitigations_already_exist"
+      impactStatement: "WAF mitigates HTTP/2 rapid reset"
+```
+
+#### Cluster-scoped — target specific workloads across namespaces
+
+```yaml
+apiVersion: kubescape.io/v1
+kind: ClusterSecurityException
+metadata:
+  name: infra-daemonset-exceptions
+spec:
+  reason: "Known CVEs in infrastructure DaemonSets, tracked in JIRA-1234"
+
+  match:
+    namespaceSelector:
+      matchExpressions:
+        - key: env
+          operator: In
+          values: ["production", "staging"]
+    resources:
+      - kind: DaemonSet
+        name: node-exporter
+      - kind: DaemonSet
+        name: fluent-bit
+
+  vulnerabilities:
+    - vulnerability:
+        id: "CVE-2023-44487"
+      status: "not_affected"
+      justification: "inline_mitigations_already_exist"
+      expiredOnFix: true
+```
+
+### VEX Status/Justification Enums
+
+Following the OpenVEX standard:
+
+- **status**: `not_affected`, `fixed`, `under_investigation`
+- **justification** (when `not_affected`): `component_not_present`, `vulnerable_code_not_present`, `vulnerable_code_not_in_execute_path`, `vulnerable_code_cannot_be_controlled_by_adversary`, `inline_mitigations_already_exist`
+
+### `expiredOnFix` Behavior
+
+When `expiredOnFix: true` is set on a vulnerability entry, the exception is automatically ignored when a fix is available for the vulnerability. This is evaluated at scan time using the scan result data — no external database lookup is needed. Grype's scan output already includes fix availability for each CVE. During exception matching in kubevuln (`getCVEExceptionMatchCVENameFromList`), if the scan result indicates a fix exists and the exception has `expiredOnFix: true`, the exception is skipped and the vulnerability is reported as usual.
+
+This means:
+- The exception remains in the CRD (it is not deleted or mutated)
+- The `status.conditions` should reflect that the exception was skipped due to fix availability
+- If the fix is later retracted (e.g., image reverted to an older version), the exception automatically applies again on the next scan
+
+### Posture Action Enums
+
+- **`ignore`** — the control finding is removed from results and compliance scoring entirely. It is not counted as a pass or fail. Use for controls that are not applicable to the workload.
+- **`alert_only`** — the control still **fails** in compliance scoring, but is annotated as acknowledged/excepted in the report. The compliance score reflects the real security state; the annotation signals the failure is known and accepted. Use for controls that genuinely fail but the risk is accepted.
+
+## Architecture
+
+### Component Interaction
+
+```
+┌─────────────┐   Watch    ┌──────────┐   Rescan    ┌──────────┐
+│  GitOps /   │──────────→ │ Operator │───────────→ │ kubevuln │
+│  kubectl    │            │ Watcher  │             │          │
+└─────────────┘            └──────────┘             └──────────┘
+      │                         │                        │
+      │ apply CRD               │ rescan trigger         │ read CRDs
+      ▼                         │                        ▼
+┌─────────────┐                 │              ┌──────────────────┐
+│  API Server │◄────────────────┘              │ SecurityException│
+│  (CRD)      │◄───────────────────────────────│ Adapter          │
+└─────────────┘                                └──────────────────┘
+                                                        │
+                                                        ▼ convert
+                                               ┌──────────────────┐
+                                               │ Existing          │
+                                               │ Exception Flow    │
+                                               │ (armotypes)       │
+                                               └──────────────────┘
+```
+
+### Integration Design
+
+#### kubevuln — Vulnerability Exception Path
+
+1. New `SecurityExceptionProvider` interface in `core/ports/providers.go`
+2. New `APIServerSecurityExceptionAdapter` using dynamic K8s client
+3. `BackendAdapter.GetCVEExceptions()` merges CRD exceptions with cloud exceptions
+4. Conversion: `SecurityException → armotypes.VulnerabilityExceptionPolicy`
+
+The key insight is that by converting CRD data into existing `armotypes.VulnerabilityExceptionPolicy` format, the entire downstream flow (`getCVEExceptionMatchCVENameFromList`, `ExceptionApplied` marking, `Summarize()` excluded stats) works unchanged.
+
+**Match conversion**: `spec.match` fields are converted to `PortalDesignator` attributes:
+- `resources[].kind` → `scope.kind`
+- `resources[].name` → `scope.name`
+- `objectSelector` / `namespaceSelector` → evaluated at fetch time to resolve matching workloads, then individual designators are created per workload
+
+#### kubescape — Posture Exception Path
+
+1. New `CRDExceptionsGetter` implementing `IExceptionsGetter`
+2. Wraps existing getter, merges CRD posture entries with inner getter results
+3. Conversion: `SecurityException → armotypes.PostureExceptionPolicy`
+4. Wired into `getExceptionsGetter()` in `initutils.go`
+
+**Match conversion**: `spec.match` fields are converted to `PostureExceptionPolicy.Resources` (array of `PortalDesignator`):
+- `resources[].kind` → `PortalDesignator.Attributes["kind"]`
+- `resources[].name` → `PortalDesignator.Attributes["name"]`
+- `namespaceSelector` → resolved to namespace list → `PortalDesignator.Attributes["namespace"]`
+
+#### operator — Watch & Rescan
+
+1. New `SecurityExceptionWatchHandler` watching both `securityexceptions` and `clustersecurityexceptions`
+2. Uses `CooldownQueue` to debounce rapid changes
+3. On change: determines affected namespaces/workloads, dispatches rescan commands
+4. Expiry controller: goroutine checking every 5 minutes for expired CRDs
+
+## Identifier Bridging
+
+Vulnerability exceptions are matched by **CVE ID** (`vulnerability.id`) and optionally scoped to specific images via `match.images` glob patterns. This covers the common use cases of excepting a known CVE globally or within specific images.
+
+**Future extension — `products` (purl-based package matching)**: A future version may add OpenVEX-style `products` fields using Package URLs (purls) for fine-grained matching at the package level inside an SBOM (e.g., `pkg:deb/debian/openssl@1.1.1`). This is deferred from v1 as CVE ID + image pattern matching is sufficient for most use cases, and purl matching adds significant complexity (purl parsing, SBOM correlation, version range matching).
+
+## Authorization & Validation
+
+### RBAC Guidance
+
+SecurityException CRDs suppress security findings — access should be restricted to trusted roles. Recommended RBAC setup:
+
+| Role | `SecurityException` | `ClusterSecurityException` |
+|------|--------------------|-----------------------------|
+| Security team / platform admins | `create`, `update`, `delete`, `get`, `list`, `watch` | `create`, `update`, `delete`, `get`, `list`, `watch` |
+| Development teams | `get`, `list`, `watch` (read-only) | `get`, `list`, `watch` (read-only) |
+| Scanner components (kubevuln, kubescape) | `get`, `list`, `watch` | `get`, `list`, `watch` |
+| Operator | `get`, `list`, `watch` | `get`, `list`, `watch` |
+
+Scanner components also need `create` and `patch` on `events` (core API group) to emit Kubernetes Events bound to SecurityException resources.
+
+Organizations should create dedicated `ClusterRole`/`Role` resources for SecurityException management rather than granting access through broad wildcard rules.
+
+**Note on cluster-wide exceptions**: A `ClusterSecurityException` with no match selectors will apply to all workloads in all namespaces. This is by design — it enables legitimate use cases like "this CVE is not exploitable anywhere in our cluster." RBAC is the appropriate control to prevent unintended broad exceptions; restrict `create`/`update` on `ClusterSecurityException` to trusted roles.
+
+### CRD Validation Rules (CEL)
+
+The CRD schema should include CEL validation rules to enforce invariants at admission time, without requiring a separate webhook:
+
+- `justification` is required when `status` is `not_affected`
+- `expiresAt`, if set, must be a valid RFC3339 timestamp in the future (at creation time)
+- At least one entry must exist in either `vulnerabilities` or `posture`
+- `posture[].action` must be one of `ignore`, `alert_only`
+- `vulnerabilities[].status` must be one of `not_affected`, `fixed`, `under_investigation`
+
+## Conflict Resolution & Precedence
+
+When both cloud-based exceptions (ARMO backend) and CRD-based exceptions exist for the same CVE/control on the same workload:
+
+- **Cloud exceptions take precedence.** If the cloud backend has an exception for a given CVE on a workload, the cloud exception's status and metadata are used, and any conflicting CRD exception for the same CVE on the same workload is ignored.
+- **Non-overlapping exceptions are merged.** CRD exceptions for CVEs/controls not covered by cloud exceptions are applied normally. Cloud exceptions for CVEs/controls not in any CRD are also applied normally.
+- **Implementation**: During the merge in `GetCVEExceptions()`, cloud exceptions are added first. CRD exceptions are only appended for CVE+workload combinations not already covered by a cloud exception.
+
+This ensures the cloud backend remains the authoritative source when both are in use, while CRD exceptions extend coverage for cases the cloud does not address.
+
+## Migration Path
+
+Cloud-based exceptions and CRD-based exceptions work simultaneously. Organizations can gradually migrate:
+
+1. Deploy SecurityException CRDs for new exceptions
+2. Existing cloud exceptions continue to work (and take precedence on overlap)
+3. Remove cloud exceptions as CRD equivalents are confirmed working
+
+## Observability
+
+SecurityException CRDs do not use the status subresource. Observability is provided through **Kubernetes Events** emitted by the scanners.
+
+### Events
+
+When a scanner evaluates exceptions during a scan, it emits Events on the SecurityException/ClusterSecurityException resource that was matched:
+
+- **kubevuln**: Emits an Event when a vulnerability exception matches during a scan (e.g., "Matched CVE-2021-44228 on Deployment/nginx-frontend in namespace production")
+- **kubescape**: Emits an Event when a posture exception matches during a scan (e.g., "Matched control C-0034 on Deployment/nginx-frontend")
+
+Users can inspect exception activity via `kubectl describe securityexception <name>` and see recent Events. Events are automatically garbage-collected by Kubernetes.
+
+### Expiry
+
+Expiry (`expiresAt`) is evaluated at scan time by the scanners — no controller or status update is needed. When a scanner reads a SecurityException and `expiresAt` is in the past, the exception is simply skipped. This means:
+
+- No component writes to the SecurityException status subresource
+- Expired exceptions remain in the cluster until explicitly deleted by the user
+- The next scan after expiry will report previously-excepted findings as normal
+
+### Audit Trail
+
+The primary audit trail for SecurityException changes is **Git history** when using a GitOps workflow (Flux, ArgoCD). For in-cluster mutations (e.g., direct `kubectl edit`), Kubernetes API server audit logging captures all changes including the user, timestamp, and diff. Organizations requiring audit compliance should ensure K8s audit logging is enabled and configured to capture `kubescape.io` resource mutations.
+
+## OpenVEX Compatibility
+
+The vulnerability exception entries align with OpenVEX statements:
+
+- `vulnerability.id` → VEX vulnerability ID
+- `status` → VEX status
+- `justification` → VEX justification
+- `impactStatement` → VEX impact statement
+
+Note: OpenVEX `products` (purl-based product/subcomponent matching) is deferred to a future version. See "Identifier Bridging" above.

--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -226,7 +226,7 @@ When `expiredOnFix: true` is set on a vulnerability entry, the exception is auto
 
 This means:
 - The exception remains in the CRD (it is not deleted or mutated)
-- The `status.conditions` should reflect that the exception was skipped due to fix availability
+- Skip-on-fix is observable via scan-time Events emitted on the SecurityException resource (no status mutation)
 - If the fix is later retracted (e.g., image reverted to an older version), the exception automatically applies again on the next scan
 
 ### Posture Action Enums
@@ -238,7 +238,7 @@ This means:
 
 ### Component Interaction
 
-```
+```text
 ┌─────────────┐   Watch    ┌──────────┐   Rescan    ┌──────────┐
 │  GitOps /   │──────────→ │ Operator │───────────→ │ kubevuln │
 │  kubectl    │            │ Watcher  │             │          │
@@ -292,7 +292,7 @@ The key insight is that by converting CRD data into existing `armotypes.Vulnerab
 1. New `SecurityExceptionWatchHandler` watching both `securityexceptions` and `clustersecurityexceptions`
 2. Uses `CooldownQueue` to debounce rapid changes
 3. On change: determines affected namespaces/workloads, dispatches rescan commands
-4. Expiry controller: goroutine checking every 5 minutes for expired CRDs
+4. Expiry controller: goroutine checking every 5 minutes for newly-expired CRDs and triggering rescans (no status writes — scanners evaluate `expiresAt` at scan time)
 
 ## Identifier Bridging
 


### PR DESCRIPTION
This pull request introduces comprehensive design documentation for the new `SecurityException` Custom Resource Definition (CRD) in Kubescape, enabling declarative, in-cluster management of vulnerability and posture exceptions. The design is closely aligned with OpenVEX, supports both namespaced and cluster-scoped resources, and emphasizes security, operational boundaries, and GitOps workflows. The changes address key concerns around authorization, validation, blast radius, conflict resolution, observability, and compliance semantics.

The most important changes are:

**Security and Authorization Controls**
- Added detailed RBAC guidance and CEL validation rules to restrict who can create or update `SecurityException` CRDs, including recommendations for role-based access and validation of critical fields (e.g., `expiresAt`, `justification`). [[1]](diffhunk://#diff-c35f9b10d46331538fc1de5f1278eb5439b442dbd7cf2eade6b85b31f3bb85cbR1-R103) [[2]](diffhunk://#diff-cf5438e0bb25e991e769f06ab5ddd6367af651577a087f72e034aaa3fe392c9fR1-R384)
- Explicitly documented that cluster-wide exceptions without match constraints are a valid use case, but should be tightly controlled via RBAC. [[1]](diffhunk://#diff-c35f9b10d46331538fc1de5f1278eb5439b442dbd7cf2eade6b85b31f3bb85cbR1-R103) [[2]](diffhunk://#diff-cf5438e0bb25e991e769f06ab5ddd6367af651577a087f72e034aaa3fe392c9fR1-R384)

**CRD Specification, Matching, and Semantics**
- Fully specified the CRD's matching logic, including `namespaceSelector`, `objectSelector`, `resources`, and `images`, with clear semantics for glob matching using Go's `path.Match`. Provided multiple YAML examples for both namespaced and cluster-scoped use cases.
- Removed the ambiguous `products` field from v1, deferring purl-based package matching to a future version to avoid compatibility hazards. [[1]](diffhunk://#diff-c35f9b10d46331538fc1de5f1278eb5439b442dbd7cf2eade6b85b31f3bb85cbR1-R103) [[2]](diffhunk://#diff-cf5438e0bb25e991e769f06ab5ddd6367af651577a087f72e034aaa3fe392c9fR1-R384)

**Exception Lifecycle and Precedence**
- Defined the behavior of the `expiredOnFix` field: exceptions are skipped (not mutated or deleted) when a fix is available, based on scan-time data, ensuring no external DB lookups are required. [[1]](diffhunk://#diff-c35f9b10d46331538fc1de5f1278eb5439b442dbd7cf2eade6b85b31f3bb85cbR1-R103) [[2]](diffhunk://#diff-cf5438e0bb25e991e769f06ab5ddd6367af651577a087f72e034aaa3fe392c9fR1-R384)
- Clarified that cloud-based exceptions take precedence over CRD exceptions in case of overlap, with deterministic merging for non-overlapping cases. [[1]](diffhunk://#diff-c35f9b10d46331538fc1de5f1278eb5439b442dbd7cf2eade6b85b31f3bb85cbR1-R103) [[2]](diffhunk://#diff-cf5438e0bb25e991e769f06ab5ddd6367af651577a087f72e034aaa3fe392c9fR1-R384)

**Observability and Auditability**
- Shifted observability from the CRD status subresource to Kubernetes Events, emitted by scanners when exceptions match, and documented reliance on Git history and Kubernetes API server audit logs for

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design docs for a declarative SecurityException CRD (namespaced and cluster-scoped), covering matching semantics, image normalization, vulnerability and posture behaviors, expiration-on-fix handling, and compliance scoring.
  * Clarified integration and precedence (cloud exceptions override CRD), observability via Kubernetes Events, RBAC/CEL validation guidance, partially addressed observability items, and a migration path for adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->