### PR TITLE
fix(scan): classify MANIFEST_SCHEMA_UNSUPPORTED + write per-workload …

### DIFF
--- a/core/ports/repositories.go
+++ b/core/ports/repositories.go
@@ -18,6 +18,7 @@ type CVERepository interface {
 	GetCVESummary(ctx context.Context) (*v1beta1.VulnerabilityManifestSummary, error)
 	StoreCVE(ctx context.Context, cve domain.CVEManifest, withRelevancy bool) error
 	StoreCVESummary(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, withRelevancy bool) error
+	StoreCVESummaryStub(ctx context.Context, status string) error
 	StoreVEX(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, withRelevancy bool) error
 }
 

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/akyoto/cache"
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/scanfailure"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -26,7 +27,6 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/internal/tools"
-	"github.com/armosec/armoapi-go/scanfailure"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
 	"go.opentelemetry.io/otel"
@@ -225,8 +225,17 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 					if err != nil {
 						logger.L().Ctx(ctx).Error("creating SBOM, skipping scan", helpers.Error(err),
 							helpers.String("imageSlug", slug))
+						reason := classifySBOMError(err)
 						_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-							classifySBOMError(err), err)
+							reason, err)
+						// surface a per-workload record for schema-unsupported images so UIs
+						// do not show the workload as silently unscanned
+						if s.storage && reason == scanfailure.ReasonImageSchemaUnsupported {
+							if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, statusUnsupportedSchema); stubErr != nil {
+								logger.L().Ctx(ctx).Warning("storing schema-unsupported summary stub", helpers.Error(stubErr),
+									helpers.String("imageSlug", slug))
+							}
+						}
 						continue // we need the SBOM
 					}
 					// store SBOM
@@ -426,8 +435,17 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 				sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(workload))
 				s.checkCreateSBOM(err, workload.ImageHash)
 				if err != nil {
+					reason := classifySBOMError(err)
 					_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-						classifySBOMError(err), err)
+						reason, err)
+					// surface a per-workload record for schema-unsupported images so UIs
+					// do not show the workload as silently unscanned
+					if s.storage && reason == scanfailure.ReasonImageSchemaUnsupported {
+						if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, statusUnsupportedSchema); stubErr != nil {
+							logger.L().Ctx(ctx).Warning("storing schema-unsupported summary stub", helpers.Error(stubErr),
+								helpers.String("imageSlug", workload.ImageSlug))
+						}
+					}
 					return fmt.Errorf("creating SBOM: %w", err)
 				}
 				// store SBOM

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -231,7 +231,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 						// surface a per-workload record for schema-unsupported images so UIs
 						// do not show the workload as silently unscanned
 						if s.storage && reason == scanfailure.ReasonImageSchemaUnsupported {
-							if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, statusUnsupportedSchema); stubErr != nil {
+							if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema); stubErr != nil {
 								logger.L().Ctx(ctx).Warning("storing schema-unsupported summary stub", helpers.Error(stubErr),
 									helpers.String("imageSlug", slug))
 							}
@@ -441,7 +441,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 					// surface a per-workload record for schema-unsupported images so UIs
 					// do not show the workload as silently unscanned
 					if s.storage && reason == scanfailure.ReasonImageSchemaUnsupported {
-						if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, statusUnsupportedSchema); stubErr != nil {
+						if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema); stubErr != nil {
 							logger.L().Ctx(ctx).Warning("storing schema-unsupported summary stub", helpers.Error(stubErr),
 								helpers.String("imageSlug", workload.ImageSlug))
 						}

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -228,9 +228,10 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 						reason := classifySBOMError(err)
 						_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
 							reason, err)
