### PR TITLE
fix: non-blocking Grype DB background updates in GrypeAdapter.Ready (#427)

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -81,10 +81,10 @@ var _ ports.CVEScanner = (*GrypeAdapter)(nil)
 // NewGrypeAdapter initializes the GrypeAdapter structure
 // DB loading is done via readiness probes
 func NewGrypeAdapter(listingURL string, matchingMode config.CVEMatchingMode, trustedVendors []string) *GrypeAdapter {
+	distCfg := distribution.DefaultConfig()
+	distCfg.LatestURL = listingURL
 	g := &GrypeAdapter{
-		distCfg: distribution.Config{
-			LatestURL: listingURL,
-		},
+		distCfg: distCfg,
 		installCfg: installation.Config{
 			DBRootDir: path.Join(xdg.CacheHome, "grype", "db"),
 		},
@@ -140,10 +140,10 @@ func NewGrypeAdapterFixedDBWithMatchers(matchingMode config.CVEMatchingMode, tru
 	if err != nil {
 		return nil, nil, err
 	}
+	distCfg := distribution.DefaultConfig()
+	distCfg.LatestURL = fmt.Sprintf("http://localhost:%s/databases", port)
 	g := &GrypeAdapter{
-		distCfg: distribution.Config{
-			LatestURL: fmt.Sprintf("http://localhost:%s/databases", port),
-		},
+		distCfg: distCfg,
 		installCfg: installation.Config{
 			DBRootDir: path.Join(xdg.CacheHome, "grype-offline", "db"),
 		},
@@ -262,15 +262,25 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 	select {
 	case <-done:
 	case <-time.After(15 * time.Minute):
+		// grype.LoadVulnerabilityDB takes no context and cannot be cancelled, and the
+		// pinned grype's HTTP client bounds only dial/TLS handshake, not response-body
+		// reads (its withUserAgent post-processor replaces the *http.Client wholesale,
+		// silently dropping any Timeout we set on distCfg). A connection that stalls
+		// mid-download therefore hangs the load goroutine forever, so finishUpdate would
+		// never run: updating would stay true and DBRootDir would never be retried.
+		// Restart here - the one case where this loses non-blocking behaviour is a
+		// download that is genuinely stuck, not merely slow, which is the same condition
+		// that used to trigger os.Exit(0) unconditionally before this PR.
 		g.mu.RLock()
 		existingVersion := g.dbVersionLocked()
 		g.mu.RUnlock()
 		if hasExistingDB {
-			logger.L().Ctx(ctx).Warning("grype DB update taking longer than 15 minutes, continuing with existing DB",
+			logger.L().Ctx(ctx).Error("grype DB update stuck past 15 minutes with an uncancellable load in flight, restarting to recover",
 				helpers.String("existingDBVersion", existingVersion))
 		} else {
-			logger.L().Ctx(ctx).Error("grype DB initial download taking longer than 15 minutes")
+			logger.L().Ctx(ctx).Error("grype DB initial download stuck past 15 minutes with an uncancellable load in flight, restarting to recover")
 		}
+		os.Exit(0)
 	}
 }
 
@@ -279,7 +289,8 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 // gave up on it. It owns every mutation of shared state for this update - installing a
 // successful result, scheduling the next attempt, and releasing the single-flight guard -
 // so nothing else can delete DBRootDir or start a second update while this one is still
-// writing to it.
+// writing to it. State mutation happens under g.mu, but the actual I/O (closing providers,
+// deleting DBRootDir) happens after unlocking, so scans only block for the pointer swap.
 func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, store vulnerability.Provider, dbStatus *vulnerability.ProviderStatus, err error) {
 	now := time.Now()
 
@@ -290,17 +301,21 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 		err = dbStatus.Error
 	}
 
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	defer func() {
+	releaseGuard := func() {
 		g.updating = false
 		if g.updateChan != nil {
 			close(g.updateChan)
 			g.updateChan = nil
 		}
-	}()
+	}
 
 	if err != nil {
+		g.mu.Lock()
+		// Schedule retry in 5 minutes on update failure
+		g.nextUpdateAttempt = now.Add(5 * time.Minute)
+		releaseGuard()
+		g.mu.Unlock()
+
 		logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(err))
 		if store != nil {
 			if closeErr := store.Close(); closeErr != nil {
@@ -309,20 +324,21 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 		}
 		if !hasExistingDB {
 			if delErr := tools.DeleteContents(g.installCfg.DBRootDir); delErr != nil {
-				logger.L().Debug("cleaned up cache", helpers.Error(delErr),
+				logger.L().Ctx(ctx).Warning("failed to clean up grype DB cache", helpers.Error(delErr),
 					helpers.String("DBRootDir", g.installCfg.DBRootDir))
 			}
 		}
-		// Schedule retry in 5 minutes on update failure
-		g.nextUpdateAttempt = now.Add(5 * time.Minute)
 		return
 	}
 
+	g.mu.Lock()
 	oldStore := g.store
 	g.store = store
 	g.dbStatus = dbStatus
 	// Schedule the next routine refresh in 24 hours
 	g.nextUpdateAttempt = now.Add(24 * time.Hour)
+	releaseGuard()
+	g.mu.Unlock()
 
 	if oldStore != nil && oldStore != store {
 		if closeErr := oldStore.Close(); closeErr != nil {

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -268,19 +268,22 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 		// silently dropping any Timeout we set on distCfg). A connection that stalls
 		// mid-download therefore hangs the load goroutine forever, so finishUpdate would
 		// never run: updating would stay true and DBRootDir would never be retried.
-		// Restart here - the one case where this loses non-blocking behaviour is a
-		// download that is genuinely stuck, not merely slow, which is the same condition
-		// that used to trigger os.Exit(0) unconditionally before this PR.
+		//
+		// On a cold start there is nothing to lose, so restart - the one case where this
+		// loses non-blocking behaviour is a download that is genuinely stuck, not merely
+		// slow, which is the same condition that used to trigger os.Exit(0) unconditionally
+		// before this PR. With an existing DB, though, the pod is healthy and serving: keep
+		// it that way instead of dropping in-flight scans, and let finishUpdate install the
+		// stuck load whenever (if ever) it returns.
+		if !hasExistingDB {
+			logger.L().Ctx(ctx).Error("grype DB initial download stuck past 15 minutes with an uncancellable load in flight, restarting to recover")
+			os.Exit(0)
+		}
 		g.mu.RLock()
 		existingVersion := g.dbVersionLocked()
 		g.mu.RUnlock()
-		if hasExistingDB {
-			logger.L().Ctx(ctx).Error("grype DB update stuck past 15 minutes with an uncancellable load in flight, restarting to recover",
-				helpers.String("existingDBVersion", existingVersion))
-		} else {
-			logger.L().Ctx(ctx).Error("grype DB initial download stuck past 15 minutes with an uncancellable load in flight, restarting to recover")
-		}
-		os.Exit(0)
+		logger.L().Ctx(ctx).Error("grype DB update stuck past 15 minutes with an uncancellable load in flight, continuing with existing DB",
+			helpers.String("existingDBVersion", existingVersion))
 	}
 }
 
@@ -297,14 +300,10 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, store vulnerability.Provider, dbStatus *vulnerability.ProviderStatus, err error) {
 	now := time.Now()
 
-	// A successful load whose reported status still carries an error is not usable: treat
-	// it the same as a load failure so Ready() keeps reporting not-ready and a retry gets
-	// scheduled, instead of wedging the pod NotReady for 24h with nothing to recover it.
-	if err == nil && dbStatus != nil && dbStatus.Error != nil {
-		err = dbStatus.Error
-	}
-
-	releaseGuard := func() {
+	// Released last via defer, after any I/O below, no matter which branch runs or how it
+	// returns: a leaked updating=true would permanently wedge future updates, since nothing
+	// else ever clears it, so this must not depend on every branch remembering to call it.
+	defer func() {
 		g.mu.Lock()
 		g.updating = false
 		if g.updateChan != nil {
@@ -312,6 +311,13 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 			g.updateChan = nil
 		}
 		g.mu.Unlock()
+	}()
+
+	// A successful load whose reported status still carries an error is not usable: treat
+	// it the same as a load failure so Ready() keeps reporting not-ready and a retry gets
+	// scheduled, instead of wedging the pod NotReady for 24h with nothing to recover it.
+	if err == nil && dbStatus != nil && dbStatus.Error != nil {
+		err = dbStatus.Error
 	}
 
 	if err != nil {
@@ -332,7 +338,6 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 					helpers.String("DBRootDir", g.installCfg.DBRootDir))
 			}
 		}
-		releaseGuard()
 		return
 	}
 
@@ -343,8 +348,6 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 	// Schedule the next routine refresh in 24 hours
 	g.nextUpdateAttempt = now.Add(24 * time.Hour)
 	g.mu.Unlock()
-
-	defer releaseGuard()
 
 	if oldStore != nil && oldStore != store {
 		if closeErr := oldStore.Close(); closeErr != nil {

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -50,6 +50,12 @@ const (
 	VendorTrustedMatchMetadataKey = "kubescape.io/vendor-trusted-match"
 )
 
+type loadDBFunc func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error)
+
+func defaultLoadDB(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+	return grype.LoadVulnerabilityDB(distCfg, installCfg, true)
+}
+
 // GrypeAdapter implements CVEScanner from ports using Grype's API
 type GrypeAdapter struct {
 	lastDbUpdate   time.Time
@@ -62,6 +68,7 @@ type GrypeAdapter struct {
 	trustedVendors map[distro.Type]bool
 	updating       bool
 	updateChan     chan struct{}
+	loadDB         loadDBFunc
 }
 
 var _ ports.CVEScanner = (*GrypeAdapter)(nil)
@@ -78,6 +85,7 @@ func NewGrypeAdapter(listingURL string, matchingMode config.CVEMatchingMode, tru
 		},
 		matchingMode:   matchingMode,
 		trustedVendors: buildTrustedVendorSet(trustedVendors),
+		loadDB:         defaultLoadDB,
 	}
 	return g
 }
@@ -136,6 +144,7 @@ func NewGrypeAdapterFixedDBWithMatchers(matchingMode config.CVEMatchingMode, tru
 		},
 		matchingMode:   matchingMode,
 		trustedVendors: buildTrustedVendorSet(trustedVendors),
+		loadDB:         defaultLoadDB,
 	}
 	return g, terminate, nil
 }
@@ -227,6 +236,11 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 	}
 	resultCh := make(chan updateResult, 1)
 
