### PR TITLE
fix: mergeMaps panics on nil map, crashing the process when storing over an object without labels or annotations

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -338,8 +338,8 @@ func (a *APIServerStore) StoreCVE(ctx context.Context, cve domain.CVEManifest, w
 				return getErr
 			}
 			// update the vulnerability manifest
-			mergeMaps(result.Annotations, manifest.Annotations)
-			mergeMaps(result.Labels, manifest.Labels)
+			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+			result.Labels = mergeMaps(result.Labels, manifest.Labels)
 			result.Spec = manifest.Spec
 			// try to send the updated vulnerability manifest
 			_, updateErr := a.StorageClient.VulnerabilityManifests(a.Namespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -576,8 +576,8 @@ func (a *APIServerStore) StoreCVESummary(ctx context.Context, cve domain.CVEMani
 				return getErr
 			}
 			// update the vulnerability manifest
-			mergeMaps(result.Annotations, manifest.Annotations)
-			mergeMaps(result.Labels, manifest.Labels)
+			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+			result.Labels = mergeMaps(result.Labels, manifest.Labels)
 			result.Spec = manifest.Spec
 			// try to send the updated vulnerability manifest
 			_, updateErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -664,8 +664,8 @@ func (a *APIServerStore) StoreCVESummaryStub(ctx context.Context, status string)
 				return nil
 			}
 			// refresh annotations/labels only, keep any existing Spec
-			mergeMaps(result.Annotations, manifest.Annotations)
-			mergeMaps(result.Labels, manifest.Labels)
+			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+			result.Labels = mergeMaps(result.Labels, manifest.Labels)
 			_, updateErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Update(context.Background(), result, metav1.UpdateOptions{})
 			return updateErr
 		})
@@ -1132,8 +1132,8 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 					return getErr
 				}
 				// update the filtered sbom
-				mergeMaps(result.Annotations, filtered.Annotations)
-				mergeMaps(result.Labels, filtered.Labels)
+				result.Annotations = mergeMaps(result.Annotations, filtered.Annotations)
+				result.Labels = mergeMaps(result.Labels, filtered.Labels)
 				result.Spec = filtered.Spec
 				// try to send the updated filtered sbom
 				_, updateErr := a.StorageClient.SBOMSyftFiltereds(a.Namespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -1166,8 +1166,8 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 					return getErr
 				}
 				// update the sbom
-				mergeMaps(result.Annotations, manifest.Annotations)
-				mergeMaps(result.Labels, manifest.Labels)
+				result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
+				result.Labels = mergeMaps(result.Labels, manifest.Labels)
 				result.Spec = manifest.Spec
 				// try to send the updated sbom
 				_, updateErr := a.StorageClient.SBOMSyfts(a.Namespace).Update(context.Background(), result, metav1.UpdateOptions{})
@@ -1201,9 +1201,15 @@ func convertToFilteredSBOM(sbom *v1beta1.SBOMSyft) *v1beta1.SBOMSyftFiltered {
 	}
 }
 