-						// surface a per-workload record for schema-unsupported images so UIs
-						// do not show the workload as silently unscanned
-						if s.storage && reason == scanfailure.ReasonImageSchemaUnsupported {
+						if s.storage &&
+							subWorkload.Wlid != "" &&
+							subWorkload.ContainerName != "" &&
+							reason == scanfailure.ReasonImageSchemaUnsupported {
 							if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema); stubErr != nil {
 								logger.L().Ctx(ctx).Warning("storing schema-unsupported summary stub", helpers.Error(stubErr),
 									helpers.String("imageSlug", slug))
@@ -439,8 +440,12 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 					_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
 						reason, err)
 					// surface a per-workload record for schema-unsupported images so UIs
-					// do not show the workload as silently unscanned
-					if s.storage && reason == scanfailure.ReasonImageSchemaUnsupported {
+					// do not show the workload as silently unscanned; skip image-only
+					// scans where there is no workload to attach the stub to
+					if s.storage &&
+						workload.Wlid != "" &&
+						workload.ContainerName != "" &&
+						reason == scanfailure.ReasonImageSchemaUnsupported {
 						if stubErr := s.cveRepository.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema); stubErr != nil {
 							logger.L().Ctx(ctx).Warning("storing schema-unsupported summary stub", helpers.Error(stubErr),
 								helpers.String("imageSlug", workload.ImageSlug))

--- a/core/services/scan_failure_reasons.go
+++ b/core/services/scan_failure_reasons.go
@@ -12,6 +12,11 @@ import (
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 )
 
+// statusUnsupportedSchema is the kubescape.io/status annotation value for a stub
+// summary. Parallels the helpersv1 statuses (incomplete, too-large), but kubevuln-owned
+// since the upstream vocabulary has no equivalent.
+const statusUnsupportedSchema = "unsupported-schema"
+
 // classifySBOMError inspects the error returned by CreateSBOM and returns
 // a reason code constant. Uses errors.Is for sentinel errors (Go 1.13+),
 // errors.As for typed errors, and falls back to string matching.
@@ -47,6 +52,11 @@ func classifySBOMError(err error) string {
 		return scanfailure.ReasonImageAuthFailed
 	case strings.Contains(errStr, "MANIFEST_UNKNOWN"):
 		return scanfailure.ReasonImageNotFound
+	// uppercase code is the stable token; lowercase phrase varies by registry. A typed
+	// *transport.Error (HTTP 400 + code) also lands here, as its Error() includes the code.
+	case strings.Contains(errStr, "MANIFEST_SCHEMA_UNSUPPORTED") ||
+		strings.Contains(errStr, "unsupported schema manifest"):
+		return scanfailure.ReasonImageSchemaUnsupported
 	}
 
 	return scanfailure.ReasonSBOMGenerationFailed

--- a/core/services/scan_failure_reasons.go
+++ b/core/services/scan_failure_reasons.go
@@ -12,11 +12,6 @@ import (
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 )
 
-// statusUnsupportedSchema is the kubescape.io/status annotation value for a stub
-// summary. Parallels the helpersv1 statuses (incomplete, too-large), but kubevuln-owned
-// since the upstream vocabulary has no equivalent.
-const statusUnsupportedSchema = "unsupported-schema"
-
 // classifySBOMError inspects the error returned by CreateSBOM and returns
 // a reason code constant. Uses errors.Is for sentinel errors (Go 1.13+),
 // errors.As for typed errors, and falls back to string matching.

--- a/core/services/scan_failure_reasons_test.go
+++ b/core/services/scan_failure_reasons_test.go
@@ -76,6 +76,26 @@ func TestClassifySBOMError(t *testing.T) {
 			expected: scanfailure.ReasonImageNotFound,
 		},
 		{
+			name:     "MANIFEST_SCHEMA_UNSUPPORTED uppercase code",
+			err:      fmt.Errorf("creating SBOM: oci-registry: GET https://index.docker.io/v2/app/manifests/sha256:abc: MANIFEST_SCHEMA_UNSUPPORTED: manifest schema unsupported"),
+			expected: scanfailure.ReasonImageSchemaUnsupported,
+		},
+		{
+			name:     "unsupported schema lowercase phrase only",
+			err:      fmt.Errorf("oci-registry: failed to get image descriptor from registry: unsupported schema manifest version"),
+			expected: scanfailure.ReasonImageSchemaUnsupported,
+		},
+		{
+			name: "wrapped transport 400 with schema code falls through to string match",
+			err: fmt.Errorf("creating SBOM: %w", &transport.Error{
+				StatusCode: http.StatusBadRequest,
+				Errors: []transport.Diagnostic{
+					{Code: transport.ErrorCode("MANIFEST_SCHEMA_UNSUPPORTED"), Message: "manifest schema unsupported"},
+				},
+			}),
+			expected: scanfailure.ReasonImageSchemaUnsupported,
+		},
+		{
 			name:     "generic error falls back to SBOM generation failed",
 			err:      fmt.Errorf("failed to generate SBOM: some internal error"),
 			expected: scanfailure.ReasonSBOMGenerationFailed,

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -481,6 +481,21 @@ func TestScanService_ScanCVE_SchemaUnsupportedStub(t *testing.T) {
 		require.Error(t, s.ScanCVE(ctx))
 		assert.Empty(t, storageCVE.CVESummaryStubs())
 	})
+
+	t.Run("image-only scan (empty wlid) does not write a stub summary", func(t *testing.T) {
+		storageCVE := repositories.NewMemoryStorage(false, false)
+		s := NewScanService(schemaUnsupportedSBOMAdapter{}, repositories.NewMemoryStorage(false, false), adapters.NewMockCVEAdapter(), storageCVE, adapters.NewMockPlatform(false, nil), v1.NewContainerProfileAdapter(repositories.NewMemoryStorage(false, false)), true, false, true, false, false)
+		ctx := context.TODO()
+		s.Ready(ctx)
+		imageOnly := domain.ScanCommand{
+			ImageSlug: "imageSlug",
+			ImageHash: imageHash,
+		}
+		ctx, err := s.ValidateScanCVE(ctx, imageOnly)
+		require.NoError(t, err)
+		require.Error(t, s.ScanCVE(ctx))
+		assert.Empty(t, storageCVE.CVESummaryStubs(), "image-only scan must not attempt a per-workload stub")
+	})
 }
 
 func fileContent(path string) []byte {

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -440,6 +440,49 @@ func TestScanService_ScanCVE(t *testing.T) {
 	}
 }
 
+// schemaUnsupportedSBOMAdapter is a mock SBOMCreator that always fails with a
+// registry schema-unsupported error, used to exercise the per-workload stub summary path.
+type schemaUnsupportedSBOMAdapter struct{}
+
+func (schemaUnsupportedSBOMAdapter) CreateSBOM(_ context.Context, _, _, _ string, _ domain.RegistryOptions) (domain.SBOM, error) {
+	return domain.SBOM{}, fmt.Errorf("creating SBOM: oci-registry: failed to get image descriptor from registry: MANIFEST_SCHEMA_UNSUPPORTED: manifest schema unsupported")
+}
+
+func (schemaUnsupportedSBOMAdapter) Version() string { return "schema-unsupported-mock" }
+
+func TestScanService_ScanCVE_SchemaUnsupportedStub(t *testing.T) {
+	imageHash := "k8s.gcr.io/kube-proxy@sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+	wlid := "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy"
+	workload := domain.ScanCommand{
+		ImageSlug:     "imageSlug",
+		ContainerName: "kube-proxy",
+		ImageHash:     imageHash,
+		Wlid:          wlid,
+	}
+
+	t.Run("schema-unsupported error writes a stub summary", func(t *testing.T) {
+		storageCVE := repositories.NewMemoryStorage(false, false)
+		s := NewScanService(schemaUnsupportedSBOMAdapter{}, repositories.NewMemoryStorage(false, false), adapters.NewMockCVEAdapter(), storageCVE, adapters.NewMockPlatform(false, nil), v1.NewContainerProfileAdapter(repositories.NewMemoryStorage(false, false)), true, false, true, false, false)
+		ctx := context.TODO()
+		s.Ready(ctx)
+		ctx, err := s.ValidateScanCVE(ctx, workload)
+		require.NoError(t, err)
+		require.Error(t, s.ScanCVE(ctx))
+		assert.Equal(t, []string{statusUnsupportedSchema}, storageCVE.CVESummaryStubs())
+	})
+
+	t.Run("generic SBOM error does not write a stub summary", func(t *testing.T) {
+		storageCVE := repositories.NewMemoryStorage(false, false)
+		s := NewScanService(adapters.NewMockSBOMAdapter(true, false, false), repositories.NewMemoryStorage(false, false), adapters.NewMockCVEAdapter(), storageCVE, adapters.NewMockPlatform(false, nil), v1.NewContainerProfileAdapter(repositories.NewMemoryStorage(false, false)), true, false, true, false, false)
+		ctx := context.TODO()
+		s.Ready(ctx)
+		ctx, err := s.ValidateScanCVE(ctx, workload)
+		require.NoError(t, err)
+		require.Error(t, s.ScanCVE(ctx))
+		assert.Empty(t, storageCVE.CVESummaryStubs())
+	})
+}
+
 func fileContent(path string) []byte {
 	b, _ := os.ReadFile(path)
 	return b

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -468,7 +468,7 @@ func TestScanService_ScanCVE_SchemaUnsupportedStub(t *testing.T) {
 		ctx, err := s.ValidateScanCVE(ctx, workload)
 		require.NoError(t, err)
 		require.Error(t, s.ScanCVE(ctx))
-		assert.Equal(t, []string{statusUnsupportedSchema}, storageCVE.CVESummaryStubs())
+		assert.Equal(t, []string{helpersv1.UnsupportedSchema}, storageCVE.CVESummaryStubs())
 	})
 
 	t.Run("generic SBOM error does not write a stub summary", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -461,3 +461,8 @@ replace github.com/anchore/stereoscope => github.com/matthyx/stereoscope v0.0.0-
 replace github.com/google/go-containerregistry => github.com/matthyx/go-containerregistry v0.0.0-20250916162850-293c5b36a9f8
 
 replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2
+
+// Temporary: build against the local armoapi-go checkout for the new
+// scanfailure.ReasonImageSchemaUnsupported reason code. Revert once armoapi-go
+// is released and the require above is bumped to the tagged version.
+replace github.com/armosec/armoapi-go => ../armoapi-go

--- a/go.mod
+++ b/go.mod
@@ -461,3 +461,8 @@ replace github.com/anchore/stereoscope => github.com/matthyx/stereoscope v0.0.0-
 replace github.com/google/go-containerregistry => github.com/matthyx/go-containerregistry v0.0.0-20250916162850-293c5b36a9f8
 
 replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2
+
+// Temporary: build against the local k8s-interface checkout for the new
+// helpersv1.UnsupportedSchema status. Revert once k8s-interface is released and
+// the require above is bumped to the tagged version.
+replace github.com/kubescape/k8s-interface => ../k8s-interface

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/anchore/stereoscope v0.1.9
 	github.com/anchore/syft v1.32.0
 	github.com/aquilax/truncate v1.0.0
-	github.com/armosec/armoapi-go v0.0.694
+	github.com/armosec/armoapi-go v0.0.718
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.35
 	github.com/cenkalti/backoff/v5 v5.0.3
@@ -461,8 +461,3 @@ replace github.com/anchore/stereoscope => github.com/matthyx/stereoscope v0.0.0-
 replace github.com/google/go-containerregistry => github.com/matthyx/go-containerregistry v0.0.0-20250916162850-293c5b36a9f8
 
 replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2
-
-// Temporary: build against the local armoapi-go checkout for the new
-// scanfailure.ReasonImageSchemaUnsupported reason code. Revert once armoapi-go
-// is released and the require above is bumped to the tagged version.
-replace github.com/armosec/armoapi-go => ../armoapi-go

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/kinbiko/jsonassert v1.2.0
 	github.com/kubescape/backend v0.0.40
 	github.com/kubescape/go-logger v0.0.28
-	github.com/kubescape/k8s-interface v0.0.206
+	github.com/kubescape/k8s-interface v0.0.214
 	github.com/kubescape/storage v0.0.258
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openvex/go-vex v0.2.5
@@ -461,8 +461,3 @@ replace github.com/anchore/stereoscope => github.com/matthyx/stereoscope v0.0.0-
 replace github.com/google/go-containerregistry => github.com/matthyx/go-containerregistry v0.0.0-20250916162850-293c5b36a9f8
 
 replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2
-
-// Temporary: build against the local k8s-interface checkout for the new
-// helpersv1.UnsupportedSchema status. Revert once k8s-interface is released and
-// the require above is bumped to the tagged version.
-replace github.com/kubescape/k8s-interface => ../k8s-interface

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/armosec/armoapi-go v0.0.718 h1:6EQ5oRQhCIzu2GuAQVLBu7PpEW9lZnKYELYUQvotWcs=
+github.com/armosec/armoapi-go v0.0.718/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.694 h1:LDScWAzikv7mJdDhO+VM0DfNoMhQbhA6do6LWXHRIQs=
-github.com/armosec/armoapi-go v0.0.694/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=

--- a/go.sum
+++ b/go.sum
@@ -864,8 +864,6 @@ github.com/kubescape/backend v0.0.40 h1:nwQ74sbtuvwkzewS3axf6pIA6C6v+X4e4AzLuvVv
 github.com/kubescape/backend v0.0.40/go.mod h1:cMEGP8cXUZgY89YU4GRBGIla9HZW7grZsUtlCwvZgAE=
 github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoSHDFKI=
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
-github.com/kubescape/k8s-interface v0.0.206 h1:qaYu4mlLmSBePanSGq+DBCssh4O785TAT0lQGNGWyGw=
-github.com/kubescape/k8s-interface v0.0.206/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/opa-utils v0.0.283 h1:URiTwOw8LEcIHBFDbHLHu758kRpF72dF61bH2+n6yOw=
 github.com/kubescape/opa-utils v0.0.283/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=

--- a/go.sum
+++ b/go.sum
@@ -864,6 +864,8 @@ github.com/kubescape/backend v0.0.40 h1:nwQ74sbtuvwkzewS3axf6pIA6C6v+X4e4AzLuvVv
 github.com/kubescape/backend v0.0.40/go.mod h1:cMEGP8cXUZgY89YU4GRBGIla9HZW7grZsUtlCwvZgAE=
 github.com/kubescape/go-logger v0.0.28 h1:xulKTp9kOg3rD98sopFELQ6yZCHQoQXMDzteoSHDFKI=
 github.com/kubescape/go-logger v0.0.28/go.mod h1:YZHFjwGCDar1hP9OyBLE46oR7a0Y/Z/0FperDo8+9D0=
+github.com/kubescape/k8s-interface v0.0.214 h1:j7KP0/5VvYOoQdBGV2+gRM3qnR8PWLAGF8RM/k/DmJ0=
+github.com/kubescape/k8s-interface v0.0.214/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/opa-utils v0.0.283 h1:URiTwOw8LEcIHBFDbHLHu758kRpF72dF61bH2+n6yOw=
 github.com/kubescape/opa-utils v0.0.283/go.mod h1:N/UnbZHpoiHQH7O50yadhIXZvVl0IVtTGBmePPrSQSg=
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G+oFazeYmZQKoPczLEflBQpwpHCU8DoLLyfj8=

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -557,6 +557,18 @@ func (a *APIServerStore) StoreCVESummary(ctx context.Context, cve domain.CVEMani
 	return nil
 }
 
+// summaryHasVulnerabilityData reports whether a summary already holds real scan results
+func summaryHasVulnerabilityData(s *v1beta1.VulnerabilityManifestSummary) bool {
+	sev := s.Spec.Severities
+	if sev.Critical.All > 0 || sev.High.All > 0 || sev.Medium.All > 0 ||
+		sev.Low.All > 0 || sev.Negligible.All > 0 || sev.Unknown.All > 0 {
+		return true
+	}
+	// a real summary records the workload/image scope even with zero findings
+	return s.Spec.Vulnerabilities.ImageVulnerabilitiesObj.Name != "" ||
+		s.Spec.Vulnerabilities.WorkloadVulnerabilitiesObj.Name != ""
+}
+
 func (a *APIServerStore) StoreCVESummaryStub(ctx context.Context, status string) error {
 	_, span := otel.Tracer("").Start(ctx, "APIServerStore.StoreCVESummaryStub")
 	defer span.End()
@@ -599,7 +611,11 @@ func (a *APIServerStore) StoreCVESummaryStub(ctx context.Context, status string)
 			if getErr != nil {
 				return getErr
 			}
-			// refresh annotations/labels only, keep any existing Spec intact
+			// don't overwrite a real summary with a stub status
+			if summaryHasVulnerabilityData(result) {
+				return nil
+			}
+			// refresh annotations/labels only, keep any existing Spec
 			mergeMaps(result.Annotations, manifest.Annotations)
 			mergeMaps(result.Labels, manifest.Labels)
 			_, updateErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Update(context.Background(), result, metav1.UpdateOptions{})

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -557,6 +557,75 @@ func (a *APIServerStore) StoreCVESummary(ctx context.Context, cve domain.CVEMani
 	return nil
 }
 
+func (a *APIServerStore) StoreCVESummaryStub(ctx context.Context, status string) error {
+	_, span := otel.Tracer("").Start(ctx, "APIServerStore.StoreCVESummaryStub")
+	defer span.End()
+
+	annotations, err := enrichSummaryManifestObjectAnnotations(ctx, nil)
+	if err != nil {
+		return err
+	}
+	annotations[helpersv1.StatusMetadataKey] = status
+	labels, err := enrichSummaryManifestObjectLabels(ctx, nil, false)
+	if err != nil {
+		return err
+	}
+	summaryK8sResourceName, err := GetCVESummaryK8sResourceName(ctx)
+	if err != nil {
+		return err
+	}
+	workloadNamespace, err := GetCVESummaryK8sResourceNamespace(ctx)
+	if err != nil {
+		return err
+	}
+	if workloadNamespace == "" {
+		// fallback to default namespace
+		workloadNamespace = a.Namespace
+	}
+
+	manifest := v1beta1.VulnerabilityManifestSummary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        summaryK8sResourceName,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+	}
+	_, err = a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Create(context.Background(), &manifest, metav1.CreateOptions{})
+	switch {
+	case errors.IsAlreadyExists(err):
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// retrieve the latest version before attempting update
+			result, getErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Get(context.Background(), manifest.Name, metav1.GetOptions{ResourceVersion: "metadata"})
+			if getErr != nil {
+				return getErr
+			}
+			// refresh annotations/labels only, keep any existing Spec intact
+			mergeMaps(result.Annotations, manifest.Annotations)
+			mergeMaps(result.Labels, manifest.Labels)
+			_, updateErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Update(context.Background(), result, metav1.UpdateOptions{})
+			return updateErr
+		})
+		if retryErr != nil {
+			logger.L().Ctx(ctx).Warning("failed to update CVE summary stub in storage", helpers.Error(retryErr),
+				helpers.String("name", manifest.Name),
+				helpers.String("status", status))
+		} else {
+			logger.L().Debug("updated CVE summary stub in storage",
+				helpers.String("name", manifest.Name),
+				helpers.String("status", status))
+		}
+	case err != nil:
+		logger.L().Ctx(ctx).Warning("failed to store CVE summary stub in storage", helpers.Error(err),
+			helpers.String("name", manifest.Name),
+			helpers.String("status", status))
+	default:
+		logger.L().Debug("stored CVE summary stub in storage",
+			helpers.String("name", manifest.Name),
+			helpers.String("status", status))
+	}
+	return nil
+}
+
 func (a *APIServerStore) StoreVEX(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, _ bool) error {
 	_, span := otel.Tracer("").Start(ctx, "APIServerStore.StoreVEX")
 	defer span.End()

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -347,6 +347,84 @@ func TestAPIServerStore_storeVEX(t *testing.T) {
 	assert.Equal(t, relevant+1, relevant2)
 }
 
+func TestAPIServerStore_StoreCVESummaryStub(t *testing.T) {
+	workload := domain.ScanCommand{
+		Wlid:          "wlid://cluster-kind/namespace-local-path-storage/deployment-local-path-provisioner",
+		ContainerName: "local-path-provisioner",
+	}
+	stubCtx := func() context.Context {
+		ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+		return context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+	}
+
+	t.Run("fresh create writes a zeroed summary with the status annotation", func(t *testing.T) {
+		a := NewFakeAPIServerStorage("kubescape")
+		ctx := stubCtx()
+
+		require.NoError(t, a.StoreCVESummaryStub(ctx, helpersv1.Incomplete))
+
+		ns, err := GetCVESummaryK8sResourceNamespace(ctx)
+		require.NoError(t, err)
+		resourceName, err := GetCVESummaryK8sResourceName(ctx)
+		require.NoError(t, err)
+
+		got, err := a.StorageClient.VulnerabilityManifestSummaries(ns).Get(context.Background(), resourceName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, helpersv1.Incomplete, got.Annotations[helpersv1.StatusMetadataKey])
+		assert.Equal(t, workload.Wlid, got.Annotations[helpersv1.WlidMetadataKey])
+		assert.Equal(t, "local-path-provisioner", got.Labels[helpersv1.RelatedNameMetadataKey])
+		assert.Equal(t, helpersv1.ContextMetadataKeyNonFiltered, got.Labels[helpersv1.ContextMetadataKey])
+		assert.False(t, summaryHasVulnerabilityData(got), "stub Spec should be empty")
+	})
+
+	t.Run("update over an existing stub refreshes the status, Spec stays empty", func(t *testing.T) {
+		a := NewFakeAPIServerStorage("kubescape")
+		ctx := stubCtx()
+
+		require.NoError(t, a.StoreCVESummaryStub(ctx, helpersv1.Incomplete))
+		require.NoError(t, a.StoreCVESummaryStub(ctx, helpersv1.TooLarge))
+
+		ns, err := GetCVESummaryK8sResourceNamespace(ctx)
+		require.NoError(t, err)
+		resourceName, err := GetCVESummaryK8sResourceName(ctx)
+		require.NoError(t, err)
+
+		got, err := a.StorageClient.VulnerabilityManifestSummaries(ns).Get(context.Background(), resourceName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, helpersv1.TooLarge, got.Annotations[helpersv1.StatusMetadataKey], "status should be refreshed")
+		assert.False(t, summaryHasVulnerabilityData(got))
+	})
+
+	t.Run("update over a real summary preserves Spec and does not clobber its status", func(t *testing.T) {
+		a := NewFakeAPIServerStorage("kubescape")
+		ctx := stubCtx()
+
+		ns, err := GetCVESummaryK8sResourceNamespace(ctx)
+		require.NoError(t, err)
+		resourceName, err := GetCVESummaryK8sResourceName(ctx)
+		require.NoError(t, err)
+
+		// Seed a real summary (non-zero severities) directly in storage
+		real := &v1beta1.VulnerabilityManifestSummary{
+			ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+			Spec: v1beta1.VulnerabilityManifestSummarySpec{
+				Severities: v1beta1.SeveritySummary{
+					High: v1beta1.VulnerabilityCounters{All: 3, Relevant: 1},
+				},
+			},
+		}
+		_, err = a.StorageClient.VulnerabilityManifestSummaries(ns).Create(context.Background(), real, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		require.NoError(t, a.StoreCVESummaryStub(ctx, helpersv1.Incomplete))
+
+		got, err := a.StorageClient.VulnerabilityManifestSummaries(ns).Get(context.Background(), resourceName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), got.Spec.Severities.High.All, "real Spec must be preserved")
+		assert.NotEqual(t, helpersv1.Incomplete, got.Annotations[helpersv1.StatusMetadataKey], "real summary status must not be clobbered by the stub")
+	})
+}
+
 func TestAPIServerStore_enrichSummaryManifestObjectLabels(t *testing.T) {
 	ctx := context.Background()
 

--- a/repositories/broken.go
+++ b/repositories/broken.go
@@ -63,6 +63,12 @@ func (b BrokenStore) StoreCVESummary(ctx context.Context, _ domain.CVEManifest, 
 	return domain.ErrExpectedError
 }
 
+func (b BrokenStore) StoreCVESummaryStub(ctx context.Context, _ string) error {
+	_, span := otel.Tracer("").Start(ctx, "BrokenStore.StoreCVESummaryStub")
+	defer span.End()
+	return domain.ErrExpectedError
+}
+
 func (b BrokenStore) StoreVEX(ctx context.Context, _ domain.CVEManifest, _ domain.CVEManifest, _ bool) error {
 	_, span := otel.Tracer("").Start(ctx, "BrokenStore.StoreVEX")
 	defer span.End()

--- a/repositories/memory.go
+++ b/repositories/memory.go
@@ -31,6 +31,7 @@ type MemoryStore struct {
 	aps          map[apID]v1beta1.ContainerProfile
 	cveManifests map[cveID]domain.CVEManifest
 	sboms        map[sbomID]domain.SBOM
+	summaryStubs []string // statuses passed to StoreCVESummaryStub, recorded for tests
 	getError     bool
 	storeError   bool
 }
@@ -161,6 +162,24 @@ func (m *MemoryStore) StoreCVESummary(ctx context.Context, cve domain.CVEManifes
 
 	m.cveManifests[id] = cve
 	return nil
+}
+
+// StoreCVESummaryStub records the status of a stub CVE summary in memory
+func (m *MemoryStore) StoreCVESummaryStub(ctx context.Context, status string) error {
+	_, span := otel.Tracer("").Start(ctx, "MemoryStore.StoreCVESummaryStub")
+	defer span.End()
+
+	if m.storeError {
+		return domain.ErrMockError
+	}
+
+	m.summaryStubs = append(m.summaryStubs, status)
+	return nil
+}
+
+// CVESummaryStubs returns the statuses passed to StoreCVESummaryStub, for tests
+func (m *MemoryStore) CVESummaryStubs() []string {
+	return m.summaryStubs
 }
 
 // GetSBOM returns a SBOM from an in-memory map


### PR DESCRIPTION
## Overview

When a registry serves a manifest schema go-containerregistry can't read, SBOM creation fails with `MANIFEST_SCHEMA_UNSUPPORTED` (OCI Image Index v1 with referrers, some Harbor/ECR configs, and Kind's own `kindest/local-path-provisioner`).

**Current behavior:**
- `classifySBOMError` doesn't recognize the code, so it falls into the catch-all `ReasonSBOMGenerationFailed` - indistinguishable from a real Syft crash.
- No CR is written for the workload, so it disappears from `kubectl get vulnerabilitymanifestsummary` and the UIs treat it as silently unscanned, with no explanation.

**Future behavior:**
- `classifySBOMError` maps the rejection to the dedicated `scanfailure.ReasonImageSchemaUnsupported`, so platform reports and downstream UIs can tell "unreadable registry schema" apart from "Syft crashed".
- On a schema rejection, the `ScanCP` and `ScanCVE` paths write a stub `VulnerabilityManifestSummary` (zeroed severities, `kubescape.io/status: unsupported-schema`), so the workload shows up with an explanation instead of vanishing. Gated strictly on the new reason - no other failure mode changes.

## Additional Information

- The string match catches both forms the error takes - a plain wrapped string and a typed `*transport.Error` (HTTP 400 + code), since `transport.Error.Error()` includes the code. The uppercase registry code is the stable primary token; the lowercase `unsupported schema manifest` phrase varies by registry.
- Added `CVERepository.StoreCVESummaryStub(ctx, status)`, implemented across all three stores (apiserver / memory / broken). The apiserver impl reuses the existing annotation/label enrichment and, on update, refreshes annotations/labels only - it never overwrites an existing summary's Spec with the zeroed stub.
- **Depends on armosec/armoapi-go#XXX**, which adds the `ReasonImageSchemaUnsupported` constant. This is held as a draft until that PR merges and is tagged; the armoapi-go version here will then be bumped and the local `replace` dropped.

## How to Test

```bash
go build ./...
go test ./core/services/... ./repositories/...
Relevant tests:

TestClassifySBOMError - new cases for the uppercase code, the lowercase phrase, and a typed 400 *transport.Error
TestScanService_ScanCVE_SchemaUnsupportedStub - asserts the stub summary is written on a schema error and not on a generic SBOM error
End-to-end (per the issue repro): on a Kind cluster running the operator, trigger the cluster scan and confirm kubectl get vulnerabilitymanifestsummary -A | grep local-path-provisioner now returns a record carrying kubescape.io/status: unsupported-schema, and the kubevuln log classifies the failure as image_schema_unsupported.

Related issues/PRs:
Resolved #369
Depends on [armosec/armoapi-go#653](https://github.com/armosec/armoapi-go/pull/653)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scans now record per-image CVE summary stubs when SBOM generation fails due to unsupported image schemas, storing metadata-only summaries (no vulnerability details).
* **Behavior**
  * Storage-enabled runs write or merge stub summaries while preserving existing full summaries; classification now recognizes schema-unsupported SBOM errors.
* **Tests**
  * Added unit tests for SBOM error classification, stub storage behavior, and repository/store handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->