### PR TITLE
fix(sbomscanner): register sqlite driver for newer RPM databases

### DIFF
--- a/cmd/sbom-scanner/main.go
+++ b/cmd/sbom-scanner/main.go
@@ -11,6 +11,15 @@ import (
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"google.golang.org/grpc"
+
+	// Register a pure-Go sqlite driver under the name "sqlite". Syft's RPM
+	// (redhat) cataloger requires it to read newer sqlite-backed RPM databases
+	// (rpmdb.sqlite) found in recent RPM-based images. Unlike the main HTTP
+	// binary, this sidecar does not import grype, so it does not transitively
+	// pull a sqlite driver; without this import the cataloger fails with
+	// "sqlite driver is required for cataloging newer RPM databases, none
+	// registered". See https://github.com/kubescape/kubevuln/issues/378.
+	_ "modernc.org/sqlite"
 )
 
 func main() {

--- a/cmd/sbom-scanner/sqlite_driver_test.go
+++ b/cmd/sbom-scanner/sqlite_driver_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestSqliteDriverRegistered guards against a regression of
+// https://github.com/kubescape/kubevuln/issues/378: Syft's RPM (redhat)
+// cataloger requires a sqlite driver registered under the name "sqlite" to read
+// newer sqlite-backed RPM databases. The sidecar does not import grype (which
+// would otherwise pull one transitively), so it must register one itself via a
+// blank import in main.go.
+func TestSqliteDriverRegistered(t *testing.T) {
+	var count int
+	for _, d := range sql.Drivers() {
+		if d == "sqlite" {
+			count++
+		}
+	}
+	if count == 0 {
+		t.Fatalf(`no sqlite driver registered; Syft's RPM cataloger needs sql.Open("sqlite", ...) to work`)
+	}
+	if count > 1 {
+		t.Fatalf("sqlite driver registered %d times; risk of \"Register called twice\" panic", count)
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open(sqlite): %v", err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping in-memory sqlite: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
+	modernc.org/sqlite v1.38.2
 	schneider.vip/problem v1.8.1
 )
 
@@ -448,7 +449,6 @@ require (
 	modernc.org/libc v1.66.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.38.2 // indirect
 	sigs.k8s.io/controller-runtime v0.21.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect


### PR DESCRIPTION
## Problem

Scanning newer RPM-based images (e.g. recent `redis`/UBI-style bases) fails in the SBOM scanner sidecar with:

```
service error - ScanCVE, error: "creating SBOM: failed to generate SBOM: failed to run tasks:
sqlite driver is required for cataloging newer RPM databases, none registered:
sql: unknown driver \"sqlite\" (forgotten import?)"
```

Fixes #378.

## Root cause

Two changes combined to surface this:

1. **syft v1.32.0** (introduced in `cd2e51c`, "migrate to grype v0.99.1", 2025-09-17) added `ensureSqliteDriverAvailable()` to its RPM (redhat) cataloger. Newer RPM databases use the sqlite format (`rpmdb.sqlite`), and Syft now requires the consumer to register a `database/sql` driver under the name **`sqlite`** — it does not bundle one.

2. **The SBOM scanner sidecar** (`cmd/sbom-scanner` + `pkg/sbomscanner/v1`, introduced in `36cd416`, "add SBOM scanner sidecar", 2026-03-23) generates SBOMs via Syft **without importing grype**. The main `cmd/http` binary transitively pulls `glebarez/go-sqlite` (which registers `"sqlite"`) through grype's DB layer, so it works. The sidecar has no such transitive import, so the driver is never registered.

Verified per-binary (redhat cataloger present / sqlite driver present):

| binary | redhat cataloger | sqlite driver |
|---|---|---|
| `cmd/http` | ✅ | ✅ (glebarez via grype) |
| `cmd/cli` | ❌ | – |
| `cmd/sbom-scanner` | ✅ | ❌ → **bug** |

## Fix

Register the pure-Go (CGO-free) `modernc.org/sqlite` driver via a blank import in the sidecar entrypoint (`cmd/sbom-scanner/main.go`). `modernc.org/sqlite` registers under the name `"sqlite"`, which is exactly what the cataloger's `sql.Open("sqlite", ...)` needs.

It is placed in the **binary entrypoint**, not the shared `pkg/sbomscanner/v1` package, on purpose: `cmd/http` imports that package *and* already has glebarez's `"sqlite"` driver, so a blank import there would cause a `sql: Register called twice for driver sqlite` panic at startup. Putting it in `cmd/sbom-scanner` keeps each binary at exactly one `"sqlite"` driver.

> Note: the issue suggested `mattn/go-sqlite3` as one option — that registers as `"sqlite3"` (and requires CGO), so it would *not* satisfy `sql.Open("sqlite", ...)`. `modernc.org/sqlite` is the correct, pure-Go choice.

## Testing

- Added `cmd/sbom-scanner/sqlite_driver_test.go` — asserts exactly one `"sqlite"` driver is registered (catches both the missing-driver regression and an accidental double registration) and that an in-memory sqlite DB opens + pings.
- `go build ./cmd/...` passes; `go vet ./cmd/...` clean.
- Confirmed no binary ends up with two `"sqlite"` drivers (no double-registration panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for scanning images that rely on SQLite-backed metadata, helping scans complete more reliably in those cases.

* **Bug Fixes**
  * Fixed an issue where the SQLite driver could be missing or not loaded consistently during scans.
  * Added coverage to confirm the SQLite connection is available and working as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->