### PR TITLE
fix: raise gRPC client/server message limits on sbom-scanner sidecar channel

### DIFF
--- a/cmd/sbom-scanner/main.go
+++ b/cmd/sbom-scanner/main.go
@@ -36,7 +36,10 @@ func main() {
 		logger.L().Fatal("failed to listen on socket", helpers.Error(err), helpers.String("path", socketPath))
 	}
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(sbomscanner.MaxgRPCMessageSize),
+		grpc.MaxSendMsgSize(sbomscanner.MaxgRPCMessageSize),
+	)
 	pb.RegisterSBOMScannerServer(srv, sbomscanner.NewScannerServer())
 
 	sigCh := make(chan os.Signal, 1)

--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -17,7 +17,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const healthCheckTimeout = 5 * time.Second
+const (
+	healthCheckTimeout = 5 * time.Second
+	MaxgRPCMessageSize = 128 * 1024 * 1024
+)
 
 type sbomScannerClient struct {
 	conn   *grpc.ClientConn
@@ -30,6 +33,10 @@ func NewSBOMScannerClient(socketPath string) (SBOMScannerClient, error) {
 	target := fmt.Sprintf("unix://%s", socketPath)
 	conn, err := grpc.NewClient(target,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize),
+			grpc.MaxCallSendMsgSize(MaxgRPCMessageSize),
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)

--- a/pkg/sbomscanner/v1/integration_test.go
+++ b/pkg/sbomscanner/v1/integration_test.go
@@ -23,12 +23,19 @@ func startIntegrationServer(t *testing.T) (SBOMScannerClient, *grpc.Server, stri
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(MaxgRPCMessageSize),
+		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
+	)
 	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
 	go srv.Serve(lis)
 
 	conn, err := grpc.NewClient("unix://"+sock,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize),
+			grpc.MaxCallSendMsgSize(MaxgRPCMessageSize),
+		),
 	)
 	require.NoError(t, err)
 

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -22,12 +22,19 @@ func startTestServer(t *testing.T) (pb.SBOMScannerClient, func()) {
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(MaxgRPCMessageSize),
+		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
+	)
 	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
 	go srv.Serve(lis)
 
 	conn, err := grpc.NewClient("unix://"+sock,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize),
+			grpc.MaxCallSendMsgSize(MaxgRPCMessageSize),
+		),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Description
This PR resolves the issue where `kubevuln` fails to scan larger images (like `wordpress:6.0.1-php7.4`) due to the default gRPC message size limit of 4 MiB on the client-side/server-side communication channel with `sbom-scanner`.

We raise the default message size limit on both ends to **128 MiB** (`128 * 1024 * 1024` bytes) to safely accommodate larger SBOM payloads.

### Changes
* **v1 Package (`pkg/sbomscanner/v1/client.go`):**
  * Defined `MaxgRPCMessageSize = 128 * 1024 * 1024`.
  * Added `grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize), grpc.MaxCallSendMsgSize(MaxgRPCMessageSize))` to `grpc.NewClient`.
* **Server Main (`cmd/sbom-scanner/main.go`):**
  * Configured `grpc.NewServer` with `grpc.MaxRecvMsgSize(sbomscanner.MaxgRPCMessageSize)` and `grpc.MaxSendMsgSize(sbomscanner.MaxgRPCMessageSize)`.
* **Tests (`pkg/sbomscanner/v1/integration_test.go` and `pkg/sbomscanner/v1/server_test.go`):**
  * Updated test gRPC servers and clients to also use `MaxgRPCMessageSize` call and server options.

Closes #381