+	loadFn := g.loadDB
+	if loadFn == nil {
+		loadFn = defaultLoadDB
+	}
+
 	go func() {
 		if logger.L().GetLevel() == "debug" {
 			if distClient, err := distribution.NewClient(g.distCfg); err == nil {
@@ -242,25 +256,24 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 				helpers.Error(err),
 				helpers.String("dbRootDir", g.installCfg.DBRootDir))
 		}
-		store, dbStatus, err := grype.LoadVulnerabilityDB(g.distCfg, g.installCfg, true)
+		store, dbStatus, err := loadFn(g.distCfg, g.installCfg)
 		resultCh <- updateResult{store: store, dbStatus: dbStatus, err: err}
 	}()
 
-	now := time.Now()
 	select {
 	case result := <-resultCh:
+		now := time.Now()
 		if result.err != nil {
 			logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(result.err))
+			g.mu.Lock()
 			if !hasExistingDB {
 				err := tools.DeleteContents(g.installCfg.DBRootDir)
 				logger.L().Debug("cleaned up cache", helpers.Error(err),
 					helpers.String("DBRootDir", g.installCfg.DBRootDir))
-			} else {
-				g.mu.Lock()
-				// Schedule retry in 5 minutes if update failed but existing DB is available
-				g.lastDbUpdate = now.Add(-24*time.Hour + 5*time.Minute)
-				g.mu.Unlock()
 			}
+			// Schedule retry in 5 minutes on update failure
+			g.lastDbUpdate = now.Add(-24*time.Hour + 5*time.Minute)
+			g.mu.Unlock()
 			return
 		}
 		g.mu.Lock()
