### PR TITLE
fix: reset VEX statements to not_affected before reapplying update

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -916,6 +916,16 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		}
 	}
 
+	// Reset every statement back to the baseline "not affected" status before
+	// reapplying the current filtered manifest. Without this, a statement that
+	// was marked "affected" during an earlier update stays "affected" forever,
+	// even after the corresponding CVE/package pair is no longer relevant.
+	for i := range vexDoc.Statements {
+		vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
+		vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
+		vexDoc.Statements[i].ImpactStatement = "Vulnerable component is not loaded into the memory"
+	}
+
 	// Now change the status of the filtered vulnerabilities to "Affected"
 	err := markRelevantVulnerabilitiesAsAffectedInVex(&vexDoc, &cvep)
 	if err != nil {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -352,6 +352,61 @@ func TestAPIServerStore_storeVEX(t *testing.T) {
 	assert.Equal(t, relevant+1, relevant2)
 }
 
+// TestAPIServerStore_storeVEX_updateRestoresNotAffected guards against a regression where
+// updateVEX only ever promoted statements to "affected" and never reset them back to
+// "not_affected" once the corresponding CVE/package pair stopped being relevant.
+func TestAPIServerStore_storeVEX_updateRestoresNotAffected(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+	require.NotEmpty(t, cveManifestFiltered.Content.Matches)
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	// First store makes the filtered CVEs "affected".
+	require.NoError(t, a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false))
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	affectedBefore := 0
+	for _, stmt := range vexContainer.Spec.Statements {
+		if stmt.Status == v1beta1.Status(vex.StatusAffected) {
+			affectedBefore++
+		}
+	}
+	assert.Equal(t, len(cveManifestFiltered.Content.Matches), affectedBefore)
+
+	// Second store with an empty filtered manifest: none of the CVEs are relevant anymore,
+	// so every previously "affected" statement should revert to "not_affected".
+	emptyFiltered := cveManifestFiltered
+	emptyContent := *cveManifestFiltered.Content
+	emptyContent.Matches = nil
+	emptyFiltered.Content = &emptyContent
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifest, emptyFiltered, false))
+
+	vexContainer, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	affectedAfter := 0
+	for _, stmt := range vexContainer.Spec.Statements {
+		if stmt.Status == v1beta1.Status(vex.StatusAffected) {
+			affectedAfter++
+		}
+	}
+	assert.Equal(t, 0, affectedAfter, "statements that are no longer relevant should be reset to not_affected")
+}
+
 // TestAPIServerStore_storeVEX_updatePreservesFieldMapping guards against a regression where
 // updateVEX swapped Vulnerability.ID and Vulnerability.Name for statements appended during an
 // update, while createVEX used the opposite (correct) mapping for the very same match data.


### PR DESCRIPTION
## Overview
Fixes the VEX update path so statements are reset to `not_affected` before the current filtered manifest is reapplied. Previously, `updateVEX` reused the stored document's statement status and `markRelevantVulnerabilitiesAsAffectedInVex` only ever promoted matches to `affected`, so a CVE/package pair that stopped being relevant in a later scan stayed marked `affected` forever.

Resolved #400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VEX statements now correctly reset to “not affected” when previously relevant vulnerabilities are no longer present in subsequent scans.
  * Prevents outdated “affected” statuses from persisting after vulnerability data changes.

* **Tests**
  * Added coverage to verify status restoration during successive VEX updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->