### PR TITLE
fix: bound SBOM scanner sidecar readiness wait and honor caller context

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -72,7 +72,7 @@ func main() {
 	var sbomAdapter ports.SBOMCreator
 	if socketPath := os.Getenv("SBOM_SCANNER_SOCKET"); socketPath != "" {
 		logger.L().Info("connecting to SBOM scanner sidecar", helpers.String("socket", socketPath))
-		scannerClient, err := sbomscanner.NewSBOMScannerClient(socketPath)
+		scannerClient, err := sbomscanner.NewSBOMScannerClient(ctx, socketPath)
 		if err != nil {
 			logger.L().Warning("failed to connect to SBOM scanner sidecar, falling back to in-process Syft",
 				helpers.Error(err))

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -72,10 +72,14 @@ func main() {
 	var sbomAdapter ports.SBOMCreator
 	if socketPath := os.Getenv("SBOM_SCANNER_SOCKET"); socketPath != "" {
 		logger.L().Info("connecting to SBOM scanner sidecar", helpers.String("socket", socketPath))
-		scannerClient, err := sbomscanner.NewSBOMScannerClient(ctx, socketPath)
+		scannerClient, err := sbomscanner.NewSBOMScannerClient(ctx, socketPath, c.ScannerReadinessTimeout)
 		if err != nil {
-			logger.L().Warning("failed to connect to SBOM scanner sidecar, falling back to in-process Syft",
-				helpers.Error(err))
+			if ctx.Err() != nil {
+				logger.L().Info("shutdown requested while waiting for SBOM scanner sidecar")
+				return
+			}
+			logger.L().Error("SBOM scanner sidecar not ready after readiness timeout, falling back to in-process Syft",
+				helpers.Error(err), helpers.String("readinessTimeout", c.ScannerReadinessTimeout.String()))
 			sbomAdapter = v1.NewSyftAdapter(c.ScanTimeout, c.MaxImageSize, c.MaxSBOMSize, c.ScanEmbeddedSboms, c.ProxyRegistryMap)
 		} else {
 			memoryLimit := os.Getenv("SCANNER_MEMORY_LIMIT")

--- a/config/config.go
+++ b/config/config.go
@@ -42,26 +42,27 @@ const (
 var defaultTrustedVendors = []string{"echo", "chainguard", "wolfi", "minimos"}
 
 type Config struct {
-	AccountID          string            `mapstructure:"accountID"`
-	ClusterName        string            `mapstructure:"clusterName"`
-	KeepLocal          bool              `mapstructure:"keepLocal"`
-	ListingURL         string            `mapstructure:"listingURL"`
-	MaxImageSize       int64             `mapstructure:"maxImageSize"`
-	MaxSBOMSize        int               `mapstructure:"maxSBOMSize"`
-	Namespace          string            `mapstructure:"namespace"`
-	NodeSbomGeneration bool              `mapstructure:"nodeSbomGeneration"`
-	PartialRelevancy   bool              `mapstructure:"partialRelevancy"`
-	ScanConcurrency    int               `mapstructure:"scanConcurrency"`
-	ProxyRegistryMap   map[string]string `mapstructure:"proxyRegistryMap"`
-	ScanEmbeddedSboms  bool              `mapstructure:"scanEmbeddedSBOMs"`
-	ScanTimeout        time.Duration     `mapstructure:"scanTimeout"`
-	RiskAcceptance     bool              `mapstructure:"riskAcceptance"`
-	Storage            bool              `mapstructure:"storage"`
-	StoreFilteredSbom  bool              `mapstructure:"storeFilteredSbom"`
-	UseDefaultMatchers bool              `mapstructure:"useDefaultMatchers"` // Deprecated: use CVEMatchingMode. Kept for backward compatibility (true -> off, false -> on).
-	CVEMatchingMode    CVEMatchingMode   `mapstructure:"cveMatchingMode"`
-	TrustedVendors     []string          `mapstructure:"trustedVendors"` // distro slugs trusted in adaptive mode; empty/unset reverts to defaultTrustedVendors
-	VexGeneration      bool              `mapstructure:"vexGeneration"`
+	AccountID               string            `mapstructure:"accountID"`
+	ClusterName             string            `mapstructure:"clusterName"`
+	KeepLocal               bool              `mapstructure:"keepLocal"`
+	ListingURL              string            `mapstructure:"listingURL"`
+	MaxImageSize            int64             `mapstructure:"maxImageSize"`
+	MaxSBOMSize             int               `mapstructure:"maxSBOMSize"`
+	Namespace               string            `mapstructure:"namespace"`
+	NodeSbomGeneration      bool              `mapstructure:"nodeSbomGeneration"`
+	PartialRelevancy        bool              `mapstructure:"partialRelevancy"`
+	ScanConcurrency         int               `mapstructure:"scanConcurrency"`
+	ProxyRegistryMap        map[string]string `mapstructure:"proxyRegistryMap"`
+	ScanEmbeddedSboms       bool              `mapstructure:"scanEmbeddedSBOMs"`
+	ScanTimeout             time.Duration     `mapstructure:"scanTimeout"`
+	ScannerReadinessTimeout time.Duration     `mapstructure:"scannerReadinessTimeout"`
+	RiskAcceptance          bool              `mapstructure:"riskAcceptance"`
+	Storage                 bool              `mapstructure:"storage"`
+	StoreFilteredSbom       bool              `mapstructure:"storeFilteredSbom"`
+	UseDefaultMatchers      bool              `mapstructure:"useDefaultMatchers"` // Deprecated: use CVEMatchingMode. Kept for backward compatibility (true -> off, false -> on).
+	CVEMatchingMode         CVEMatchingMode   `mapstructure:"cveMatchingMode"`
+	TrustedVendors          []string          `mapstructure:"trustedVendors"` // distro slugs trusted in adaptive mode; empty/unset reverts to defaultTrustedVendors
+	VexGeneration           bool              `mapstructure:"vexGeneration"`
 }
 
 // LoadConfig reads configuration from file or environment variables.
@@ -77,6 +78,7 @@ func LoadConfig(path string) (Config, error) {
 	v.SetDefault("maxSBOMSize", 20*1024*1024)
 	v.SetDefault("scanConcurrency", 1)
 	v.SetDefault("scanTimeout", 5*time.Minute)
+	v.SetDefault("scannerReadinessTimeout", 60*time.Second)
 	v.SetDefault("vexGeneration", false)
 	v.SetDefault("namespace", "kubescape")
 	v.SetDefault("scanEmbeddedSBOMs", false)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -171,6 +171,7 @@ The main configuration file. All options can be overridden via environment varia
 | `scanConcurrency` | int | `1` | Number of concurrent scans |
 | `scanTimeout` | duration | `5m` | Timeout for SBOM generation |
 | `scanEmbeddedSBOMs` | bool | `false` | Scan for embedded SBOMs in images |
+| `scannerReadinessTimeout` | duration | `60s` | Maximum time to wait for the SBOM scanner sidecar to become ready at startup. A value of `0` or less does not mean "wait forever": it makes the readiness deadline expire immediately, causing startup to fall back to the built-in Syft scanner right away. |
 
 #### Vulnerability Database Options
 
@@ -254,6 +255,11 @@ The main configuration file. All options can be overridden via environment varia
     "scanTimeout": {
       "type": "string",
       "default": "5m",
+      "pattern": "^[0-9]+(s|m|h)$"
+    },
+    "scannerReadinessTimeout": {
+      "type": "string",
+      "default": "60s",
       "pattern": "^[0-9]+(s|m|h)$"
     },
     "storage": {

--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -40,6 +40,8 @@ type sbomScannerClient struct {
 // If ctx is canceled before readiness is reached, the returned error satisfies
 // errors.Is(err, context.Cause(ctx)) so callers can distinguish cancellation from a genuinely
 // unhealthy sidecar.
+// A readinessTimeout of zero or less does not mean "wait indefinitely": it makes the
+// readiness deadline expire immediately, so the sidecar is treated as unready right away.
 func NewSBOMScannerClient(ctx context.Context, socketPath string, readinessTimeout time.Duration) (SBOMScannerClient, error) {
 	target := fmt.Sprintf("unix://%s", socketPath)
 	conn, err := grpc.NewClient(target,

--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -20,10 +20,13 @@ import (
 const (
 	healthCheckTimeout = 5 * time.Second
 	MaxgRPCMessageSize = 128 * 1024 * 1024
-	// readinessTimeout bounds how long NewSBOMScannerClient waits for the
-	// sidecar to report ready, so a permanently unhealthy sidecar fails
-	// startup instead of blocking it.
-	readinessTimeout = 60 * time.Second
+	// DefaultReadinessTimeout is used when the caller does not configure an
+	// explicit readiness timeout.
+	DefaultReadinessTimeout = 60 * time.Second
+	// readinessMaxInterval caps the exponential backoff between health checks so
+	// the effective wait tracks readinessTimeout closely instead of overshooting
+	// it by a full backoff interval.
+	readinessMaxInterval = 5 * time.Second
 )
 
 type sbomScannerClient struct {
@@ -34,7 +37,10 @@ type sbomScannerClient struct {
 // NewSBOMScannerClient creates a gRPC client connected to the scanner sidecar via Unix socket.
 // It performs a health check with exponential backoff before returning. The wait is bounded by
 // readinessTimeout and cancelable via ctx, so it cannot block process startup indefinitely.
-func NewSBOMScannerClient(ctx context.Context, socketPath string) (SBOMScannerClient, error) {
+// If ctx is canceled before readiness is reached, the returned error satisfies
+// errors.Is(err, context.Cause(ctx)) so callers can distinguish cancellation from a genuinely
+// unhealthy sidecar.
+func NewSBOMScannerClient(ctx context.Context, socketPath string, readinessTimeout time.Duration) (SBOMScannerClient, error) {
 	target := fmt.Sprintf("unix://%s", socketPath)
 	conn, err := grpc.NewClient(target,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -56,6 +62,8 @@ func NewSBOMScannerClient(ctx context.Context, socketPath string) (SBOMScannerCl
 	// cancelable via ctx so an unhealthy sidecar cannot hang startup.
 	readinessCtx, readinessCancel := context.WithTimeout(ctx, readinessTimeout)
 	defer readinessCancel()
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxInterval = readinessMaxInterval
 	_, err = backoff.Retry(readinessCtx, func() (struct{}, error) {
 		healthCtx, cancel := context.WithTimeout(readinessCtx, healthCheckTimeout)
 		defer cancel()
@@ -67,7 +75,7 @@ func NewSBOMScannerClient(ctx context.Context, socketPath string) (SBOMScannerCl
 			return struct{}{}, fmt.Errorf("scanner not ready")
 		}
 		return struct{}{}, nil
-	}, backoff.WithBackOff(backoff.NewExponentialBackOff()), backoff.WithMaxElapsedTime(readinessTimeout))
+	}, backoff.WithBackOff(bo), backoff.WithMaxElapsedTime(readinessTimeout))
 	if err != nil {
 		logger.L().Error("SBOM scanner sidecar health check failed after retries", helpers.Error(err))
 		conn.Close()
@@ -91,16 +99,16 @@ func (c *sbomScannerClient) CreateSBOM(ctx context.Context, req ScanRequest) (*S
 	}
 
 	pbReq := &pb.CreateSBOMRequest{
-		ImageId:                req.ImageID,
-		ImageTag:               req.ImageTag,
-		Platform:               req.Options.Platform,
-		Credentials:            creds,
-		InsecureSkipTlsVerify:  req.Options.InsecureSkipTLSVerify,
-		InsecureUseHttp:        req.Options.InsecureUseHTTP,
-		MaxImageSize:           req.MaxImageSize,
-		MaxSbomSize:            req.MaxSBOMSize,
-		EnableEmbeddedSboms:    req.EnableEmbeddedSBOMs,
-		TimeoutSeconds:         int64(req.Timeout.Seconds()),
+		ImageId:               req.ImageID,
+		ImageTag:              req.ImageTag,
+		Platform:              req.Options.Platform,
+		Credentials:           creds,
+		InsecureSkipTlsVerify: req.Options.InsecureSkipTLSVerify,
+		InsecureUseHttp:       req.Options.InsecureUseHTTP,
+		MaxImageSize:          req.MaxImageSize,
+		MaxSbomSize:           req.MaxSBOMSize,
+		EnableEmbeddedSboms:   req.EnableEmbeddedSBOMs,
+		TimeoutSeconds:        int64(req.Timeout.Seconds()),
 	}
 
 	resp, err := c.client.CreateSBOM(ctx, pbReq)

--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -20,6 +20,10 @@ import (
 const (
 	healthCheckTimeout = 5 * time.Second
 	MaxgRPCMessageSize = 128 * 1024 * 1024
+	// readinessTimeout bounds how long NewSBOMScannerClient waits for the
+	// sidecar to report ready, so a permanently unhealthy sidecar fails
+	// startup instead of blocking it.
+	readinessTimeout = 60 * time.Second
 )
 
 type sbomScannerClient struct {
@@ -28,8 +32,9 @@ type sbomScannerClient struct {
 }
 
 // NewSBOMScannerClient creates a gRPC client connected to the scanner sidecar via Unix socket.
-// It performs a health check with exponential backoff before returning.
-func NewSBOMScannerClient(socketPath string) (SBOMScannerClient, error) {
+// It performs a health check with exponential backoff before returning. The wait is bounded by
+// readinessTimeout and cancelable via ctx, so it cannot block process startup indefinitely.
+func NewSBOMScannerClient(ctx context.Context, socketPath string) (SBOMScannerClient, error) {
 	target := fmt.Sprintf("unix://%s", socketPath)
 	conn, err := grpc.NewClient(target,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -47,11 +52,14 @@ func NewSBOMScannerClient(socketPath string) (SBOMScannerClient, error) {
 		client: pb.NewSBOMScannerClient(conn),
 	}
 
-	// Wait for the sidecar to become ready
-	_, err = backoff.Retry(context.Background(), func() (struct{}, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), healthCheckTimeout)
+	// Wait for the sidecar to become ready, bounded by readinessTimeout and
+	// cancelable via ctx so an unhealthy sidecar cannot hang startup.
+	readinessCtx, readinessCancel := context.WithTimeout(ctx, readinessTimeout)
+	defer readinessCancel()
+	_, err = backoff.Retry(readinessCtx, func() (struct{}, error) {
+		healthCtx, cancel := context.WithTimeout(readinessCtx, healthCheckTimeout)
 		defer cancel()
-		resp, err := c.client.Health(ctx, &pb.HealthRequest{})
+		resp, err := c.client.Health(healthCtx, &pb.HealthRequest{})
 		if err != nil {
 			return struct{}{}, fmt.Errorf("health check failed: %w", err)
 		}
@@ -59,7 +67,7 @@ func NewSBOMScannerClient(socketPath string) (SBOMScannerClient, error) {
 			return struct{}{}, fmt.Errorf("scanner not ready")
 		}
 		return struct{}{}, nil
-	}, backoff.WithBackOff(backoff.NewExponentialBackOff()))
+	}, backoff.WithBackOff(backoff.NewExponentialBackOff()), backoff.WithMaxElapsedTime(readinessTimeout))
 	if err != nil {
 		logger.L().Error("SBOM scanner sidecar health check failed after retries", helpers.Error(err))
 		conn.Close()

--- a/pkg/sbomscanner/v1/integration_test.go
+++ b/pkg/sbomscanner/v1/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kubescape/kubevuln/core/domain"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
@@ -92,4 +93,20 @@ func TestIntegration_ReadyCheck(t *testing.T) {
 	assert.False(t, client.Ready())
 
 	client.Close()
+}
+
+func TestNewSBOMScannerClient_CancelableReadinessWait(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "unreachable.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	client, err := NewSBOMScannerClient(ctx, sock)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Less(t, elapsed, readinessTimeout, "readiness wait must respect the caller's context instead of blocking for the full readiness timeout")
 }

--- a/pkg/sbomscanner/v1/integration_test.go
+++ b/pkg/sbomscanner/v1/integration_test.go
@@ -103,10 +103,10 @@ func TestNewSBOMScannerClient_CancelableReadinessWait(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	client, err := NewSBOMScannerClient(ctx, sock)
+	client, err := NewSBOMScannerClient(ctx, sock, DefaultReadinessTimeout)
 	elapsed := time.Since(start)
 
-	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Nil(t, client)
-	assert.Less(t, elapsed, readinessTimeout, "readiness wait must respect the caller's context instead of blocking for the full readiness timeout")
+	assert.Less(t, elapsed, 5*time.Second, "readiness wait must return on the caller's context, not on the readiness timeout")
 }


### PR DESCRIPTION
## Overview
`NewSBOMScannerClient` waited for sidecar readiness using `backoff.Retry(context.Background(), ...)` with no explicit `WithMaxElapsedTime` and a non-cancelable parent context, so the wait relied on the library's implicit 15-minute default and could not be shortened or interrupted by the process shutdown signal context already built in `cmd/http/main.go`. This PR adds an explicit `readinessTimeout` (60s) and threads the caller's context through so the wait is bounded and cancelable.

Resolved #425

## What Changed
- `pkg/sbomscanner/v1/client.go`: `NewSBOMScannerClient` now takes a `context.Context`, derives a bounded `readinessCtx` from it via `context.WithTimeout(ctx, readinessTimeout)`, and passes that to `backoff.Retry` along with an explicit `backoff.WithMaxElapsedTime(readinessTimeout)`.
- `cmd/http/main.go`: passes the existing signal-aware `ctx` to `sbomscanner.NewSBOMScannerClient`.
- `pkg/sbomscanner/v1/integration_test.go`: adds `TestNewSBOMScannerClient_CancelableReadinessWait`, which asserts the constructor returns promptly when the caller's context is canceled instead of blocking for the full readiness timeout.

## Verification
- `go build ./...` — passed
- `go vet ./...` — passed
- `gofmt -l pkg/sbomscanner/v1/client.go cmd/http/main.go pkg/sbomscanner/v1/integration_test.go` — no issues in changed files
- `go test ./pkg/sbomscanner/... ./cmd/...` — passed, except two pre-existing failures unrelated to this change: `TestIntegration_SimulatedCrash` and `TestCreateSBOM_ContextCancelled` fail on this machine because macOS rejects the long `t.TempDir()` Unix socket path (`bind: invalid argument`); reproduced identically on `upstream/main` before this change.
- `go test ./...` — all other packages pass; `core/services` `TestScanService_NginxTest` fails only because this environment has no Docker daemon (`rootless Docker not found`), unrelated to this change.

## Scope
Only the SBOM scanner sidecar readiness wait and its direct caller/tests were touched; no unrelated files were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SBOM scanner startup now respects application cancellation and configurable readiness timeouts.
  * Connections to unavailable scanners fail promptly instead of retrying indefinitely.
  * If the external scanner does not become ready in time, scanning falls back to the built-in adapter.
  * Scanner readiness checks continue validating connectivity before proceeding.

* **Tests**
  * Added coverage for timeout behavior when the scanner cannot be reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->