### PR TITLE
[ LFX 2026 ] feat: scope vulnerability SecurityExceptions by match selectors

### DIFF
--- a/adapters/mockplatform.go
+++ b/adapters/mockplatform.go
@@ -52,7 +52,8 @@ func (m MockPlatform) GetCVEExceptions(ctx context.Context) (domain.CVEException
 	}
 
 	if len(seList) > 0 || len(cseList) > 0 {
-		policies := v1.ConvertToVulnerabilityExceptionPolicies(seList, cseList)
+		target := v1.BuildExceptionTarget(ctx, workload, seList, cseList, m.securityExceptionRepo)
+		policies := v1.ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
 		return policies, nil
 	}
 

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -111,7 +111,8 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions", helpers.Error(err))
 	} else if len(seList) > 0 || len(cseList) > 0 {
-		crdPolicies := ConvertToVulnerabilityExceptionPolicies(seList, cseList)
+		target := BuildExceptionTarget(ctx, workload, seList, cseList, a.securityExceptionRepo)
+		crdPolicies := ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
 		vulnExceptionList = append(vulnExceptionList, crdPolicies...)
 	}
 

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -505,10 +505,20 @@ type mockSecurityExceptionRepo struct {
 	exceptions        []sev1beta1.SecurityException
 	clusterExceptions []sev1beta1.ClusterSecurityException
 	err               error
+	workloadLabels    map[string]string
+	namespaceLabels   map[string]string
 }
 
 func (m *mockSecurityExceptionRepo) GetSecurityExceptions(_ context.Context, _ string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
 	return m.exceptions, m.clusterExceptions, m.err
+}
+
+func (m *mockSecurityExceptionRepo) GetWorkloadLabels(_ context.Context, _, _, _ string) (map[string]string, error) {
+	return m.workloadLabels, nil
+}
+
+func (m *mockSecurityExceptionRepo) GetNamespaceLabels(_ context.Context, _ string) (map[string]string, error) {
+	return m.namespaceLabels, nil
 }
 
 func TestGetCVEExceptions_MergesCRDExceptions(t *testing.T) {
@@ -549,4 +559,38 @@ func TestGetCVEExceptions_MergesCRDExceptions(t *testing.T) {
 	assert.Len(t, exceptions, 2, "should merge cloud + CRD exceptions")
 	assert.Equal(t, "CVE-CLOUD-1", exceptions[0].VulnerabilityPolicies[0].Name)
 	assert.Equal(t, "CVE-CRD-1", exceptions[1].VulnerabilityPolicies[0].Name)
+}
+
+func TestGetCVEExceptions_ScopesCRDByMatch(t *testing.T) {
+	// A cluster exception scoped to redis images must NOT be applied to an
+	// nginx workload — this is the fail-open regression the match logic fixes.
+	mockRepo := &mockSecurityExceptionRepo{
+		clusterExceptions: []sev1beta1.ClusterSecurityException{
+			{
+				Spec: sev1beta1.SecurityExceptionSpec{
+					Match: sev1beta1.ExceptionMatch{Images: []string{"docker.io/library/redis:*"}},
+					Vulnerabilities: []sev1beta1.VulnerabilityException{
+						{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-REDIS-ONLY"}},
+					},
+				},
+			},
+		},
+	}
+
+	a := &BackendAdapter{
+		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
+		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
+		securityExceptionRepo: mockRepo,
+	}
+
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:               "wlid://cluster-test/namespace-production/deployment-nginx",
+		ImageTagNormalized: "docker.io/library/nginx:1.25",
+	})
+
+	exceptions, err := a.GetCVEExceptions(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, exceptions, "redis-scoped exception must not apply to an nginx workload")
 }

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -502,11 +502,13 @@ func TestBackendAdapter_ReportScanFailure_NilError(t *testing.T) {
 }
 
 type mockSecurityExceptionRepo struct {
-	exceptions        []sev1beta1.SecurityException
-	clusterExceptions []sev1beta1.ClusterSecurityException
-	err               error
-	workloadLabels    map[string]string
-	namespaceLabels   map[string]string
+	exceptions         []sev1beta1.SecurityException
+	clusterExceptions  []sev1beta1.ClusterSecurityException
+	err                error
+	workloadLabels     map[string]string
+	namespaceLabels    map[string]string
+	workloadLabelsErr  error
+	namespaceLabelsErr error
 }
 
 func (m *mockSecurityExceptionRepo) GetSecurityExceptions(_ context.Context, _ string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
@@ -514,11 +516,11 @@ func (m *mockSecurityExceptionRepo) GetSecurityExceptions(_ context.Context, _ s
 }
 
 func (m *mockSecurityExceptionRepo) GetWorkloadLabels(_ context.Context, _, _, _ string) (map[string]string, error) {
-	return m.workloadLabels, nil
+	return m.workloadLabels, m.workloadLabelsErr
 }
 
 func (m *mockSecurityExceptionRepo) GetNamespaceLabels(_ context.Context, _ string) (map[string]string, error) {
-	return m.namespaceLabels, nil
+	return m.namespaceLabels, m.namespaceLabelsErr
 }
 
 func TestGetCVEExceptions_MergesCRDExceptions(t *testing.T) {

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -15,7 +15,11 @@ import (
 // ConvertToVulnerabilityExceptionPolicies converts SecurityException and
 // ClusterSecurityException CRDs into armotypes.VulnerabilityExceptionPolicy
 // slices compatible with the existing exception pipeline.
-func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityException, clusterExceptions []sev1beta1.ClusterSecurityException) []armotypes.VulnerabilityExceptionPolicy {
+//
+// Only exceptions whose spec.match applies to target are converted, so an
+// exception scoped by resources/images/objectSelector/namespaceSelector is not
+// applied to workloads it does not target. Expired exceptions are skipped.
+func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityException, clusterExceptions []sev1beta1.ClusterSecurityException, target ExceptionTarget) []armotypes.VulnerabilityExceptionPolicy {
 	var policies []armotypes.VulnerabilityExceptionPolicy
 
 	now := time.Now()
@@ -23,6 +27,9 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 	for i := range exceptions {
 		se := &exceptions[i]
 		if isExpired(se.Spec.ExpiresAt, now) {
+			continue
+		}
+		if !matchExceptionTarget(se.Spec.Match, target, false) {
 			continue
 		}
 		namespace := se.Namespace
@@ -38,6 +45,9 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 	for i := range clusterExceptions {
 		cse := &clusterExceptions[i]
 		if isExpired(cse.Spec.ExpiresAt, now) {
+			continue
+		}
+		if !matchExceptionTarget(cse.Spec.Match, target, true) {
 			continue
 		}
 		for _, vuln := range cse.Spec.Vulnerabilities {

--- a/adapters/v1/securityexception_match.go
+++ b/adapters/v1/securityexception_match.go
@@ -23,7 +23,11 @@ type ExceptionTarget struct {
 	Namespace string
 	Kind      string
 	Name      string
-	APIGroup  string
+	// APIGroup is the target's resolved API group. A nil pointer means the group
+	// is unknown (the kind could not be resolved); an empty string "" is the core
+	// group. These must stay distinct so a group-scoped exception never matches a
+	// core resource or an unverified one.
+	APIGroup *string
 	// Image is the fully-qualified, normalized image reference (as produced by
 	// tools.NormalizeReference), e.g. "docker.io/library/nginx:latest".
 	Image string
@@ -33,6 +37,14 @@ type ExceptionTarget struct {
 	// NamespaceLabels are the labels of the workload's namespace, resolved
 	// lazily and only when a ClusterSecurityException uses match.namespaceSelector.
 	NamespaceLabels map[string]string
+	// WorkloadLabelsResolved reports whether WorkloadLabels reflect a successful
+	// lookup. When an objectSelector is in play but resolution failed (missing
+	// workload, nil repo, lookup error), this stays false and matching fails
+	// closed — a negative selector (DoesNotExist/NotIn) would otherwise match an
+	// empty label set and wrongly suppress findings.
+	WorkloadLabelsResolved bool
+	// NamespaceLabelsResolved is the namespaceSelector equivalent.
+	NamespaceLabelsResolved bool
 }
 
 // matchExceptionTarget reports whether spec.match applies to the given target.
@@ -52,11 +64,17 @@ func matchExceptionTarget(match sev1beta1.ExceptionMatch, target ExceptionTarget
 	if !matchImages(match.Images, target.Image) {
 		return false
 	}
-	if !labelSelectorMatches(match.ObjectSelector, target.WorkloadLabels) {
-		return false
+	// objectSelector: when a selector is set but the workload's labels could not
+	// be resolved, fail closed rather than evaluate against an empty label set.
+	if match.ObjectSelector != nil {
+		if !target.WorkloadLabelsResolved || !labelSelectorMatches(match.ObjectSelector, target.WorkloadLabels) {
+			return false
+		}
 	}
-	if clusterScoped && !labelSelectorMatches(match.NamespaceSelector, target.NamespaceLabels) {
-		return false
+	if clusterScoped && match.NamespaceSelector != nil {
+		if !target.NamespaceLabelsResolved || !labelSelectorMatches(match.NamespaceSelector, target.NamespaceLabels) {
+			return false
+		}
 	}
 	return true
 }
@@ -74,9 +92,12 @@ func matchResources(resources []sev1beta1.ResourceMatch, target ExceptionTarget)
 		if r.Name != "" && r.Name != target.Name {
 			continue
 		}
-		// apiGroup is optional and defaults to all groups. Only enforce it when
-		// both the exception and the resolved target group are known.
-		if r.APIGroup != "" && target.APIGroup != "" && !strings.EqualFold(r.APIGroup, target.APIGroup) {
+		// apiGroup is optional. When the exception pins a group, the target's
+		// resolved group must equal it; if the target group is unknown (nil), the
+		// exception does not apply — fail closed rather than match a resource whose
+		// group was never verified. A non-nil "" is the core group and only matches
+		// an exception that pins "" (or none).
+		if r.APIGroup != "" && (target.APIGroup == nil || !strings.EqualFold(r.APIGroup, *target.APIGroup)) {
 			continue
 		}
 		return true
@@ -138,7 +159,8 @@ func BuildExceptionTarget(ctx context.Context, workload domain.ScanCommand, exce
 	// is simply skipped.
 	if kind != "" {
 		if gvr, err := k8sinterface.GetGroupVersionResource(kind); err == nil {
-			target.APIGroup = gvr.Group
+			group := gvr.Group
+			target.APIGroup = &group
 		}
 	}
 
@@ -146,21 +168,26 @@ func BuildExceptionTarget(ctx context.Context, workload domain.ScanCommand, exce
 		return target
 	}
 
+	// Labels are resolved only when a selector actually needs them. A failed
+	// resolution leaves the corresponding *Resolved flag false so the selector
+	// fails closed in matchExceptionTarget.
 	if usesObjectSelector(exceptions, clusterExceptions) && namespace != "" && kind != "" && name != "" {
 		if lbls, err := repo.GetWorkloadLabels(ctx, namespace, kind, name); err != nil {
-			logger.L().Ctx(ctx).Warning("failed to resolve workload labels for SecurityException objectSelector",
+			logger.L().Ctx(ctx).Warning("failed to resolve workload labels for SecurityException objectSelector; exception will not apply to this workload",
 				helpers.Error(err), helpers.String("namespace", namespace), helpers.String("kind", kind), helpers.String("name", name))
 		} else {
 			target.WorkloadLabels = lbls
+			target.WorkloadLabelsResolved = true
 		}
 	}
 
 	if usesNamespaceSelector(clusterExceptions) && namespace != "" {
 		if lbls, err := repo.GetNamespaceLabels(ctx, namespace); err != nil {
-			logger.L().Ctx(ctx).Warning("failed to resolve namespace labels for ClusterSecurityException namespaceSelector",
+			logger.L().Ctx(ctx).Warning("failed to resolve namespace labels for ClusterSecurityException namespaceSelector; exception will not apply to this namespace",
 				helpers.Error(err), helpers.String("namespace", namespace))
 		} else {
 			target.NamespaceLabels = lbls
+			target.NamespaceLabelsResolved = true
 		}
 	}
 

--- a/adapters/v1/securityexception_match.go
+++ b/adapters/v1/securityexception_match.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
+	"github.com/kubescape/kubevuln/internal/tools"
 	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -86,6 +87,12 @@ func matchResources(resources []sev1beta1.ResourceMatch, target ExceptionTarget)
 		return true
 	}
 	for _, r := range resources {
+		// An entry that constrains nothing would match every workload, defeating
+		// the point of listing resources at all. CRD validation requires kind, but
+		// an explicit empty kind still satisfies that, so reject it here too.
+		if r.Kind == "" && r.Name == "" && r.APIGroup == "" {
+			continue
+		}
 		if r.Kind != "" && !strings.EqualFold(r.Kind, target.Kind) {
 			continue
 		}
@@ -108,6 +115,13 @@ func matchResources(resources []sev1beta1.ResourceMatch, target ExceptionTarget)
 // matchImages returns true if the image matches any of the glob patterns (OR).
 // Patterns use path.Match syntax ('*' does not cross '/'). An empty list
 // matches everything; a non-empty list never matches an empty image.
+//
+// path.Match is a full-string match, so each pattern is tried against every
+// equivalent form of the reference (see tools.ReferenceMatchForms): a pattern
+// pinning a tag ("docker.io/library/nginx:1.25") must still match a workload
+// deployed with a digest ("docker.io/library/nginx:1.25@sha256:..."), and a
+// pattern naming the bare repository ("docker.io/library/nginx") matches that
+// repository at any tag or digest.
 func matchImages(patterns []string, image string) bool {
 	if len(patterns) == 0 {
 		return true
@@ -115,9 +129,12 @@ func matchImages(patterns []string, image string) bool {
 	if image == "" {
 		return false
 	}
+	forms := tools.ReferenceMatchForms(image)
 	for _, p := range patterns {
-		if ok, err := path.Match(p, image); err == nil && ok {
-			return true
+		for _, form := range forms {
+			if ok, err := path.Match(p, form); err == nil && ok {
+				return true
+			}
 		}
 	}
 	return false

--- a/adapters/v1/securityexception_match.go
+++ b/adapters/v1/securityexception_match.go
@@ -1,0 +1,191 @@
+package v1
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	wlidpkg "github.com/armosec/utils-k8s-go/wlid"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/kubevuln/core/domain"
+	"github.com/kubescape/kubevuln/core/ports"
+	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ExceptionTarget describes the workload/image currently being scanned. It is
+// evaluated against a SecurityException's spec.match to decide whether the
+// exception applies to this scan.
+type ExceptionTarget struct {
+	Namespace string
+	Kind      string
+	Name      string
+	APIGroup  string
+	// Image is the fully-qualified, normalized image reference (as produced by
+	// tools.NormalizeReference), e.g. "docker.io/library/nginx:latest".
+	Image string
+	// WorkloadLabels are the labels of the workload being scanned, resolved
+	// lazily and only when an exception uses match.objectSelector.
+	WorkloadLabels map[string]string
+	// NamespaceLabels are the labels of the workload's namespace, resolved
+	// lazily and only when a ClusterSecurityException uses match.namespaceSelector.
+	NamespaceLabels map[string]string
+}
+
+// matchExceptionTarget reports whether spec.match applies to the given target.
+//
+// Semantics (per the SecurityException design doc):
+//   - all specified selector types (resources, images, objectSelector,
+//     namespaceSelector) must match (AND);
+//   - within resources / images the entries are OR-ed;
+//   - an omitted/nil selector matches everything;
+//   - namespaceSelector is only meaningful on a ClusterSecurityException
+//     (clusterScoped=true); on a namespaced SecurityException it is ignored,
+//     since the exception is already scoped to its own namespace.
+func matchExceptionTarget(match sev1beta1.ExceptionMatch, target ExceptionTarget, clusterScoped bool) bool {
+	if !matchResources(match.Resources, target) {
+		return false
+	}
+	if !matchImages(match.Images, target.Image) {
+		return false
+	}
+	if !labelSelectorMatches(match.ObjectSelector, target.WorkloadLabels) {
+		return false
+	}
+	if clusterScoped && !labelSelectorMatches(match.NamespaceSelector, target.NamespaceLabels) {
+		return false
+	}
+	return true
+}
+
+// matchResources returns true if the target matches any of the resource
+// entries (OR). An empty list matches everything.
+func matchResources(resources []sev1beta1.ResourceMatch, target ExceptionTarget) bool {
+	if len(resources) == 0 {
+		return true
+	}
+	for _, r := range resources {
+		if r.Kind != "" && !strings.EqualFold(r.Kind, target.Kind) {
+			continue
+		}
+		if r.Name != "" && r.Name != target.Name {
+			continue
+		}
+		// apiGroup is optional and defaults to all groups. Only enforce it when
+		// both the exception and the resolved target group are known.
+		if r.APIGroup != "" && target.APIGroup != "" && !strings.EqualFold(r.APIGroup, target.APIGroup) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// matchImages returns true if the image matches any of the glob patterns (OR).
+// Patterns use path.Match syntax ('*' does not cross '/'). An empty list
+// matches everything; a non-empty list never matches an empty image.
+func matchImages(patterns []string, image string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	if image == "" {
+		return false
+	}
+	for _, p := range patterns {
+		if ok, err := path.Match(p, image); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// labelSelectorMatches evaluates a standard Kubernetes label selector against a
+// label set. A nil selector matches everything; an invalid selector matches
+// nothing (fail-closed, so a malformed exception never silently suppresses
+// findings).
+func labelSelectorMatches(sel *metav1.LabelSelector, lbls map[string]string) bool {
+	if sel == nil {
+		return true
+	}
+	selector, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return false
+	}
+	return selector.Matches(labels.Set(lbls))
+}
+
+// BuildExceptionTarget assembles the ExceptionTarget for the workload in the
+// scan context. Workload and namespace labels are resolved through repo only
+// when at least one exception actually uses objectSelector/namespaceSelector,
+// to avoid extra API calls on the common path.
+func BuildExceptionTarget(ctx context.Context, workload domain.ScanCommand, exceptions []sev1beta1.SecurityException, clusterExceptions []sev1beta1.ClusterSecurityException, repo ports.SecurityExceptionRepository) ExceptionTarget {
+	namespace := wlidpkg.GetNamespaceFromWlid(workload.Wlid)
+	kind := wlidpkg.GetKindFromWlid(workload.Wlid)
+	name := wlidpkg.GetNameFromWlid(workload.Wlid)
+
+	target := ExceptionTarget{
+		Namespace: namespace,
+		Kind:      kind,
+		Name:      name,
+		Image:     workload.ImageTagNormalized,
+	}
+
+	// Best-effort resolution of the workload's API group for apiGroup matching.
+	// If the resource map is not initialized (e.g. offline), apiGroup matching
+	// is simply skipped.
+	if kind != "" {
+		if gvr, err := k8sinterface.GetGroupVersionResource(kind); err == nil {
+			target.APIGroup = gvr.Group
+		}
+	}
+
+	if repo == nil {
+		return target
+	}
+
+	if usesObjectSelector(exceptions, clusterExceptions) && namespace != "" && kind != "" && name != "" {
+		if lbls, err := repo.GetWorkloadLabels(ctx, namespace, kind, name); err != nil {
+			logger.L().Ctx(ctx).Warning("failed to resolve workload labels for SecurityException objectSelector",
+				helpers.Error(err), helpers.String("namespace", namespace), helpers.String("kind", kind), helpers.String("name", name))
+		} else {
+			target.WorkloadLabels = lbls
+		}
+	}
+
+	if usesNamespaceSelector(clusterExceptions) && namespace != "" {
+		if lbls, err := repo.GetNamespaceLabels(ctx, namespace); err != nil {
+			logger.L().Ctx(ctx).Warning("failed to resolve namespace labels for ClusterSecurityException namespaceSelector",
+				helpers.Error(err), helpers.String("namespace", namespace))
+		} else {
+			target.NamespaceLabels = lbls
+		}
+	}
+
+	return target
+}
+
+func usesObjectSelector(exceptions []sev1beta1.SecurityException, clusterExceptions []sev1beta1.ClusterSecurityException) bool {
+	for i := range exceptions {
+		if exceptions[i].Spec.Match.ObjectSelector != nil {
+			return true
+		}
+	}
+	for i := range clusterExceptions {
+		if clusterExceptions[i].Spec.Match.ObjectSelector != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func usesNamespaceSelector(clusterExceptions []sev1beta1.ClusterSecurityException) bool {
+	for i := range clusterExceptions {
+		if clusterExceptions[i].Spec.Match.NamespaceSelector != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/adapters/v1/securityexception_match_test.go
+++ b/adapters/v1/securityexception_match_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/kubescape/kubevuln/core/domain"
@@ -36,8 +37,10 @@ func TestMatchImages(t *testing.T) {
 	}
 }
 
+func strptr(s string) *string { return &s }
+
 func TestMatchResources(t *testing.T) {
-	target := ExceptionTarget{Kind: "deployment", Name: "nginx", APIGroup: "apps"}
+	target := ExceptionTarget{Kind: "deployment", Name: "nginx", APIGroup: strptr("apps")}
 	tests := []struct {
 		name      string
 		resources []sev1beta1.ResourceMatch
@@ -52,7 +55,9 @@ func TestMatchResources(t *testing.T) {
 		{name: "OR across entries", resources: []sev1beta1.ResourceMatch{{Kind: "StatefulSet", Name: "db"}, {Kind: "Deployment", Name: "nginx"}}, target: target, want: true},
 		{name: "apiGroup match", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "apps"}}, target: target, want: true},
 		{name: "apiGroup mismatch", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "batch"}}, target: target, want: false},
-		{name: "apiGroup skipped when target group unknown", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "apps"}}, target: ExceptionTarget{Kind: "deployment", Name: "nginx"}, want: true},
+		{name: "apiGroup fails closed when target group unknown", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "apps"}}, target: ExceptionTarget{Kind: "deployment", Name: "nginx"}, want: false},
+		{name: "core group target does not match a group-scoped exception", resources: []sev1beta1.ResourceMatch{{Kind: "Pod", APIGroup: "apps"}}, target: ExceptionTarget{Kind: "pod", Name: "p", APIGroup: strptr("")}, want: false},
+		{name: "core group target matches a groupless exception", resources: []sev1beta1.ResourceMatch{{Kind: "Pod"}}, target: ExceptionTarget{Kind: "pod", Name: "p", APIGroup: strptr("")}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -107,12 +112,14 @@ func TestLabelSelectorMatches(t *testing.T) {
 
 func TestMatchExceptionTarget(t *testing.T) {
 	target := ExceptionTarget{
-		Namespace:       "production",
-		Kind:            "deployment",
-		Name:            "nginx",
-		Image:           "docker.io/library/nginx:1.25",
-		WorkloadLabels:  map[string]string{"app": "nginx"},
-		NamespaceLabels: map[string]string{"env": "staging"},
+		Namespace:               "production",
+		Kind:                    "deployment",
+		Name:                    "nginx",
+		Image:                   "docker.io/library/nginx:1.25",
+		WorkloadLabels:          map[string]string{"app": "nginx"},
+		NamespaceLabels:         map[string]string{"env": "staging"},
+		WorkloadLabelsResolved:  true,
+		NamespaceLabelsResolved: true,
 	}
 
 	t.Run("empty match applies to all", func(t *testing.T) {
@@ -155,6 +162,28 @@ func TestMatchExceptionTarget(t *testing.T) {
 		m := sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}}}
 		assert.True(t, matchExceptionTarget(m, target, true))
 	})
+
+	t.Run("unresolved workload labels fail closed even for a negative selector", func(t *testing.T) {
+		// A negative selector matches an empty label set, so an unresolved
+		// objectSelector must NOT apply the exception.
+		neg := sev1beta1.ExceptionMatch{ObjectSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "tier", Operator: metav1.LabelSelectorOpDoesNotExist},
+		}}}
+		unresolved := ExceptionTarget{Namespace: "production", Kind: "deployment", Name: "nginx"} // WorkloadLabelsResolved == false
+		assert.False(t, matchExceptionTarget(neg, unresolved, false))
+		// Resolved-but-empty labels genuinely have no "tier" label, so the same
+		// negative selector legitimately matches.
+		resolvedEmpty := ExceptionTarget{Namespace: "production", Kind: "deployment", Name: "nginx", WorkloadLabelsResolved: true}
+		assert.True(t, matchExceptionTarget(neg, resolvedEmpty, false))
+	})
+
+	t.Run("unresolved namespace labels fail closed for cluster-scoped negative selector", func(t *testing.T) {
+		neg := sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "env", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"prod"}},
+		}}}
+		unresolved := ExceptionTarget{Namespace: "production"} // NamespaceLabelsResolved == false
+		assert.False(t, matchExceptionTarget(neg, unresolved, true))
+	})
 }
 
 func TestConvertScopesByMatch(t *testing.T) {
@@ -181,9 +210,9 @@ func TestConvertScopesByMatch(t *testing.T) {
 				Vulnerabilities: cveEntry,
 			},
 		}}
-		matching := ConvertToVulnerabilityExceptionPolicies(se, nil, ExceptionTarget{Namespace: "production", WorkloadLabels: map[string]string{"app": "nginx"}})
+		matching := ConvertToVulnerabilityExceptionPolicies(se, nil, ExceptionTarget{Namespace: "production", WorkloadLabels: map[string]string{"app": "nginx"}, WorkloadLabelsResolved: true})
 		assert.Len(t, matching, 1)
-		notMatching := ConvertToVulnerabilityExceptionPolicies(se, nil, ExceptionTarget{Namespace: "production", WorkloadLabels: map[string]string{"app": "redis"}})
+		notMatching := ConvertToVulnerabilityExceptionPolicies(se, nil, ExceptionTarget{Namespace: "production", WorkloadLabels: map[string]string{"app": "redis"}, WorkloadLabelsResolved: true})
 		assert.Empty(t, notMatching)
 	})
 
@@ -194,9 +223,9 @@ func TestConvertScopesByMatch(t *testing.T) {
 				Vulnerabilities: cveEntry,
 			},
 		}}
-		matching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{NamespaceLabels: map[string]string{"env": "staging"}})
+		matching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{NamespaceLabels: map[string]string{"env": "staging"}, NamespaceLabelsResolved: true})
 		assert.Len(t, matching, 1)
-		notMatching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{NamespaceLabels: map[string]string{"env": "prod"}})
+		notMatching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{NamespaceLabels: map[string]string{"env": "prod"}, NamespaceLabelsResolved: true})
 		assert.Empty(t, notMatching)
 	})
 
