### PR TITLE
Adaptive CPE matching for trusted image vendors

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -361,7 +361,8 @@ func (g *GrypeAdapter) resolveUseDefaultMatchers(dist *distro.Distro) bool {
 	case config.CVEMatchingAdaptive:
 		return dist != nil && g.trustedVendors[dist.Type]
 	default:
-		// unreachable: config validation rejects unknown modes
+		// LoadConfig rejects unknown modes, but NewGrypeAdapter is exported and
+		// takes a raw mode; fall back to CPE-on (the safe, no-false-negative choice).
 		return false
 	}
 }

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/kubevuln/config"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/internal/tools"
@@ -38,22 +39,34 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
+// Observability annotation keys for CVE manifests. They follow the same
+// kubescape.io/<kebab> convention as the shared keys in k8s-interface, but are
+// kubevuln-local since they describe a kubevuln scanning decision.
+const (
+	// CVEMatchingModeMetadataKey records the configured matching mode (off/on/adaptive).
+	CVEMatchingModeMetadataKey = "kubescape.io/cve-matching-mode"
+	// VendorTrustedMatchMetadataKey records the trusted vendor distro when adaptive
+	// mode downgraded a scan to that vendor's authoritative feed.
+	VendorTrustedMatchMetadataKey = "kubescape.io/vendor-trusted-match"
+)
+
 // GrypeAdapter implements CVEScanner from ports using Grype's API
 type GrypeAdapter struct {
-	lastDbUpdate       time.Time
-	dbStatus           *vulnerability.ProviderStatus
-	store              vulnerability.Provider
-	distCfg            distribution.Config
-	installCfg         installation.Config
-	mu                 sync.RWMutex
-	useDefaultMatchers bool
+	lastDbUpdate   time.Time
+	dbStatus       *vulnerability.ProviderStatus
+	store          vulnerability.Provider
+	distCfg        distribution.Config
+	installCfg     installation.Config
+	mu             sync.RWMutex
+	matchingMode   config.CVEMatchingMode
+	trustedVendors map[distro.Type]bool
 }
 
 var _ ports.CVEScanner = (*GrypeAdapter)(nil)
 
 // NewGrypeAdapter initializes the GrypeAdapter structure
 // DB loading is done via readiness probes
