### PR TITLE
fix: log real error instead of preceding sentinel/nil at 5 sites

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -279,7 +279,7 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 
 	imageManifest, e := ParseImageManifest(cve.Content)
 	if e != nil {
-		logger.L().Ctx(ctx).Warning("failed to parse image manifest from grype document", helpers.Error(err))
+		logger.L().Ctx(ctx).Warning("failed to parse image manifest from grype document", helpers.Error(e))
 	}
 
 	// merge cve and cvep

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -348,7 +348,7 @@ func (a *APIServerStore) StoreCVE(ctx context.Context, cve domain.CVEManifest, w
 			return updateErr
 		})
 		if retryErr != nil {
-			logger.L().Ctx(ctx).Warning("failed to update CVE manifest in storage", helpers.Error(err),
+			logger.L().Ctx(ctx).Warning("failed to update CVE manifest in storage", helpers.Error(retryErr),
 				helpers.String("name", cve.Name),
 				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
 		} else {
@@ -585,7 +585,7 @@ func (a *APIServerStore) StoreCVESummary(ctx context.Context, cve domain.CVEMani
 			return updateErr
 		})
 		if retryErr != nil {
-			logger.L().Ctx(ctx).Warning("failed to update CVE summary manifest in storage", helpers.Error(err),
+			logger.L().Ctx(ctx).Warning("failed to update CVE summary manifest in storage", helpers.Error(retryErr),
 				helpers.String("name", cve.Name),
 				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
 		} else {
@@ -1124,7 +1124,7 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 				return updateErr
 			})
 			if retryErr != nil {
-				logger.L().Ctx(ctx).Warning("failed to update filtered SBOM in storage", helpers.Error(err),
+				logger.L().Ctx(ctx).Warning("failed to update filtered SBOM in storage", helpers.Error(retryErr),
 					helpers.String("name", sbom.Name))
 			} else {
 				logger.L().Debug("updated filtered SBOM in storage",
@@ -1157,7 +1157,7 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 				return updateErr
 			})
 			if retryErr != nil {
-				logger.L().Ctx(ctx).Warning("failed to update SBOM in storage", helpers.Error(err),
+				logger.L().Ctx(ctx).Warning("failed to update SBOM in storage", helpers.Error(retryErr),
 					helpers.String("name", sbom.Name))
 			} else {
 				logger.L().Debug("updated SBOM in storage",


### PR DESCRIPTION
## Overview

Two related log-correctness bugs, same root cause: a `Warning` log captures the wrong Go variable — one that's guaranteed `nil` or semantically meaningless — instead of the actual error that just occurred.

In `repositories/apiserver.go` (StoreCVE L351, StoreCVESummary L588, StoreSBOM filtered L1127, StoreSBOM unfiltered L1160) the retry-exhaustion warning logs `helpers.Error(err)` — the original `IsAlreadyExists` sentinel — instead of `helpers.Error(retryErr)` — the actual Get/Update failure. `StoreCVESummaryStub` L673 in the same file proves the intended pattern.

In `adapters/v1/backend.go` SubmitCVE L282 the manifest parse failure warning logs `helpers.Error(err)` (guaranteed `nil` at that point) instead of `helpers.Error(e)` (the actual parse error).

## Additional Information

- 5 one-line changes total (4 in apiserver.go, 1 in backend.go)
- No new imports needed
- No behavioral change — only the correct error variable is now logged

## How to Test

1. `go build ./...`
2. `go test ./repositories/...`
3. `go test ./adapters/v1/... -run TestBackend`
4. Verify no regressions: `go test ./...`

The 3 `Test_syftAdapter_CreateSBOM` failures are pre-existing (`arm64` vs `amd64` fixture mismatch, fail on clean `main` too).

## Related issues/PRs

Fixes #389

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes