### PR TITLE
fix: revalidate SECURITY-INSIGHTS.yml and gate it in CI

### DIFF
--- a/.github/workflows/security-insights.yaml
+++ b/.github/workflows/security-insights.yaml
@@ -13,7 +13,11 @@ on:
       - 'SECURITY-INSIGHTS.yml'
       - '.github/workflows/security-insights.yaml'
   schedule:
-    - cron: '0 6 * * 1'
+    # Monthly, not weekly: the pull_request trigger above only fires when someone
+    # edits the manifest, and it went untouched from 2023 until this PR -- so a
+    # schedule is the only thing that ever runs the expiry check. Against the
+    # 60-day warning window below, monthly still fires twice before expiry.
+    - cron: '0 6 1 * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/security-insights.yaml
+++ b/.github/workflows/security-insights.yaml
@@ -1,0 +1,103 @@
+name: security-insights
+
+# SECURITY-INSIGHTS.yml is a hand-maintained manifest with a self-declared
+# expiry. Nothing consumes it in-tree, so it previously rotted unnoticed for
+# ~2 years (expired 2024-10-12, invalid `stage` key, emeritus maintainers).
+# This workflow makes both failure modes loud: schema drift fails on the PR
+# that introduces it, and impending expiry fails on a weekly schedule while
+# there is still time to review.
+
+on:
+  pull_request:
+    paths:
+      - 'SECURITY-INSIGHTS.yml'
+      - '.github/workflows/security-insights.yaml'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Validate against the OpenSSF Security Insights schema
+        run: |
+          # Schema tag is pinned to header.schema-version. Bump both together.
+          SCHEMA_VERSION=$(yq -r '.header.schema-version' SECURITY-INSIGHTS.yml)
+          echo "Validating against Security Insights v${SCHEMA_VERSION}"
+          curl -sSfL -o /tmp/si-schema.yaml \
+            "https://raw.githubusercontent.com/ossf/security-insights/v${SCHEMA_VERSION}/security-insights-schema.yaml"
+          # The [format] extra is required, not optional: the schema constrains 21
+          # fields with `format: iri` plus `date`, `date-time` and `idn-email`, and
+          # jsonschema silently skips every one of those checks unless the extra is
+          # installed. Without it FORMAT_CHECKER below is a no-op.
+          pip install --quiet pyyaml 'jsonschema[format]'
+          # NB: check-jsonschema cannot be used here. It metaschema-validates the
+          # schema file first, and the upstream v1.0.0 schema's `pgp-key` pattern
+          # is not a valid `format: regex`, so it errors out before ever looking
+          # at the manifest. Draft7Validator validates the instance directly.
+          python3 - <<'EOF'
+          import sys, yaml
+          from jsonschema import Draft7Validator
+
+          schema = yaml.safe_load(open("/tmp/si-schema.yaml"))
+          doc = yaml.safe_load(open("SECURITY-INSIGHTS.yml"))
+          validator = Draft7Validator(schema, format_checker=Draft7Validator.FORMAT_CHECKER)
+          errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+          if not errors:
+              print("SECURITY-INSIGHTS.yml is valid")
+              sys.exit(0)
+          for e in errors:
+              loc = "/".join(str(p) for p in e.path) or "(root)"
+              print(f"::error file=SECURITY-INSIGHTS.yml::{loc}: {e.message}")
+          sys.exit(1)
+          EOF
+
+      - name: Fail if the manifest is expired or expires within 60 days
+        run: |
+          expiry=$(yq -r '.header.expiration-date' SECURITY-INSIGHTS.yml)
+          expiry_epoch=$(date -u -d "${expiry}" +%s)
+          now_epoch=$(date -u +%s)
+          days=$(( (expiry_epoch - now_epoch) / 86400 ))
+          echo "expiration-date: ${expiry} (${days} days remaining)"
+          if [ "${days}" -lt 0 ]; then
+            echo "::error file=SECURITY-INSIGHTS.yml::Manifest expired ${days#-} days ago. Re-review it against https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md and refresh header.last-reviewed / header.expiration-date."
+            exit 1
+          fi
+          if [ "${days}" -lt 60 ]; then
+            echo "::error file=SECURITY-INSIGHTS.yml::Manifest expires in ${days} days. Re-review it against https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md and refresh header.last-reviewed / header.expiration-date."
+            exit 1
+          fi
+
+      - name: Report core-maintainer drift from project-governance
+        # Advisory only: this parses a Markdown table in another repo, which is
+        # too brittle to gate a merge on. It annotates the run so the weekly
+        # schedule surfaces drift instead of waiting for the expiry to lapse.
+        continue-on-error: true
+        run: |
+          curl -sSfL -o /tmp/MAINTAINERS.md \
+            https://raw.githubusercontent.com/kubescape/project-governance/main/MAINTAINERS.md
+          # Core maintainers are the rows above the "commiters" heading.
+          sed -n '1,/commiters/p' /tmp/MAINTAINERS.md \
+            | grep -oE '\[@[A-Za-z0-9_-]+\]' | tr -d '[]@' | sort -fu > /tmp/governance.txt
+          yq -r '.project-lifecycle.core-maintainers[]' SECURITY-INSIGHTS.yml \
+            | sed 's/^github://' | sort -fu > /tmp/manifest.txt
+          if ! diff -iu /tmp/governance.txt /tmp/manifest.txt > /tmp/drift.txt; then
+            echo "::warning file=SECURITY-INSIGHTS.yml::core-maintainers differs from project-governance/MAINTAINERS.md"
+            cat /tmp/drift.txt
+          else
+            echo "core-maintainers matches project-governance/MAINTAINERS.md"
+          fi

