### PR TITLE
fix: set viper delim key and test proxyRegistryMap

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,28 +36,30 @@ type Config struct {
 
 // LoadConfig reads configuration from file or environment variables.
 func LoadConfig(path string) (Config, error) {
-	viper.AddConfigPath(path)
-	viper.SetConfigName("clusterData")
-	viper.SetConfigType("json")
+	// set key delimiter to :: to allow nested config when using JSON files
+	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
+	v.AddConfigPath(path)
+	v.SetConfigName("clusterData")
+	v.SetConfigType("json")
 
-	viper.SetDefault("listingURL", "https://grype.anchore.io/databases")
-	viper.SetDefault("maxImageSize", 512*1024*1024)
-	viper.SetDefault("maxSBOMSize", 20*1024*1024)
-	viper.SetDefault("scanConcurrency", 1)
-	viper.SetDefault("scanTimeout", 5*time.Minute)
-	viper.SetDefault("vexGeneration", false)
-	viper.SetDefault("namespace", "kubescape")
-	viper.SetDefault("scanEmbeddedSBOMs", false)
+	v.SetDefault("listingURL", "https://grype.anchore.io/databases")
+	v.SetDefault("maxImageSize", 512*1024*1024)
+	v.SetDefault("maxSBOMSize", 20*1024*1024)
+	v.SetDefault("scanConcurrency", 1)
+	v.SetDefault("scanTimeout", 5*time.Minute)
+	v.SetDefault("vexGeneration", false)
+	v.SetDefault("namespace", "kubescape")
+	v.SetDefault("scanEmbeddedSBOMs", false)
 
-	viper.AutomaticEnv()
+	v.AutomaticEnv()
 
-	err := viper.ReadInConfig()
+	err := v.ReadInConfig()
 	if err != nil {
 		return Config{}, err
 	}
 
 	var config Config
-	err = viper.Unmarshal(&config)
+	err = v.Unmarshal(&config)
 	return config, err
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,3 +24,16 @@ func TestLoadBackendServicesConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://api.armosec.io", services.GetApiServerUrl())
 }
+
+// test proxyRegistryMap is loaded correctly
+func TestLoadConfigProxyRegistryMap(t *testing.T) {
+	viper.Reset()
+	config, err := LoadConfig("testdata")
+	assert.NoError(t, err)
+	expected := map[string]string{
+		"docker.io": "my-mirror.example.com",
+		"quay.io":   "my-mirror.example.com",
+		"gcr.io":    "my-mirror.example.com",
+	}
+	assert.Equal(t, expected, config.ProxyRegistryMap)
+}

--- a/config/testdata/clusterData.json
+++ b/config/testdata/clusterData.json
@@ -10,5 +10,10 @@
   "backendOpenAPI": "https://api.armosec.io/api",
   "eventReceiverRestURL": "https://report.armo.cloud",
   "eventReceiverWebsocketURL": "wss://report.armo.cloud",
-  "rootGatewayURL": "wss://ens.euprod1.cyberarmorsoft.com/v1/waitfornotification"       
+  "rootGatewayURL": "wss://ens.euprod1.cyberarmorsoft.com/v1/waitfornotification",
+  "proxyRegistryMap": {
+    "docker.io": "my-mirror.example.com",
+    "quay.io": "my-mirror.example.com",
+    "gcr.io": "my-mirror.example.com"
+  }
 }


### PR DESCRIPTION
## Overview

Create instance of Viper with delimiter key of `::` to properly support `proxyRegistryMap` (e.g. keys will likely contain `.`'s)

## How to Test

Run tests to ensure no regression, to test particular change run `go test ./config -run=TestLoadConfigProxyRegistryMap`

## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

If this resolved an issue, write "Resolved #359 

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

There is no `dev` branch.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration system enhanced to support nested configuration keys for improved organization.
  * New proxy registry mapping capability enables defining container image mirrors for multiple registries (Docker Hub, Quay.io, GCR).

* **Tests**
  * Added comprehensive test coverage validating proxy registry mapping configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubevuln/pull/361)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->