### PR TITLE
fix: bounded concurrency, context propagation, and non-fatal cleanup in SyftAdapter.CreateSBOM (#429)

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/DmitriyVTitov/size"
@@ -55,12 +54,15 @@ type SyftAdapter struct {
 	maxImageSize      int64
 	maxSBOMSize       int
 	proxyRegistryMap  map[string]string
-	pullMutex         sync.Mutex
+	concurrencySem    chan struct{}
 	scanTimeout       time.Duration
 	scanEmbeddedSBOMs bool
 }
 
-const digestDelim = "@"
+const (
+	digestDelim                = "@"
+	defaultMaxConcurrentPulls = 10
+)
 
 var _ ports.SBOMCreator = (*SyftAdapter)(nil)
 
@@ -72,6 +74,7 @@ func NewSyftAdapter(scanTimeout time.Duration, maxImageSize int64, maxSBOMSize i
 		proxyRegistryMap:  proxyRegistryMap,
 		scanTimeout:       scanTimeout,
 		scanEmbeddedSBOMs: scanEmbeddedSBOMs,
+		concurrencySem:    make(chan struct{}, defaultMaxConcurrentPulls),
 	}
 }
 
@@ -189,7 +192,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// download image
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))
 
-	ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, s.maxImageSize)
+	ctxWithSize := context.WithValue(ctx, image.MaxImageSize, s.maxImageSize)
 	pullRef := rewriteImageRef(imageID, s.proxyRegistryMap)
 	src, err := syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
 
@@ -239,15 +242,23 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// use a deadline to prevent the process from hanging for too long
 	// TODO check memory usage and see if we can kill the goroutine
 	var syftSBOM *sbom.SBOM
-	// ensure no parallel pulls
-	s.pullMutex.Lock()
-	defer s.pullMutex.Unlock()
+	// Bounded concurrency control to prevent disk/memory exhaustion while enabling parallel processing
+	if s.concurrencySem == nil {
+		s.concurrencySem = make(chan struct{}, defaultMaxConcurrentPulls)
+	}
+	select {
+	case s.concurrencySem <- struct{}{}:
+		defer func() { <-s.concurrencySem }()
+	case <-ctx.Done():
+		return domainSBOM, ctx.Err()
+	}
+
 	dl := deadline.New(s.scanTimeout)
 	err = dl.Run(func(stopper <-chan struct{}) error {
-		// make sure we clean the temp dir
+		// make sure we clean the temp dir safely without crashing on cleanup warnings
 		defer func(src source.Source) {
 			if err := src.Close(); err != nil {
-				logger.L().Ctx(ctx).Fatal("failed to close source", helpers.Error(err),
+				logger.L().Ctx(ctx).Warning("failed to close source", helpers.Error(err),
 					helpers.String("imageID", imageID))
 			}
 		}(src)
@@ -268,7 +279,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 			// ask Syft to also scan the image for embedded SBOMs
 			cfg.WithCatalogers(pkgcataloging.NewCatalogerReference(sbomcataloger.NewCataloger(), []string{pkgcataloging.ImageTag}))
 		}
-		syftSBOM, err = syft.CreateSBOM(context.Background(), src, cfg)
+		syftSBOM, err = syft.CreateSBOM(ctx, src, cfg)
 		if err != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", err)
 		}

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -373,3 +373,13 @@ func TestRewriteImageRef(t *testing.T) {
 		})
 	}
 }
+
+func Test_syftAdapter_ContextCancellation(t *testing.T) {
+	s := NewSyftAdapter(10*time.Second, 1000000, 1000000, false, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := s.CreateSBOM(ctx, "test", "library/alpine@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501", "", domain.RegistryOptions{})
+	require.Error(t, err)
+}
+


### PR DESCRIPTION
## Overview

`SyftAdapter.CreateSBOM` previously used a single global mutex (`s.pullMutex`), forcing all container image SBOM generation requests across the service to run in a strictly single-threaded queue. When multiple workloads required scanning simultaneously, every request blocked until prior images completed, causing widespread request timeouts.

Additionally, `SyftAdapter` passed `context.Background()` to `syft.GetSource` and `syft.CreateSBOM`, discarding caller request cancellation and distributed tracing, and invoked `logger.Fatal` (`os.Exit(1)`) on temporary directory cleanup errors during `src.Close()`.

This PR refactors `SyftAdapter.CreateSBOM` to use bounded concurrency control, propagate caller contexts, and log warnings on cleanup errors without terminating the service.

## Additional Information

- **Bounded Concurrency Control**: Replaced global `s.pullMutex` with a configurable concurrency channel (`concurrencySem`, defaulting to 10 workers), allowing parallel image SBOM generation while avoiding disk/memory exhaustion.
- **Context Cancellation & Tracing**: Propagated caller `ctx` (with `image.MaxImageSize`) down to `syft.GetSource` and `syft.CreateSBOM`, allowing request cancellation (`ctx.Done()`) to immediately unblock waiting jobs.
- **Process Stability**: Replaced `logger.Fatal` with `logger.Warning` in `src.Close()` defer blocks so minor temporary directory cleanup errors do not crash the `kubevuln` pod (`os.Exit(1)`).

## How to Test

Run unit tests for `adapters/v1`:
```bash
go test -v -count=1 -run "Test_syftAdapter_ContextCancellation|Test_domainJSONToSyft" ./adapters/v1/...
```

## Related issues/PRs:

* Resolved #429

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan cancellation so interrupted requests stop promptly.
  * Increased scan throughput by allowing a controlled number of scans to run concurrently.
  * Improved handling of source cleanup issues by recording warnings instead of failing scans.
  * Ensured scan operations consistently honor the caller’s cancellation and timeout settings.

* **Tests**
  * Added coverage for cancellation of already-stopped scan requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->