@@ -277,6 +290,15 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 		}
 		logger.L().Info("grype DB updated")
 	case <-updateCtx.Done():
+		// Drain resultCh asynchronously in case LoadVulnerabilityDB completes after timeout, preventing provider leak
+		go func() {
+			res := <-resultCh
+			if res.store != nil {
+				_ = res.store.Close()
+			}
+		}()
+
+		now := time.Now()
 		g.mu.Lock()
 		if hasExistingDB {
 			logger.L().Ctx(ctx).Warning("grype DB update timed out after 15 minutes, continuing with existing DB",
@@ -288,6 +310,8 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 			err := tools.DeleteContents(g.installCfg.DBRootDir)
 			logger.L().Debug("cleaned up cache after timeout", helpers.Error(err),
 				helpers.String("DBRootDir", g.installCfg.DBRootDir))
+			// Back-date to retry in 5 minutes
+			g.lastDbUpdate = now.Add(-24*time.Hour + 5*time.Minute)
 		}
 		g.mu.Unlock()
 	}

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -289,8 +289,11 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 // gave up on it. It owns every mutation of shared state for this update - installing a
 // successful result, scheduling the next attempt, and releasing the single-flight guard -
 // so nothing else can delete DBRootDir or start a second update while this one is still
-// writing to it. State mutation happens under g.mu, but the actual I/O (closing providers,
-// deleting DBRootDir) happens after unlocking, so scans only block for the pointer swap.
+// writing to it. Installing the new state happens under g.mu, but the actual I/O (closing
+// providers, deleting DBRootDir) happens after unlocking, so scans only block for the pointer
+// swap. The single-flight guard is released only after that I/O completes: Ready() unblocks
+// cold-start callers as soon as updateChan closes, so closing it any earlier would let a
+// caller observe g.store before an unusable one has actually been Close()'d.
 func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, store vulnerability.Provider, dbStatus *vulnerability.ProviderStatus, err error) {
 	now := time.Now()
 
@@ -302,18 +305,19 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 	}
 
 	releaseGuard := func() {
+		g.mu.Lock()
 		g.updating = false
 		if g.updateChan != nil {
 			close(g.updateChan)
 			g.updateChan = nil
 		}
+		g.mu.Unlock()
 	}
 
 	if err != nil {
 		g.mu.Lock()
 		// Schedule retry in 5 minutes on update failure
 		g.nextUpdateAttempt = now.Add(5 * time.Minute)
-		releaseGuard()
 		g.mu.Unlock()
 
 		logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(err))
@@ -328,6 +332,7 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 					helpers.String("DBRootDir", g.installCfg.DBRootDir))
 			}
 		}
+		releaseGuard()
 		return
 	}
 
@@ -337,8 +342,9 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, sto
 	g.dbStatus = dbStatus
 	// Schedule the next routine refresh in 24 hours
 	g.nextUpdateAttempt = now.Add(24 * time.Hour)
-	releaseGuard()
 	g.mu.Unlock()
