### PR TITLE
fix: StoreVEX write path lacks conflict-safe retry

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -700,31 +700,57 @@ func (a *APIServerStore) StoreVEX(ctx context.Context, cve domain.CVEManifest, c
 		return nil
 	}
 
-	err := a.createVEX(ctx, cve, cvep)
+	// Check for an existing container first so the common "VEX already exists" path
+	// (every scan after the first one for a given image) goes straight to the cheap
+	// update below, instead of paying for building the full VEX document, hashing it,
+	// and POSTing it via createVEX only to discard the result on AlreadyExists.
+	_, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{})
 	switch {
-	case errors.IsAlreadyExists(err):
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			// retrieve the latest version before attempting update
-			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-			vexContainer, getErr := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{})
-			if getErr != nil {
-				return getErr
-			}
-			return a.updateVEX(ctx, cve, cvep, vexContainer)
-		})
-		if retryErr != nil {
-			logger.L().Debug("failed to update VEX in storage", helpers.Error(retryErr),
+	case errors.IsNotFound(err):
+		err = a.createVEX(ctx, cve, cvep)
+		switch {
+		case err == nil:
+			logger.L().Debug("stored VEX in storage", helpers.String("name", cvep.Name))
+			return nil
+		case errors.IsAlreadyExists(err):
+			// A concurrent writer created the container between our Get and our
+			// Create; fall through to the retry-on-conflict update path below
+			// instead of surfacing the raw AlreadyExists error.
+		default:
+			logger.L().Debug("failed to store VEX in storage", helpers.Error(err),
 				helpers.String("name", cvep.Name))
-			return fmt.Errorf("failed to update VEX in storage: %w", retryErr)
+			return fmt.Errorf("failed to store VEX in storage: %w", err)
 		}
-		logger.L().Debug("updated VEX in storage", helpers.String("name", cvep.Name))
 	case err != nil:
-		logger.L().Debug("failed to store VEX in storage", helpers.Error(err),
+		logger.L().Debug("failed to get VEX from storage", helpers.Error(err),
 			helpers.String("name", cvep.Name))
-		return fmt.Errorf("failed to store VEX in storage: %w", err)
-	default:
-		logger.L().Debug("stored VEX in storage", helpers.String("name", cvep.Name))
+		return fmt.Errorf("failed to get VEX from storage: %w", err)
 	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// retrieve the latest version before attempting update
+		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+		//
+		// NOTE: this must NOT use GetOptions{ResourceVersion: "metadata"} like the
+		// sibling Store* methods do. That option returns an ObjectMeta-only object
+		// with a zero Spec in kubescape/storage's apiserver, which is safe for the
+		// siblings because they overwrite Spec wholesale. updateVEX instead merges
+		// into vexContainer.Spec.Statements, so a metadata-only read would silently
+		// drop every previously stored statement and then fail when it tries to
+		// parse the zeroed Spec.Metadata.Timestamp. The fake clientset used in tests
+		// ignores GetOptions entirely, so no test can catch a regression here.
+		vexContainer, getErr := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		return a.updateVEX(ctx, cve, cvep, vexContainer)
+	})
+	if retryErr != nil {
+		logger.L().Debug("failed to update VEX in storage", helpers.Error(retryErr),
+			helpers.String("name", cvep.Name))
+		return fmt.Errorf("failed to update VEX in storage: %w", retryErr)
+	}
+	logger.L().Debug("updated VEX in storage", helpers.String("name", cvep.Name))
 
 	return nil
 }

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -706,7 +706,7 @@ func (a *APIServerStore) StoreVEX(ctx context.Context, cve domain.CVEManifest, c
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			// retrieve the latest version before attempting update
 			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-			vexContainer, getErr := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{ResourceVersion: "metadata"})
