### PR TITLE
fix(exceptions): normalize vulnerability ID casing and trim whitespace

### DIFF
--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -276,7 +277,7 @@ func getCVEExceptionMatchCVENameFromList(srcCVEList []armotypes.VulnerabilityExc
 
 	for i := range srcCVEList {
 		for j := range srcCVEList[i].VulnerabilityPolicies {
-			if srcCVEList[i].VulnerabilityPolicies[j].Name == CVEName {
+			if strings.EqualFold(srcCVEList[i].VulnerabilityPolicies[j].Name, CVEName) {
 				if filterFixed && srcCVEList[i].ExpiredOnFix != nil && *srcCVEList[i].ExpiredOnFix {
 					continue
 				}

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -165,6 +165,42 @@ func TestGetCVEExceptionMatchCVENameFromList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "case-insensitive: lowercase CVE matches uppercase policy",
+			srcCVEList: []armotypes.VulnerabilityExceptionPolicy{
+				{
+					VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
+						{Name: "CVE-2021-1234"},
+					},
+				},
+			},
+			CVEName: "cve-2021-1234",
+			expected: []armotypes.VulnerabilityExceptionPolicy{
+				{
+					VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
+						{Name: "CVE-2021-1234"},
+					},
+				},
+			},
+		},
+		{
+			name: "case-insensitive: GHSA mixed-case policy matches grype-reported ID",
+			srcCVEList: []armotypes.VulnerabilityExceptionPolicy{
+				{
+					VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
+						{Name: "GHSA-jc7w-c686-c4v9"},
+					},
+				},
+			},
+			CVEName: "GHSA-JC7W-C686-C4V9",
+			expected: []armotypes.VulnerabilityExceptionPolicy{
+				{
+					VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
+						{Name: "GHSA-jc7w-c686-c4v9"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"strings"
 	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
@@ -26,6 +27,9 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 		}
 		namespace := se.Namespace
 		for _, vuln := range se.Spec.Vulnerabilities {
+			if strings.TrimSpace(vuln.Vulnerability.ID) == "" {
+				continue
+			}
 			p := buildPolicy(se.Spec, vuln, namespace)
 			policies = append(policies, p)
 		}
@@ -37,6 +41,9 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 			continue
 		}
 		for _, vuln := range cse.Spec.Vulnerabilities {
+			if strings.TrimSpace(vuln.Vulnerability.ID) == "" {
+				continue
+			}
 			p := buildPolicy(cse.Spec, vuln, "")
 			policies = append(policies, p)
 		}
@@ -54,7 +61,7 @@ func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.Vulnerabil
 		PolicyType: "vulnerabilityExceptionPolicy",
 		Actions:    []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
 		VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
-			{Name: vuln.Vulnerability.ID},
+			{Name: strings.TrimSpace(vuln.Vulnerability.ID)},
 		},
 		Reason: spec.Reason,
 	}

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -239,6 +239,51 @@ func TestApplySecurityExceptions_ExpiredOnFix(t *testing.T) {
 	assert.Len(t, doc.IgnoredMatches, 0, "nothing should be ignored when fix is available and expiredOnFix is set")
 }
 
+func TestConvertSkipsEmptyAndWhitespaceIDs(t *testing.T) {
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: ""}},
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "   "}},
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "  CVE-2024-1234  "}},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil)
+
+	assert.Len(t, policies, 1)
+	assert.Equal(t, "CVE-2024-1234", policies[0].VulnerabilityPolicies[0].Name)
+}
+
+func TestApplySecurityExceptions_CaseInsensitive(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "GHSA-JC7W-C686-C4V9"}}},
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2023-9999"}}},
+		},
+	}
+
+	// Exception stored with mixed-case GHSA ID (canonical form from CRD)
+	exceptions := domain.CVEExceptions{
+		{
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "GHSA-jc7w-c686-c4v9"}},
+		},
+	}
+
+	ApplySecurityExceptions(doc, exceptions)
+
+	assert.Len(t, doc.Matches, 1)
+	assert.Equal(t, "CVE-2023-9999", doc.Matches[0].Vulnerability.ID)
+	assert.Len(t, doc.IgnoredMatches, 1)
+	assert.Equal(t, "GHSA-JC7W-C686-C4V9", doc.IgnoredMatches[0].Vulnerability.ID)
+}
+
 func TestApplySecurityExceptions_NilDoc(t *testing.T) {
 	ApplySecurityExceptions(nil, domain.CVEExceptions{})
 }


### PR DESCRIPTION
## Summary

Port of the fix from kubescape/kubescape#1979, adapted to kubevuln's architecture.

- **`getCVEExceptionMatchCVENameFromList`**: switch from `==` to `strings.EqualFold` so exception matching is case-insensitive. grype's vulnerability IDs are case-sensitive and advisory sources use mixed conventions (CVE IDs are uppercase; GHSA IDs have a lowercase suffix like `GHSA-jc7w-c686-c4v9`). A user listing `GHSA-jc7w-c686-c4v9` in a `SecurityException` CRD would silently fail to suppress the vulnerability if grype reported it as `GHSA-JC7W-C686-C4V9`.
- **`ConvertToVulnerabilityExceptionPolicies` / `buildPolicy`**: trim leading/trailing whitespace from vulnerability IDs and skip empty/whitespace-only entries so hand-edited CRDs are tolerant of accidental spacing and cannot produce a blank policy name that matches everything.

## Test plan

- [x] `TestGetCVEExceptionMatchCVENameFromList` — 2 new subtests: lowercase CVE matches uppercase policy, GHSA mixed-case policy matches grype-reported uppercase ID
- [x] `TestConvertSkipsEmptyAndWhitespaceIDs` — empty string, whitespace-only, and padded entries; only the trimmed non-empty ID produces a policy
- [x] `TestApplySecurityExceptions_CaseInsensitive` — end-to-end: exception with canonical lowercase GHSA ID suppresses a grype match reported in uppercase
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)