### PR TITLE
fix: detach HTTP request context from cancellation for background tasks

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -61,10 +62,11 @@ func (h HTTPController) GenerateSBOM(c *gin.Context) {
 
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
+	bgCtx := context.WithoutCancel(ctx)
 	h.workerPool.Submit(func() {
-		err = h.scanService.GenerateSBOM(ctx)
+		err = h.scanService.GenerateSBOM(bgCtx)
 		if err != nil {
-			logger.L().Ctx(ctx).Error("service error - GenerateSBOM", helpers.Error(err),
+			logger.L().Ctx(bgCtx).Error("service error - GenerateSBOM", helpers.Error(err),
 				helpers.String("imageSlug", newScan.ImageSlug),
 				helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
 				helpers.String("imageHash", newScan.ImageHash))
@@ -117,16 +119,17 @@ func (h HTTPController) ScanCP(c *gin.Context) {
 
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
+	bgCtx := context.WithoutCancel(ctx)
 	h.workerPool.Submit(func() {
-		err = h.scanService.ScanCP(ctx)
+		err = h.scanService.ScanCP(bgCtx)
 		if err != nil {
 			if errors.Is(err, domain.ErrPartialContainerProfile) {
-				logger.L().Ctx(ctx).Warning("service warning - ScanCP", helpers.Error(err),
+				logger.L().Ctx(bgCtx).Warning("service warning - ScanCP", helpers.Error(err),
 					helpers.String("wlid", newScan.Wlid),
 					helpers.String("name", name),
 					helpers.String("namespace", namespace))
 			} else {
-				logger.L().Ctx(ctx).Error("service error - ScanCP", helpers.Error(err),
+				logger.L().Ctx(bgCtx).Error("service error - ScanCP", helpers.Error(err),
 					helpers.String("wlid", newScan.Wlid),
 					helpers.String("name", name),
 					helpers.String("namespace", namespace))
@@ -163,10 +166,11 @@ func (h HTTPController) ScanCVE(c *gin.Context) {
 
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
+	bgCtx := context.WithoutCancel(ctx)
 	h.workerPool.Submit(func() {
-		err = h.scanService.ScanCVE(ctx)
+		err = h.scanService.ScanCVE(bgCtx)
 		if err != nil {
-			logger.L().Ctx(ctx).Error("service error - ScanCVE", helpers.Error(err),
+			logger.L().Ctx(bgCtx).Error("service error - ScanCVE", helpers.Error(err),
 				helpers.String("wlid", newScan.Wlid),
 				helpers.String("imageSlug", newScan.ImageSlug),
 				helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
@@ -232,10 +236,11 @@ func (h HTTPController) ScanRegistry(c *gin.Context) {
 
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
+	bgCtx := context.WithoutCancel(ctx)
 	h.workerPool.Submit(func() {
-		err = h.scanService.ScanRegistry(ctx)
+		err = h.scanService.ScanRegistry(bgCtx)
 		if err != nil {
-			logger.L().Ctx(ctx).Error("service error - ScanRegistry", helpers.Error(err),
+			logger.L().Ctx(bgCtx).Error("service error - ScanRegistry", helpers.Error(err),
 				helpers.String("imageSlug", newScan.ImageSlug),
 				helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
 				helpers.String("imageHash", newScan.ImageHash))

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -1,15 +1,19 @@
 package controllers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	wssc "github.com/armosec/armoapi-go/apis"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/gammazero/workerpool"
 	"github.com/gin-gonic/gin"
+	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/core/services"
 	"github.com/kubescape/kubevuln/internal/tools"
@@ -279,3 +283,136 @@ func Test_registryScanCommandToScanCommand(t *testing.T) {
 		assert.Equal(t, tests[i].ParentJobID, scanComm.ParentJobID)
 	}
 }
+
+type contextSpyScanService struct {
+	lastGenerateSBOMCtx context.Context
+	lastScanCPCtx       context.Context
+	lastScanCVECtx      context.Context
+	lastScanRegistryCtx context.Context
+	generateSBOMCh      chan struct{}
+	scanCPCh            chan struct{}
+	scanCVECh           chan struct{}
+	scanRegistryCh      chan struct{}
+}
+
+var _ ports.ScanService = (*contextSpyScanService)(nil)
+
+func (s *contextSpyScanService) GenerateSBOM(ctx context.Context) error {
+	s.lastGenerateSBOMCtx = ctx
+	close(s.generateSBOMCh)
+	return nil
+}
+
+func (s *contextSpyScanService) Ready(ctx context.Context) bool {
+	return true
+}
+
+func (s *contextSpyScanService) ScanCP(ctx context.Context) error {
+	s.lastScanCPCtx = ctx
+	close(s.scanCPCh)
+	return nil
+}
+
+func (s *contextSpyScanService) ScanCVE(ctx context.Context) error {
+	s.lastScanCVECtx = ctx
+	close(s.scanCVECh)
+	return nil
+}
+
+func (s *contextSpyScanService) ScanRegistry(ctx context.Context) error {
+	s.lastScanRegistryCtx = ctx
+	close(s.scanRegistryCh)
+	return nil
+}
+
+func (s *contextSpyScanService) ValidateGenerateSBOM(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+func (s *contextSpyScanService) ValidateScanCP(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+func (s *contextSpyScanService) ValidateScanCVE(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+func (s *contextSpyScanService) ValidateScanRegistry(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+func TestHTTPController_ContextCancellationIsDetached(t *testing.T) {
+	spy := &contextSpyScanService{
+		generateSBOMCh: make(chan struct{}),
+		scanCPCh:       make(chan struct{}),
+		scanCVECh:      make(chan struct{}),
+		scanRegistryCh: make(chan struct{}),
+	}
+
+	c := HTTPController{
+		scanService: spy,
+		workerPool:  workerpool.New(4),
+	}
+	defer c.Shutdown()
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+	router.POST("/v1/scanCP", c.ScanCP)
+	router.POST("/v1/scanCVE", c.ScanCVE)
+	router.POST("/v1/scanRegistryImage", c.ScanRegistry)
+
+	// Helper function to send requests
+	sendRequest := func(path string) {
+		payload := `{
+			"imageTag": "k8s.gcr.io/kube-proxy:v1.24.3",
+			"wlid": "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy",
+			"containerName": "kube-proxy",
+			"imageHash": "k8s.gcr.io/kube-proxy@sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+			"args": {
+				"name": "daemonset-kube-proxy",
+				"namespace": "kube-system"
+			}
+		}`
+		req, _ := http.NewRequest("POST", path, strings.NewReader(payload))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// 1. GenerateSBOM
+	sendRequest("/v1/generateSBOM")
+	select {
+	case <-spy.generateSBOMCh:
+		assert.NoError(t, spy.lastGenerateSBOMCtx.Err())
+	case <-time.After(1 * time.Second):
+		t.Fatal("GenerateSBOM worker was not executed in time")
+	}
+
+	// 2. ScanCP
+	sendRequest("/v1/scanCP")
+	select {
+	case <-spy.scanCPCh:
+		assert.NoError(t, spy.lastScanCPCtx.Err())
+	case <-time.After(1 * time.Second):
+		t.Fatal("ScanCP worker was not executed in time")
+	}
+
+	// 3. ScanCVE
+	sendRequest("/v1/scanCVE")
+	select {
+	case <-spy.scanCVECh:
+		assert.NoError(t, spy.lastScanCVECtx.Err())
+	case <-time.After(1 * time.Second):
+		t.Fatal("ScanCVE worker was not executed in time")
+	}
+
+	// 4. ScanRegistry
+	sendRequest("/v1/scanRegistryImage")
+	select {
+	case <-spy.scanRegistryCh:
+		assert.NoError(t, spy.lastScanRegistryCtx.Err())
+	case <-time.After(1 * time.Second):
+		t.Fatal("ScanRegistry worker was not executed in time")
+	}
+}
+


### PR DESCRIPTION
This PR fixes a bug in the HTTP controller endpoints (GenerateSBOM, ScanCP, ScanCVE, ScanRegistry) where the request context was passed to asynchronous tasks submitted to the background worker pool. In Go 1.20+, the request context is cancelled as soon as the HTTP handler returns, resulting in the background worker aborting due to the cancelled context. Wrapping the context in `context.WithoutCancel` fixes this. Added unit tests to verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Background scan operations (SBOM generation, container package scans, CVE scans, and registry scans) now continue reliably even if the initial request is cancelled, improving overall system resilience and preventing incomplete scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->