+			vexContainer, getErr := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{})
 			if getErr != nil {
 				return getErr
 			}

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -704,7 +704,10 @@ func (a *APIServerStore) StoreVEX(ctx context.Context, cve domain.CVEManifest, c
 	// (every scan after the first one for a given image) goes straight to the cheap
 	// update below, instead of paying for building the full VEX document, hashing it,
 	// and POSTing it via createVEX only to discard the result on AlreadyExists.
-	_, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{})
+	existing, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cvep.Name, metav1.GetOptions{})
+	// Get returns a non-nil (but empty) object even on error, so success must be
+	// tracked explicitly rather than by checking the returned pointer for nil.
+	haveExisting := err == nil
 	switch {
 	case errors.IsNotFound(err):
 		err = a.createVEX(ctx, cve, cvep)
@@ -728,20 +731,29 @@ func (a *APIServerStore) StoreVEX(ctx context.Context, cve domain.CVEManifest, c
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// retrieve the latest version before attempting update
-		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-		//
-		// NOTE: this must NOT use GetOptions{ResourceVersion: "metadata"} like the
-		// sibling Store* methods do. That option returns an ObjectMeta-only object
-		// with a zero Spec in kubescape/storage's apiserver, which is safe for the
-		// siblings because they overwrite Spec wholesale. updateVEX instead merges
-		// into vexContainer.Spec.Statements, so a metadata-only read would silently
-		// drop every previously stored statement and then fail when it tries to
-		// parse the zeroed Spec.Metadata.Timestamp. The fake clientset used in tests
-		// ignores GetOptions entirely, so no test can catch a regression here.
-		vexContainer, getErr := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return getErr
+		// Reuse the object already fetched above on the first attempt, so the common
+		// "VEX already exists" path only costs a single Get. Any retry (after a real
+		// conflict) forces a fresh Get for the latest resourceVersion.
+		vexContainer := existing
+		alreadyHadExisting := haveExisting
+		haveExisting = false
+		if !alreadyHadExisting {
+			// retrieve the latest version before attempting update
+			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+			//
+			// NOTE: this must NOT use GetOptions{ResourceVersion: "metadata"} like the
+			// sibling Store* methods do. That option returns an ObjectMeta-only object
+			// with a zero Spec in kubescape/storage's apiserver, which is safe for the
+			// siblings because they overwrite Spec wholesale. updateVEX instead merges
+			// into vexContainer.Spec.Statements, so a metadata-only read would silently
+			// drop every previously stored statement and then fail when it tries to
+			// parse the zeroed Spec.Metadata.Timestamp. The fake clientset used in tests
+			// ignores GetOptions entirely, so no test can catch a regression here.
+			var getErr error
+			vexContainer, getErr = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cvep.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
 		}
 		return a.updateVEX(ctx, cve, cvep, vexContainer)
 	})

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -700,30 +700,33 @@ func (a *APIServerStore) StoreVEX(ctx context.Context, cve domain.CVEManifest, c
 		return nil
 	}
 
-	// Check if VEX already exists
-	// If it does, update it
-	// If it doesn't, create it
-	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// Create VEX
-			err = a.createVEX(ctx, cve, cvep)
-			if err != nil {
-				return err
+	err := a.createVEX(ctx, cve, cvep)
+	switch {
+	case errors.IsAlreadyExists(err):
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// retrieve the latest version before attempting update
+			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+			vexContainer, getErr := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cvep.Name, metav1.GetOptions{ResourceVersion: "metadata"})
+			if getErr != nil {
+				return getErr
 			}
-		} else {
-			return err
+			return a.updateVEX(ctx, cve, cvep, vexContainer)
+		})
+		if retryErr != nil {
+			logger.L().Debug("failed to update VEX in storage", helpers.Error(retryErr),
+				helpers.String("name", cvep.Name))
+			return fmt.Errorf("failed to update VEX in storage: %w", retryErr)
 		}