@@ -240,6 +269,7 @@ func TestBuildExceptionTarget(t *testing.T) {
 		se := []sev1beta1.SecurityException{{Spec: sev1beta1.SecurityExceptionSpec{Match: sev1beta1.ExceptionMatch{ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}}}}}
 		target := BuildExceptionTarget(context.Background(), workload, se, nil, repo)
 		assert.Equal(t, map[string]string{"app": "nginx"}, target.WorkloadLabels)
+		assert.True(t, target.WorkloadLabelsResolved)
 	})
 
 	t.Run("resolves namespace labels when CSE namespaceSelector present", func(t *testing.T) {
@@ -247,12 +277,23 @@ func TestBuildExceptionTarget(t *testing.T) {
 		cse := []sev1beta1.ClusterSecurityException{{Spec: sev1beta1.SecurityExceptionSpec{Match: sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}}}}}}
 		target := BuildExceptionTarget(context.Background(), workload, nil, cse, repo)
 		assert.Equal(t, map[string]string{"env": "staging"}, target.NamespaceLabels)
+		assert.True(t, target.NamespaceLabelsResolved)
 		assert.Nil(t, target.WorkloadLabels)
+		assert.False(t, target.WorkloadLabelsResolved)
+	})
+
+	t.Run("label lookup error leaves labels unresolved (fail closed)", func(t *testing.T) {
+		repo := &mockSecurityExceptionRepo{workloadLabelsErr: errors.New("api error")}
+		se := []sev1beta1.SecurityException{{Spec: sev1beta1.SecurityExceptionSpec{Match: sev1beta1.ExceptionMatch{ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}}}}}
+		target := BuildExceptionTarget(context.Background(), workload, se, nil, repo)
+		assert.Nil(t, target.WorkloadLabels)
+		assert.False(t, target.WorkloadLabelsResolved)
 	})
 
 	t.Run("nil repo yields no labels", func(t *testing.T) {
 		target := BuildExceptionTarget(context.Background(), workload, nil, nil, nil)
 		assert.Equal(t, "docker.io/library/nginx:1.25", target.Image)
 		assert.Nil(t, target.WorkloadLabels)
+		assert.False(t, target.WorkloadLabelsResolved)
 	})
 }

