### PR TITLE
fix: close previous grype DB store before replacing on 24h refresh

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -192,6 +192,11 @@ func (g *GrypeAdapter) Ready(ctx context.Context) bool {
 				logger.L().Info("restarting to release previous grype DB")
 				os.Exit(0)
 			}
+			if g.store != nil {
+				if err := g.store.Close(); err != nil {
+					logger.L().Ctx(ctx).Warning("failed to close previous grype DB", helpers.Error(err))
+				}
+			}
 			g.store = result.store
 			g.dbStatus = result.dbStatus
 			g.lastDbUpdate = now


### PR DESCRIPTION
## Summary

- `GrypeAdapter.Ready()` calls `grype.LoadVulnerabilityDB` every 24h to refresh the vulnerability DB
- On success, `g.store` was replaced with the new store without calling `Close()` on the old one
- `vulnerability.Provider` embeds `io.Closer`, so the SQLite file descriptor and GORM connection resources from the previous store were abandoned to the GC finalizer rather than closed explicitly

## Test plan

- [ ] `go build ./adapters/v1/...` passes (confirmed locally)
- [ ] Existing grype adapter tests pass: `go test ./adapters/v1/... -run TestGrype` (requires Docker for the offline DB container)
- [ ] Verify no slow file-descriptor growth after 24h in a running pod (`lsof -p <pid> | grep grype | wc -l` should stay at 1)

## Context

Identified during memory investigation of v0.3.132 → v0.3.137 upgrade. The leak was not visually detectable in the Grafana RSS graph (GC finalizers eventually close the store), but explicit resource management is correct regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling during update failures to ensure proper cleanup and resource management before process restart.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubevuln/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->