-	} else {
-		// Update VEX
-		err = a.updateVEX(ctx, cve, cvep, vexContainer)
-		if err != nil {
-			return err
-		}
+		logger.L().Debug("updated VEX in storage", helpers.String("name", cvep.Name))
+	case err != nil:
+		logger.L().Debug("failed to store VEX in storage", helpers.Error(err),
+			helpers.String("name", cvep.Name))
+		return fmt.Errorf("failed to store VEX in storage: %w", err)
+	default:
+		logger.L().Debug("stored VEX in storage", helpers.String("name", cvep.Name))
 	}
 
 	return nil
-
 }
 
 func createProductStructForImageAndPackage(imagePullable string, packagePURL string) (*v1beta1.Product, error) {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1291,4 +1291,7 @@ func TestAPIServerStore_StoreVEX_concurrentCreateRace(t *testing.T) {
 	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, vexContainer)
+	// updateVEX bumps Metadata.Version on every successful update, so a version > 0
+	// confirms the fallback actually went through updateVEX rather than a no-op.
+	require.Greater(t, vexContainer.Spec.Metadata.Version, int64(0))
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
@@ -1210,4 +1211,84 @@ func TestAPIServerStore_StoreCVESummaryStub_retryExhausted_transientError(t *tes
 	err = a.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema)
 	require.True(t, apierrors.IsConflict(err))
 	require.Equal(t, retry.DefaultRetry.Steps, updateCalls)
+}
+
+func TestAPIServerStore_StoreVEX_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "openvulnerabilityexchangecontainers", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
+	err := a.StoreVEX(context.TODO(), cve, cve, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreVEX_updateGetFailure_transientError(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	clientset.PrependReactor("create", "openvulnerabilityexchangecontainers", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "openvulnerabilityexchangecontainers"}, name)
+	})
+	clientset.PrependReactor("get", "openvulnerabilityexchangecontainers", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, injectedErr
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
+	err := a.StoreVEX(context.TODO(), cve, cve, false)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestAPIServerStore_StoreVEX_retryExhausted_transientError(t *testing.T) {
+	seeded := &v1beta1.OpenVulnerabilityExchangeContainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "kubescape",
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+		Spec: v1beta1.VEX{
+			Metadata: v1beta1.Metadata{Timestamp: time.Now().Format(time.RFC3339)},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	var updateCalls int
+	clientset.PrependReactor("update", "openvulnerabilityexchangecontainers", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "openvulnerabilityexchangecontainers"}, name, fmt.Errorf("conflict"))
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
+	err := a.StoreVEX(context.TODO(), cve, cve, false)
+	require.True(t, apierrors.IsConflict(err))
+	require.Equal(t, retry.DefaultRetry.Steps, updateCalls)
+}
+
+// TestAPIServerStore_StoreVEX_concurrentCreateRace guards against a regression where a
+// caller that loses a concurrent create race (the VEX container was created by a concurrent
+// writer between this caller's earlier NotFound check and its own Create call) received the
+// raw AlreadyExists error instead of falling back to an update, unlike every other Store*
+// method in this file.
+func TestAPIServerStore_StoreVEX_concurrentCreateRace(t *testing.T) {
+	// Seed the container as if a concurrent writer already created it, so this caller's
+	// own Create call naturally races and loses with AlreadyExists.
+	seeded := &v1beta1.OpenVulnerabilityExchangeContainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kubescape",
+		},
+		Spec: v1beta1.VEX{
+			Metadata: v1beta1.Metadata{Timestamp: time.Now().Format(time.RFC3339)},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
+	err := a.StoreVEX(context.TODO(), cve, cve, false)
+	require.NoError(t, err)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, vexContainer)
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1231,7 +1231,15 @@ func TestAPIServerStore_StoreVEX_updateGetFailure_transientError(t *testing.T) {
 	clientset.PrependReactor("create", "openvulnerabilityexchangecontainers", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "openvulnerabilityexchangecontainers"}, name)
 	})