--- a/adapters/v1/securityexception_match_test.go
+++ b/adapters/v1/securityexception_match_test.go
@@ -11,6 +11,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// testDigest is a syntactically valid sha256 digest; the reference parser
+// rejects malformed ones, which would silently skip the digest-aware forms.
+const testDigest = "aaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999"
+
 func TestMatchImages(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -21,7 +25,19 @@ func TestMatchImages(t *testing.T) {
 		{name: "no patterns matches everything", patterns: nil, image: "docker.io/library/nginx:1.25", want: true},
 		{name: "non-empty patterns never match empty image", patterns: []string{"docker.io/library/nginx:*"}, image: "", want: false},
 		{name: "tag wildcard matches", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx:1.25", want: true},
-		{name: "tag wildcard matches digest suffix", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx:latest@sha256:abc", want: true},
+		{name: "tag wildcard matches digest suffix", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx:latest@sha256:" + testDigest, want: true},
+		// A tag-pinned pattern must still match a workload deployed with that tag
+		// pinned to a digest, which is what ImageTagNormalized carries.
+		{name: "exact tag pattern matches tag+digest reference", patterns: []string{"docker.io/library/nginx:1.25"}, image: "docker.io/library/nginx:1.25@sha256:" + testDigest, want: true},
+		{name: "exact tag pattern does not match a different tag pinned to a digest", patterns: []string{"docker.io/library/nginx:1.24"}, image: "docker.io/library/nginx:1.25@sha256:" + testDigest, want: false},
+		// A digest-only deployment has no tag at all, so only the repository form
+		// or an exact digest pin can match it.
+		{name: "repository pattern matches digest-only reference", patterns: []string{"docker.io/library/nginx"}, image: "docker.io/library/nginx@sha256:" + testDigest, want: true},
+		{name: "repository pattern matches any tag", patterns: []string{"docker.io/library/nginx"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "repository pattern does not match another repository", patterns: []string{"docker.io/library/nginx"}, image: "docker.io/library/redis:7", want: false},
+		{name: "exact digest pin matches", patterns: []string{"docker.io/library/nginx@sha256:" + testDigest}, image: "docker.io/library/nginx@sha256:" + testDigest, want: true},
+		{name: "tag wildcard does not match digest-only reference", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx@sha256:" + testDigest, want: false},
+		{name: "registry with port is not split by the repository form", patterns: []string{"my-registry.io:5000/team/app"}, image: "my-registry.io:5000/team/app:v1", want: true},
 		{name: "repo wildcard matches", patterns: []string{"docker.io/*/nginx:*"}, image: "docker.io/library/nginx:1.25", want: true},
 		{name: "name wildcard matches", patterns: []string{"docker.io/library/*:*"}, image: "docker.io/library/nginx:1.25", want: true},
 		{name: "star does not cross slash", patterns: []string{"*/nginx:*"}, image: "docker.io/library/nginx:1.25", want: false},
@@ -58,6 +74,9 @@ func TestMatchResources(t *testing.T) {
 		{name: "apiGroup fails closed when target group unknown", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "apps"}}, target: ExceptionTarget{Kind: "deployment", Name: "nginx"}, want: false},
 		{name: "core group target does not match a group-scoped exception", resources: []sev1beta1.ResourceMatch{{Kind: "Pod", APIGroup: "apps"}}, target: ExceptionTarget{Kind: "pod", Name: "p", APIGroup: strptr("")}, want: false},
 		{name: "core group target matches a groupless exception", resources: []sev1beta1.ResourceMatch{{Kind: "Pod"}}, target: ExceptionTarget{Kind: "pod", Name: "p", APIGroup: strptr("")}, want: true},
+		{name: "fully empty entry constrains nothing and does not match", resources: []sev1beta1.ResourceMatch{{}}, target: target, want: false},
+		{name: "fully empty entry does not widen other entries", resources: []sev1beta1.ResourceMatch{{}, {Kind: "StatefulSet"}}, target: target, want: false},
+		{name: "name-only entry still matches", resources: []sev1beta1.ResourceMatch{{Name: "nginx"}}, target: target, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapters/v1/securityexception_match_test.go
+++ b/adapters/v1/securityexception_match_test.go
@@ -1,0 +1,258 @@
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/kubevuln/core/domain"
+	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMatchImages(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		image    string
+		want     bool
+	}{
+		{name: "no patterns matches everything", patterns: nil, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "non-empty patterns never match empty image", patterns: []string{"docker.io/library/nginx:*"}, image: "", want: false},
+		{name: "tag wildcard matches", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "tag wildcard matches digest suffix", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx:latest@sha256:abc", want: true},
+		{name: "repo wildcard matches", patterns: []string{"docker.io/*/nginx:*"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "name wildcard matches", patterns: []string{"docker.io/library/*:*"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "star does not cross slash", patterns: []string{"*/nginx:*"}, image: "docker.io/library/nginx:1.25", want: false},
+		{name: "exact non-match", patterns: []string{"docker.io/library/redis:6"}, image: "docker.io/library/nginx:1.25", want: false},
+		{name: "exact match", patterns: []string{"docker.io/library/nginx:1.25"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "OR across patterns", patterns: []string{"docker.io/library/redis:*", "docker.io/library/nginx:*"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "malformed pattern is skipped", patterns: []string{"[bad"}, image: "docker.io/library/nginx:1.25", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchImages(tt.patterns, tt.image))
+		})
+	}
+}
+
+func TestMatchResources(t *testing.T) {
+	target := ExceptionTarget{Kind: "deployment", Name: "nginx", APIGroup: "apps"}
+	tests := []struct {
+		name      string
+		resources []sev1beta1.ResourceMatch
+		target    ExceptionTarget
+		want      bool
+	}{
+		{name: "empty matches everything", resources: nil, target: target, want: true},
+		{name: "kind case-insensitive match", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", Name: "nginx"}}, target: target, want: true},
+		{name: "kind-only match ignores name", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment"}}, target: target, want: true},
+		{name: "kind mismatch", resources: []sev1beta1.ResourceMatch{{Kind: "StatefulSet"}}, target: target, want: false},
+		{name: "name mismatch", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", Name: "other"}}, target: target, want: false},
+		{name: "OR across entries", resources: []sev1beta1.ResourceMatch{{Kind: "StatefulSet", Name: "db"}, {Kind: "Deployment", Name: "nginx"}}, target: target, want: true},
+		{name: "apiGroup match", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "apps"}}, target: target, want: true},
+		{name: "apiGroup mismatch", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "batch"}}, target: target, want: false},
+		{name: "apiGroup skipped when target group unknown", resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", APIGroup: "apps"}}, target: ExceptionTarget{Kind: "deployment", Name: "nginx"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchResources(tt.resources, tt.target))
+		})
+	}
+}
+
+func TestLabelSelectorMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector *metav1.LabelSelector
+		labels   map[string]string
+		want     bool
+	}{
+		{name: "nil selector matches everything", selector: nil, labels: map[string]string{"app": "nginx"}, want: true},
+		{name: "empty selector matches everything", selector: &metav1.LabelSelector{}, labels: map[string]string{"app": "nginx"}, want: true},
+		{name: "matchLabels match", selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}, labels: map[string]string{"app": "nginx", "env": "prod"}, want: true},
+		{name: "matchLabels mismatch", selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}, labels: map[string]string{"app": "redis"}, want: false},
+		{name: "matchLabels against nil labels", selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}, labels: nil, want: false},
+		{
+			name: "matchExpressions In match",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod", "staging"}},
+			}},
+			labels: map[string]string{"env": "staging"},
+			want:   true,
+		},
+		{
+			name: "matchExpressions In mismatch",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}},
+			}},
+			labels: map[string]string{"env": "dev"},
+			want:   false,
+		},
+		{
+			name: "invalid selector fails closed",
+			selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: nil}, // In requires values
+			}},
+			labels: map[string]string{"env": "prod"},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, labelSelectorMatches(tt.selector, tt.labels))
+		})
+	}
+}
+
+func TestMatchExceptionTarget(t *testing.T) {
+	target := ExceptionTarget{
+		Namespace:       "production",
+		Kind:            "deployment",
+		Name:            "nginx",
+		Image:           "docker.io/library/nginx:1.25",
+		WorkloadLabels:  map[string]string{"app": "nginx"},
+		NamespaceLabels: map[string]string{"env": "staging"},
+	}
+
+	t.Run("empty match applies to all", func(t *testing.T) {
+		assert.True(t, matchExceptionTarget(sev1beta1.ExceptionMatch{}, target, false))
+		assert.True(t, matchExceptionTarget(sev1beta1.ExceptionMatch{}, target, true))
+	})
+
+	t.Run("images gate the match", func(t *testing.T) {
+		assert.True(t, matchExceptionTarget(sev1beta1.ExceptionMatch{Images: []string{"docker.io/library/nginx:*"}}, target, true))
+		assert.False(t, matchExceptionTarget(sev1beta1.ExceptionMatch{Images: []string{"docker.io/library/redis:*"}}, target, true))
+	})
+
+	t.Run("resources gate the match", func(t *testing.T) {
+		assert.True(t, matchExceptionTarget(sev1beta1.ExceptionMatch{Resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", Name: "nginx"}}}, target, false))
+		assert.False(t, matchExceptionTarget(sev1beta1.ExceptionMatch{Resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", Name: "other"}}}, target, false))
+	})
+
+	t.Run("objectSelector gates the match", func(t *testing.T) {
+		assert.True(t, matchExceptionTarget(sev1beta1.ExceptionMatch{ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}}, target, false))
+		assert.False(t, matchExceptionTarget(sev1beta1.ExceptionMatch{ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "redis"}}}, target, false))
+	})
+
+	t.Run("all specified selectors must match (AND)", func(t *testing.T) {
+		m := sev1beta1.ExceptionMatch{
+			Resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", Name: "nginx"}},
+			Images:    []string{"docker.io/library/redis:*"}, // does not match
+		}
+		assert.False(t, matchExceptionTarget(m, target, true))
+	})
+
+	t.Run("namespaceSelector only applies to cluster-scoped", func(t *testing.T) {
+		m := sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}}
+		// cluster-scoped: namespace labels are env=staging, so selector env=prod does not match
+		assert.False(t, matchExceptionTarget(m, target, true))
+		// namespaced: namespaceSelector is ignored -> matches
+		assert.True(t, matchExceptionTarget(m, target, false))
+	})
+
+	t.Run("namespaceSelector cluster-scoped positive", func(t *testing.T) {
+		m := sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}}}
+		assert.True(t, matchExceptionTarget(m, target, true))
+	})
+}
+
+func TestConvertScopesByMatch(t *testing.T) {
+	cveEntry := []sev1beta1.VulnerabilityException{{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2023-1"}}}
+
+	t.Run("CSE images scope filters by image", func(t *testing.T) {
+		cse := []sev1beta1.ClusterSecurityException{{
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Match:           sev1beta1.ExceptionMatch{Images: []string{"docker.io/library/nginx:*"}},
+				Vulnerabilities: cveEntry,
+			},
+		}}
+		matching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{Image: "docker.io/library/nginx:1.25"})
+		assert.Len(t, matching, 1)
+		notMatching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{Image: "docker.io/library/redis:7"})
+		assert.Empty(t, notMatching)
+	})
+
+	t.Run("SE objectSelector scope filters by workload labels", func(t *testing.T) {
+		se := []sev1beta1.SecurityException{{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "production"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Match:           sev1beta1.ExceptionMatch{ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}},
+				Vulnerabilities: cveEntry,
+			},
+		}}
+		matching := ConvertToVulnerabilityExceptionPolicies(se, nil, ExceptionTarget{Namespace: "production", WorkloadLabels: map[string]string{"app": "nginx"}})
+		assert.Len(t, matching, 1)
+		notMatching := ConvertToVulnerabilityExceptionPolicies(se, nil, ExceptionTarget{Namespace: "production", WorkloadLabels: map[string]string{"app": "redis"}})
+		assert.Empty(t, notMatching)
+	})
+
+	t.Run("CSE namespaceSelector scope filters by namespace labels", func(t *testing.T) {
+		cse := []sev1beta1.ClusterSecurityException{{
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Match:           sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}}},
+				Vulnerabilities: cveEntry,
+			},
+		}}
+		matching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{NamespaceLabels: map[string]string{"env": "staging"}})
+		assert.Len(t, matching, 1)
+		notMatching := ConvertToVulnerabilityExceptionPolicies(nil, cse, ExceptionTarget{NamespaceLabels: map[string]string{"env": "prod"}})
+		assert.Empty(t, notMatching)
+	})
+
+	t.Run("namespaced SE ignores namespaceSelector", func(t *testing.T) {
+		se := []sev1beta1.SecurityException{{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "production"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Match:           sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}},
+				Vulnerabilities: cveEntry,
+			},
+		}}
+		// even though namespace labels don't match, a namespaced SE is applied
+		policies := ConvertToVulnerabilityExceptionPolicies(se, nil, ExceptionTarget{Namespace: "production", NamespaceLabels: map[string]string{"env": "staging"}})
+		assert.Len(t, policies, 1)
+	})
+}
+
+func TestBuildExceptionTarget(t *testing.T) {
+	workload := domain.ScanCommand{
+		Wlid:               "wlid://cluster-c/namespace-production/deployment-nginx",
+		ImageTagNormalized: "docker.io/library/nginx:1.25",
+	}
+
+	t.Run("parses wlid and image, no labels when no selectors", func(t *testing.T) {
+		repo := &mockSecurityExceptionRepo{
+			workloadLabels:  map[string]string{"app": "nginx"},
+			namespaceLabels: map[string]string{"env": "staging"},
+		}
+		se := []sev1beta1.SecurityException{{Spec: sev1beta1.SecurityExceptionSpec{Match: sev1beta1.ExceptionMatch{Resources: []sev1beta1.ResourceMatch{{Kind: "Deployment"}}}}}}
+		target := BuildExceptionTarget(context.Background(), workload, se, nil, repo)
+		assert.Equal(t, "production", target.Namespace)
+		assert.Equal(t, "nginx", target.Name)
+		assert.Equal(t, "docker.io/library/nginx:1.25", target.Image)
+		// no objectSelector/namespaceSelector => labels not resolved
+		assert.Nil(t, target.WorkloadLabels)
+		assert.Nil(t, target.NamespaceLabels)
+	})
+
+	t.Run("resolves workload labels when objectSelector present", func(t *testing.T) {
+		repo := &mockSecurityExceptionRepo{workloadLabels: map[string]string{"app": "nginx"}}
+		se := []sev1beta1.SecurityException{{Spec: sev1beta1.SecurityExceptionSpec{Match: sev1beta1.ExceptionMatch{ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}}}}}}
+		target := BuildExceptionTarget(context.Background(), workload, se, nil, repo)
+		assert.Equal(t, map[string]string{"app": "nginx"}, target.WorkloadLabels)
+	})
+
+	t.Run("resolves namespace labels when CSE namespaceSelector present", func(t *testing.T) {
+		repo := &mockSecurityExceptionRepo{namespaceLabels: map[string]string{"env": "staging"}}
+		cse := []sev1beta1.ClusterSecurityException{{Spec: sev1beta1.SecurityExceptionSpec{Match: sev1beta1.ExceptionMatch{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "staging"}}}}}}
+		target := BuildExceptionTarget(context.Background(), workload, nil, cse, repo)
+		assert.Equal(t, map[string]string{"env": "staging"}, target.NamespaceLabels)
+		assert.Nil(t, target.WorkloadLabels)
+	})
+
+	t.Run("nil repo yields no labels", func(t *testing.T) {
+		target := BuildExceptionTarget(context.Background(), workload, nil, nil, nil)
+		assert.Equal(t, "docker.io/library/nginx:1.25", target.Image)
+		assert.Nil(t, target.WorkloadLabels)
+	})
+}

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -39,7 +39,7 @@ func TestConvertVulnerabilityExceptions(t *testing.T) {
 		},
 	}
 
