### PR TITLE
fix: port GCP Workload-Identity ADC fallback to sidecar scanner

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -202,22 +202,27 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	}
 
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
-		if isGCPRegistry(imageID) {
+		unauthorizedErr := err
+		if isGCPRegistry(pullRef) {
 			if gcpCreds, gcpErr := gcpCredentials(ctx); gcpErr != nil {
 				logger.L().Debug("GCP ADC unavailable, falling back to anonymous",
+					helpers.Error(gcpErr),
 					helpers.String("imageID", imageID))
 			} else {
 				registryOptions.Credentials = []image.RegistryCredentials{*gcpCreds}
-				src, err = syft.GetSource(ctxWithSize, imageID, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+				src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
 			}
 		}
 		// If GCP ADC was not attempted, succeeded in auth but still got 401, or the image is not a GCP registry,
 		// fall back to anonymous access. err/src retain the result of the last attempt.
-		if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
-			logger.L().Debug("got 401, retrying without credentials",
+		if err != nil {
+			logger.L().Debug("retrying without credentials",
 				helpers.String("imageID", imageID))
 			registryOptions.Credentials = nil
-			src, err = syft.GetSource(ctxWithSize, rewriteImageRef(imageID, s.proxyRegistryMap), syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+			src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
+				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
+			}
 		}
 	}
 

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -26,7 +26,73 @@ import (
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"golang.org/x/oauth2/google"
 )
+
+func isGCPRegistry(imageID string) bool {
+	host, _, _ := strings.Cut(imageID, "/")
+	return host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") || strings.HasSuffix(host, "-docker.pkg.dev")
+}
+
+func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, err
+	}
+	token, err := creds.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+	return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: token.AccessToken}, nil
+}
+
+// gcpCredsFn is an indirection over gcpCredentials so resolveSource can be
+// unit-tested without a live GCP environment.
+var gcpCredsFn = gcpCredentials
+
+// sourceGetter abstracts the syft.GetSource call so the fallback ordering in
+// resolveSource is testable with a scripted implementation.
+type sourceGetter func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error)
+
+// resolveSource downloads an image source, applying the MANIFEST_UNKNOWN and
+// 401/ADC/anonymous fallbacks in order. It mirrors the retry chain in
+// adapters/v1/syft.go so the sidecar and in-process adapters behave the same.
+func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag string, opts image.RegistryOptions) (source.Source, error) {
+	pullRef := imageID
+	src, err := get(ctx, pullRef, &opts)
+	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
+			helpers.String("imageTag", imageTag),
+			helpers.String("imageID", imageID))
+		pullRef = imageTag
+		src, err = get(ctx, pullRef, &opts)
+	}
+	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
+		unauthorizedErr := err
+		if isGCPRegistry(imageID) {
+			if gcpCreds, gcpErr := gcpCredsFn(ctx); gcpErr != nil {
+				logger.L().Debug("GCP ADC unavailable, falling back to anonymous",
+					helpers.Error(gcpErr),
+					helpers.String("imageID", imageID))
+			} else {
+				opts.Credentials = []image.RegistryCredentials{*gcpCreds}
+				src, err = get(ctx, pullRef, &opts)
+			}
+		}
+		// If GCP ADC was not attempted, succeeded in auth but still got 401, or
+		// the image is not a GCP registry, fall back to anonymous access.
+		if err != nil {
+			logger.L().Debug("retrying without credentials",
+				helpers.String("imageID", imageID))
+			opts.Credentials = nil
+			src, err = get(ctx, pullRef, &opts)
+			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
+				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
+			}
+		}
+	}
+	return src, err
+}
 
 type scannerServer struct {
 	pb.UnimplementedSBOMScannerServer
@@ -95,25 +161,12 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 
 	// Download image from registry
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))
-	ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, req.MaxImageSize)
-	src, err := syft.GetSource(ctxWithSize, imageID,
-		syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithPlatform(imgPlatform).WithSources("registry"))
-
-	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
-		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
-			helpers.String("imageTag", imageTag),
-			helpers.String("imageID", imageID))
-		src, err = syft.GetSource(ctxWithSize, imageTag,
-			syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithPlatform(imgPlatform).WithSources("registry"))
-	}
-
-	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
-		logger.L().Debug("got 401, retrying without credentials",
-			helpers.String("imageID", imageID))
-		registryOptions.Credentials = nil
-		src, err = syft.GetSource(ctxWithSize, imageID,
-			syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithPlatform(imgPlatform).WithSources("registry"))
-	}
+	src, err := resolveSource(ctx, func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		// Pulls intentionally run on a detached context (see #421); the request ctx is used only for gcpCredentials inside resolveSource.
+		ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, req.MaxImageSize)
+		return syft.GetSource(ctxWithSize, ref,
+			syft.DefaultGetSourceConfig().WithRegistryOptions(opts).WithPlatform(imgPlatform).WithSources("registry"))
+	}, imageID, imageTag, registryOptions)
 
 	switch {
 	case err != nil && strings.Contains(err.Error(), image.ErrImageTooLarge.Error()):

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -2,11 +2,14 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/anchore/syft/syft/source"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,4 +73,147 @@ func TestCreateSBOM_ContextCancelled(t *testing.T) {
 	})
 	assert.Nil(t, resp)
 	require.Error(t, err)
