### PR TITLE
fix: set action_statement on affected VEX statements

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -746,6 +746,20 @@ func createProductStructForImageAndPackage(imagePullable string, packagePURL str
 	return &product, nil
 }
 
+// defaultActionStatement is used when a match does not carry enough fix data to build a
+// more specific remediation string.
+const defaultActionStatement = "Upgrade the vulnerable component to a version that is not affected"
+
+// buildActionStatement returns a remediation string for an affected VEX statement. When the
+// match reports a fixed state with known fix versions, it names them; otherwise it falls back
+// to defaultActionStatement.
+func buildActionStatement(v v1beta1.Match) string {
+	if v.Vulnerability.Fix.State == "fixed" && len(v.Vulnerability.Fix.Versions) > 0 {
+		return fmt.Sprintf("Upgrade %s to version %s", v.Artifact.PURL, strings.Join(v.Vulnerability.Fix.Versions, " or "))
+	}
+	return defaultActionStatement
+}
+
 func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domain.CVEManifest) error {
 	// Now change the status of the filtered vulnerabilities to "Affected"
 	for _, v := range cvep.Content.Matches {
@@ -757,8 +771,8 @@ func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domai
 						if sc.ID == v.Artifact.PURL {
 							vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusAffected)
 							vexDoc.Statements[i].Justification = ""
-							vexDoc.Statements[i].ImpactStatement = "Vulnerable component is loaded into the memory"
-							vexDoc.Statements[i].ActionStatement = "Upgrade the vulnerable component to a version that is not affected"
+							vexDoc.Statements[i].ImpactStatement = ""
+							vexDoc.Statements[i].ActionStatement = buildActionStatement(v)
 							foundProduct = true
 						}
 						if foundProduct {
@@ -770,6 +784,16 @@ func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domai
 					}
 				}
 			}
+		}
+	}
+
+	// Backfill statements that were already marked "affected" by a version of kubevuln
+	// predating action_statement support, or that were left stale because their CVE fell
+	// out of the current relevancy set before the backfill could run on a prior update.
+	for i, s := range vexDoc.Statements {
+		if s.Status == v1beta1.Status(vex.StatusAffected) && s.ActionStatement == "" {
+			vexDoc.Statements[i].ImpactStatement = ""
+			vexDoc.Statements[i].ActionStatement = defaultActionStatement
 		}
 	}
 	return nil

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -758,6 +758,7 @@ func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domai
 							vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusAffected)
 							vexDoc.Statements[i].Justification = ""
 							vexDoc.Statements[i].ImpactStatement = "Vulnerable component is loaded into the memory"
+							vexDoc.Statements[i].ActionStatement = "Upgrade the vulnerable component to a version that is not affected"
 							foundProduct = true
 						}
 						if foundProduct {

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -786,16 +786,6 @@ func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domai
 			}
 		}
 	}
-
-	// Backfill statements that were already marked "affected" by a version of kubevuln
-	// predating action_statement support, or that were left stale because their CVE fell
-	// out of the current relevancy set before the backfill could run on a prior update.
-	for i, s := range vexDoc.Statements {
-		if s.Status == v1beta1.Status(vex.StatusAffected) && s.ActionStatement == "" {
-			vexDoc.Statements[i].ImpactStatement = ""
-			vexDoc.Statements[i].ActionStatement = defaultActionStatement
-		}
-	}
 	return nil
 }
 
@@ -952,6 +942,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
 		vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
 		vexDoc.Statements[i].ImpactStatement = "Vulnerable component is not loaded into the memory"
+		vexDoc.Statements[i].ActionStatement = ""
 	}
 
 	// Now change the status of the filtered vulnerabilities to "Affected"

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -405,6 +405,7 @@ func TestAPIServerStore_storeVEX_updateRestoresNotAffected(t *testing.T) {
 		if stmt.Status == v1beta1.Status(vex.StatusAffected) {
 			affectedAfter++
 		}
+		assert.Empty(t, stmt.ActionStatement, "not_affected statement %q must not carry an action_statement", stmt.Vulnerability.Name)
 	}
 	assert.Equal(t, 0, affectedAfter, "statements that are no longer relevant should be reset to not_affected")
 }
@@ -445,66 +446,6 @@ func TestAPIServerStore_storeVEX_affectedStatementsHaveActionStatement(t *testin
 		}
 	}
 	require.True(t, foundAffected, "expected at least one affected statement in test fixture")