-	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, clusterExceptions)
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, clusterExceptions, ExceptionTarget{})
 
 	assert.Len(t, policies, 2)
 
@@ -96,7 +96,7 @@ func TestConvertExpiredOnFix(t *testing.T) {
 				},
 			}
 
-			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil)
+			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 			assert.Len(t, policies, 1)
 
 			if tt.wantNil {
@@ -145,7 +145,7 @@ func TestConvertSkipsExpired(t *testing.T) {
 		},
 	}
 
-	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, clusterExceptions)
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, clusterExceptions, ExceptionTarget{})
 
 	assert.Len(t, policies, 1)
 	assert.Equal(t, "CVE-VALID", policies[0].VulnerabilityPolicies[0].Name)
@@ -169,7 +169,9 @@ func TestConvertMatchResources(t *testing.T) {
 		},
 	}
 
-	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil)
+	// target matches the first resource entry (Deployment/my-app)
+	target := ExceptionTarget{Namespace: "production", Kind: "Deployment", Name: "my-app"}
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, target)
 
 	assert.Len(t, policies, 1)
 	assert.Len(t, policies[0].Designatores, 2)
@@ -253,7 +255,7 @@ func TestConvertSkipsEmptyAndWhitespaceIDs(t *testing.T) {
 		},
 	}
 