-func NewGrypeAdapter(listingURL string, useDefaultMatchers bool) *GrypeAdapter {
+func NewGrypeAdapter(listingURL string, matchingMode config.CVEMatchingMode, trustedVendors []string) *GrypeAdapter {
 	g := &GrypeAdapter{
 		distCfg: distribution.Config{
 			LatestURL: listingURL,
@@ -61,9 +74,19 @@ func NewGrypeAdapter(listingURL string, useDefaultMatchers bool) *GrypeAdapter {
 		installCfg: installation.Config{
 			DBRootDir: path.Join(xdg.CacheHome, "grype", "db"),
 		},
-		useDefaultMatchers: useDefaultMatchers,
+		matchingMode:   matchingMode,
+		trustedVendors: buildTrustedVendorSet(trustedVendors),
 	}
 	return g
+}
+
+// buildTrustedVendorSet maps configured vendor slugs to Grype distro types.
+func buildTrustedVendorSet(vendors []string) map[distro.Type]bool {
+	set := make(map[distro.Type]bool, len(vendors))
+	for _, v := range vendors {
+		set[distro.Type(v)] = true
+	}
+	return set
 }
 
 func startGrypeOfflineDBContainer(ctx context.Context) (port string, terminate func(), err error) {
@@ -92,12 +115,12 @@ func startGrypeOfflineDBContainer(ctx context.Context) (port string, terminate f
 }
 
 func NewGrypeAdapterFixedDB() (*GrypeAdapter, func(), error) {
-	return NewGrypeAdapterFixedDBWithMatchers(false)
+	return NewGrypeAdapterFixedDBWithMatchers(config.CVEMatchingOn, nil)
 }
 
 // NewGrypeAdapterFixedDBWithMatchers is like NewGrypeAdapterFixedDB but lets
 // callers exercise the same matcher mode as production (see NewGrypeAdapter).
-func NewGrypeAdapterFixedDBWithMatchers(useDefaultMatchers bool) (*GrypeAdapter, func(), error) {
+func NewGrypeAdapterFixedDBWithMatchers(matchingMode config.CVEMatchingMode, trustedVendors []string) (*GrypeAdapter, func(), error) {
 	port, terminate, err := startGrypeOfflineDBContainer(context.Background())
 	if err != nil {
 		return nil, nil, err
@@ -109,7 +132,8 @@ func NewGrypeAdapterFixedDBWithMatchers(useDefaultMatchers bool) (*GrypeAdapter,
 		installCfg: installation.Config{
 			DBRootDir: path.Join(xdg.CacheHome, "grype-offline", "db"),
 		},
-		useDefaultMatchers: useDefaultMatchers,
+		matchingMode:   matchingMode,
+		trustedVendors: buildTrustedVendorSet(trustedVendors),
 	}
 	return g, terminate, nil
 }
@@ -267,9 +291,10 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 		Source: &s.Source,
 		Distro: dist,
 	}
+	useDefaultMatchers := g.resolveUseDefaultMatchers(dist)
 	vulnMatcher := grype.VulnerabilityMatcher{
 		VulnerabilityProvider: g.store,
-		Matchers:              getMatchers(g.useDefaultMatchers),
+		Matchers:              getMatchers(useDefaultMatchers),
 		NormalizeByCVE:        true,
 	}
 
@@ -301,6 +326,14 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 	}
 	sbom.Annotations[helpersv1.ScanIdMetadataKey] = scanID
 
+	// record the matching mode so backend/UI can explain count differences;
+	// when adaptive mode actually downgraded this scan to a trusted vendor's
+	// feed, flag the matched vendor distro as well.
+	sbom.Annotations[CVEMatchingModeMetadataKey] = string(g.matchingMode)
+	if g.matchingMode == config.CVEMatchingAdaptive && useDefaultMatchers && dist != nil {
+		sbom.Annotations[VendorTrustedMatchMetadataKey] = dist.Type.String()
+	}
+
 	logger.L().Debug("returning CVE manifest",
 		helpers.String("name", sbom.Name),
 		helpers.Int("vulnerabilities", len(vulnerabilityResults.Matches)))
@@ -313,6 +346,24 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 		Labels:             sbom.Labels,
 		Content:            vulnerabilityResults,
 	}, nil
+}
+
+// resolveUseDefaultMatchers decides, for a single scan, whether to use Grype's
+// default (CPE-off) matcher configuration. In adaptive mode this is true only
+// when the scanned image's distro is a trusted vendor, so CPE name-fuzzing is
+// dropped in favour of the vendor's authoritative feed.
+func (g *GrypeAdapter) resolveUseDefaultMatchers(dist *distro.Distro) bool {
+	switch g.matchingMode {
+	case config.CVEMatchingOff:
+		return true
+	case config.CVEMatchingOn:
+		return false
+	case config.CVEMatchingAdaptive:
+		return dist != nil && g.trustedVendors[dist.Type]
+	default:
+		// unreachable: config validation rejects unknown modes
+		return false
+	}
 }
 
 func getMatchers(useDefaultMatchers bool) []match.Matcher {
@@ -371,8 +422,6 @@ func checkDBDirWritable(dir string) error {
 // Version returns Grype's version which is used to tag CVE manifests
 func (g *GrypeAdapter) Version() string {
 	v := tools.PackageVersion("github.com/anchore/grype")
-	if g.useDefaultMatchers {
-		v += "-default-matchers"
-	}
+	v += "-matching-" + string(g.matchingMode)
 	return v
 }

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -78,6 +78,10 @@ func Test_grypeAdapter_ScanSBOM(t *testing.T) {
 			require.NoError(t, err)
 			ja := jsonassert.New(t)
 			ja.Assert(string(content), string(fileContent(tt.format)))
+			// observability: adapter runs in CVEMatchingOn here (non-trusted scan),
+			// so the mode is annotated but the vendor-trusted flag is not.
+			assert.Equal(t, string(config.CVEMatchingOn), got.Annotations[CVEMatchingModeMetadataKey])
+			assert.NotContains(t, got.Annotations, VendorTrustedMatchMetadataKey)
 		})
 	}
 }
@@ -108,6 +112,7 @@ func Test_grypeAdapter_resolveUseDefaultMatchers(t *testing.T) {
 		{name: "adaptive + trusted distro -> default matchers", mode: config.CVEMatchingAdaptive, dist: echoDistro, want: true},
 		{name: "adaptive + untrusted distro -> CPE matchers", mode: config.CVEMatchingAdaptive, dist: ubuntuDistro, want: false},
 		{name: "adaptive + nil distro -> CPE matchers", mode: config.CVEMatchingAdaptive, dist: nil, want: false},
+		{name: "unknown mode falls back to CPE matchers", mode: config.CVEMatchingMode("bogus"), dist: echoDistro, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anchore/grype/grype/distro"
 	"github.com/google/uuid"
 	"github.com/kinbiko/jsonassert"
+	"github.com/kubescape/kubevuln/config"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -81,7 +83,36 @@ func Test_grypeAdapter_ScanSBOM(t *testing.T) {
 }
 
 func Test_grypeAdapter_Version(t *testing.T) {
-	g := NewGrypeAdapter("", false)
+	g := NewGrypeAdapter("", config.CVEMatchingOn, nil)
 	version := g.Version()
 	assert.NotEqual(t, version, "")
+}
+
+func Test_grypeAdapter_resolveUseDefaultMatchers(t *testing.T) {
+	trusted := []string{"echo", "chainguard", "wolfi", "minimos"}
+	echoDistro := &distro.Distro{Type: distro.Echo}
+	ubuntuDistro := &distro.Distro{Type: distro.Ubuntu}
+
+	tests := []struct {
+		name string
+		mode config.CVEMatchingMode
+		dist *distro.Distro
+		want bool
+	}{
+		{name: "off + trusted distro -> default matchers", mode: config.CVEMatchingOff, dist: echoDistro, want: true},
+		{name: "off + untrusted distro -> default matchers", mode: config.CVEMatchingOff, dist: ubuntuDistro, want: true},
+		{name: "off + nil distro -> default matchers", mode: config.CVEMatchingOff, dist: nil, want: true},
+		{name: "on + trusted distro -> CPE matchers", mode: config.CVEMatchingOn, dist: echoDistro, want: false},
+		{name: "on + untrusted distro -> CPE matchers", mode: config.CVEMatchingOn, dist: ubuntuDistro, want: false},
+		{name: "on + nil distro -> CPE matchers", mode: config.CVEMatchingOn, dist: nil, want: false},
+		{name: "adaptive + trusted distro -> default matchers", mode: config.CVEMatchingAdaptive, dist: echoDistro, want: true},
+		{name: "adaptive + untrusted distro -> CPE matchers", mode: config.CVEMatchingAdaptive, dist: ubuntuDistro, want: false},
+		{name: "adaptive + nil distro -> CPE matchers", mode: config.CVEMatchingAdaptive, dist: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GrypeAdapter{matchingMode: tt.mode, trustedVendors: buildTrustedVendorSet(trusted)}
+			assert.Equal(t, tt.want, g.resolveUseDefaultMatchers(tt.dist))
+		})
+	}
 }

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -84,7 +84,7 @@ func main() {
 	} else {
 		sbomAdapter = v1.NewSyftAdapter(c.ScanTimeout, c.MaxImageSize, c.MaxSBOMSize, c.ScanEmbeddedSboms, c.ProxyRegistryMap)
 	}
-	cveAdapter := v1.NewGrypeAdapter(c.ListingURL, c.UseDefaultMatchers)
+	cveAdapter := v1.NewGrypeAdapter(c.ListingURL, c.CVEMatchingMode, c.TrustedVendors)
 
 	// SecurityException CRD integration requires storage and riskAcceptance RBAC
 	var seRepo ports.SecurityExceptionRepository

--- a/config/config.go
+++ b/config/config.go
@@ -52,9 +52,9 @@ type Config struct {
 	RiskAcceptance     bool              `mapstructure:"riskAcceptance"`
 	Storage            bool              `mapstructure:"storage"`
 	StoreFilteredSbom  bool              `mapstructure:"storeFilteredSbom"`
-	UseDefaultMatchers bool              `mapstructure:"useDefaultMatchers"`
+	UseDefaultMatchers bool              `mapstructure:"useDefaultMatchers"` // Deprecated: use CVEMatchingMode. Kept for backward compatibility (true -> off, false -> on).
 	CVEMatchingMode    CVEMatchingMode   `mapstructure:"cveMatchingMode"`
-	TrustedVendors     []string          `mapstructure:"trustedVendors"`
+	TrustedVendors     []string          `mapstructure:"trustedVendors"` // distro slugs trusted in adaptive mode; empty/unset reverts to defaultTrustedVendors
 	VexGeneration      bool              `mapstructure:"vexGeneration"`
 }
 
@@ -95,11 +95,16 @@ func LoadConfig(path string) (Config, error) {
 	// always wins. Backward compatibility: when cveMatchingMode is absent but
 	// the legacy useDefaultMatchers boolean is set, derive the mode from it
 	// (true -> off, false -> on). With neither set, the default is adaptive.
+	// Read through viper's getters rather than the unmarshalled struct: with
+	// AutomaticEnv, a value supplied purely via environment variable is visible
+	// to IsSet/GetString but is NOT populated by Unmarshal, so relying on the
+	// struct field here would drop env overrides (and, for the mode, fail
+	// validation below).
 	switch {
 	case v.IsSet("cveMatchingMode"):
-		// keep config.CVEMatchingMode as unmarshalled; validated below
+		config.CVEMatchingMode = CVEMatchingMode(v.GetString("cveMatchingMode"))
 	case v.IsSet("useDefaultMatchers"):
-		if config.UseDefaultMatchers {
+		if v.GetBool("useDefaultMatchers") {
 			config.CVEMatchingMode = CVEMatchingOff
 		} else {
 			config.CVEMatchingMode = CVEMatchingOn

--- a/config/config.go
+++ b/config/config.go
@@ -122,7 +122,8 @@ func LoadConfig(path string) (Config, error) {
 	}
 
 	if len(config.TrustedVendors) == 0 {
-		config.TrustedVendors = defaultTrustedVendors
+		// copy to avoid aliasing the package-level default slice
+		config.TrustedVendors = append([]string{}, defaultTrustedVendors...)
 	}
 
 	return config, nil

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,28 @@ import (
 	"github.com/spf13/viper"
 )
 
+// CVEMatchingMode controls how kubevuln configures Grype's CPE-based matching.
+type CVEMatchingMode string
+
+const (
+	// CVEMatchingOff disables CPE matching everywhere (Grype defaults).
+	// Equivalent to the legacy useDefaultMatchers: true.
+	CVEMatchingOff CVEMatchingMode = "off"
+	// CVEMatchingOn enables CPE matching everywhere.
+	// Equivalent to the legacy useDefaultMatchers: false.
+	CVEMatchingOn CVEMatchingMode = "on"
+	// CVEMatchingAdaptive enables CPE matching everywhere except for images
+	// from trusted vendors (identified via Grype's distro detection), where
+	// Grype defaults apply for that scan. This is the default mode.
+	CVEMatchingAdaptive CVEMatchingMode = "adaptive"
+)
+
+// defaultTrustedVendors are the distro identifiers (as recognised by Grype's
+// distro detection) of vendors that maintain authoritative vulnerability feeds
+// already integrated into the Grype DB. For these images CPE name-fuzzing only
+// adds false positives, so adaptive mode falls back to Grype defaults.
+var defaultTrustedVendors = []string{"echo", "chainguard", "wolfi", "minimos"}
+
 type Config struct {
 	AccountID          string            `mapstructure:"accountID"`
 	ClusterName        string            `mapstructure:"clusterName"`
@@ -31,6 +53,8 @@ type Config struct {
 	Storage            bool              `mapstructure:"storage"`
 	StoreFilteredSbom  bool              `mapstructure:"storeFilteredSbom"`
 	UseDefaultMatchers bool              `mapstructure:"useDefaultMatchers"`
+	CVEMatchingMode    CVEMatchingMode   `mapstructure:"cveMatchingMode"`
+	TrustedVendors     []string          `mapstructure:"trustedVendors"`
 	VexGeneration      bool              `mapstructure:"vexGeneration"`
 }
 
@@ -50,6 +74,10 @@ func LoadConfig(path string) (Config, error) {
 	v.SetDefault("vexGeneration", false)
 	v.SetDefault("namespace", "kubescape")
 	v.SetDefault("scanEmbeddedSBOMs", false)
+	// NB: cveMatchingMode is intentionally NOT given a viper default. viper
+	// reports SetDefault keys as "set" via IsSet, which would defeat the
+	// presence detection used below for backward compatibility. The default
+	// (adaptive) is applied in code instead.
 
 	v.AutomaticEnv()
 
@@ -59,8 +87,40 @@ func LoadConfig(path string) (Config, error) {
 	}
 
 	var config Config
-	err = v.Unmarshal(&config)
-	return config, err
+	if err = v.Unmarshal(&config); err != nil {
+		return Config{}, err
+	}
+
+	// Resolve the effective CVE matching mode. An explicit cveMatchingMode
+	// always wins. Backward compatibility: when cveMatchingMode is absent but
+	// the legacy useDefaultMatchers boolean is set, derive the mode from it
+	// (true -> off, false -> on). With neither set, the default is adaptive.
+	switch {
+	case v.IsSet("cveMatchingMode"):
+		// keep config.CVEMatchingMode as unmarshalled; validated below
+	case v.IsSet("useDefaultMatchers"):
+		if config.UseDefaultMatchers {
+			config.CVEMatchingMode = CVEMatchingOff
+		} else {
+			config.CVEMatchingMode = CVEMatchingOn
+		}
+	default:
+		config.CVEMatchingMode = CVEMatchingAdaptive
+	}
+
+	switch config.CVEMatchingMode {
+	case CVEMatchingOff, CVEMatchingOn, CVEMatchingAdaptive:
+		// valid
+	default:
+		return Config{}, fmt.Errorf("invalid cveMatchingMode %q: must be one of %q, %q, %q",
+			config.CVEMatchingMode, CVEMatchingOff, CVEMatchingOn, CVEMatchingAdaptive)
+	}
+
+	if len(config.TrustedVendors) == 0 {
+		config.TrustedVendors = defaultTrustedVendors
+	}
+
+	return config, nil
 }
 
 // LoadBackendServicesConfig loads backend service URLs from configDir/services.json if

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,6 +54,26 @@ func TestLoadConfigCVEMatchingMode(t *testing.T) {
 	}
 }
 
+// TestLoadConfigCVEMatchingModeEnv verifies env-var overrides are honored and
+// do not crash LoadConfig (AutomaticEnv values are not unmarshalled, so the
+// resolution must read through viper's getters).
+func TestLoadConfigCVEMatchingModeEnv(t *testing.T) {
+	t.Run("mode via env on empty-key config", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("CVEMATCHINGMODE", "on")
+		c, err := LoadConfig("testdata")
+		assert.NoError(t, err)
+		assert.Equal(t, CVEMatchingOn, c.CVEMatchingMode)
+	})
+	t.Run("legacy bool via env maps to off", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("USEDEFAULTMATCHERS", "true")
+		c, err := LoadConfig("testdata")
+		assert.NoError(t, err)
+		assert.Equal(t, CVEMatchingOff, c.CVEMatchingMode)
+	})
+}
+
 // TestLoadConfigTrustedVendors covers the trusted-vendor default and override.
 func TestLoadConfigTrustedVendors(t *testing.T) {
 	viper.Reset()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,48 @@ func TestLoadBackendServicesConfig(t *testing.T) {
 	assert.Equal(t, "https://api.armosec.io", services.GetApiServerUrl())
 }
 
+// TestLoadConfigCVEMatchingMode covers mode resolution and backward compatibility.
+func TestLoadConfigCVEMatchingMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantMode CVEMatchingMode
+		wantErr  bool
+	}{
+		{name: "neither set defaults to adaptive", path: "testdata", wantMode: CVEMatchingAdaptive},
+		{name: "legacy true maps to off", path: "testdata_matching/legacy_true", wantMode: CVEMatchingOff},
+		{name: "legacy false maps to on", path: "testdata_matching/legacy_false", wantMode: CVEMatchingOn},
+		{name: "explicit mode wins over legacy", path: "testdata_matching/explicit_wins", wantMode: CVEMatchingOn},
+		{name: "explicit adaptive", path: "testdata_matching/explicit_adaptive", wantMode: CVEMatchingAdaptive},
+		{name: "invalid mode errors", path: "testdata_matching/invalid", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			c, err := LoadConfig(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantMode, c.CVEMatchingMode)
+		})
+	}
+}
+
+// TestLoadConfigTrustedVendors covers the trusted-vendor default and override.
+func TestLoadConfigTrustedVendors(t *testing.T) {
+	viper.Reset()
+	c, err := LoadConfig("testdata")
+	assert.NoError(t, err)
+	assert.Equal(t, defaultTrustedVendors, c.TrustedVendors)
+
+	viper.Reset()
+	c, err = LoadConfig("testdata_matching/explicit_adaptive")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"echo", "acme"}, c.TrustedVendors)
+}
+
 // test proxyRegistryMap is loaded correctly
 func TestLoadConfigProxyRegistryMap(t *testing.T) {
 	viper.Reset()

--- a/config/testdata_matching/explicit_adaptive/clusterData.json
+++ b/config/testdata_matching/explicit_adaptive/clusterData.json
@@ -1,0 +1,6 @@
+{
+  "accountID": "12345",
+  "clusterName": "clusterName",
+  "cveMatchingMode": "adaptive",
+  "trustedVendors": ["echo", "acme"]
+}

--- a/config/testdata_matching/explicit_wins/clusterData.json
+++ b/config/testdata_matching/explicit_wins/clusterData.json
@@ -1,0 +1,6 @@
+{
+  "accountID": "12345",
+  "clusterName": "clusterName",
+  "useDefaultMatchers": true,
+  "cveMatchingMode": "on"
+}

--- a/config/testdata_matching/invalid/clusterData.json
+++ b/config/testdata_matching/invalid/clusterData.json
@@ -1,0 +1,5 @@
+{
+  "accountID": "12345",
+  "clusterName": "clusterName",
+  "cveMatchingMode": "bogus"
+}

--- a/config/testdata_matching/legacy_false/clusterData.json
+++ b/config/testdata_matching/legacy_false/clusterData.json
@@ -1,0 +1,5 @@
+{
+  "accountID": "12345",
+  "clusterName": "clusterName",
+  "useDefaultMatchers": false
+}

--- a/config/testdata_matching/legacy_true/clusterData.json
+++ b/config/testdata_matching/legacy_true/clusterData.json
@@ -1,0 +1,5 @@
+{
+  "accountID": "12345",
+  "clusterName": "clusterName",
+  "useDefaultMatchers": true
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -447,7 +447,7 @@ For clusters with > 500 pods:
   "scanTimeout": "15m",
   "maxImageSize": 2147483648,
   "maxSBOMSize": 52428800,
-  "useDefaultMatchers": true,
+  "cveMatchingMode": "off",
   "vexGeneration": true,
   "partialRelevancy": true
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,6 +10,7 @@ This document provides comprehensive documentation for configuring Kubevuln.
 - [Configuration Methods](#configuration-methods)
 - [Environment Variables](#environment-variables)
 - [Configuration File Reference](#configuration-file-reference)
+- [CVE Matching Mode](#cve-matching-mode)
 - [Backend Services Configuration](#backend-services-configuration)
 - [Credentials Configuration](#credentials-configuration)
 - [Configuration Examples](#configuration-examples)
@@ -176,7 +177,9 @@ The main configuration file. All options can be overridden via environment varia
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `listingURL` | string | `https://grype.anchore.io/databases` | Grype vulnerability database URL |
-| `useDefaultMatchers` | bool | `false` | Use Grype's default matchers (less aggressive CPE matching) |
+| `cveMatchingMode` | string | `adaptive` | CPE matching policy: `off` (Grype defaults everywhere), `on` (aggressive CPE matching everywhere), or `adaptive` (CPE matching everywhere except trusted-vendor images, which fall back to Grype defaults). See [CVE Matching Mode](#cve-matching-mode). |
+| `trustedVendors` | []string | `["echo","chainguard","wolfi","minimos"]` | Distro identifiers (as recognised by Grype's distro detection) treated as trusted vendors in `adaptive` mode. Override to add/remove vendors without a release. |
+| `useDefaultMatchers` | bool | `false` | **Deprecated**, kept for backward compatibility. Maps to `cveMatchingMode`: `true` -> `off`, `false` -> `on`. An explicit `cveMatchingMode` always wins. |
 
 #### Storage Options
 
@@ -261,6 +264,16 @@ The main configuration file. All options can be overridden via environment varia
       "type": "boolean",
       "default": false
     },
+    "cveMatchingMode": {
+      "type": "string",
+      "enum": ["off", "on", "adaptive"],
+      "default": "adaptive"
+    },
+    "trustedVendors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": ["echo", "chainguard", "wolfi", "minimos"]
+    },
     "useDefaultMatchers": {
       "type": "boolean",
       "default": false
@@ -272,6 +285,45 @@ The main configuration file. All options can be overridden via environment varia
   }
 }
 ```
+
+---
+
+## CVE Matching Mode
+
+Kubevuln uses Grype as its scanning engine. Grype connects packages to CVEs
+through two mechanisms: ecosystem/feed-based matching and CPE name-fuzzing.
+CPE matching avoids false negatives but, for images whose vendor maintains an
+authoritative vulnerability feed already in the Grype DB, it only adds false
+positives. `cveMatchingMode` controls this trade-off.
+
+| Mode | Behavior |
+|------|----------|
+| `off` | Grype defaults everywhere (CPE matching disabled). Equivalent to the legacy `useDefaultMatchers: true`. |
+| `on` | CPE matching enabled everywhere (most aggressive). Equivalent to the legacy `useDefaultMatchers: false`. |
+| `adaptive` **(default)** | CPE matching enabled, except when the scanned image's distro is a trusted vendor, in which case Grype defaults apply for that scan. |
+
+### Trusted vendors
+
+In `adaptive` mode, the per-scan decision reuses Grype's own distro detection:
+Syft parses the image's `/etc/os-release` into the SBOM, and Grype maps the
+release ID to a distro type. When that type is in `trustedVendors`, CPE
+matching is disabled for that scan and matching relies on the vendor's
+authoritative feed. The default set is `echo` (Echo.ai), `chainguard` and
+`wolfi` (Chainguard), and `minimos` (Minimus).
+
+### Backward compatibility
+
+The legacy `useDefaultMatchers` boolean is still honored. When
+`cveMatchingMode` is not set explicitly, the boolean is mapped to a mode
+(`true` -> `off`, `false` -> `on`). An explicit `cveMatchingMode` always wins.
+If neither is set, the mode defaults to `adaptive`.
+
+### Observability
+
+When `adaptive` mode downgrades a scan to a trusted vendor's feed, the CVE
+manifest is annotated with `kubescape.io/cve-matching-mode` and
+`kubescape.io/vendor-trusted-match`, so the backend/UI can explain why two
+similar images may show different vulnerability counts.
 
 ---
 
@@ -499,7 +551,7 @@ Some configuration is validated at runtime:
 | Setting | Impact |
 |---------|--------|
 | `scanConcurrency` | Higher = more CPU usage |
-| `useDefaultMatchers` | `true` = less CPU (fewer matches) |
+| `cveMatchingMode` | `off`/`adaptive` = less CPU than `on` (fewer CPE matches) |
 
 ### Disk Usage
 


### PR DESCRIPTION
## What

Implements the [trusted-image-vendors proposal](https://github.com/kubescape/designs-and-proposals/pull/6): a three-mode `cveMatchingMode` config replacing the boolean `useDefaultMatchers`.

| Mode | Behavior |
|------|----------|
| `off` | Grype defaults everywhere (CPE off). = legacy `useDefaultMatchers: true` |
| `on` | CPE matching everywhere. = legacy `useDefaultMatchers: false` |
| `adaptive` **(default)** | CPE on, except auto-disabled per-scan for trusted-vendor images. |

In `adaptive` mode, trusted-vendor images (Echo.ai, Chainguard/Wolfi, Minimus) fall back to Grype's default matching and rely on the vendor's authoritative feed already integrated into the Grype DB. This removes the CPE name-fuzzing false positives those images accumulated (e.g. Echo's `kafka-ui`: 16 crit/80 high in kubevuln vs 7/49 in plain Grype).

## How

- **Reuses Grype's existing distro detection** — the resolved `*distro.Distro` is already available in `ScanSBOM` before matchers are built, so the per-scan decision needs no pipeline change. No new identification logic, no vendored code.
- `config/config.go`: new `CVEMatchingMode` enum + `TrustedVendors` slice; `LoadConfig` resolves the effective mode with presence detection.
- `adapters/v1/grype.go`: `GrypeAdapter` carries the mode + trusted-vendor set; `resolveUseDefaultMatchers(dist)` decides per scan; `getMatchers`/`defaultMatcherConfig` unchanged.
- Observability: manifest annotated with `kubescape.io/cve-matching-mode` and `kubescape.io/vendor-trusted-match` when a scan is downgraded.

## Backward compatibility

The legacy `useDefaultMatchers` boolean still works and maps to `off`/`on` when `cveMatchingMode` is unset; an explicit `cveMatchingMode` always wins. With neither set, the mode defaults to `adaptive` — note this changes behavior on upgrade for deployments that left the boolean unset (previously CPE-on).

Note: `Version()` now appends `-matching-<mode>` to `CVEScannerVersion`, which will trigger rescans on upgrade (intended, since matching behavior changed).

## Out of scope (follow-ups)

- Optional registry allowlist (AND distro + registry) — deferred per design discussion.
- helm-charts values/configmap plumbing for `cveMatchingMode` / `trustedVendors` — separate repo PR. Code works with the keys absent (defaults to `adaptive`).

## Testing

- `config`: table test for mode resolution (unset→adaptive, legacy bool→off/on, explicit wins, invalid→error) + trusted-vendor default/override — **12 pass**.
- `adapters/v1`: `resolveUseDefaultMatchers` matrix (mode × trusted/untrusted/nil distro) + `Version` — **11 pass**.
- `adapters/v1`: container-backed `ScanSBOM`/`DBVersion` regression (runs in `on` mode = prior default) — **4 pass**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable CVE vulnerability matching modes (`off`, `on`, `adaptive`) for enhanced control over vulnerability scanning behavior.
  * Added support for specifying trusted vendors to customize CVE matching behavior.

* **Documentation**
  * Updated configuration reference with detailed CVE matching mode documentation and backward compatibility guidance for legacy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->