### PR TITLE
fix: surface storage failures in StoreCVE/StoreCVESummary/StoreSBOM

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -346,18 +346,19 @@ func (a *APIServerStore) StoreCVE(ctx context.Context, cve domain.CVEManifest, w
 			return updateErr
 		})
 		if retryErr != nil {
-			logger.L().Ctx(ctx).Warning("failed to update CVE manifest in storage", helpers.Error(retryErr),
+			logger.L().Debug("failed to update CVE manifest in storage", helpers.Error(retryErr),
 				helpers.String("name", cve.Name),
 				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-		} else {
-			logger.L().Debug("updated CVE manifest in storage",
-				helpers.String("name", cve.Name),
-				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
+			return fmt.Errorf("failed to update CVE manifest in storage: %w", retryErr)
 		}
-	case err != nil:
-		logger.L().Ctx(ctx).Warning("failed to store CVE manifest in storage", helpers.Error(err),
+		logger.L().Debug("updated CVE manifest in storage",
 			helpers.String("name", cve.Name),
 			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
+	case err != nil:
+		logger.L().Debug("failed to store CVE manifest in storage", helpers.Error(err),
+			helpers.String("name", cve.Name),
+			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
+		return fmt.Errorf("failed to store CVE manifest in storage: %w", err)
 	default:
 		logger.L().Debug("stored CVE manifest in storage",
 			helpers.String("name", cve.Name),
@@ -583,18 +584,19 @@ func (a *APIServerStore) StoreCVESummary(ctx context.Context, cve domain.CVEMani
 			return updateErr
 		})
 		if retryErr != nil {
-			logger.L().Ctx(ctx).Warning("failed to update CVE summary manifest in storage", helpers.Error(retryErr),
+			logger.L().Debug("failed to update CVE summary manifest in storage", helpers.Error(retryErr),
 				helpers.String("name", cve.Name),
 				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-		} else {
-			logger.L().Debug("updated CVE summary manifest in storage",
-				helpers.String("name", cve.Name),
-				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
+			return fmt.Errorf("failed to update CVE summary manifest in storage: %w", retryErr)
 		}
-	case err != nil:
-		logger.L().Ctx(ctx).Warning("failed to store CVE summary manifest in storage", helpers.Error(err),
+		logger.L().Debug("updated CVE summary manifest in storage",
 			helpers.String("name", cve.Name),
 			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
+	case err != nil:
+		logger.L().Debug("failed to store CVE summary manifest in storage", helpers.Error(err),
+			helpers.String("name", cve.Name),
+			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
+		return fmt.Errorf("failed to store CVE summary manifest in storage: %w", err)
 	default:
 		logger.L().Debug("stored CVE summary manifest in storage",
 			helpers.String("name", manifest.Name),
@@ -668,18 +670,19 @@ func (a *APIServerStore) StoreCVESummaryStub(ctx context.Context, status string)
 			return updateErr
 		})
 		if retryErr != nil {
-			logger.L().Ctx(ctx).Warning("failed to update CVE summary stub in storage", helpers.Error(retryErr),
+			logger.L().Debug("failed to update CVE summary stub in storage", helpers.Error(retryErr),
 				helpers.String("name", manifest.Name),
 				helpers.String("status", status))
-		} else {
-			logger.L().Debug("updated CVE summary stub in storage",
-				helpers.String("name", manifest.Name),
-				helpers.String("status", status))
+			return fmt.Errorf("failed to update CVE summary stub in storage: %w", retryErr)
 		}
-	case err != nil:
-		logger.L().Ctx(ctx).Warning("failed to store CVE summary stub in storage", helpers.Error(err),
+		logger.L().Debug("updated CVE summary stub in storage",
 			helpers.String("name", manifest.Name),
 			helpers.String("status", status))
+	case err != nil:
+		logger.L().Debug("failed to store CVE summary stub in storage", helpers.Error(err),
+			helpers.String("name", manifest.Name),
+			helpers.String("status", status))
+		return fmt.Errorf("failed to store CVE summary stub in storage: %w", err)
 	default:
 		logger.L().Debug("stored CVE summary stub in storage",
 			helpers.String("name", manifest.Name),
@@ -1137,15 +1140,16 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 				return updateErr
 			})
 			if retryErr != nil {
-				logger.L().Ctx(ctx).Warning("failed to update filtered SBOM in storage", helpers.Error(retryErr),
+				logger.L().Debug("failed to update filtered SBOM in storage", helpers.Error(retryErr),
 					helpers.String("name", sbom.Name))
-			} else {
-				logger.L().Debug("updated filtered SBOM in storage",
-					helpers.String("name", sbom.Name))
+				return fmt.Errorf("failed to update filtered SBOM in storage: %w", retryErr)
 			}
-		case err != nil:
-			logger.L().Ctx(ctx).Warning("failed to store filtered SBOM in storage", helpers.Error(err),
+			logger.L().Debug("updated filtered SBOM in storage",
 				helpers.String("name", sbom.Name))
+		case err != nil:
+			logger.L().Debug("failed to store filtered SBOM in storage", helpers.Error(err),
+				helpers.String("name", sbom.Name))
+			return fmt.Errorf("failed to store filtered SBOM in storage: %w", err)
 		default:
 			logger.L().Debug("stored filtered SBOM in storage",
 				helpers.String("name", sbom.Name))
@@ -1170,15 +1174,16 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 				return updateErr
 			})
 			if retryErr != nil {
-				logger.L().Ctx(ctx).Warning("failed to update SBOM in storage", helpers.Error(retryErr),
+				logger.L().Debug("failed to update SBOM in storage", helpers.Error(retryErr),
 					helpers.String("name", sbom.Name))
-			} else {
-				logger.L().Debug("updated SBOM in storage",
-					helpers.String("name", sbom.Name))
+				return fmt.Errorf("failed to update SBOM in storage: %w", retryErr)
 			}
-		case err != nil:
-			logger.L().Ctx(ctx).Warning("failed to store SBOM in storage", helpers.Error(err),
+			logger.L().Debug("updated SBOM in storage",
 				helpers.String("name", sbom.Name))
+		case err != nil:
+			logger.L().Debug("failed to store SBOM in storage", helpers.Error(err),
+				helpers.String("name", sbom.Name))
+			return fmt.Errorf("failed to store SBOM in storage: %w", err)
 		default:
 			logger.L().Debug("stored SBOM in storage",
 				helpers.String("name", sbom.Name))

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -16,7 +16,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/retry"
 )
 
 const name = "k8s.gcr.io-kube-proxy-sha256-c1b13"
@@ -882,4 +884,275 @@ func TestAPIServerStore_GetSBOM_transientError(t *testing.T) {
 	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
 	_, err := a.GetSBOM(context.TODO(), name, "")
 	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreCVE_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "vulnerabilitymanifests", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreCVE(context.TODO(), domain.CVEManifest{Name: name}, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreSBOM_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "sbomsyfts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreSBOM(context.TODO(), domain.SBOM{Name: name}, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreSBOMFiltered_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "sbomsyftfiltereds", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreSBOM(context.TODO(), domain.SBOM{Name: name}, true)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreCVESummary_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "vulnerabilitymanifestsummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:ead0a4a53df89fd173874b46093b6e62d8c72967bbf606d672c9e8c9b601a4fc",
+		InstanceID:    "",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	err := a.StoreCVESummary(ctx, cveManifest, domain.CVEManifest{}, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreCVE_updateGetFailure_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "vulnerabilitymanifests", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "vulnerabilitymanifests"}, name)
+	})
+	clientset.PrependReactor("get", "vulnerabilitymanifests", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreCVE(context.TODO(), domain.CVEManifest{Name: name}, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreSBOM_updateGetFailure_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "sbomsyfts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "sbomsyfts"}, name)
+	})
+	clientset.PrependReactor("get", "sbomsyfts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreSBOM(context.TODO(), domain.SBOM{Name: name}, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreSBOMFiltered_updateGetFailure_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "sbomsyftfiltereds", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "sbomsyftfiltereds"}, name)
+	})
+	clientset.PrependReactor("get", "sbomsyftfiltereds", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreSBOM(context.TODO(), domain.SBOM{Name: name}, true)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreCVESummary_updateGetFailure_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "vulnerabilitymanifestsummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "vulnerabilitymanifestsummaries"}, name)
+	})
+	clientset.PrependReactor("get", "vulnerabilitymanifestsummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:ead0a4a53df89fd173874b46093b6e62d8c72967bbf606d672c9e8c9b601a4fc",
+		InstanceID:    "",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	err := a.StoreCVESummary(ctx, cveManifest, domain.CVEManifest{}, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreCVE_retryExhausted_transientError(t *testing.T) {
+	seeded := &v1beta1.VulnerabilityManifest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "kubescape",
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	var updateCalls int
+	clientset.PrependReactor("update", "vulnerabilitymanifests", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "vulnerabilitymanifests"}, name, fmt.Errorf("conflict"))
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreCVE(context.TODO(), domain.CVEManifest{Name: name}, false)
+	require.True(t, apierrors.IsConflict(err))
+	require.Equal(t, retry.DefaultRetry.Steps, updateCalls)
+}
+
+func TestAPIServerStore_StoreSBOM_retryExhausted_transientError(t *testing.T) {
+	seeded := &v1beta1.SBOMSyft{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "kubescape",
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	var updateCalls int
+	clientset.PrependReactor("update", "sbomsyfts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "sbomsyfts"}, name, fmt.Errorf("conflict"))
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreSBOM(context.TODO(), domain.SBOM{Name: name}, false)
+	require.True(t, apierrors.IsConflict(err))
+	require.Equal(t, retry.DefaultRetry.Steps, updateCalls)
+}
+
+func TestAPIServerStore_StoreSBOMFiltered_retryExhausted_transientError(t *testing.T) {
+	seeded := &v1beta1.SBOMSyftFiltered{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "kubescape",
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	var updateCalls int
+	clientset.PrependReactor("update", "sbomsyftfiltereds", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "sbomsyftfiltereds"}, name, fmt.Errorf("conflict"))
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreSBOM(context.TODO(), domain.SBOM{Name: name}, true)
+	require.True(t, apierrors.IsConflict(err))
+	require.Equal(t, retry.DefaultRetry.Steps, updateCalls)
+}
+
+func TestAPIServerStore_StoreCVESummary_retryExhausted_transientError(t *testing.T) {
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:ead0a4a53df89fd173874b46093b6e62d8c72967bbf606d672c9e8c9b601a4fc",
+		InstanceID:    "",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+
+	resourceName, err := GetCVESummaryK8sResourceNameWithCVEName(ctx, name)
+	require.NoError(t, err)
+	ns, err := GetCVESummaryK8sResourceNamespace(ctx)
+	require.NoError(t, err)
+
+	seeded := &v1beta1.VulnerabilityManifestSummary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        resourceName,
+			Namespace:   ns,
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	var updateCalls int
+	clientset.PrependReactor("update", "vulnerabilitymanifestsummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "vulnerabilitymanifestsummaries"}, resourceName, fmt.Errorf("conflict"))
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err = a.StoreCVESummary(ctx, cveManifest, domain.CVEManifest{}, false)
+	require.True(t, apierrors.IsConflict(err))
+	require.Equal(t, retry.DefaultRetry.Steps, updateCalls)
+}
+
+func TestAPIServerStore_StoreCVESummaryStub_transientError(t *testing.T) {
+	workload := domain.ScanCommand{
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ContainerName: "anyJobContName",
+	}
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "vulnerabilitymanifestsummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err := a.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreCVESummaryStub_retryExhausted_transientError(t *testing.T) {
+	workload := domain.ScanCommand{
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ContainerName: "anyJobContName",
+	}
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	resourceName, err := GetCVESummaryK8sResourceName(ctx)
+	require.NoError(t, err)
+	ns, err := GetCVESummaryK8sResourceNamespace(ctx)
+	require.NoError(t, err)
+
+	seeded := &v1beta1.VulnerabilityManifestSummary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        resourceName,
+			Namespace:   ns,
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	var updateCalls int
+	clientset.PrependReactor("update", "vulnerabilitymanifestsummaries", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "vulnerabilitymanifestsummaries"}, resourceName, fmt.Errorf("conflict"))
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	err = a.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema)
+	require.True(t, apierrors.IsConflict(err))
+	require.Equal(t, retry.DefaultRetry.Steps, updateCalls)
 }


### PR DESCRIPTION
Fixes #398

## Overview

`APIServerStore.StoreCVE`, `APIServerStore.StoreCVESummary`, `APIServerStore.StoreCVESummaryStub`
and `APIServerStore.StoreSBOM` in `repositories/apiserver.go` always returned `nil`, even when the
initial Create failed or the Create-on-conflict retry was exhausted. Storage failures were only
logged as warnings, so callers could not distinguish "stored" from "storage failed".

This was raised by @matthyx during review of #395:

> at all 5 retry sites the function logs the failure and then still `return nil`, so a caller
> cannot distinguish "stored" from "retries exhausted". ... worth its own issue.

The concrete consequence: `GenerateSBOM` in `core/services/scan.go` (L127-131) has a live branch
that reports `scanfailure.ScanFailureBackendPost` with `ReasonSBOMStorageFailed` and returns the
error — but it was dead code in production because `StoreSBOM` never returned a non-nil error.
The same applied to the warn-and-continue error branches of all other Store callers, and to the
`StoreCVESummaryStub` callers at `scan.go:235` and `:449` (schema-unsupported workloads silently
got no stub).

## Changes

### `repositories/apiserver.go` — 10 return sites across 4 functions

Each failure arm now returns a wrapped error instead of falling through to `return nil`,
matching the propagation pattern `StoreVEX` already uses (apiserver.go:691-724) and the
in-memory siblings (`MemoryStore` returns `ErrMockError`, memory.go:123-125, 142-144).

| Function | retry-exhausted arm | `case err != nil` arm |
|---|---|---|
| `StoreCVE` | `retryErr` | `err` |
| `StoreCVESummary` | `retryErr` | `err` |
| `StoreCVESummaryStub` | `retryErr` | `err` |
| `StoreSBOM` (filtered) | `retryErr` | `err` |
| `StoreSBOM` (unfiltered) | `retryErr` | `err` |

Each returns `fmt.Errorf("failed to <update/store> ... in storage: %w", err|retryErr)`.

The repository-side failure logs are demoted from `Warning` to `Debug` (no `Ctx`): the error is
now returned, so the caller owns the reported log — one record per failure instead of two.

### Callers — no change required

All Store callers in `core/services/scan.go` already handle non-nil errors:
- `GenerateSBOM` L127-131: aborts via `return err` + `ReportScanFailure(... ReasonSBOMStorageFailed)` — this branch is now live, which is the intended fix.
- All others (L235, 244, 285, 291, 302, 307, 325, 351, 359, 449, 458, 494, 499, 509, 514): warn-and-continue.

## Tests added — 14 transientError tests (`repositories/apiserver_test.go`)

Each of the 4 Store methods now covers the initial-create failure, the get-inside-update-closure
failure, and the real conflict-exhaustion path:

| Test | Arm exercised |
|---|---|
| `TestAPIServerStore_StoreCVE_transientError` | create fails |
| `TestAPIServerStore_StoreCVE_updateGetFailure_transientError` | create → AlreadyExists, get inside retry fails |
| `TestAPIServerStore_StoreCVE_retryExhausted_transientError` | create → AlreadyExists, update always Conflict → `RetryOnConflict` exhausts (`retry.DefaultRetry.Steps` attempts) |
| `TestAPIServerStore_StoreCVESummary_transientError` | create fails |
| `TestAPIServerStore_StoreCVESummary_updateGetFailure_transientError` | create → AlreadyExists, get inside retry fails |
| `TestAPIServerStore_StoreCVESummary_retryExhausted_transientError` | update always Conflict → retries exhausted |
| `TestAPIServerStore_StoreCVESummaryStub_transientError` | create fails |
| `TestAPIServerStore_StoreCVESummaryStub_retryExhausted_transientError` | update always Conflict → retries exhausted |
| `TestAPIServerStore_StoreSBOM_transientError` | create fails (unfiltered) |
| `TestAPIServerStore_StoreSBOM_updateGetFailure_transientError` | create → AlreadyExists, get inside retry fails (unfiltered) |
| `TestAPIServerStore_StoreSBOM_retryExhausted_transientError` | update always Conflict → retries exhausted (unfiltered) |
| `TestAPIServerStore_StoreSBOMFiltered_transientError` | create fails (filtered) |
| `TestAPIServerStore_StoreSBOMFiltered_updateGetFailure_transientError` | create → AlreadyExists, get inside retry fails (filtered) |
| `TestAPIServerStore_StoreSBOMFiltered_retryExhausted_transientError` | update always Conflict → retries exhausted (filtered) |

The `_retryExhausted_` tests seed the object via `fake.NewSimpleClientset(seeded)` (so the
tracker returns `AlreadyExists` on Create and the seeded object on Get), stub the `update`
reactor to always return `apierrors.NewConflict(...)`, and assert both `apierrors.IsConflict(err)`
and that the update reactor was called exactly `retry.DefaultRetry.Steps` (5) times.

All 14 tests were proven to **fail on base** (error swallowed, `nil` returned) and **pass with
this change**.

## Why this is safe

- `IsNotFound` and empty-name branches are unchanged.
- No caller changes needed — all already handle errors; the only behavioral activation is the intended `GenerateSBOM` abort branch.
- Pattern proven by `StoreVEX` and `MemoryStore`.
- No new runtime imports (`fmt` was already imported).

## How to Test

```
go build ./...
go test ./repositories/... -count=1
go test ./core/... -count=1
gofmt -l repositories/
go vet ./repositories/...
```

Local results: `repositories` 52 passed, `core` 108 passed, gofmt clean, vet clean, build clean.

## Notes for reviewers

- **Behavioral decision:** I kept `GenerateSBOM` aborting (`return err`) on storage failure,
  since that is what the existing branch at scan.go:127-131 was written to do. Happy to switch
  it to warn-and-continue if the maintainers prefer a non-fatal path.
- `StoreCVESummary` / `StoreCVESummaryStub` tests require a `domain.WorkloadKey{}`- and
  `domain.TimestampKey{}`-carrying context (already handled in the test fixtures).

## Checklist

- [x] Code style followed
- [x] Self-review completed
- [x] Tests added and passing locally
- [x] DCO signed off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage failures when creating or updating CVE and SBOM data are now reported instead of being silently ignored.
  * Error details are preserved for temporary failures and exhausted retries, improving troubleshooting and reliability.
  * Conflict retries now honor the configured retry limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->