+	var getCalls int
 	clientset.PrependReactor("get", "openvulnerabilityexchangecontainers", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 1 {
+			// the initial existence check: let it fall through to the tracker, which
+			// reports NotFound since nothing has been created yet
+			return false, nil, nil
+		}
+		// the Get inside the retry-on-conflict loop, after createVEX raced to AlreadyExists
 		return true, nil, injectedErr
 	})
 	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
@@ -1266,32 +1274,69 @@ func TestAPIServerStore_StoreVEX_retryExhausted_transientError(t *testing.T) {
 }
 
 // TestAPIServerStore_StoreVEX_concurrentCreateRace guards against a regression where a
-// caller that loses a concurrent create race (the VEX container was created by a concurrent
-// writer between this caller's earlier NotFound check and its own Create call) received the
-// raw AlreadyExists error instead of falling back to an update, unlike every other Store*
-// method in this file.
+// caller whose Create lost the race (another writer created the container between this
+// caller's own NotFound-returning Get and its Create call) received the raw AlreadyExists
+// error instead of falling back to an update, unlike every other Store* method in this file.
 func TestAPIServerStore_StoreVEX_concurrentCreateRace(t *testing.T) {
-	// Seed the container as if a concurrent writer already created it, so this caller's
-	// own Create call naturally races and loses with AlreadyExists.
-	seeded := &v1beta1.OpenVulnerabilityExchangeContainer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "kubescape",
-		},
-		Spec: v1beta1.VEX{
-			Metadata: v1beta1.Metadata{Timestamp: time.Now().Format(time.RFC3339)},
-		},
-	}
-	clientset := fake.NewSimpleClientset(seeded)
+	clientset := fake.NewSimpleClientset()
+	var createCalls int
+	clientset.PrependReactor("create", "openvulnerabilityexchangecontainers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createCalls++
+		// Simulate a concurrent writer's createVEX beating this caller's Create:
+		// insert the object directly into the tracker (bypassing the Fake's own
+		// action-invocation lock, which is already held while this reactor runs,
+		// to avoid deadlocking on a reentrant call through the client) and report
+		// AlreadyExists back to the caller, exactly as the real apiserver would.
+		created := action.(k8stesting.CreateAction).GetObject().(*v1beta1.OpenVulnerabilityExchangeContainer).DeepCopy()
+		require.NoError(t, clientset.Tracker().Create(action.GetResource(), created, action.GetNamespace()))
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "openvulnerabilityexchangecontainers"}, name)
+	})
 	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
 	cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
 	err := a.StoreVEX(context.TODO(), cve, cve, false)
 	require.NoError(t, err)
+	require.Equal(t, 1, createCalls)
 
 	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, vexContainer)
 	// updateVEX bumps Metadata.Version on every successful update, so a version > 0
 	// confirms the fallback actually went through updateVEX rather than a no-op.
+	require.Greater(t, vexContainer.Spec.Metadata.Version, int64(0))
+}
+
+// TestAPIServerStore_StoreVEX_recoversFromTransientConflict guards against a regression
+// where the retry loop stops actually retrying (e.g. a future refactor hoists the Get
+// outside the closure and keeps retrying against a stale resourceVersion). It asserts the
+// headline behaviour promised by RetryOnConflict: a single transient conflict is absorbed
+// and the second attempt succeeds.
+func TestAPIServerStore_StoreVEX_recoversFromTransientConflict(t *testing.T) {
+	seeded := &v1beta1.OpenVulnerabilityExchangeContainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "kubescape",
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+		Spec: v1beta1.VEX{
+			Metadata: v1beta1.Metadata{Timestamp: time.Now().Format(time.RFC3339)},
+		},
+	}
+	clientset := fake.NewSimpleClientset(seeded)
+	var updateCalls int
+	clientset.PrependReactor("update", "openvulnerabilityexchangecontainers", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "openvulnerabilityexchangecontainers"}, name, fmt.Errorf("conflict"))
+		}
+		return false, nil, nil // fall through to the tracker's default update handling
+	})
+	a := &APIServerStore{StorageClient: clientset.SpdxV1beta1(), Namespace: "kubescape"}
+	cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
+	require.NoError(t, a.StoreVEX(context.TODO(), cve, cve, false))
+	require.Equal(t, 2, updateCalls)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+	require.NoError(t, err)
 	require.Greater(t, vexContainer.Spec.Metadata.Version, int64(0))
 }


