### PR TITLE
fix(repositories): synchronize labels and annotations on updateVEX

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -963,6 +963,8 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 	vexDoc.Metadata.ID = calculatedId
 
 	// Update the VEX container
+	vexContainer.Annotations = mergeMaps(vexContainer.Annotations, cvep.Annotations)
+	vexContainer.Labels = mergeMaps(vexContainer.Labels, cvep.Labels)
 	vexContainer.Spec = vexDoc
 	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(context.Background(), vexContainer, metav1.UpdateOptions{})
 

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -601,6 +601,72 @@ func TestAPIServerStore_updateVEX_doesNotNormalizeCorrectShapeWithNonURLDataSour
 	}
 }
 
+func TestAPIServerStore_updateVEX_mergesMetadataOnUpdate(t *testing.T) {
+	cveManifestFull := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+	require.NotEmpty(t, cveManifestFull.Content.Matches)
+
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	// Create with initial annotations/labels preserving existing metadata
+	if cveManifestFull.Annotations == nil {
+		cveManifestFull.Annotations = make(map[string]string)
+	}
+	cveManifestFull.Annotations["keep-me"] = "init-val"
+	cveManifestFull.Annotations["k1"] = "v1"
+
+	if cveManifestFiltered.Annotations == nil {
+		cveManifestFiltered.Annotations = make(map[string]string)
+	}
+	cveManifestFiltered.Annotations["keep-me"] = "init-val"
+	cveManifestFiltered.Annotations["k1"] = "v1"
+
+	if cveManifestFull.Labels == nil {
+		cveManifestFull.Labels = make(map[string]string)
+	}
+	cveManifestFull.Labels["l1"] = "v2"
+
+	if cveManifestFiltered.Labels == nil {
+		cveManifestFiltered.Labels = make(map[string]string)
+	}
+	cveManifestFiltered.Labels["l1"] = "v2"
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+
+	// Verify they are created correctly
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "v1", vexContainer.Annotations["k1"])
+	assert.Equal(t, "v2", vexContainer.Labels["l1"])
+	assert.Equal(t, "init-val", vexContainer.Annotations["keep-me"])
+
+	// Update with new annotations/labels (omitting keep-me to verify merge retention)
+	cveManifestFull.Annotations = map[string]string{"k1": "new-v1", "k2": "v2"}
+	cveManifestFull.Labels = map[string]string{"l1": "new-v2", "l2": "v3"}
+	cveManifestFiltered.Annotations = map[string]string{"k1": "new-v1", "k2": "v2"}
+	cveManifestFiltered.Labels = map[string]string{"l1": "new-v2", "l2": "v3"}
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+
+	// Verify they are merged on update
+	vexContainerAfterUpdate, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "new-v1", vexContainerAfterUpdate.Annotations["k1"])
+	assert.Equal(t, "v2", vexContainerAfterUpdate.Annotations["k2"])
+	assert.Equal(t, "init-val", vexContainerAfterUpdate.Annotations["keep-me"])
+	assert.Equal(t, "new-v2", vexContainerAfterUpdate.Labels["l1"])
+	assert.Equal(t, "v3", vexContainerAfterUpdate.Labels["l2"])
+}
+
 func TestAPIServerStore_StoreCVESummaryStub(t *testing.T) {
 	workload := domain.ScanCommand{
 		Wlid:          "wlid://cluster-kind/namespace-local-path-storage/deployment-local-path-provisioner",


### PR DESCRIPTION
## Overview
This PR adds the missing metadata (labels and annotations) synchronization to the `StoreVEX` update path inside `repositories/apiserver.go`. 

When updating a VEX container, it now merges labels and annotations from the incoming `CVEManifest` using the `mergeMaps` helper, aligning it with the other sibling storage methods.

## Additional Information
N/A

## How to Test
A new unit test `TestAPIServerStore_updateVEX_mergesMetadataOnUpdate` has been added to verify that initial labels/annotations are created properly, and that consecutive updates to metadata are correctly merged (new keys added, existing keys updated) instead of remaining frozen.

Run the following command:
`TMPDIR=/tmp go test -count=1 -v ./repositories -run TestAPIServerStore_updateVEX_mergesMetadataOnUpdate`

## Examples/Screenshots
**Before (Failing test showing the bug):**
<img width="1101" height="653" alt="Screenshot 2026-08-02 at 10 30 44 AM" src="https://github.com/user-attachments/assets/37c5b05f-3bc5-4a73-9a67-48c3d4d43570" />


**After (Passing test showing the fix):**
<img width="1079" height="126" alt="Screenshot 2026-08-02 at 10 31 33 AM" src="https://github.com/user-attachments/assets/e000612a-bd51-4dca-9605-c9faea115d03" />


## Related issues/PRs:
* Resolved #418

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - VEX updates now preserve existing metadata while incorporating new annotations and labels.
  - Metadata is retained consistently when VEX records are updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->