+}
+
+func TestIsGCPRegistry(t *testing.T) {
+	tests := []struct {
+		imageID string
+		want    bool
+	}{
+		{"gcr.io/foo/bar", true},
+		{"us.gcr.io/foo/bar", true},
+		{"us-docker.pkg.dev/foo/bar", true},
+		{"europe-west1-docker.pkg.dev/project/repo/image:tag", true},
+		{"quay.io/foo/bar", false},
+		{"quay.io/foo/bar-docker.pkg.dev/x", false},
+		{"index.docker.io/library/alpine", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.imageID, func(t *testing.T) {
+			assert.Equal(t, tt.want, isGCPRegistry(tt.imageID))
+		})
+	}
+}
+
+func TestResolveSource(t *testing.T) {
+	err401 := errors.New("401 Unauthorized")
+	err403 := errors.New("403 Forbidden")
+	manifestUnknownErr := errors.New("MANIFEST_UNKNOWN")
+
+	tests := []struct {
+		name            string
+		imageID         string
+		imageTag        string
+		results         []error
+		adcErr          error
+		wantCalls       int
+		wantLastCreds   []image.RegistryCredentials
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+		wantRefs        []string
+	}{
+		{
+			name:      "non-GCP image + 401 falls back to anonymous",
+			imageID:   "docker.io/library/nginx",
+			results:   []error{err401, err403},
+			wantCalls: 2,
+			wantErr:   true,
+		},
+		{
+			name:      "GCP image, ADC unavailable, falls back to anonymous",
+			imageID:   "gcr.io/project/image",
+			results:   []error{err401, err403},
+			adcErr:    errors.New("ADC unavailable"),
+			wantCalls: 2,
+			wantErr:   true,
+		},
+		{
+			name:    "GCP image, ADC available, retry succeeds",
+			imageID: "gcr.io/project/image",
+			results: []error{err401, nil},
+			wantLastCreds: []image.RegistryCredentials{
+				{Username: "oauth2accesstoken", Password: "token"},
+			},
+			wantCalls: 2,
+		},
+		{
+			name:      "GCP image, ADC succeeds but pull fails non-401, still anonymous and restores Unauthorize",
+			imageID:   "gcr.io/project/image",
+			results:   []error{err401, err403, err403},
+			wantCalls: 3,
+			wantErr:   true,
+			wantErrIs: err401,
+		},
+		{
+			name:     "MANIFEST_UNKNOWN on imageID, 401 on imageTag, retries use imageTag",
+			imageID:  "gcr.io/project/image@sha256:abc",
+			imageTag: "gcr.io/project/image:latest",
+			results:  []error{manifestUnknownErr, err401, err403, err403},
+			wantRefs: []string{
+				"gcr.io/project/image@sha256:abc",
+				"gcr.io/project/image:latest",
+				"gcr.io/project/image:latest",
+				"gcr.io/project/image:latest",
+			},
+			wantCalls: 4,
+			wantErr:   true,
+			wantErrIs: err401,
+		},
+		{
+			name:            "too-large during anonymous retry is not masked by original 401",
+			imageID:         "gcr.io/project/image",
+			adcErr:          errors.New("ADC unavailable"),
+			results:         []error{err401, image.ErrImageTooLarge},
+			wantCalls:       2,
+			wantErr:         true,
+			wantErrContains: image.ErrImageTooLarge.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := gcpCredsFn
+			defer func() { gcpCredsFn = orig }()
+			gcpCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
+				if tt.adcErr != nil {
+					return nil, tt.adcErr
+				}
+				return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "token"}, nil
+			}
+
+			var calls [][]image.RegistryCredentials
+			var refs []string
+			callCount := 0
+			get := func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+				refs = append(refs, ref)
+				creds := append([]image.RegistryCredentials(nil), opts.Credentials...)
+				calls = append(calls, creds)
+				res := tt.results[callCount]
+				callCount++
+				return nil, res
+			}
+
+			_, err := resolveSource(context.Background(), get, tt.imageID, tt.imageTag, image.RegistryOptions{})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantErrIs != nil {
+				assert.ErrorIs(t, err, tt.wantErrIs)
+			}
+			if tt.wantErrContains != "" {
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+			}
+			assert.Equal(t, tt.wantCalls, callCount)
+			if tt.wantLastCreds != nil {
+				assert.Equal(t, tt.wantLastCreds, calls[len(calls)-1])
+			}
+			if tt.wantRefs != nil {
+				assert.Equal(t, tt.wantRefs, refs)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes #423

## Overview

PR #351 added a GCP Workload-Identity / ADC fallback to the in-process Syft
adapter (`adapters/v1/syft.go`), but the gRPC sidecar server
(`pkg/sbomscanner/v1/server.go`) never received the port. In sidecar mode
(`SBOM_SCANNER_SOCKET` set), private `gcr.io` / `*-docker.pkg.dev` images
relying on Workload Identity fail with 401, while the same image scans fine
through the in-process adapter. Verified via git history: `7c80e87` touched
only `syft.go`/`syft_test.go`/`go.mod`; `isGCPRegistry` has never appeared in
`server.go`.

## Changes

### pkg/sbomscanner/v1/server.go
- Port `isGCPRegistry` and `gcpCredentials` (mirrors syft.go:36-51).
- Extract the retry chain (MANIFEST_UNKNOWN + 401/ADC/anonymous) into
  `resolveSource`, behind a `sourceGetter` seam so the fallback ordering is
  unit-testable with a scripted implementation.
- The anonymous fallback now runs on any ADC failure, not just a 401. The
  original 401 is stashed and restored when the anonymous retry fails with a
  non-401, so the response still classifies as `helpersv1.Unauthorize`.
- `gcpErr` is now logged so operators can see why ADC failed.
- Decision note on context: `FindDefaultCredentials` honors the request `ctx`;
  `Token()` performs the actual token fetch without a context, so only
  credential lookup is cancellable. The surrounding `context.Background()`
  calls in this file are out of scope here — tracked separately in #421.
- One new import (`golang.org/x/oauth2/google`, already in go.mod); no new
  module dependencies (`stereoscope/pkg/image` was already imported).

### adapters/v1/syft.go
- Same anonymous-fallback fix as the sidecar (parity — the in-process adapter
  had the identical structure per review): the retry now runs on any ADC
  failure, the original 401 is preserved for `Unauthorize` classification,
  and `gcpErr` is logged.

### pkg/sbomscanner/v1/server_test.go
- `TestResolveSource` covers the retry ordering with a scripted sourceGetter:
  non-GCP + 401 → anonymous retry; GCP + ADC unavailable → anonymous retry;
  GCP + ADC available + retry succeeds → no anonymous retry (credentials
  swapped); GCP + ADC available + retry fails non-401 → anonymous retry runs
  and the original 401 is still reported. Verified to fail with the buggy
  401-guard and pass with the fix.

## Verification

- `TMPDIR=/tmp go test ./pkg/sbomscanner/v1/... -count=1` — 19 passed
- `go build ./...` — clean
- `gofmt -l` / `go vet` on the changed files — clean
  (the socket-based tests need `TMPDIR=/tmp` on macOS due to Unix socket path
  length; this is a local test-harness quirk, not a code issue)

## Follow-up option

Happy to extract `isGCPRegistry`/`gcpCredentials` into a shared internal
package — and with it, scope the GCP credential's `Authority` and append rather
than replace the pull secrets — in a separate PR if you'd prefer not to keep
the two copies.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pulling images from Google Container Registry and Google Artifact Registry.
  - Automatically uses available Google Cloud credentials when registry authentication is required.
  - Falls back to anonymous access when credentials are unavailable or unsuccessful.

- **Bug Fixes**
  - Improved image resolution for missing tags and authentication failures.
  - Preserves the original authorization error when fallback attempts fail, providing more accurate error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->