### PR TITLE
fix: send actual lifecycle status in BackendAdapter.SendStatus

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -214,7 +214,7 @@ func (a *BackendAdapter) SendStatus(ctx context.Context, step int) error {
 	report.Status = statuses[step]
 
 	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, &http.Client{}, a.getRequestHeaders(), report)
-	a.sendStatusFunc(sender, sysreport.JobSuccess, true)
+	a.sendStatusFunc(sender, report.Status, true)
 	return nil
 }
 

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -214,7 +214,7 @@ func (a *BackendAdapter) SendStatus(ctx context.Context, step int) error {
 	report.Status = statuses[step]
 
 	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, &http.Client{}, a.getRequestHeaders(), report)
-	a.sendStatusFunc(sender, report.Status, true)
+	a.sendStatusFunc(sender, statuses[step], true)
 	return nil
 }
 

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -312,6 +312,7 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 				sendStatusFunc: func(sender *beClientV1.BaseReportSender, s string, b bool) {
 					report := sender.GetBaseReport()
 					assert.NotEqual(t, *report, tt.report) //nolint:govet
+					assert.Equal(t, statuses[tt.step], s)
 				},
 			}
 			ctx := context.TODO()

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -289,7 +289,6 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 	tests := []struct {
 		name       string
 		step       int
-		report     sysreport.BaseReport
 		wantStatus string
 		wantErr    bool
 	}{
@@ -297,15 +296,6 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 			name:       "send status",
 			step:       1,
 			wantStatus: sysreport.JobStarted,
-			report: sysreport.BaseReport{
-				Reporter:   ReporterName,
-				Target:     "vuln scan:: scanning wlid: wlid , container: container imageTag: imageTag imageHash: imageHash",
-				Status:     "Dequeueing",
-				ActionName: ActionName,
-				ActionID:   "1",
-				ActionIDN:  1,
-				Details:    "started",
-			},
 		},
 		{
 			name:       "inqueueing step reports started",
@@ -323,12 +313,12 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 			wantStatus: sysreport.JobDone,
 		},
 	}
-	for _, tt := range tests { //nolint:govet
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var called bool
 			a := &BackendAdapter{
 				sendStatusFunc: func(sender *beClientV1.BaseReportSender, s string, b bool) {
-					report := sender.GetBaseReport()
-					assert.NotEqual(t, *report, tt.report) //nolint:govet
+					called = true
 					assert.Equal(t, tt.wantStatus, s)
 				},
 			}
@@ -344,6 +334,7 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 			if err := a.SendStatus(ctx, tt.step); (err != nil) != tt.wantErr {
 				t.Errorf("SendStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			assert.True(t, called, "sendStatusFunc was never invoked")
 		})
 	}
 }

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -287,14 +287,16 @@ func TestNewBackendAdapter(t *testing.T) {
 
 func TestBackendAdapter_SendStatus(t *testing.T) {
 	tests := []struct {
-		name    string
-		step    int
-		report  sysreport.BaseReport
-		wantErr bool
+		name       string
+		step       int
+		report     sysreport.BaseReport
+		wantStatus string
+		wantErr    bool
 	}{
 		{
-			name: "send status",
-			step: 1,
+			name:       "send status",
+			step:       1,
+			wantStatus: sysreport.JobStarted,
 			report: sysreport.BaseReport{
 				Reporter:   ReporterName,
 				Target:     "vuln scan:: scanning wlid: wlid , container: container imageTag: imageTag imageHash: imageHash",
@@ -305,6 +307,21 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 				Details:    "started",
 			},
 		},
+		{
+			name:       "inqueueing step reports started",
+			step:       0,
+			wantStatus: sysreport.JobStarted,
+		},
+		{
+			name:       "second dequeueing step reports success",
+			step:       2,
+			wantStatus: sysreport.JobSuccess,
+		},
+		{
+			name:       "final dequeueing step reports done",
+			step:       3,
+			wantStatus: sysreport.JobDone,
+		},
 	}
 	for _, tt := range tests { //nolint:govet
 		t.Run(tt.name, func(t *testing.T) {
@@ -312,7 +329,7 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 				sendStatusFunc: func(sender *beClientV1.BaseReportSender, s string, b bool) {
 					report := sender.GetBaseReport()
 					assert.NotEqual(t, *report, tt.report) //nolint:govet
-					assert.Equal(t, statuses[tt.step], s)
+					assert.Equal(t, tt.wantStatus, s)
 				},
 			}
 			ctx := context.TODO()


### PR DESCRIPTION
## Overview
`BackendAdapter.SendStatus` computed the correct lifecycle status (`JobStarted`, `JobSuccess`, `JobDone`) into `report.Status`, but the call to `sendStatusFunc` always passed the hardcoded `sysreport.JobSuccess` constant instead of `report.Status`. This fix passes `report.Status` so the transport-level status argument matches the step being reported.

## How to Test
Run `go test ./adapters/v1/... -run TestBackendAdapter_SendStatus -v`. The updated test asserts that the status passed to `sendStatusFunc` matches the expected status for the given step.

## Related issues/PRs:
Resolved #406

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status reports now accurately reflect the computed result of each job step instead of always reporting success.

* **Tests**
  * Added coverage to verify that emitted statuses match the expected step results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->