### PR DESCRIPTION
## Overview

`StoreVEX`/`createVEX`/`updateVEX` in `repositories/apiserver.go` were the only write path in `APIServerStore` missing the conflict-safe write pattern already used by every sibling `Store*` method (`StoreCVE`, `StoreCVESummary`, `StoreCVESummaryStub`, `StoreSBOM`): fall back to an update on `AlreadyExists`, and retry the update with `retry.RetryOnConflict`.

Previously, `StoreVEX` did a `Get`-then-branch: if two callers raced and both observed `NotFound`, the loser's `createVEX` call returned a raw `AlreadyExists` error with no fallback to an update. Separately, `updateVEX`'s final `Update()` call had no conflict retry at all, so any concurrent writer bumping the object's `resourceVersion` between `Get` and `Update` produced an unretried 409. Since `core/services/scan.go` only logs a warning when `StoreVEX` fails ("storing the VEX is not critical"), both failure modes silently left the VEX document out of sync with the CVE manifest/summary written in the same scan — a routine occurrence whenever two workloads share an image are scanned concurrently.

`StoreVEX` now checks for an existing container first (`Get`), same as before. On `NotFound` it calls `createVEX`; if that races and comes back `AlreadyExists`, it falls through into a `retry.RetryOnConflict` loop instead of surfacing the raw error. If the container already exists, it goes straight into the same retry loop, which re-`Get`s the latest object and calls `updateVEX` against it, retrying on conflict. This keeps the common "already exists" path cheap (no wasted full-document build/hash/POST via `createVEX` that gets thrown away), while still closing both race windows. Errors are wrapped and returned instead of being dropped. No change to VEX content/statement logic in `updateVEX`/`createVEX` (ID/Name mapping, not_affected reset, product/statement construction) — this PR is scoped purely to the write-conflict robustness envelope.

The retry loop's `Get` deliberately uses plain `GetOptions{}`, **not** `GetOptions{ResourceVersion: "metadata"}` like the sibling methods use — that variant returns an ObjectMeta-only object with a zero `Spec` in `kubescape/storage`, which the siblings can tolerate because they overwrite `Spec` wholesale. `updateVEX` instead merges into `Spec.Statements`, so a metadata-only read would silently drop every existing statement. This is called out in a comment at the call site since the fake clientset used in tests ignores `GetOptions` entirely and can't catch a regression here.

## Additional Information

This is the same class of correctness issue already fixed for the other four `Store*` methods in #396 / #399 (surfacing storage failures, adding `retry.RetryOnConflict`), but that fix pass never reached `StoreVEX`, which had a structurally different (and unsafe) shape.

A pre-existing, unrelated gap was found during review — `updateVEX` never refreshes `Labels`/`Annotations` from the latest scan, unlike its siblings which `mergeMaps` them before `Update`. That's tracked separately as #419 rather than folded into this PR.

## How to Test

```
go build ./...
go vet ./repositories/...
go test ./repositories/... -run TestAPIServerStore -v
```

All existing VEX tests plus the new ones added in this PR pass, including a test that a container created concurrently by another writer is correctly picked up via the update fallback, and a test that a single transient conflict is retried and recovered from (not just that retries eventually exhaust).

## Related issues/PRs:

* Resolved #410

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when saving VEX data, including scenarios where multiple operations attempt to create the same container simultaneously.
  - Existing containers are now refreshed and updated more consistently.
  - Added recovery for temporary conflicts during updates.
  - Improved error reporting when container creation, retrieval, or updates fail, making issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->