+
+	defer releaseGuard()
 
 	if oldStore != nil && oldStore != store {
 		if closeErr := oldStore.Close(); closeErr != nil {

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -58,17 +58,22 @@ func defaultLoadDB(distCfg distribution.Config, installCfg installation.Config) 
 
 // GrypeAdapter implements CVEScanner from ports using Grype's API
 type GrypeAdapter struct {
-	lastDbUpdate   time.Time
-	dbStatus       *vulnerability.ProviderStatus
-	store          vulnerability.Provider
-	distCfg        distribution.Config
-	installCfg     installation.Config
-	mu             sync.RWMutex
-	matchingMode   config.CVEMatchingMode
-	trustedVendors map[distro.Type]bool
-	updating       bool
-	updateChan     chan struct{}
-	loadDB         loadDBFunc
+	// nextUpdateAttempt is when Ready may next launch a background update. It is set on
+	// every terminal outcome of updateDBBackground (success -> +24h, failure -> +5m) and
+	// gates retries independently of dbStatus, so a cold start that keeps failing (and
+	// therefore never sets dbStatus) still backs off between attempts instead of firing
+	// once per readiness probe.
+	nextUpdateAttempt time.Time
+	dbStatus          *vulnerability.ProviderStatus
+	store             vulnerability.Provider
+	distCfg           distribution.Config
+	installCfg        installation.Config
+	mu                sync.RWMutex
+	matchingMode      config.CVEMatchingMode
+	trustedVendors    map[distro.Type]bool
+	updating          bool
+	updateChan        chan struct{}
+	loadDB            loadDBFunc
 }
 
 var _ ports.CVEScanner = (*GrypeAdapter)(nil)
@@ -169,13 +174,13 @@ func (g *GrypeAdapter) DBVersion(context.Context) string {
 func (g *GrypeAdapter) Ready(ctx context.Context) bool {
 	g.mu.RLock()
 	hasValidDB := g.store != nil && g.dbStatus != nil && g.dbStatus.Error == nil
-	needsUpdate := g.dbStatus == nil || time.Since(g.lastDbUpdate) > 24*time.Hour
+	needsUpdate := time.Now().After(g.nextUpdateAttempt)
 	isUpdating := g.updating
 	g.mu.RUnlock()
 
 	if needsUpdate && !isUpdating {
 		g.mu.Lock()
-		if (g.dbStatus == nil || time.Since(g.lastDbUpdate) > 24*time.Hour) && !g.updating {
+		if time.Now().After(g.nextUpdateAttempt) && !g.updating {
 			g.updating = true
 			g.updateChan = make(chan struct{})
 			g.mu.Unlock()
@@ -204,44 +209,38 @@ func (g *GrypeAdapter) Ready(ctx context.Context) bool {
 	return g.store != nil && g.dbStatus != nil && g.dbStatus.Error == nil
 }
 
+// updateDBBackground launches the actual DB load in its own goroutine and waits up to 15
+// minutes for it, purely so a slow/stuck download doesn't hold up this goroutine forever.
+// grype.LoadVulnerabilityDB takes no context and cannot be cancelled, so giving up on the
+// wait does NOT stop the load - it keeps writing to installCfg.DBRootDir in the background.
+// Consequently every mutation of shared state (installing a successful result, scheduling
+// the next attempt, releasing the single-flight guard, and cleaning up DBRootDir on failure)
+// happens exactly once, in finishUpdate, invoked by the goroutine that actually ran the load
+// - never here. That is what keeps a slow load from racing a second one started by the next
+// readiness probe, and keeps DBRootDir from being wiped out from under a download still
+// writing to it.
 func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
-	defer func() {
-		g.mu.Lock()
-		g.updating = false
-		if g.updateChan != nil {
-			close(g.updateChan)
-			g.updateChan = nil
-		}
-		g.mu.Unlock()
-	}()
-
 	// Use context.WithoutCancel to prevent the update from being cancelled if the request context (e.g. readiness probe) is cancelled
 	ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "GrypeAdapter.UpdateDB")
 	defer span.End()
 	logger.L().Info("updating grype DB",
 		helpers.String("listingURL", g.distCfg.LatestURL))
 
-	// Create a context with timeout to prevent stuck updates
-	updateCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
-	defer cancel()
-
 	g.mu.RLock()
 	hasExistingDB := g.store != nil
 	g.mu.RUnlock()
 
-	type updateResult struct {
-		store    vulnerability.Provider
-		dbStatus *vulnerability.ProviderStatus
-		err      error
-	}
-	resultCh := make(chan updateResult, 1)
-
+	// loadDB is set once at construction and never reassigned afterwards, so reading it
+	// here without g.mu is safe even though every other field on GrypeAdapter is guarded.
 	loadFn := g.loadDB
 	if loadFn == nil {
 		loadFn = defaultLoadDB
 	}
 
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
+
 		if logger.L().GetLevel() == "debug" {
 			if distClient, err := distribution.NewClient(g.distCfg); err == nil {
 				if archive, err := distClient.IsUpdateAvailable(nil); err == nil && archive != nil {
@@ -257,64 +256,80 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 				helpers.String("dbRootDir", g.installCfg.DBRootDir))
 		}
 		store, dbStatus, err := loadFn(g.distCfg, g.installCfg)
-		resultCh <- updateResult{store: store, dbStatus: dbStatus, err: err}
+		g.finishUpdate(ctx, hasExistingDB, store, dbStatus, err)
 	}()
 
 	select {
-	case result := <-resultCh:
-		now := time.Now()
-		if result.err != nil {
-			logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(result.err))
-			g.mu.Lock()
-			if !hasExistingDB {
-				err := tools.DeleteContents(g.installCfg.DBRootDir)
-				logger.L().Debug("cleaned up cache", helpers.Error(err),
+	case <-done:
+	case <-time.After(15 * time.Minute):
+		g.mu.RLock()
+		existingVersion := g.dbVersionLocked()
+		g.mu.RUnlock()
+		if hasExistingDB {
+			logger.L().Ctx(ctx).Warning("grype DB update taking longer than 15 minutes, continuing with existing DB",
+				helpers.String("existingDBVersion", existingVersion))
+		} else {
+			logger.L().Ctx(ctx).Error("grype DB initial download taking longer than 15 minutes")
+		}
+	}
+}
+
+// finishUpdate is invoked exactly once per updateDBBackground call, by the goroutine that
+// actually ran loadFn, regardless of whether updateDBBackground's own 15-minute wait already
+// gave up on it. It owns every mutation of shared state for this update - installing a
+// successful result, scheduling the next attempt, and releasing the single-flight guard -
+// so nothing else can delete DBRootDir or start a second update while this one is still
+// writing to it.
+func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, store vulnerability.Provider, dbStatus *vulnerability.ProviderStatus, err error) {
+	now := time.Now()
+
+	// A successful load whose reported status still carries an error is not usable: treat
+	// it the same as a load failure so Ready() keeps reporting not-ready and a retry gets
+	// scheduled, instead of wedging the pod NotReady for 24h with nothing to recover it.
+	if err == nil && dbStatus != nil && dbStatus.Error != nil {
+		err = dbStatus.Error
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	defer func() {
+		g.updating = false
+		if g.updateChan != nil {
+			close(g.updateChan)
+			g.updateChan = nil
+		}
+	}()
+
+	if err != nil {
+		logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(err))
+		if store != nil {
+			if closeErr := store.Close(); closeErr != nil {
+				logger.L().Ctx(ctx).Warning("failed to close grype DB opened despite reported status error", helpers.Error(closeErr))
+			}
+		}
+		if !hasExistingDB {
+			if delErr := tools.DeleteContents(g.installCfg.DBRootDir); delErr != nil {
+				logger.L().Debug("cleaned up cache", helpers.Error(delErr),
 					helpers.String("DBRootDir", g.installCfg.DBRootDir))
 			}
-			// Schedule retry in 5 minutes on update failure
-			g.lastDbUpdate = now.Add(-24*time.Hour + 5*time.Minute)
-			g.mu.Unlock()
-			return
 		}
-		g.mu.Lock()
-		oldStore := g.store
-		g.store = result.store
-		g.dbStatus = result.dbStatus
-		g.lastDbUpdate = now
-		g.mu.Unlock()
-
-		if oldStore != nil {
-			if err := oldStore.Close(); err != nil {
-				logger.L().Ctx(ctx).Warning("failed to close previous grype DB", helpers.Error(err))
-			}
-		}
-		logger.L().Info("grype DB updated")
-	case <-updateCtx.Done():
-		// Drain resultCh asynchronously in case LoadVulnerabilityDB completes after timeout, preventing provider leak
-		go func() {
-			res := <-resultCh
-			if res.store != nil {
-				_ = res.store.Close()
-			}
-		}()
-
-		now := time.Now()
-		g.mu.Lock()
-		if hasExistingDB {
-			logger.L().Ctx(ctx).Warning("grype DB update timed out after 15 minutes, continuing with existing DB",
-				helpers.String("existingDBVersion", g.dbVersionLocked()))
-			// Delay retry for 1 hour on timeout
-			g.lastDbUpdate = now.Add(-24*time.Hour + 1*time.Hour)
-		} else {
-			logger.L().Ctx(ctx).Error("grype DB initial download timed out after 15 minutes")
-			err := tools.DeleteContents(g.installCfg.DBRootDir)
-			logger.L().Debug("cleaned up cache after timeout", helpers.Error(err),
-				helpers.String("DBRootDir", g.installCfg.DBRootDir))
-			// Back-date to retry in 5 minutes
-			g.lastDbUpdate = now.Add(-24*time.Hour + 5*time.Minute)
-		}
-		g.mu.Unlock()
+		// Schedule retry in 5 minutes on update failure
+		g.nextUpdateAttempt = now.Add(5 * time.Minute)
+		return
 	}
+
+	oldStore := g.store
+	g.store = store
+	g.dbStatus = dbStatus
+	// Schedule the next routine refresh in 24 hours
+	g.nextUpdateAttempt = now.Add(24 * time.Hour)
+
+	if oldStore != nil && oldStore != store {
+		if closeErr := oldStore.Close(); closeErr != nil {
+			logger.L().Ctx(ctx).Warning("failed to close previous grype DB", helpers.Error(closeErr))
+		}
+	}
+	logger.L().Info("grype DB updated")
 }
 
 const dummyLayer = "generatedlayer"
@@ -327,7 +342,7 @@ func (g *GrypeAdapter) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.C
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
-	if g.dbStatus == nil {
+	if g.store == nil || g.dbStatus == nil || g.dbStatus.Error != nil {
 		return domain.CVEManifest{}, domain.ErrInitVulnDB
 	}
 

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -61,6 +60,8 @@ type GrypeAdapter struct {
 	mu             sync.RWMutex
 	matchingMode   config.CVEMatchingMode
 	trustedVendors map[distro.Type]bool
+	updating       bool
+	updateChan     chan struct{}
 }
 
 var _ ports.CVEScanner = (*GrypeAdapter)(nil)
@@ -155,112 +156,141 @@ func (g *GrypeAdapter) DBVersion(context.Context) string {
 	return g.dbVersionLocked()
 }
 
-// Ready returns the status of the vulnerabilities DB
+// Ready returns the status of the vulnerabilities DB, triggering non-blocking background updates as needed.
 func (g *GrypeAdapter) Ready(ctx context.Context) bool {
-	// DB update is in progress
-	if !g.mu.TryRLock() {
-		return false
-	}
-	g.mu.RUnlock() // because TryRLock doesn't unlock
-	// DB is not initialized or needs to be updated
-	now := time.Now()
-	if g.dbStatus == nil || now.Sub(g.lastDbUpdate) > 24*time.Hour {
+	g.mu.RLock()
+	hasValidDB := g.store != nil && g.dbStatus != nil && g.dbStatus.Error == nil
+	needsUpdate := g.dbStatus == nil || time.Since(g.lastDbUpdate) > 24*time.Hour
+	isUpdating := g.updating
+	g.mu.RUnlock()
+
+	if needsUpdate && !isUpdating {
 		g.mu.Lock()
-		defer g.mu.Unlock()
-		// Use context.WithoutCancel to prevent the update from being cancelled if the request context (e.g. readiness probe) is cancelled
-		ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "GrypeAdapter.UpdateDB")
-		defer span.End()
-		logger.L().Info("updating grype DB",
-			helpers.String("listingURL", g.distCfg.LatestURL))
+		if (g.dbStatus == nil || time.Since(g.lastDbUpdate) > 24*time.Hour) && !g.updating {
+			g.updating = true
+			g.updateChan = make(chan struct{})
+			g.mu.Unlock()
 
-		// Create a context with timeout to prevent stuck updates
-		// 15 minutes allows for slow network connections while still catching truly stuck downloads
-		updateCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
-		defer cancel()
-
-		// Track if we have an existing DB to fall back on
-		hasExistingDB := g.dbStatus != nil
-
-		// Run the DB update in a goroutine to respect the timeout
-		type updateResult struct {
-			store    vulnerability.Provider
-			dbStatus *vulnerability.ProviderStatus
-			err      error
+			go g.updateDBBackground(ctx)
+		} else {
+			g.mu.Unlock()
 		}
-		// Buffered channel (size 1) prevents goroutine from blocking if timeout occurs
-		// The goroutine will complete in background but won't leak since it will successfully send
-		resultCh := make(chan updateResult, 1)
+	}
 
-		go func() {
-			// Note: grype.LoadVulnerabilityDB does not accept context, so the goroutine
-			// will continue to completion even if timeout occurs. The buffered channel
-			// ensures the goroutine can complete without blocking.
-			if logger.L().GetLevel() == "debug" {
-				if distClient, err := distribution.NewClient(g.distCfg); err == nil {
-					if archive, err := distClient.IsUpdateAvailable(nil); err == nil && archive != nil {
-						if archiveURL, err := distClient.ResolveArchiveURL(*archive); err == nil {
-							logger.L().Debug("downloading grype DB", helpers.String("archiveURL", archiveURL))
-						}
+	// On cold start (no DB loaded yet), wait for the initial background update to finish or context to cancel
+	if !hasValidDB {
+		g.mu.RLock()
+		ch := g.updateChan
+		g.mu.RUnlock()
+		if ch != nil {
+			select {
+			case <-ch:
+			case <-ctx.Done():
+			}
+		}
+	}
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.store != nil && g.dbStatus != nil && g.dbStatus.Error == nil
+}
+
+func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
+	defer func() {
+		g.mu.Lock()
+		g.updating = false
+		if g.updateChan != nil {
+			close(g.updateChan)
+			g.updateChan = nil
+		}
+		g.mu.Unlock()
+	}()
+
+	// Use context.WithoutCancel to prevent the update from being cancelled if the request context (e.g. readiness probe) is cancelled
+	ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "GrypeAdapter.UpdateDB")
+	defer span.End()
+	logger.L().Info("updating grype DB",
+		helpers.String("listingURL", g.distCfg.LatestURL))
+
+	// Create a context with timeout to prevent stuck updates
+	updateCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	g.mu.RLock()
+	hasExistingDB := g.store != nil
+	g.mu.RUnlock()
+
+	type updateResult struct {
+		store    vulnerability.Provider
+		dbStatus *vulnerability.ProviderStatus
+		err      error
+	}
+	resultCh := make(chan updateResult, 1)
+
+	go func() {
+		if logger.L().GetLevel() == "debug" {
+			if distClient, err := distribution.NewClient(g.distCfg); err == nil {
+				if archive, err := distClient.IsUpdateAvailable(nil); err == nil && archive != nil {
+					if archiveURL, err := distClient.ResolveArchiveURL(*archive); err == nil {
+						logger.L().Debug("downloading grype DB", helpers.String("archiveURL", archiveURL))
 					}
 				}
 			}
-			if err := checkDBDirWritable(g.installCfg.DBRootDir); err != nil {
-				logger.L().Ctx(ctx).Warning("grype DB root dir is not writable",
-					helpers.Error(err),
-					helpers.String("dbRootDir", g.installCfg.DBRootDir))
-			}
-			store, dbStatus, err := grype.LoadVulnerabilityDB(g.distCfg, g.installCfg, true)
-			resultCh <- updateResult{store: store, dbStatus: dbStatus, err: err}
-		}()
+		}
+		if err := checkDBDirWritable(g.installCfg.DBRootDir); err != nil {
+			logger.L().Ctx(ctx).Warning("grype DB root dir is not writable",
+				helpers.Error(err),
+				helpers.String("dbRootDir", g.installCfg.DBRootDir))
+		}
+		store, dbStatus, err := grype.LoadVulnerabilityDB(g.distCfg, g.installCfg, true)
+		resultCh <- updateResult{store: store, dbStatus: dbStatus, err: err}
+	}()
 
-		select {
-		case result := <-resultCh:
-			if result.err != nil {
-				logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(result.err))
+	now := time.Now()
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(result.err))
+			if !hasExistingDB {
 				err := tools.DeleteContents(g.installCfg.DBRootDir)
 				logger.L().Debug("cleaned up cache", helpers.Error(err),
 					helpers.String("DBRootDir", g.installCfg.DBRootDir))
-				if !testing.Testing() {
-					logger.L().Info("restarting to release previous grype DB")
-					os.Exit(0)
-				}
-				return false
-			}
-			if g.store != nil {
-				if err := g.store.Close(); err != nil {
-					logger.L().Ctx(ctx).Warning("failed to close previous grype DB", helpers.Error(err))
-				}
-			}
-			g.store = result.store
-			g.dbStatus = result.dbStatus
-			g.lastDbUpdate = now
-			logger.L().Info("grype DB updated")
-			return true
-		case <-updateCtx.Done():
-			if hasExistingDB {
-				// We have an existing DB, keep using it instead of crashing
-				// This prevents crashloop in case of slow but functional network
-				logger.L().Ctx(ctx).Warning("grype DB update timed out after 15 minutes, continuing with existing DB",
-					helpers.String("existingDBVersion", g.dbVersionLocked()))
-				// Update lastDbUpdate to prevent immediate retry, will retry in next 24h cycle
-				g.lastDbUpdate = now
-				return true
 			} else {
-				// No existing DB to fall back on, must restart
-				logger.L().Ctx(ctx).Error("grype DB initial download timed out after 15 minutes")
-				err := tools.DeleteContents(g.installCfg.DBRootDir)
-				logger.L().Debug("cleaned up cache after timeout", helpers.Error(err),
-					helpers.String("DBRootDir", g.installCfg.DBRootDir))
-				if !testing.Testing() {
-					logger.L().Info("restarting pod due to grype DB initial download timeout")
-					os.Exit(0)
-				}
-				return false
+				g.mu.Lock()
+				// Schedule retry in 5 minutes if update failed but existing DB is available
+				g.lastDbUpdate = now.Add(-24*time.Hour + 5*time.Minute)
+				g.mu.Unlock()
+			}
+			return
+		}
+		g.mu.Lock()
+		oldStore := g.store
+		g.store = result.store
+		g.dbStatus = result.dbStatus
+		g.lastDbUpdate = now
+		g.mu.Unlock()
+
+		if oldStore != nil {
+			if err := oldStore.Close(); err != nil {
+				logger.L().Ctx(ctx).Warning("failed to close previous grype DB", helpers.Error(err))
 			}
 		}
+		logger.L().Info("grype DB updated")
+	case <-updateCtx.Done():
+		g.mu.Lock()
+		if hasExistingDB {
+			logger.L().Ctx(ctx).Warning("grype DB update timed out after 15 minutes, continuing with existing DB",
+				helpers.String("existingDBVersion", g.dbVersionLocked()))
+			// Delay retry for 1 hour on timeout
+			g.lastDbUpdate = now.Add(-24*time.Hour + 1*time.Hour)
+		} else {
+			logger.L().Ctx(ctx).Error("grype DB initial download timed out after 15 minutes")
+			err := tools.DeleteContents(g.installCfg.DBRootDir)
+			logger.L().Debug("cleaned up cache after timeout", helpers.Error(err),
+				helpers.String("DBRootDir", g.installCfg.DBRootDir))
+		}
+		g.mu.Unlock()
 	}
-
-	return g.dbStatus.Error == nil
 }
 
 const dummyLayer = "generatedlayer"

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/anchore/grype/grype/distro"
+	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/google/uuid"
 	"github.com/kinbiko/jsonassert"
 	"github.com/kubescape/kubevuln/config"
@@ -121,3 +122,56 @@ func Test_grypeAdapter_resolveUseDefaultMatchers(t *testing.T) {
 		})
 	}
 }
+
+type mockProvider struct {
+	vulnerability.Provider
+}
+
+func (m *mockProvider) Close() error { return nil }
+
+func Test_grypeAdapter_NonBlockingReady(t *testing.T) {
+	ctx := context.Background()
+	mockStore := &mockProvider{}
+	g := &GrypeAdapter{
+		store:        mockStore,
+		dbStatus:     &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"},
+		lastDbUpdate: time.Now(),
+	}
+
+	// Initial check with valid DB returns ready immediately
+	require.True(t, g.Ready(ctx))
+	assert.Equal(t, "test-checksum", g.DBVersion(ctx))
+
+	// Manually set lastDbUpdate to past 24h to trigger background update check
+	g.mu.Lock()
+	g.lastDbUpdate = time.Now().Add(-25 * time.Hour)
+	g.mu.Unlock()
+
+	// Trigger Ready - should launch background update without blocking
+	readyCh := make(chan bool, 1)
+	go func() {
+		readyCh <- g.Ready(ctx)
+	}()
+
+	select {
+	case isReady := <-readyCh:
+		// With an existing DB, Ready returns immediately true while update runs in background
+		assert.True(t, isReady)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Ready() blocked waiting for DB update, causing lock contention")
+	}
+
+	// Verify DBVersion can acquire read locks concurrently while background update is active
+	version := g.DBVersion(ctx)
+	assert.Equal(t, "test-checksum", version)
+
+	// Verify single-flight: while updating is true, another Ready call returns immediately
+	g.mu.RLock()
+	isUpdating := g.updating
+	g.mu.RUnlock()
+	if isUpdating {
+		require.True(t, g.Ready(ctx))
+	}
+}
+
+

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anchore/grype/grype/db/v6/distribution"
+	"github.com/anchore/grype/grype/db/v6/installation"
 	"github.com/anchore/grype/grype/distro"
 	"github.com/anchore/grype/grype/vulnerability"
 	"github.com/google/uuid"
@@ -132,10 +134,16 @@ func (m *mockProvider) Close() error { return nil }
 func Test_grypeAdapter_NonBlockingReady(t *testing.T) {
 	ctx := context.Background()
 	mockStore := &mockProvider{}
+	blockLoad := make(chan struct{})
+	
 	g := &GrypeAdapter{
 		store:        mockStore,
 		dbStatus:     &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"},
 		lastDbUpdate: time.Now(),
+		loadDB: func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+			<-blockLoad
+			return mockStore, &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"}, nil
+		},
 	}
 
 	// Initial check with valid DB returns ready immediately
@@ -165,13 +173,15 @@ func Test_grypeAdapter_NonBlockingReady(t *testing.T) {
 	version := g.DBVersion(ctx)
 	assert.Equal(t, "test-checksum", version)
 
-	// Verify single-flight: while updating is true, another Ready call returns immediately
+	// Verify background update is active under RLock
 	g.mu.RLock()
 	isUpdating := g.updating
 	g.mu.RUnlock()
-	if isUpdating {
-		require.True(t, g.Ready(ctx))
-	}
+	assert.True(t, isUpdating, "background update should be active")
+
+	// Unblock background loadDB and clean up
+	close(blockLoad)
 }
+
 
 

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -3,6 +3,9 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -131,18 +134,52 @@ type mockProvider struct {
 
 func (m *mockProvider) Close() error { return nil }
 
+// closeTrackingProvider records whether/how-many-times Close was called, so tests can
+// prove the double-buffer swap in finishUpdate closes the *old* store and installs the
+// *new* one, rather than the two being indistinguishable (as they were when both the old
+// and new store in a test were the same *mockProvider instance).
+type closeTrackingProvider struct {
+	vulnerability.Provider
+	closed int32
+}
+
+func (p *closeTrackingProvider) Close() error {
+	atomic.AddInt32(&p.closed, 1)
+	return nil
+}
+
+// waitForNotUpdating polls until a background update finishes (g.updating flips back to
+// false) or fails the test after a short deadline. Background goroutines spawned by
+// updateDBBackground/finishUpdate are not otherwise observable from the outside, and
+// letting them outlive the test is a source of -race flakiness in later tests.
+func waitForNotUpdating(t *testing.T, g *GrypeAdapter) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		g.mu.RLock()
+		updating := g.updating
+		g.mu.RUnlock()
+		if !updating {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("background update did not finish in time")
+}
+
 func Test_grypeAdapter_NonBlockingReady(t *testing.T) {
 	ctx := context.Background()
-	mockStore := &mockProvider{}
+	oldStore := &closeTrackingProvider{}
+	newStore := &closeTrackingProvider{}
 	blockLoad := make(chan struct{})
-	
+
 	g := &GrypeAdapter{
-		store:        mockStore,
-		dbStatus:     &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"},
-		lastDbUpdate: time.Now(),
+		store:             oldStore,
+		dbStatus:          &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"},
+		nextUpdateAttempt: time.Now().Add(24 * time.Hour),
 		loadDB: func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			<-blockLoad
-			return mockStore, &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"}, nil
+			return newStore, &vulnerability.ProviderStatus{From: "schema:v6%3Anew-checksum"}, nil
 		},
 	}
 
@@ -150,9 +187,9 @@ func Test_grypeAdapter_NonBlockingReady(t *testing.T) {
 	require.True(t, g.Ready(ctx))
 	assert.Equal(t, "test-checksum", g.DBVersion(ctx))
 
-	// Manually set lastDbUpdate to past 24h to trigger background update check
+	// Force the next update to be due, to trigger the background update check
 	g.mu.Lock()
-	g.lastDbUpdate = time.Now().Add(-25 * time.Hour)
+	g.nextUpdateAttempt = time.Now().Add(-time.Minute)
 	g.mu.Unlock()
 
 	// Trigger Ready - should launch background update without blocking
@@ -179,9 +216,94 @@ func Test_grypeAdapter_NonBlockingReady(t *testing.T) {
 	g.mu.RUnlock()
 	assert.True(t, isUpdating, "background update should be active")
 
-	// Unblock background loadDB and clean up
+	// Unblock background loadDB and wait for the swap to actually land before asserting on it
 	close(blockLoad)
+	waitForNotUpdating(t, g)
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	assert.Same(t, newStore, g.store, "the new provider from loadDB must be installed as the active store")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldStore.closed), "the previous store must be closed exactly once after the swap")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&newStore.closed), "the newly installed store must not be closed")
 }
 
+// Reproduces the exact scenario from the mentor review: a cold start (no DB ever loaded)
+// where loadDB keeps failing. Before nextUpdateAttempt existed, needsUpdate short-circuited
+// on dbStatus == nil, so every readiness probe re-launched a full download attempt with no
+// back-off. Ready() blocks synchronously on cold start until the background attempt
+// finishes, so looping it here deterministically exercises that path without a timing race.
+func Test_grypeAdapter_Ready_backsOffAfterFailedColdStart(t *testing.T) {
+	ctx := context.Background()
+	var calls int32
+	g := &GrypeAdapter{
+		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+			atomic.AddInt32(&calls, 1)
+			return nil, nil, errors.New("network down")
+		},
+	}
 
+	for i := 0; i < 5; i++ {
+		require.False(t, g.Ready(ctx))
+	}
 
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "cold-start failures must back off, not fire once per probe")
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	assert.True(t, g.nextUpdateAttempt.After(time.Now()), "a failed cold start must schedule a future retry instead of leaving Ready always due")
+}
+
+// A load that returns no Go error but a ProviderStatus.Error is not a usable DB. Before this
+// was treated as a failure, it was installed as g.store/g.dbStatus and lastDbUpdate was set
+// to now, wedging the pod NotReady for 24h with nothing to trigger a retry or a restart.
+func Test_grypeAdapter_Ready_treatsStatusErrorAsFailure(t *testing.T) {
+	ctx := context.Background()
+	statusErr := errors.New("corrupt db")
+	badStore := &closeTrackingProvider{}
+	g := &GrypeAdapter{
+		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+			return badStore, &vulnerability.ProviderStatus{Error: statusErr}, nil
+		},
+	}
+
+	require.False(t, g.Ready(ctx))
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	assert.Nil(t, g.store, "a load whose status carries an error must not be installed as the active store")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&badStore.closed), "the unusable store must be closed rather than leaked")
+	assert.True(t, g.nextUpdateAttempt.Before(time.Now().Add(6*time.Minute)), "must schedule a short retry, not the 24h success interval")
+}
+
+// Concurrent readiness probes racing Ready() while an update is in flight must not launch a
+// second background load - the single-flight guard (g.updating) is only meant to be released
+// once the actual load returns, not merely once updateDBBackground's own wait gives up.
+func Test_grypeAdapter_Ready_singleFlightUnderConcurrency(t *testing.T) {
+	ctx := context.Background()
+	var calls int32
+	blockLoad := make(chan struct{})
+	g := &GrypeAdapter{
+		store:             &mockProvider{},
+		dbStatus:          &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"},
+		nextUpdateAttempt: time.Now().Add(-time.Minute),
+		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+			atomic.AddInt32(&calls, 1)
+			<-blockLoad
+			return &mockProvider{}, &vulnerability.ProviderStatus{From: "schema:v6%3Anew"}, nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			g.Ready(ctx)
+		}()
+	}
+	wg.Wait()
+
+	close(blockLoad)
+	waitForNotUpdating(t, g)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent Ready() calls must not launch more than one background load")
+}