--- a/.github/workflows/security-insights.yaml
+++ b/.github/workflows/security-insights.yaml
@@ -4,7 +4,7 @@ name: security-insights
 # expiry. Nothing consumes it in-tree, so it previously rotted unnoticed for
 # ~2 years (expired 2024-10-12, invalid `stage` key, emeritus maintainers).
 # This workflow makes both failure modes loud: schema drift fails on the PR
-# that introduces it, and impending expiry fails on a weekly schedule while
+# that introduces it, and impending expiry fails on a monthly schedule while
 # there is still time to review.
 
 on:
@@ -26,6 +26,10 @@ concurrency:
 
 permissions:
   contents: read
+  # Needed by the tracking-issue step below. Scheduled-run failure notifications
+  # go only to whoever last committed to this file, who may not be a maintainer,
+  # so a red run alone would leave the manifest rotting exactly as before.
+  issues: write
 
 jobs:
   validate:
@@ -42,7 +46,7 @@ jobs:
           # Schema tag is pinned to header.schema-version. Bump both together.
           SCHEMA_VERSION=$(yq -r '.header.schema-version' SECURITY-INSIGHTS.yml)
           echo "Validating against Security Insights v${SCHEMA_VERSION}"
-          curl -sSfL -o /tmp/si-schema.yaml \
+          curl -sSfL --connect-timeout 10 --max-time 60 -o /tmp/si-schema.yaml \
             "https://raw.githubusercontent.com/ossf/security-insights/v${SCHEMA_VERSION}/security-insights-schema.yaml"
           # The [format] extra is required, not optional: the schema constrains 21
           # fields with `format: iri` plus `date`, `date-time` and `idn-email`, and
@@ -71,32 +75,80 @@ jobs:
           EOF
 
       - name: Fail if the manifest is expired or expires within 60 days
+        id: expiry
         run: |
           expiry=$(yq -r '.header.expiration-date' SECURITY-INSIGHTS.yml)
           expiry_epoch=$(date -u -d "${expiry}" +%s)
           now_epoch=$(date -u +%s)
           days=$(( (expiry_epoch - now_epoch) / 86400 ))
           echo "expiration-date: ${expiry} (${days} days remaining)"