-}
-
-// TestAPIServerStore_updateVEX_backfillsActionStatementOnStaleAffectedStatements guards against a
-// regression where a statement marked "affected" by an older kubevuln (before action_statement
-// support) kept an empty action_statement forever. Since updateVEX now resets every statement to
-// "not_affected" before reapplying the current filtered manifest, a CVE that fell out of the
-// relevancy set is expected to be reset rather than backfilled.
-func TestAPIServerStore_updateVEX_backfillsActionStatementOnStaleAffectedStatements(t *testing.T) {
-	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
-	cveManifestFiltered2 := tools.FileToCVEManifest("testdata/nginx-cve-filtered-2.json")
-	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
-
-	a := NewFakeAPIServerStorage("kubescape")
-
-	ctx := context.TODO()
-	workload := domain.ScanCommand{
-		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
-		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
-		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
-		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
-		ContainerName: "anyJobContName",
-	}
-	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
-
-	// First store: CVE-2005-2541 is relevant and marked affected.
-	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered2, false)
-	assert.Equal(t, err, nil)
-
-	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
-	assert.Equal(t, err, nil)
-
-	// Simulate a document written by a pre-fix kubevuln: affected but no action_statement.
-	found := false
-	for i, stmt := range vexContainer.Spec.Statements {
-		if stmt.Vulnerability.Name == "CVE-2005-2541" {
-			vexContainer.Spec.Statements[i].ActionStatement = ""
-			found = true
-		}
-	}
-	require.True(t, found, "expected CVE-2005-2541 to be present after the first store")
-
-	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(ctx, vexContainer, metav1.UpdateOptions{})
-	assert.Equal(t, err, nil)
-
-	// Second store: CVE-2005-2541 is no longer in the filtered manifest.
-	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
-	assert.Equal(t, err, nil)
-
-	vexContainer, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
-	assert.Equal(t, err, nil)
-
-	found = false
-	for _, stmt := range vexContainer.Spec.Statements {
-		if stmt.Vulnerability.Name == "CVE-2005-2541" {
-			found = true
-			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status, "statement no longer relevant should be reset to not_affected")
-			assert.Empty(t, stmt.ActionStatement, "not_affected statement must not carry an action_statement")
-		}
-	}
-	require.True(t, found, "expected CVE-2005-2541 statement to still be present after the update")
 }
 
 // TestAPIServerStore_storeVEX_updatePreservesFieldMapping guards against a regression where

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -441,9 +441,71 @@ func TestAPIServerStore_storeVEX_affectedStatementsHaveActionStatement(t *testin
 		if stmt.Status == v1beta1.Status(vex.StatusAffected) {
 			foundAffected = true
 			assert.NotEmpty(t, stmt.ActionStatement, "affected statement %q must carry an action_statement", stmt.Vulnerability.Name)
+			assert.Empty(t, stmt.ImpactStatement, "affected statement %q must not carry an impact_statement", stmt.Vulnerability.Name)
 		}
 	}
 	require.True(t, foundAffected, "expected at least one affected statement in test fixture")
