### PR TITLE
fix: surface transient apiserver errors in GetCVE/GetSBOM

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -232,9 +232,7 @@ func (a *APIServerStore) GetCVE(ctx context.Context, name, SBOMCreatorVersion, C
 			helpers.String("name", name))
 		return domain.CVEManifest{}, nil
 	case err != nil:
-		logger.L().Ctx(ctx).Warning("failed to get CVE manifest from apiserver", helpers.Error(err),
-			helpers.String("name", name))
-		return domain.CVEManifest{}, nil
+		return domain.CVEManifest{}, fmt.Errorf("failed to get CVE manifest from apiserver: %w", err)
 	}
 	// discard the manifest if it was created by an older version of the scanner
 	if manifest.Annotations[helpersv1.ToolVersionMetadataKey] != SBOMCreatorVersion ||
@@ -1041,9 +1039,7 @@ func (a *APIServerStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion s
 			helpers.String("name", name))
 		return domain.SBOM{}, nil
 	case err != nil:
-		logger.L().Ctx(ctx).Warning("failed to get SBOM from apiserver", helpers.Error(err),
-			helpers.String("name", name))
-		return domain.SBOM{}, nil
+		return domain.SBOM{}, fmt.Errorf("failed to get SBOM from apiserver: %w", err)
 	}
 	// discard the manifest if it was created by an older version of the scanner
 	if semver.Compare(manifest.Spec.Metadata.Tool.Version, SBOMCreatorVersion) == -1 {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2,16 +2,21 @@ package repositories
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/tools"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	"github.com/openvex/go-vex/pkg/vex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 const name = "k8s.gcr.io-kube-proxy-sha256-c1b13"
@@ -702,4 +707,26 @@ func TestMergeMaps(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.existing)
 		})
 	}
+}
+
+func TestAPIServerStore_GetCVE_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("get", "vulnerabilitymanifests", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	_, err := a.GetCVE(context.TODO(), name, "", "", "")
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_GetSBOM_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("get", "sbomsyfts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	_, err := a.GetSBOM(context.TODO(), name, "")
+	require.ErrorIs(t, err, injectedErr)
 }


### PR DESCRIPTION
Refs #390

## Overview
GetCVE and GetSBOM in repositories/apiserver.go swallowed non-NotFound apiserver errors by returning (zero, nil) — byte-for-byte identical to the manifest-not-present path. This PR surfaces those errors to the caller so a transient flake is distinguishable from a genuine miss.

Note: the headline harm in #390 — a transient flake still triggers a full 30s+ SBOM regeneration because callers currently fall through on error — is NOT changed by this PR. It stays tracked in #390 for a follow-up.

## Changes

### repositories/apiserver.go (2 sites)
- GetCVE (L235): returns domain.CVEManifest{}, fmt.Errorf("failed to get CVE manifest from apiserver: %w", err)
- GetSBOM (L1042): returns domain.SBOM{}, fmt.Errorf("failed to get SBOM from apiserver: %w", err)

The now-redundant repository-level Warning was removed to avoid double-logging. The removed record is not lost: all five callers in scan.go (L108/200/213/415/427) already log the returned error at Warning level with imageSlug context.

## Why this is safe
- IsNotFound branch unchanged
- Empty-name early-return unchanged
- All 5 callers already treat non-nil errors as non-fatal warnings
- Wrapped-error pattern matches GetContainerProfile (L213-216)

## Tests added
- TestAPIServerStore_GetCVE_transientError — fake clientset reactor returning apierrors.NewInternalError; fails on base 2131f54, passes here (verified)
- TestAPIServerStore_GetSBOM_transientError — same, on "sbomsyfts"

## Scope note
GetCVESummary (L282-285) has the same swallow but is intentionally left for a follow-up to keep this PR scoped. Happy to extend if preferred.

## How to Test
1. go build ./...
2. go test ./repositories/...
3. go test ./core/services/...
4. gofmt -l repositories/                       # clean
5. go vet ./repositories/...                    # clean

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when CVE or SBOM data cannot be retrieved.
  * Retrieval failures now report an error instead of appearing as successful requests with empty results.
* **Tests**
  * Added coverage for transient storage failures affecting CVE and SBOM retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->