-	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil)
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 
 	assert.Len(t, policies, 1)
 	assert.Equal(t, "CVE-2024-1234", policies[0].VulnerabilityPolicies[0].Name)

--- a/core/ports/repositories.go
+++ b/core/ports/repositories.go
@@ -33,10 +33,12 @@ type SBOMRepository interface {
 type SecurityExceptionRepository interface {
 	GetSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error)
 	// GetWorkloadLabels returns the labels of the given workload, used to
-	// evaluate match.objectSelector. Returns nil when the workload cannot be
-	// found or its group/version cannot be resolved.
+	// evaluate match.objectSelector. It returns an error when the workload cannot
+	// be found or resolved, so the caller fails closed — a negative selector must
+	// not match an unresolved workload's empty label set.
 	GetWorkloadLabels(ctx context.Context, namespace, kind, name string) (map[string]string, error)
 	// GetNamespaceLabels returns the labels of the given namespace, used to
-	// evaluate match.namespaceSelector. Returns nil when the namespace is not found.
+	// evaluate match.namespaceSelector. It returns an error when the namespace
+	// cannot be found or resolved (see GetWorkloadLabels).
 	GetNamespaceLabels(ctx context.Context, name string) (map[string]string, error)
 }

--- a/core/ports/repositories.go
+++ b/core/ports/repositories.go
@@ -28,7 +28,15 @@ type SBOMRepository interface {
 	StoreSBOM(ctx context.Context, sbom domain.SBOM, isFiltered bool) error
 }
 
-// SecurityExceptionRepository reads SecurityException CRDs from the cluster
+// SecurityExceptionRepository reads SecurityException CRDs from the cluster and
+// resolves the labels needed to evaluate objectSelector/namespaceSelector.
 type SecurityExceptionRepository interface {
 	GetSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error)
+	// GetWorkloadLabels returns the labels of the given workload, used to
+	// evaluate match.objectSelector. Returns nil when the workload cannot be
+	// found or its group/version cannot be resolved.
+	GetWorkloadLabels(ctx context.Context, namespace, kind, name string) (map[string]string, error)
+	// GetNamespaceLabels returns the labels of the given namespace, used to
+	// evaluate match.namespaceSelector. Returns nil when the namespace is not found.
+	GetNamespaceLabels(ctx context.Context, name string) (map[string]string, error)
 }

--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -75,6 +75,24 @@ This means patterns should always be written against the full form:
 - `my-registry.io/team/*:*` — matches any image under `my-registry.io/team/` (one level deep)
 - `docker.io/library/nginx:1.25` — matches exact image reference
 
+##### Digests
+
+Normalization preserves any digest the workload was deployed with, so a digest-pinned deployment (common with GitOps tooling) produces a reference like `docker.io/library/nginx:1.25@sha256:…` or, when pinned without a tag, `docker.io/library/nginx@sha256:…`.
+
+Since `path.Match` matches the whole string, each pattern is tried against every equivalent form of the reference — as deployed, without the digest, and the bare repository name:
+
+| Pattern | `nginx:1.25` | `nginx:1.25@sha256:…` | `nginx@sha256:…` |
+|---------|--------------|------------------------|-------------------|
+| `docker.io/library/nginx:1.25` | ✅ | ✅ | ❌ (no tag) |
+| `docker.io/library/nginx:*` | ✅ | ✅ | ❌ (no tag) |
+| `docker.io/library/nginx` | ✅ | ✅ | ✅ |
+| `docker.io/library/nginx@sha256:…` | ❌ | ❌ | ✅ (exact pin) |
+
+Guidance:
+- A tag pattern (`nginx:1.25`, `nginx:*`) matches that tag whether or not it is pinned to a digest, but never matches an image deployed **without** a tag.
+- To cover a repository regardless of how it is referenced, write the **bare repository** (`docker.io/library/nginx`).
+- To except one exact build, pin the digest (`docker.io/library/nginx@sha256:…`).
+
 ### Full YAML Examples
 
 #### Namespaced — target specific workloads by label and name