+}
+
+// TestAPIServerStore_updateVEX_backfillsActionStatementOnStaleAffectedStatements guards against a
+// regression where a statement marked "affected" by an older kubevuln (before action_statement
+// support) - or one that fell out of the relevancy set before it could be backfilled - kept an
+// empty action_statement forever, because markRelevantVulnerabilitiesAsAffectedInVex only
+// revisits statements for CVEs present in the current filtered manifest.
+func TestAPIServerStore_updateVEX_backfillsActionStatementOnStaleAffectedStatements(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered2 := tools.FileToCVEManifest("testdata/nginx-cve-filtered-2.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	// First store: CVE-2005-2541 is relevant and marked affected.
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered2, false)
+	assert.Equal(t, err, nil)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	assert.Equal(t, err, nil)
+
+	// Simulate a document written by a pre-fix kubevuln: affected but no action_statement.
+	found := false
+	for i, stmt := range vexContainer.Spec.Statements {
+		if stmt.Vulnerability.Name == "CVE-2005-2541" {
+			vexContainer.Spec.Statements[i].ActionStatement = ""
+			found = true
+		}
+	}
+	require.True(t, found, "expected CVE-2005-2541 to be present after the first store")
+
+	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(ctx, vexContainer, metav1.UpdateOptions{})
+	assert.Equal(t, err, nil)
+
+	// Second store: CVE-2005-2541 is no longer in the filtered manifest.
+	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	assert.Equal(t, err, nil)
+
+	vexContainer, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	assert.Equal(t, err, nil)
+
+	found = false
+	for _, stmt := range vexContainer.Spec.Statements {
+		if stmt.Vulnerability.Name == "CVE-2005-2541" {
+			found = true
+			assert.Equal(t, v1beta1.Status(vex.StatusAffected), stmt.Status, "stale affected statement should remain affected")
+			assert.NotEmpty(t, stmt.ActionStatement, "stale affected statement must be backfilled with an action_statement")
+			assert.Empty(t, stmt.ImpactStatement, "stale affected statement must not carry an impact_statement")
+		}
+	}
+	require.True(t, found, "expected CVE-2005-2541 statement to still be present after the update")
 }
 
 // TestAPIServerStore_storeVEX_updatePreservesFieldMapping guards against a regression where

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -449,9 +449,9 @@ func TestAPIServerStore_storeVEX_affectedStatementsHaveActionStatement(t *testin
 
 // TestAPIServerStore_updateVEX_backfillsActionStatementOnStaleAffectedStatements guards against a
 // regression where a statement marked "affected" by an older kubevuln (before action_statement
-// support) - or one that fell out of the relevancy set before it could be backfilled - kept an
-// empty action_statement forever, because markRelevantVulnerabilitiesAsAffectedInVex only
-// revisits statements for CVEs present in the current filtered manifest.
+// support) kept an empty action_statement forever. Since updateVEX now resets every statement to
+// "not_affected" before reapplying the current filtered manifest, a CVE that fell out of the
+// relevancy set is expected to be reset rather than backfilled.
 func TestAPIServerStore_updateVEX_backfillsActionStatementOnStaleAffectedStatements(t *testing.T) {
 	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
 	cveManifestFiltered2 := tools.FileToCVEManifest("testdata/nginx-cve-filtered-2.json")
@@ -500,9 +500,8 @@ func TestAPIServerStore_updateVEX_backfillsActionStatementOnStaleAffectedStateme
 	for _, stmt := range vexContainer.Spec.Statements {
 		if stmt.Vulnerability.Name == "CVE-2005-2541" {
 			found = true
-			assert.Equal(t, v1beta1.Status(vex.StatusAffected), stmt.Status, "stale affected statement should remain affected")
-			assert.NotEmpty(t, stmt.ActionStatement, "stale affected statement must be backfilled with an action_statement")
-			assert.Empty(t, stmt.ImpactStatement, "stale affected statement must not carry an impact_statement")
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status, "statement no longer relevant should be reset to not_affected")
+			assert.Empty(t, stmt.ActionStatement, "not_affected statement must not carry an action_statement")
 		}
 	}
 	require.True(t, found, "expected CVE-2005-2541 statement to still be present after the update")

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -409,6 +409,43 @@ func TestAPIServerStore_storeVEX_updateRestoresNotAffected(t *testing.T) {
 	assert.Equal(t, 0, affectedAfter, "statements that are no longer relevant should be reset to not_affected")
 }
 
+// TestAPIServerStore_storeVEX_affectedStatementsHaveActionStatement guards against a regression
+// where markRelevantVulnerabilitiesAsAffectedInVex set an "affected" status without also setting
+// an ActionStatement, which the storage API type comments require for that status.
+func TestAPIServerStore_storeVEX_affectedStatementsHaveActionStatement(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	require.NotEmpty(t, cveManifestFiltered.Content.Matches)
+
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	assert.Equal(t, err, nil)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	assert.Equal(t, err, nil)
+
+	foundAffected := false
+	for _, stmt := range vexContainer.Spec.Statements {
+		if stmt.Status == v1beta1.Status(vex.StatusAffected) {
+			foundAffected = true
+			assert.NotEmpty(t, stmt.ActionStatement, "affected statement %q must carry an action_statement", stmt.Vulnerability.Name)
+		}
+	}
+	require.True(t, foundAffected, "expected at least one affected statement in test fixture")
+}
+
 // TestAPIServerStore_storeVEX_updatePreservesFieldMapping guards against a regression where
 // updateVEX swapped Vulnerability.ID and Vulnerability.Name for statements appended during an
 // update, while createVEX used the opposite (correct) mapping for the very same match data.


### PR DESCRIPTION
## Overview
markRelevantVulnerabilitiesAsAffectedInVex set a VEX statement's status to affected but never set ActionStatement, even though the vendored github.com/kubescape/storage API type comments require an action statement for that status. This PR sets ActionStatement (and clears ImpactStatement) when a statement is marked affected, and resets ActionStatement back to empty in the same reset-to-not_affected loop introduced by #401 so a statement that stops being relevant does not keep a stale action statement.

Resolved #403

## How to Test
- go test ./repositories/...

## Related issues/PRs:
* Resolved #403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remediation guidance to affected vulnerability statements, using known fixed versions when available or a default upgrade recommendation.
  * Existing impact details are cleared when remediation guidance is provided.
  * Remediation guidance is automatically cleared when a statement returns to a not-affected status.

* **Bug Fixes**
  * Improved VEX statement updates to keep remediation and impact information consistent with the current assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->