-          if [ "${days}" -lt 0 ]; then
-            echo "::error file=SECURITY-INSIGHTS.yml::Manifest expired ${days#-} days ago. Re-review it against https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md and refresh header.last-reviewed / header.expiration-date."
-            exit 1
+          # Classify on epoch seconds, not the truncated day count: a manifest that
+          # expired a few hours ago yields days=0, which would fall through to the
+          # "expires in 0 days" branch and report an already-invalid file as merely
+          # expiring soon.
+          if [ "${expiry_epoch}" -le "${now_epoch}" ]; then
+            message="SECURITY-INSIGHTS.yml EXPIRED on ${expiry}."
+          elif [ "${days}" -lt 60 ]; then
+            message="SECURITY-INSIGHTS.yml expires on ${expiry} (in ${days} days)."
+          else
+            exit 0
           fi
-          if [ "${days}" -lt 60 ]; then
-            echo "::error file=SECURITY-INSIGHTS.yml::Manifest expires in ${days} days. Re-review it against https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md and refresh header.last-reviewed / header.expiration-date."
-            exit 1
+          message="${message} Re-review it against https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md and refresh header.last-reviewed / header.expiration-date."
+          echo "message=${message}" >> "$GITHUB_OUTPUT"
+          echo "::error file=SECURITY-INSIGHTS.yml::${message}"
+          exit 1
+
+      - name: Open or refresh the expiry tracking issue
+        # Only on scheduled runs: on a pull_request the red check is already in
+        # front of someone who can act on it. On a schedule nothing else routes
+        # this to a maintainer, so raise an issue they will actually see.
+        if: ${{ always() && github.event_name == 'schedule' && steps.expiry.outcome == 'failure' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MESSAGE: ${{ steps.expiry.outputs.message }}
+          TITLE: 'SECURITY-INSIGHTS.yml needs review'
+        run: |
+          body="${MESSAGE}
+
+          Raised automatically by \`${GITHUB_WORKFLOW}\`: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # Match on title rather than a label, so the step does not depend on a
+          # label existing in the repo.
+          existing=$(gh issue list --state open --search "in:title \"${TITLE}\"" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            echo "refreshing existing issue #${existing}"
+            gh issue comment "${existing}" --body "${body}"
+          else
+            echo "opening a new tracking issue"
+            gh issue create --title "${TITLE}" --body "${body}"
           fi
 
       - name: Report core-maintainer drift from project-governance
         # Advisory only: this parses a Markdown table in another repo, which is
-        # too brittle to gate a merge on. It annotates the run so the weekly
+        # too brittle to gate a merge on. It annotates the run so the monthly
         # schedule surfaces drift instead of waiting for the expiry to lapse.
         continue-on-error: true
         run: |
-          curl -sSfL -o /tmp/MAINTAINERS.md \
+          curl -sSfL --connect-timeout 10 --max-time 60 -o /tmp/MAINTAINERS.md \
             https://raw.githubusercontent.com/kubescape/project-governance/main/MAINTAINERS.md
-          # Core maintainers are the rows above the "commiters" heading.
-          sed -n '1,/commiters/p' /tmp/MAINTAINERS.md \
-            | grep -oE '\[@[A-Za-z0-9_-]+\]' | tr -d '[]@' | sort -fu > /tmp/governance.txt
+          # Core maintainers are the rows above the committers heading. The range
+          # end is anchored to that heading and tolerates both spellings, so
+          # correcting the current upstream typo ("commiters") does not silently
+          # widen the range to the whole file and fold committers and emeritus
+          # maintainers into the comparison.
+          heading='^The following table lists the Kubescape project committ?ers'
+          if ! grep -qE "${heading}" /tmp/MAINTAINERS.md; then
+            echo "::warning file=SECURITY-INSIGHTS.yml::could not locate the committers heading in project-governance/MAINTAINERS.md; core-maintainer drift not checked"
+            exit 0
+          fi
+          # `|| true` keeps a no-match from tripping pipefail before the emptiness
+          # check below can distinguish "format changed" from "no drift".
+          sed -nE "1,/${heading}/p" /tmp/MAINTAINERS.md \
+            | grep -oE '\[@[A-Za-z0-9_-]+\]' | tr -d '[]@' | sort -fu > /tmp/governance.txt || true
+          if [ ! -s /tmp/governance.txt ]; then
+            echo "::warning file=SECURITY-INSIGHTS.yml::parsed no maintainers from project-governance/MAINTAINERS.md (link format may have changed); core-maintainer drift not checked"
+            exit 0
+          fi
           yq -r '.project-lifecycle.core-maintainers[]' SECURITY-INSIGHTS.yml \
             | sed 's/^github://' | sort -fu > /tmp/manifest.txt
           if ! diff -iu /tmp/governance.txt /tmp/manifest.txt > /tmp/drift.txt; then

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -4,7 +4,6 @@ header:
   last-reviewed: '2026-07-29'
   expiration-date: '2027-07-29T00:00:00.000Z'
   project-url: https://github.com/kubescape/kubevuln/
-  project-release: v0.3.159
   changelog: https://github.com/kubescape/kubevuln/releases
   license: https://github.com/kubescape/kubevuln/blob/main/LICENSE
 project-lifecycle:
@@ -30,9 +29,7 @@ contribution-policy:
     path:
     - /
     comment: |
-      Dependabot opens dependency-bump PRs against main. Scanner dependencies
-      (github.com/anchore/syft, github.com/anchore/grype) are excluded from the
-      automated flow and are upgraded manually by maintainers.
+      Dependabot opens dependency-bump PRs against main.
   contributing-policy: https://github.com/kubescape/project-governance/blob/main/CONTRIBUTING.md
   code-of-conduct: https://github.com/kubescape/project-governance/blob/main/CODE_OF_CONDUCT.md
 documentation:
@@ -62,8 +59,9 @@ security-testing:
     ci: true
     before-release: false
   comment: |
-    CodeQL analysis runs on every pull request through the shared
-    kubescape/workflows go-basic-tests workflow.
+    CodeQL analysis runs on pull requests through the shared kubescape/workflows
+    go-basic-tests workflow (advisory; does not block merge), except for paths
+    excluded by that workflow's path filters.
 - tool-type: sca
   tool-name: Snyk
   tool-version: latest
@@ -72,8 +70,10 @@ security-testing:
     ci: true
     before-release: false
   comment: |
-    Snyk runs on every pull request through the shared kubescape/workflows
-    go-basic-tests workflow when the SNYK_TOKEN secret is configured.
+    Snyk runs on same-repository pull requests through the shared
+    kubescape/workflows go-basic-tests workflow (advisory; does not block merge).
+    Fork pull requests have no access to the SNYK_TOKEN secret, so the step is
+    skipped there.
 security-contacts:
 - type: email
   value: cncf-kubescape-maintainers@lists.cncf.io

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,30 +1,46 @@
 header:
   schema-version: 1.0.0
-  last-updated: '2023-10-12'
-  last-reviewed: '2023-10-12'
-  expiration-date: '2024-10-12T01:00:00.000Z'
+  last-updated: '2026-07-29'
+  last-reviewed: '2026-07-29'
+  expiration-date: '2027-07-29T00:00:00.000Z'
   project-url: https://github.com/kubescape/kubevuln/
-  project-release: 1.0.0
+  project-release: v0.3.159
+  changelog: https://github.com/kubescape/kubevuln/releases
+  license: https://github.com/kubescape/kubevuln/blob/main/LICENSE
 project-lifecycle:
-  stage: active
+  # Source of truth for this list:
+  # https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md
+  # Emeritus maintainers are tracked there and must not be listed here.
+  status: active
   bug-fixes-only: false
   core-maintainers:
   - github:amirmalka
-  - github:amitschendel
-  - github:bezbran
-  - github:craigbox
-  - github:dwertent
+  - github:Bezbran
   - github:matthyx
   - github:rotemamsa
   - github:slashben
 contribution-policy:
   accepts-pull-requests: true
-  accepts-automated-pull-requests: false
-  code-of-conduct: https://github.com/kubescape/kubescape/blob/master/CODE_OF_CONDUCT.md
+  # Dependabot pull requests are routinely reviewed and merged (e.g. #384-#386),
+  # so the policy is declared explicitly rather than left as a bare boolean.
+  accepts-automated-pull-requests: true
+  automated-tools-list:
+  - automated-tool: dependabot
+    action: allowed
+    path:
+    - /
+    comment: |
+      Dependabot opens dependency-bump PRs against main. Scanner dependencies
+      (github.com/anchore/syft, github.com/anchore/grype) are excluded from the
+      automated flow and are upgraded manually by maintainers.
+  contributing-policy: https://github.com/kubescape/project-governance/blob/main/CONTRIBUTING.md
+  code-of-conduct: https://github.com/kubescape/project-governance/blob/main/CODE_OF_CONDUCT.md
 documentation:
-- https://github.com/kubescape/kubescape/tree/master/docs
+- https://github.com/kubescape/kubevuln/tree/main/docs
+- https://kubescape.io/docs/
 distribution-points:
 - https://github.com/kubescape/kubevuln/
+- https://quay.io/repository/kubescape/kubevuln
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -38,12 +54,32 @@ security-testing:
     before-release: true
   comment: |
     Dependabot is enabled for this repo.
+- tool-type: sast
+  tool-name: CodeQL
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: false
+  comment: |
+    CodeQL analysis runs on every pull request through the shared
+    kubescape/workflows go-basic-tests workflow.
+- tool-type: sca
+  tool-name: Snyk
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: false
+  comment: |
+    Snyk runs on every pull request through the shared kubescape/workflows
+    go-basic-tests workflow when the SNYK_TOKEN secret is configured.
 security-contacts:
 - type: email
   value: cncf-kubescape-maintainers@lists.cncf.io
 vulnerability-reporting:
   accepts-vulnerability-reports: true
-  security-policy: https://github.com/kubescape/kubescape/security/policy
+  security-policy: https://github.com/kubescape/project-governance/blob/main/SECURITY.md
   email-contact: cncf-kubescape-maintainers@lists.cncf.io
   comment: |
     The first and best way to report a vulnerability is by using private security issues in GitHub.


### PR DESCRIPTION
## Overview

`SECURITY-INSIGHTS.yml` currently **fails validation against the very schema it declares** (`schema-version: 1.0.0`), and has drifted from reality for ~2 years. This corrects the manifest and adds a CI job so neither can happen silently again.

Validating the file on `main` against the official schema from the `ossf/security-insights` `v1.0.0` tag:

```
FAIL  SECURITY-INSIGHTS.yml: 2 schema violation(s)
  - project-lifecycle: Additional properties are not allowed ('stage' was unexpected)
  - project-lifecycle: 'status' is a required property
```

**Root cause.** The v1.0.0 property is `status`; `stage` was the pre-release name, renamed during v1.0.0 development ([ossf/security-insights#52](https://github.com/ossf/security-insights-spec/pull/52)). The file was authored against a draft and never machine-checked. Nothing in-tree reads it — no Go file, Makefile, Dockerfile or workflow — so nothing could ever fail because of it, and it rotted.

### What was wrong

| | Field | Was | Now |
|---|---|---|---|
| 1 | `project-lifecycle.stage` | invalid key → **schema failure** | `status: active` |
| 2 | `header.expiration-date` | `2024-10-12` (**656 days** past) | `2027-07-29` |
| 3 | `core-maintainers` | included `craigbox`, `dwertent` — **emeritus** per [project-governance/MAINTAINERS.md](https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md) | synced to the 5 core maintainers |
| 4 | `accepts-automated-pull-requests` | `false`, while Dependabot PRs #384–#386 were merged — and contradicting this file's own `security-testing` block | `true` + explicit `automated-tools-list` |
| 5 | `project-release` | `1.0.0` | `v0.3.159` (actual latest) |
| 6 | `documentation` | the **kubescape CLI's** docs | this repo's `docs/` + kubescape.io |
| 7 | `distribution-points` | GitHub repo only | + `quay.io/kubescape/kubevuln`, the actual artifact |
| 8 | `security-testing` | Dependabot only | + CodeQL (`sast`) and Snyk (`sca`), both confirmed in `kubescape/workflows/go-basic-tests.yaml` |
| 9 | CoC / security-policy | pointed at `kubescape/kubescape` | pointed at `project-governance`, matching this repo's own `CODE_OF_CONDUCT.md` / `SECURITY.md` |

Items 1 and 5–9 were found while fixing 2–4.

## Additional Information

**Deliberately not done: migration to spec v2.2.0.** v1.0.0 is three majors behind, but v2.0.0 was a breaking overhaul (`core-maintainers` → `core-team`). Migrating one repo while the rest of the org is on v1.0.0 would fragment the org's manifests, so this PR keeps `schema-version: 1.0.0` and makes the file *valid and true*. Happy to take the v2 direction instead if preferred.

**This is org-wide.** `kubescape/kubescape/SECURITY-INSIGHTS.yml` is byte-identical in every disputed field — same expiry, same 8-name list, same `accepts-automated-pull-requests: false`. This PR **intentionally diverges** from it. The org-wide sync and the v2 migration both feel like `project-governance` decisions rather than something to do unilaterally here — happy to open an issue there.

**Two calls for the reviewer:**

1. **`amitschendel` removed.** Governance lists him under *committers*, a separate table from core maintainers, and the schema field is `core-maintainers`. If the intent is "core team" (which is what v2.0.0 renamed the field to), say the word and I'll add him back — one line.
2. **`security-testing` omits GitGuardian, go-licenses and Scorecard** even though they run in CI. The `tool-type` enum is exactly `['sast','dast','iast','fuzzer','sca']` — there is no valid value for secret-scanning or license-scanning, so adding them would re-break validation.

**The `check-jsonschema` trap** (noted in the workflow): the obvious validator can't be used here. It metaschema-validates the schema file first, and upstream's `pgp-key` pattern is not a valid `format: regex`, so it errors before ever reading the manifest. The workflow uses `Draft7Validator` on the instance directly.

## How to Test

```bash
curl -sSL -o /tmp/si-schema.yaml \
  https://raw.githubusercontent.com/ossf/security-insights/v1.0.0/security-insights-schema.yaml
pip install pyyaml jsonschema

python3 - <<'EOF'
import yaml
from jsonschema import Draft7Validator
schema = yaml.safe_load(open("/tmp/si-schema.yaml"))
doc = yaml.safe_load(open("SECURITY-INSIGHTS.yml"))
errs = sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: list(e.path))
print("valid" if not errs else "\n".join(f"{'/'.join(map(str,e.path))}: {e.message}" for e in errs))
EOF
```

`git stash` the change and re-run to see the two failures on `main`.

Results:

```
main       → FAIL (2 violations: 'stage' unexpected / 'status' required)   exit=1
this PR    → SECURITY-INSIGHTS.yml is valid                                exit=0
```

Expiry gate:

```
2027-07-29 → 364 days remaining → pass
2024-10-12 → -656 days          → FAIL (expired)
```

Maintainer-drift check, parsing the governance table live:

```
governance: amirmalka Bezbran matthyx rotemamsa slashben
manifest:   amirmalka Bezbran matthyx rotemamsa slashben
→ IN SYNC
```

Blast radius: no in-tree consumer of the manifest; all 6 workflows parse; `go build ./...` and the hermetic test packages (`config`, `internal/tools`, `controllers`) unchanged and green.

## Related issues/PRs:

No tracking issue — filing directly per CONTRIBUTING's "small changes" path. Happy to open one if maintainers prefer.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation for security metadata, including schema compliance and expiration-date checks.
  * Added advisory checks for discrepancies in listed core maintainers.
  * Added scheduled tracking for expiring security metadata.
* **Documentation**
  * Refreshed governance metadata, project links, lifecycle details, and security testing information, including CodeQL and Snyk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->