### PR TITLE
fix: correct reversed strings.HasPrefix args in linkToVuln

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -242,9 +242,9 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 
 func linkToVuln(id string) string {
 	switch {
-	case strings.HasPrefix("EUVD-", id):
+	case strings.HasPrefix(id, "EUVD-"):
 		return "https://euvd.enisa.europa.eu/enisa/" + id
-	case strings.HasPrefix("GHSA-", id):
+	case strings.HasPrefix(id, "GHSA-"):
 		return "https://github.com/advisories/" + id
 	default:
 		return "https://nvd.nist.gov/vuln/detail/" + id

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -238,3 +238,17 @@ func Test_suggestedVersion(t *testing.T) {
 		})
 	}
 }
+
+func Test_linkToVuln(t *testing.T) {
+	tests := []struct{ name, id, want string }{
+		{"GHSA advisory", "GHSA-jc7w-c686-c4v9", "https://github.com/advisories/GHSA-jc7w-c686-c4v9"},
+		{"EUVD advisory", "EUVD-2022-1234", "https://euvd.enisa.europa.eu/enisa/EUVD-2022-1234"},
+		{"CVE defaults to NVD", "CVE-2021-21300", "https://nvd.nist.gov/vuln/detail/CVE-2021-21300"},
+		{"short corrupt id not EUVD", "E", "https://nvd.nist.gov/vuln/detail/E"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, linkToVuln(tt.id))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #408

## Overview

`linkToVuln` in `adapters/v1/domain_to_armo.go` passed the arguments to
`strings.HasPrefix` in the wrong order, which made both the `EUVD-` and
`GHSA-` branches unreachable dead code:

- Every GHSA/EUVD advisory fell through to the NVD default, so scan reports
  rendered links like `https://nvd.nist.gov/vuln/detail/GHSA-...` (404).
- Short/corrupt ids such as `"E"` matched the reversed `EUVD-` check and were
  rewritten to a bogus ENISA URL.

This swaps the argument order so `EUVD-` and `GHSA-` ids map to their correct
advisory URLs.

## Changes

### adapters/v1/domain_to_armo.go (L245, L247)

- `strings.HasPrefix("EUVD-", id)` → `strings.HasPrefix(id, "EUVD-")`
- `strings.HasPrefix("GHSA-", id)` → `strings.HasPrefix(id, "GHSA-")`

The default/NVD branch is unchanged, so CVE ids behave identically to before.

### adapters/v1/domain_to_armo_test.go

- New `Test_linkToVuln` table-driven test covering `GHSA-`, `EUVD-`, `CVE-`,
  and short/corrupt-id inputs, using the repo's own fixture id
  `GHSA-jc7w-c686-c4v9`.
- Verified to fail on the base version (only the CVE row passes) and pass with
  this change, so the dead branches cannot silently regress.

## Verification

- `go build ./...` — clean
- `go vet` / `gofmt -l` on the changed files — clean
- `go test ./adapters/v1/ -run 'Test_linkToVuln|Test_domainToArmo|Test_suggestedVersion'` — all pass
- Note: `Test_syftAdapter_CreateSBOM` fails on this arm64 machine on `main`
  too (pre-existing amd64-vs-arm64 golden-fixture mismatch, confirmed against
  a pristine `upstream/main` checkout) — unrelated to this change.

## Scope note

This fixes the URL data produced by kubevuln. Frontend rendering of
`github.com/advisories/...` links lives in the operator UI repo and is out of
scope here.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected links for EUVD vulnerabilities so they direct to the appropriate vulnerability pages.
  * Preserved correct link handling for GHSA and CVE identifiers, including short or invalid IDs.

* **Tests**
  * Added coverage for vulnerability link generation across supported identifier formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->