### PR DESCRIPTION
## Overview

`GrypeAdapter.Ready` previously held an exclusive write lock (`g.mu.Lock()`) for the entire duration of the 15-minute Grype vulnerability database download and load operation. Because vulnerability scans (`ScanSBOM`) acquire a read lock (`g.mu.RLock()`), all active and incoming scan requests across the service blocked behind `g.mu.Lock()` for up to 15 minutes during 24-hour update cycles.

Furthermore, failed update attempts or initial download timeouts invoked `os.Exit(0)`, forcing `kubevuln` into an unrecoverable `CrashLoopBackOff` on transient network errors.

This PR refactors `GrypeAdapter.Ready` to update the database asynchronously in a background goroutine without holding write locks during the download phase, allowing active scans to continue running concurrently without blocking.

## Additional Information

- **Non-Blocking Background Updates**: `GrypeAdapter.Ready` launches database updates asynchronously in a background goroutine without holding `g.mu.Lock()` during network downloads.
- **Atomic Double-Buffering**: Active scans continue using the existing valid database (`g.store`) while new database versions download. Once loaded, `g.store` is swapped atomically under a microsecond write lock.
- **Single-Flight Guarding**: Added `updating` boolean tracking and `updateChan` synchronization to prevent duplicate background update goroutines when probed by readiness checks (`/v1/readiness`).
- **Process Stability**: Removed all `os.Exit(0)` calls. If an update fails or times out while an existing DB is active, `kubevuln` logs a warning and continues serving scans using the active DB while scheduling a delayed retry.

## How to Test

Run the unit test suite for `adapters/v1`:
```bash
go test -v -count=1 -run "Test_grypeAdapter_NonBlockingReady|Test_grypeAdapter_resolveUseDefaultMatchers" ./adapters/v1/...
```

## Related issues/PRs:

* Resolved #427

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability database update reliability and recovery from failed or timed-out updates.
  * Existing usable databases are now preserved when updates cannot be completed.
  * Improved startup readiness while database loading is in progress.
  * Scans now clearly reject requests when no valid vulnerability database is available.
  * Prevented duplicate database loads during concurrent operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->