@@ -314,6 +332,8 @@ SecurityException CRDs suppress security findings — access should be restricte
 | Operator | `get`, `list`, `watch` | `get`, `list`, `watch` |
 
 Scanner components also need `create` and `patch` on `events` (core API group) to emit Kubernetes Events bound to SecurityException resources.
+
+Scanner components additionally need `get` on `namespaces` and on every workload kind an exception may target (`pods`, `replicationcontrollers`, `apps/deployments`, `apps/statefulsets`, `apps/daemonsets`, `apps/replicasets`, `batch/jobs`, `batch/cronjobs`) in order to read the labels that `match.objectSelector` and `match.namespaceSelector` are evaluated against. These lookups fail closed: if the scanner cannot read a workload's or namespace's labels, the exception does **not** apply and the finding is reported. A selector-based exception that targets a kind outside this list will therefore never apply until the scanner is granted `get` on that kind.
 
 Organizations should create dedicated `ClusterRole`/`Role` resources for SecurityException management rather than granting access through broad wildcard rules.
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -113,6 +113,37 @@ func NormalizeReference(ref string) string {
 	return reference.TagNameOnly(n).String()
 }
 
+// ReferenceMatchForms returns the equivalent forms of an image reference that a
+// user-written pattern may reasonably be matched against, most specific first:
+// the reference itself, the same reference without its digest, and the bare
+// repository name. Duplicates are omitted, so a plain "repo:tag" yields only
+// two forms and an unparsable reference only itself.
+//
+// A normalized reference keeps any digest it was deployed with
+// ("docker.io/library/nginx:1.25@sha256:..."), so matching against the
+// reference alone would never match a pattern written against the tag.
+func ReferenceMatchForms(ref string) []string {
+	forms := []string{ref}
+	n, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return forms
+	}
+	name := n.Name()
+	if tagged, ok := n.(reference.NamedTagged); ok {
+		forms = appendUnique(forms, name+":"+tagged.Tag())
+	}
+	return appendUnique(forms, name)
+}
+
+func appendUnique(forms []string, form string) []string {
+	for _, f := range forms {
+		if f == form {
+			return forms
+		}
+	}
+	return append(forms, form)
+}
+
 func RemoveContainerFromSlug(slug, container string) string {
 	i := strings.LastIndex(slug, container)
 	if i == -1 {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -183,3 +183,48 @@ func TestRemoveContainerFromSlug(t *testing.T) {
 		})
 	}
 }
+
+func TestReferenceMatchForms(t *testing.T) {
+	const digest = "sha256:aaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999"
+	tests := []struct {
+		name string
+		ref  string
+		want []string
+	}{
+		{
+			name: "tag only",
+			ref:  "docker.io/library/nginx:1.25",
+			want: []string{"docker.io/library/nginx:1.25", "docker.io/library/nginx"},
+		},
+		{
+			name: "tag and digest",
+			ref:  "docker.io/library/nginx:1.25@" + digest,
+			want: []string{"docker.io/library/nginx:1.25@" + digest, "docker.io/library/nginx:1.25", "docker.io/library/nginx"},
+		},
+		{
+			name: "digest only has no tag form",
+			ref:  "docker.io/library/nginx@" + digest,
+			want: []string{"docker.io/library/nginx@" + digest, "docker.io/library/nginx"},
+		},
+		{
+			name: "registry with port keeps its port",
+			ref:  "my-registry.io:5000/team/app:v1",
+			want: []string{"my-registry.io:5000/team/app:v1", "my-registry.io:5000/team/app"},
+		},
+		{
+			name: "unparsable reference yields only itself",
+			ref:  "not a reference",
+			want: []string{"not a reference"},
+		},
+		{
+			name: "empty reference yields only itself",
+			ref:  "",
+			want: []string{""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ReferenceMatchForms(tt.ref))
+		})
+	}
+}

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -57,6 +57,11 @@ var (
 		Version:  "v1beta1",
 		Resource: "clustersecurityexceptions",
 	}
+	namespaceGVR = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}
 )
 
 var _ ports.ContainerProfileRepository = (*APIServerStore)(nil)
@@ -147,6 +152,50 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 	}
 
 	return exceptions, clusterExceptions, nil