-// mergeMaps merges new into existing, overwriting existing keys with new values
-func mergeMaps(existing, new map[string]string) {
-	for k, v := range new {
+// mergeMaps merges incoming into existing, overwriting existing keys with new values,
+// and returns the merged map. Callers MUST use the returned value: when existing is
+// nil a fresh map is allocated, so ignoring the return silently drops the merge.
+func mergeMaps(existing, incoming map[string]string) map[string]string {
+	if existing == nil {
+		existing = make(map[string]string, len(incoming))
+	}
+	for k, v := range incoming {
 		existing[k] = v
 	}
+	return existing
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -854,14 +854,49 @@ func TestMergeMaps(t *testing.T) {
 			new:      map[string]string{},
 			expected: map[string]string{},
 		},
+		{
+			name:     "merge with nil existing map",
+			existing: nil,
+			new:      map[string]string{"key1": "value1"},
+			expected: map[string]string{"key1": "value1"},
+		},
+		{
+			name:     "merge with nil existing and nil new maps",
+			existing: nil,
+			new:      nil,
+			expected: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mergeMaps(tt.existing, tt.new)
-			assert.Equal(t, tt.expected, tt.existing)
+			got := mergeMaps(tt.existing, tt.new)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestAPIServerStore_StoreCVE_mergesMetadataOnUpdate(t *testing.T) {
+	seeded := &v1beta1.VulnerabilityManifest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kubescape",
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+
+	cve := domain.CVEManifest{
+		Name:        name,
+		Annotations: map[string]string{"k1": "v1"},
+		Labels:      map[string]string{"l1": "v2"},
+	}
+	require.NoError(t, a.StoreCVE(context.TODO(), cve, false))
+
+	got, err := a.StorageClient.VulnerabilityManifests("kubescape").Get(context.TODO(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "v1", got.Annotations["k1"])
+	assert.Equal(t, "v2", got.Labels["l1"])
 }
 
 func TestAPIServerStore_GetCVE_transientError(t *testing.T) {
@@ -1006,13 +1041,16 @@ func TestAPIServerStore_StoreCVESummary_updateGetFailure_transientError(t *testi
 	require.ErrorIs(t, err, injectedErr)
 }
 
+// NOTE: the missing Annotations/Labels seeds here are load-bearing — they drive the
+// nil-map update path (the mergeMaps crash). See also the SBOM/summary/stub
+// retryExhausted tests. Do NOT re-add empty map seeds; that silently deletes the
+// regression coverage. The "merged and saved" half is covered by
+// TestAPIServerStore_StoreCVE_mergesMetadataOnUpdate.
 func TestAPIServerStore_StoreCVE_retryExhausted_transientError(t *testing.T) {
 	seeded := &v1beta1.VulnerabilityManifest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   "kubescape",
-			Annotations: map[string]string{},
-			Labels:      map[string]string{},
+			Name:      name,
+			Namespace: "kubescape",
 		},
 	}
 	clientset := fake.NewSimpleClientset(seeded)
@@ -1030,10 +1068,8 @@ func TestAPIServerStore_StoreCVE_retryExhausted_transientError(t *testing.T) {
 func TestAPIServerStore_StoreSBOM_retryExhausted_transientError(t *testing.T) {
 	seeded := &v1beta1.SBOMSyft{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   "kubescape",
-			Annotations: map[string]string{},
-			Labels:      map[string]string{},
+			Name:      name,
+			Namespace: "kubescape",
 		},
 	}
 	clientset := fake.NewSimpleClientset(seeded)
@@ -1051,10 +1087,8 @@ func TestAPIServerStore_StoreSBOM_retryExhausted_transientError(t *testing.T) {
 func TestAPIServerStore_StoreSBOMFiltered_retryExhausted_transientError(t *testing.T) {
 	seeded := &v1beta1.SBOMSyftFiltered{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   "kubescape",
-			Annotations: map[string]string{},
-			Labels:      map[string]string{},
+			Name:      name,
+			Namespace: "kubescape",
 		},
 	}
 	clientset := fake.NewSimpleClientset(seeded)
@@ -1088,10 +1122,8 @@ func TestAPIServerStore_StoreCVESummary_retryExhausted_transientError(t *testing
 
 	seeded := &v1beta1.VulnerabilityManifestSummary{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName,
-			Namespace:   ns,
-			Annotations: map[string]string{},
-			Labels:      map[string]string{},
+			Name:      resourceName,
+			Namespace: ns,
 		},
 	}
 	clientset := fake.NewSimpleClientset(seeded)
@@ -1139,10 +1171,8 @@ func TestAPIServerStore_StoreCVESummaryStub_retryExhausted_transientError(t *tes
 
 	seeded := &v1beta1.VulnerabilityManifestSummary{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName,
-			Namespace:   ns,
-			Annotations: map[string]string{},
-			Labels:      map[string]string{},
+			Name:      resourceName,
+			Namespace: ns,
 		},
 	}
 	clientset := fake.NewSimpleClientset(seeded)


### PR DESCRIPTION
Fixes #402

## What's going on

`mergeMaps` in `repositories/apiserver.go` wrote straight into the destination map without checking whether it was `nil`. That's fine when the object we're updating already has labels and annotations — but a Kubernetes object without `metadata.labels` / `metadata.annotations` decodes to a **nil** map, not an empty one. In that case the merge panicked with `assignment to entry in nil map`, and since nothing recovers panics in the store layer, the whole kubevuln process went down. The offending object stayed in storage, so the next scan of the same image hit it again.

Every `Store*` update path was affected — 10 call sites across 5 blocks. That's how we found it: while reviewing #399, @matthyx noticed our retry-exhaustion tests had to seed `Annotations: map[string]string{}` explicitly, and dropping those seeds turned the tests panic-red. He filed this issue with a clear diagnosis, and it's a real crash waiting for the right stored object.

## The fix

`mergeMaps` now guards against a nil destination and returns the merged map:

```go
func mergeMaps(existing, new map[string]string) map[string]string {
	if existing == nil {
		existing = make(map[string]string, len(new))
	}
	for k, v := range new {
		existing[k] = v
	}
	return existing
}
```

The 10 call sites (StoreCVE, StoreCVESummary, StoreCVESummaryStub, StoreSBOM filtered and unfiltered) assign the returned map back to the object being updated, so the freshly-allocated map is actually used.

## Tests

- `TestMergeMaps` updated for the new signature, with two new cases covering a nil `existing` map.
- The five retry-exhaustion tests now seed their objects **without** labels/annotations, so they drive the exact update path a malformed stored object would. On the old code they panic; with this change they pass.

## Verification

- `go build ./...` — clean
- `go test ./repositories/...` — 54 passed
- `go test ./core/...` — 108 passed
- `gofmt -l repositories/` and `go vet ./repositories/...` — clean
- Reverting the guard reproduces the exact panic from the issue (`assignment to entry in nil map`) on the retry-exhaustion tests; with the fix they pass.

No behavior change for objects that already have labels/annotations — only the nil case is handled, and callers already assign the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed updates to CVE and SBOM records so merged labels and annotations are consistently saved.
  * Improved handling when existing metadata is missing, preventing update failures and ensuring metadata is preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->