### PR TITLE
feat(grype): expose useDefaultMatchers on the fixed-DB constructor

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -92,7 +92,12 @@ func startGrypeOfflineDBContainer(ctx context.Context) (port string, terminate f
 }
 
 func NewGrypeAdapterFixedDB() (*GrypeAdapter, func(), error) {
-	// start grype-offline-db container
+	return NewGrypeAdapterFixedDBWithMatchers(false)
+}
+
+// NewGrypeAdapterFixedDBWithMatchers is like NewGrypeAdapterFixedDB but lets
+// callers exercise the same matcher mode as production (see NewGrypeAdapter).
+func NewGrypeAdapterFixedDBWithMatchers(useDefaultMatchers bool) (*GrypeAdapter, func(), error) {
 	port, terminate, err := startGrypeOfflineDBContainer(context.Background())
 	if err != nil {
 		return nil, nil, err
@@ -104,6 +109,7 @@ func NewGrypeAdapterFixedDB() (*GrypeAdapter, func(), error) {
 		installCfg: installation.Config{
 			DBRootDir: path.Join(xdg.CacheHome, "grype-offline", "db"),
 		},
+		useDefaultMatchers: useDefaultMatchers,
 	}
 	return g, terminate, nil
 }


### PR DESCRIPTION
## Summary
Add `NewGrypeAdapterFixedDBWithMatchers(useDefaultMatchers bool)` alongside the existing `NewGrypeAdapterFixedDB()`. The existing function becomes a thin wrapper passing `false`, so no current callers need changes.

## Motivation
`NewGrypeAdapter(listingURL, useDefaultMatchers)` takes the flag and threads it into `getMatchers`. `NewGrypeAdapterFixedDB()` doesn't accept the flag and leaves `useDefaultMatchers=false`. Consumers like [armosec/vulnerability-scanner](https://github.com/armosec/vulnerability-scanner) override the global scanner with `NewGrypeAdapterFixedDB()` in tests — which means their CI runs against the `false` matcher path regardless of how production is configured. There's no clean way to align test and prod matcher mode short of `reflect+unsafe` on the unexported field.

This PR closes that gap: tests that need to mirror production matcher selection now have a dedicated constructor.

## Compatibility
Non-breaking. `NewGrypeAdapterFixedDB()` keeps the same signature and behavior (defaults to `useDefaultMatchers=false`). Internal callers in `adapters/v1/grype_test.go` and `core/services/scan_test.go` are unaffected.

## Test plan
- [x] `go build ./adapters/v1/` clean
- [ ] Existing kubevuln tests still pass (they call the no-arg variant)
- [ ] Downstream PR in armosec/vulnerability-scanner switches its test override to `NewGrypeAdapterFixedDBWithMatchers(UseDefaultMatchers)` once this lands

## Context
Downstream PR that needs this: armosec/vulnerability-scanner#38 — flips `UseDefaultMatchers` to `true` to eliminate language-ecosystem CPE false positives (Ruby gem `gitlab` 6.1.0 being flagged against GitLab CE/EE CVEs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved adapter initialization flexibility with configurable matcher behavior options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubevuln/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->