+}
+
+// GetWorkloadLabels resolves the labels of a workload so that a
+// SecurityException's match.objectSelector can be evaluated. The workload's
+// GroupVersionResource is derived from its kind; if it cannot be resolved or the
+// workload is not found, nil labels are returned (the selector then matches
+// nothing, i.e. the exception is not applied — the safe default for a
+// suppression feature).
+func (a *APIServerStore) GetWorkloadLabels(ctx context.Context, namespace, kind, name string) (map[string]string, error) {
+	if namespace == "" || kind == "" || name == "" {
+		return nil, nil
+	}
+	gvr, err := k8sinterface.GetGroupVersionResource(kind)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve GroupVersionResource for kind %q: %w", kind, err)
+	}
+	getCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	obj, err := a.DynamicClient.Resource(gvr).Namespace(namespace).Get(getCtx, name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return obj.GetLabels(), nil
+}
+
+// GetNamespaceLabels resolves the labels of a namespace so that a
+// ClusterSecurityException's match.namespaceSelector can be evaluated.
+func (a *APIServerStore) GetNamespaceLabels(ctx context.Context, name string) (map[string]string, error) {
+	if name == "" {
+		return nil, nil
+	}
+	getCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	obj, err := a.DynamicClient.Resource(namespaceGVR).Get(getCtx, name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return obj.GetLabels(), nil
 }
 
 func (a *APIServerStore) GetContainerProfile(ctx context.Context, namespace string, name string) (v1beta1.ContainerProfile, error) {

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -172,9 +172,9 @@ func (a *APIServerStore) GetWorkloadLabels(ctx context.Context, namespace, kind,
 	defer cancel()
 	obj, err := a.DynamicClient.Resource(gvr).Namespace(namespace).Get(getCtx, name, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
+		// Propagate NotFound as an error (rather than nil labels) so the caller
+		// fails closed: a negative objectSelector must not match a workload that
+		// could not be resolved.
 		return nil, err
 	}
 	return obj.GetLabels(), nil
@@ -190,9 +190,8 @@ func (a *APIServerStore) GetNamespaceLabels(ctx context.Context, name string) (m
 	defer cancel()
 	obj, err := a.DynamicClient.Resource(namespaceGVR).Get(getCtx, name, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
+		// Propagate NotFound as an error so the caller fails closed (see
+		// GetWorkloadLabels).
 		return nil, err
 	}
 	return obj.GetLabels(), nil

--- a/repositories/noop_security_exception.go
+++ b/repositories/noop_security_exception.go
@@ -2,9 +2,14 @@ package repositories
 
 import (
 	"context"
+	"errors"
 
 	"github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 )
+
+// errNoClusterConnection is returned by the label resolvers so that a
+// selector-based exception fails closed when no cluster is available.
+var errNoClusterConnection = errors.New("security exception label resolution requires a cluster connection")
 
 // NoOpSecurityExceptionRepository returns empty results for environments
 // where SecurityException CRDs are not available (e.g., local/test mode).
@@ -15,9 +20,9 @@ func (n *NoOpSecurityExceptionRepository) GetSecurityExceptions(_ context.Contex
 }
 
 func (n *NoOpSecurityExceptionRepository) GetWorkloadLabels(_ context.Context, _, _, _ string) (map[string]string, error) {
-	return nil, nil
+	return nil, errNoClusterConnection
 }
 
 func (n *NoOpSecurityExceptionRepository) GetNamespaceLabels(_ context.Context, _ string) (map[string]string, error) {
-	return nil, nil
+	return nil, errNoClusterConnection
 }

--- a/repositories/noop_security_exception.go
+++ b/repositories/noop_security_exception.go
@@ -13,3 +13,11 @@ type NoOpSecurityExceptionRepository struct{}
 func (n *NoOpSecurityExceptionRepository) GetSecurityExceptions(_ context.Context, _ string) ([]v1beta1.SecurityException, []v1beta1.ClusterSecurityException, error) {
 	return nil, nil, nil
 }
+
+func (n *NoOpSecurityExceptionRepository) GetWorkloadLabels(_ context.Context, _, _, _ string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (n *NoOpSecurityExceptionRepository) GetNamespaceLabels(_ context.Context, _ string) (map[string]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION

**Repo:** `kubescape/kubevuln`
**Branch:** `yugal07:lfx-securityexception-vuln-match` → `kubescape/kubevuln:main`
**Parent issue:** kubescape/kubescape#1982 (SecurityException CRD)
**Design doc:** `kubevuln/docs/security-exception-design.md`

## Summary

The vulnerability-scanning path only scoped `SecurityException` / `ClusterSecurityException`
CRDs by **namespace**. The `spec.match` selectors that the design doc defines —
`images`, `resources`, `objectSelector`, `namespaceSelector` — were never evaluated
when applying vulnerability exceptions, so an exception applied far more broadly than
declared (fail-open). This PR makes the vulnerability path honor all four selectors.

## Problem

In `adapters/v1/securityexception.go`, `ConvertToVulnerabilityExceptionPolicies` converted
every non-expired exception in the workload's namespace into an ignore policy keyed by CVE
ID, and `getCVEExceptionMatchCVENameFromList` (`adapters/v1/backend_utils.go`) matched
purely by CVE ID. Consequences:

- `match.images` was **never read** — a `ClusterSecurityException` scoped to
  `docker.io/library/nginx:*` suppressed its CVEs on **every** image cluster-wide.
- `match.objectSelector` / `match.namespaceSelector` were **never read** — a CSE scoped to
  `namespaceSelector: {env: staging}` suppressed its CVEs in production too.
- `match.resources` was converted into `PortalDesignator`s that the matcher then ignored,
  so kind/name scoping was not enforced either.
- Zero test coverage for any of these fields.

This is the same scoping the posture path already enforces
(kubescape/kubescape#2322 `namespaceSelector`, kubescape/kubescape#2480
`objectSelector.matchExpressions`); this PR brings the vulnerability path to parity.

## Solution

A new pure matcher decides, per scanned workload, whether an exception's `spec.match`
applies — then only matching exceptions are converted to ignore policies.

- **`adapters/v1/securityexception_match.go` (new)**
  - `ExceptionTarget` — the workload being scanned (namespace, kind, name, apiGroup,
    normalized image, and lazily-resolved workload/namespace labels).
  - `matchExceptionTarget(match, target, clusterScoped)` — AND across selector types,
    OR within `resources`/`images`; omitted selector matches everything.
    - `images`: `path.Match` glob against the fully-qualified `ImageTagNormalized`
      (`*` does not cross `/`, per the design doc).
    - `resources`: case-insensitive kind, optional name, optional apiGroup
      (enforced only when both sides are known).
    - `objectSelector`: standard label selector over the workload's labels.
    - `namespaceSelector`: standard label selector over the namespace's labels —
      **only** for `ClusterSecurityException`; ignored on a namespaced `SecurityException`
      (already scoped to its own namespace).
    - **Fail-closed**: an invalid selector, a label-lookup error, or a missing workload
      means the exception does **not** apply — a malformed exception never silently
      suppresses a finding.
  - `BuildExceptionTarget(...)` — assembles the target; workload/namespace labels are
    resolved **lazily**, only when an exception actually uses
    `objectSelector`/`namespaceSelector`, so the common path adds no extra API calls.
- **`adapters/v1/securityexception.go`** — `ConvertToVulnerabilityExceptionPolicies` now
  takes an `ExceptionTarget` and skips exceptions whose match does not apply.
- **`adapters/v1/backend.go`, `adapters/mockplatform.go`** — build the target and pass it in.
- **`core/ports/repositories.go`** — `SecurityExceptionRepository` gains
  `GetWorkloadLabels` and `GetNamespaceLabels`.
- **`repositories/apiserver.go`** — real label lookups via the dynamic client;
  the workload's `GroupVersionResource` is derived with
  `k8sinterface.GetGroupVersionResource` (same helper the store already uses).
  `repositories/noop_security_exception.go` returns nil.

Image matching relies on `ImageTagNormalized` being fully qualified, which
`tools.NormalizeReference` guarantees (e.g. `nginx` → `docker.io/library/nginx:latest`),
matching the design doc's "fully qualified, normalized image reference" contract.

## Testing

- **Unit** (`adapters/v1/securityexception_match_test.go`): glob matching (incl.
  `*`-does-not-cross-`/`, digest suffixes, malformed patterns), resource kind/name/apiGroup,
  label selectors (`matchLabels` + `matchExpressions`, invalid → fail-closed),
  AND/OR combination, cluster-vs-namespaced `namespaceSelector`, per-selector conversion
  scoping, and lazy label resolution in `BuildExceptionTarget`.
- **Integration** (`adapters/v1/backend_test.go`): a redis-image-scoped
  `ClusterSecurityException` is correctly **not** applied to an nginx workload
  (the exact fail-open regression).
- **Live** (kind cluster, `kubescape.io/v1beta1`): `GetWorkloadLabels` and
  `GetNamespaceLabels` resolve real labels; a missing workload returns empty/no-error;
  `GetGroupVersionResource` resolves `deployment → apps/v1/deployments` offline.
- `go build ./...`, `go vet` (changed non-test packages), and the SecurityException test
  suites pass. Existing exception behavior (expiry, `expiredOnFix`, CVE case-insensitive
  matching, cloud+CRD merge/precedence) is unchanged.

## Related

- **Parent:** kubescape/kubescape#1982 — SecurityException CRD
- **kubevuln (prior, this builds on):** #342 (integrate CRDs into vuln scanning),
  #349 (keepLocal mode), #358 (riskAcceptance flag)
- **kubescape posture parity:** #2322 (`namespaceSelector`), #2480 (`objectSelector`),
  #2023 (expiry filter), #2291 (exception match events)
- **helm-charts:** #817 (CRDs/RBAC), #859 (CEL validation), #875 (scanner RBAC)
- **headlamp-plugin:** #86 (SecurityException UI) · **operator:** #392 (watch + rescan)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security exceptions are now applied only when their image, resource, workload labels, and namespace selectors match the scanned workload.
  * Cluster-scoped exceptions no longer affect unrelated workloads.
  * Invalid or missing selector information fails safely without applying unintended exceptions.

* **New Features**
  * Added support for matching exceptions using workload and namespace labels.
  * Workload and namespace labels are resolved automatically when required for exception evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->