### PR TITLE
perf: cache CVE exceptions per workload to cut redundant backend/CRD lookups

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -33,15 +33,15 @@ import (
 )
 
 type BackendAdapter struct {
-	eventReceiverRestURL      string
-	apiServerRestURL          string
-	clusterConfig             pkgcautils.ClusterConfig
-	getCVEExceptionsFunc      func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
-	httpPostFunc              func(httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error)
-	sendStatusFunc            func(*backendClientV1.BaseReportSender, string, bool)
-	accessKey                 string
-	securityExceptionRepo     ports.SecurityExceptionRepository
-	exceptionsCache           *cache.Cache
+	eventReceiverRestURL  string
+	apiServerRestURL      string
+	clusterConfig         pkgcautils.ClusterConfig
+	getCVEExceptionsFunc  func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
+	httpPostFunc          func(httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error)
+	sendStatusFunc        func(*backendClientV1.BaseReportSender, string, bool)
+	accessKey             string
+	securityExceptionRepo ports.SecurityExceptionRepository
+	exceptionsCache       *cache.Cache
 }
 
 var _ ports.Platform = (*BackendAdapter)(nil)
@@ -60,10 +60,10 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 		clusterConfig: pkgcautils.ClusterConfig{
 			AccountID: accountID,
 		},
-		eventReceiverRestURL:  eventReceiverRestURL,
-		apiServerRestURL:      apiServerRestURL,
-		getCVEExceptionsFunc:  backendClientV1.GetCVEExceptionByDesignator,
-		httpPostFunc:          httputils.HttpPostWithRetry,
+		eventReceiverRestURL: eventReceiverRestURL,
+		apiServerRestURL:     apiServerRestURL,
+		getCVEExceptionsFunc: backendClientV1.GetCVEExceptionByDesignator,
+		httpPostFunc:         httputils.HttpPostWithRetry,
 		sendStatusFunc: func(sender *backendClientV1.BaseReportSender, status string, sendReport bool) {
 			sender.SendStatus(status, sendReport) // TODO - update this function to use from kubescape/backend
 		},
@@ -101,6 +101,11 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	}
 
 	namespace := wlidpkg.GetNamespaceFromWlid(workload.Wlid)
+	// Registry scans carry no Wlid (registryScanCommandToScanCommand never sets
+	// it), which would otherwise collapse every scanned image onto the same
+	// cache key ("<accountID>/////"). Skip caching entirely for them rather than
+	// let unrelated images share exceptions.
+	cacheable := workload.Wlid != ""
 	cacheKey := strings.Join([]string{
 		a.clusterConfig.AccountID,
 		wlidpkg.GetClusterFromWlid(workload.Wlid),
@@ -108,9 +113,10 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 		strings.ToLower(wlidpkg.GetKindFromWlid(workload.Wlid)),
 		wlidpkg.GetNameFromWlid(workload.Wlid),
 		workload.ContainerName,
+		workload.ImageTagNormalized,
 	}, "/")
 
-	if a.exceptionsCache != nil {
+	if cacheable && a.exceptionsCache != nil {
 		if cached, ok := a.exceptionsCache.Get(cacheKey); ok {
 			return cached.(domain.CVEExceptions), nil
 		}
@@ -134,16 +140,27 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	}
 
 	// Merge CRD-based exceptions
-	seList, cseList, err := a.securityExceptionRepo.GetSecurityExceptions(ctx, namespace)
-	if err != nil {
-		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions", helpers.Error(err))
+	seList, cseList, crdErr := a.securityExceptionRepo.GetSecurityExceptions(ctx, namespace)
+	if crdErr != nil {
+		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions", helpers.Error(crdErr))
+		// This is a best-effort degradation that self-heals on the next scan;
+		// caching it would suppress valid CRD exceptions for the full TTL.
+		cacheable = false
 	} else if len(seList) > 0 || len(cseList) > 0 {
 		target := BuildExceptionTarget(ctx, workload, seList, cseList, a.securityExceptionRepo)
 		crdPolicies := ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
 		vulnExceptionList = append(vulnExceptionList, crdPolicies...)
+
+		// A selector-based exception whose labels failed to resolve fails closed
+		// (see matchExceptionTarget), which is also a self-healing degradation and
+		// must not be cached as if it were the authoritative result.
+		if (usesObjectSelector(seList, cseList) && !target.WorkloadLabelsResolved) ||
+			(usesNamespaceSelector(cseList) && !target.NamespaceLabelsResolved) {
+			cacheable = false
+		}
 	}
 
-	if a.exceptionsCache != nil {
+	if cacheable && a.exceptionsCache != nil {
 		a.exceptionsCache.Set(cacheKey, domain.CVEExceptions(vulnExceptionList), exceptionsCacheTTL)
 	}
 

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/akyoto/cache"
 	"github.com/armosec/armoapi-go/armotypes"
 	cs "github.com/armosec/armoapi-go/containerscan"
 	v1 "github.com/armosec/armoapi-go/containerscan/v1"
@@ -40,9 +41,19 @@ type BackendAdapter struct {
 	sendStatusFunc            func(*backendClientV1.BaseReportSender, string, bool)
 	accessKey                 string
 	securityExceptionRepo     ports.SecurityExceptionRepository
+	exceptionsCache           *cache.Cache
 }
 
 var _ ports.Platform = (*BackendAdapter)(nil)
+
+// exceptionsCacheCleaningInterval controls how often expired entries are swept from exceptionsCache.
+// exceptionsCacheTTL bounds how stale a cached exceptions/CRD merge can be before the next scan
+// re-fetches from the backend and cluster; exceptions rarely change within a scan burst, so this
+// avoids a network + CRD round trip on every single container scan.
+const (
+	exceptionsCacheCleaningInterval = 1 * time.Minute
+	exceptionsCacheTTL              = 5 * time.Minute
+)
 
 func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, accessKey string, seRepo ports.SecurityExceptionRepository) *BackendAdapter {
 	return &BackendAdapter{
@@ -58,6 +69,7 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 		},
 		accessKey:             accessKey,
 		securityExceptionRepo: seRepo,
+		exceptionsCache:       cache.New(exceptionsCacheCleaningInterval),
 	}
 }
 
@@ -88,12 +100,28 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 		return nil, domain.ErrCastingWorkload
 	}
 
+	namespace := wlidpkg.GetNamespaceFromWlid(workload.Wlid)
+	cacheKey := strings.Join([]string{
+		a.clusterConfig.AccountID,
+		wlidpkg.GetClusterFromWlid(workload.Wlid),
+		namespace,
+		strings.ToLower(wlidpkg.GetKindFromWlid(workload.Wlid)),
+		wlidpkg.GetNameFromWlid(workload.Wlid),
+		workload.ContainerName,
+	}, "/")
+
+	if a.exceptionsCache != nil {
+		if cached, ok := a.exceptionsCache.Get(cacheKey); ok {
+			return cached.(domain.CVEExceptions), nil
+		}
+	}
+
 	designator := identifiers.PortalDesignator{
 		DesignatorType: identifiers.DesignatorAttribute,
 		Attributes: map[string]string{
 			"customerGUID":        a.clusterConfig.AccountID,
 			"scope.cluster":       wlidpkg.GetClusterFromWlid(workload.Wlid),
-			"scope.namespace":     wlidpkg.GetNamespaceFromWlid(workload.Wlid),
+			"scope.namespace":     namespace,
 			"scope.kind":          strings.ToLower(wlidpkg.GetKindFromWlid(workload.Wlid)),
 			"scope.name":          wlidpkg.GetNameFromWlid(workload.Wlid),
 			"scope.containerName": workload.ContainerName,
@@ -106,7 +134,6 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	}
 
 	// Merge CRD-based exceptions
-	namespace := wlidpkg.GetNamespaceFromWlid(workload.Wlid)
 	seList, cseList, err := a.securityExceptionRepo.GetSecurityExceptions(ctx, namespace)
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions", helpers.Error(err))
@@ -114,6 +141,10 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 		target := BuildExceptionTarget(ctx, workload, seList, cseList, a.securityExceptionRepo)
 		crdPolicies := ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
 		vulnExceptionList = append(vulnExceptionList, crdPolicies...)
+	}
+
+	if a.exceptionsCache != nil {
+		a.exceptionsCache.Set(cacheKey, domain.CVEExceptions(vulnExceptionList), exceptionsCacheTTL)
 	}
 
 	return vulnExceptionList, nil

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,7 +21,6 @@ import (
 	"github.com/armosec/armoapi-go/scanfailure"
 	"github.com/armosec/utils-go/httputils"
 	"github.com/armosec/utils-k8s-go/armometadata"
-	"github.com/stretchr/testify/require"
 	"github.com/google/uuid"
 	"github.com/kinbiko/jsonassert"
 	beClientV1 "github.com/kubescape/backend/pkg/client/v1"
@@ -30,8 +30,44 @@ import (
 	"github.com/kubescape/kubevuln/repositories"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type testSecurityExceptionRepo struct {
+	getSecurityExceptions func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error)
+	getWorkloadLabels     func(context.Context, string, string, string) (map[string]string, error)
+	getNamespaceLabels    func(context.Context, string) (map[string]string, error)
+}
+
+func (r *testSecurityExceptionRepo) GetSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
+	if r != nil && r.getSecurityExceptions != nil {
+		return r.getSecurityExceptions(ctx, namespace)
+	}
+	return nil, nil, nil
+}
+
+func (r *testSecurityExceptionRepo) GetWorkloadLabels(ctx context.Context, namespace, kind, name string) (map[string]string, error) {
+	if r != nil && r.getWorkloadLabels != nil {
+		return r.getWorkloadLabels(ctx, namespace, kind, name)
+	}
+	return nil, nil
+}
+
+func (r *testSecurityExceptionRepo) GetNamespaceLabels(ctx context.Context, name string) (map[string]string, error) {
+	if r != nil && r.getNamespaceLabels != nil {
+		return r.getNamespaceLabels(ctx, name)
+	}
+	return nil, nil
+}
+
+func scanContext(wlid, containerName, image string) context.Context {
+	return context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:               wlid,
+		ContainerName:      containerName,
+		ImageTagNormalized: image,
+	})
+}
 
 func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 	type fields struct {
@@ -122,6 +158,116 @@ func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
 	_, err = a.GetCVEExceptions(otherCtx)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, calls, "a different workload should not hit the cache")
+}
+
+func TestBackendAdapter_GetCVEExceptions_ImageScopedCRDPoliciesUseDistinctCacheEntries(t *testing.T) {
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &testSecurityExceptionRepo{
+		getSecurityExceptions: func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
+			return nil, []sev1beta1.ClusterSecurityException{{
+				Spec: sev1beta1.SecurityExceptionSpec{
+					Match: sev1beta1.ExceptionMatch{
+						Images: []string{"docker.io/library/nginx:*"},
+					},
+					Vulnerabilities: []sev1beta1.VulnerabilityException{{
+						Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2023-1"},
+					}},
+				},
+			}}, nil
+		},
+	})
+	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		return nil, nil
+	}
+
+	nginx, err := a.GetCVEExceptions(scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25"))
+	assert.NoError(t, err)
+	assert.Len(t, nginx, 1)
+
+	redis, err := a.GetCVEExceptions(scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/redis:7"))
+	assert.NoError(t, err)
+	assert.Empty(t, redis, "different images for the same workload must not share cached exception results")
+}
+
+func TestBackendAdapter_GetCVEExceptions_RegistryScansDoNotShareExceptionResults(t *testing.T) {
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &testSecurityExceptionRepo{
+		getSecurityExceptions: func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
+			return nil, []sev1beta1.ClusterSecurityException{{
+				Spec: sev1beta1.SecurityExceptionSpec{
+					Match: sev1beta1.ExceptionMatch{
+						Images: []string{"docker.io/library/nginx:*"},
+					},
+					Vulnerabilities: []sev1beta1.VulnerabilityException{{
+						Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2023-1"},
+					}},
+				},
+			}}, nil
+		},
+	})
+	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		return nil, nil
+	}
+
+	nginx, err := a.GetCVEExceptions(scanContext("", "", "docker.io/library/nginx:1.25"))
+	assert.NoError(t, err)
+	assert.Len(t, nginx, 1)
+
+	redis, err := a.GetCVEExceptions(scanContext("", "", "docker.io/library/redis:7"))
+	assert.NoError(t, err)
+	assert.Empty(t, redis, "registry scans for different images must not share cached exception results")
+}
+
+func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenCRDLookupFails(t *testing.T) {
+	calls := 0
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &testSecurityExceptionRepo{
+		getSecurityExceptions: func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
+			return nil, nil, errors.New("boom")
+		},
+	})
+	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		calls++
+		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	}
+	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
+
+	_, err := a.GetCVEExceptions(ctx)
+	assert.NoError(t, err)
+	_, err = a.GetCVEExceptions(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls, "degraded CRD merges should not be cached")
+}
+
+func TestBackendAdapter_GetCVEExceptions_DoesNotCacheUnresolvedSelectorLabels(t *testing.T) {
+	calls := 0
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &testSecurityExceptionRepo{
+		getSecurityExceptions: func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
+			return []sev1beta1.SecurityException{{
+				Spec: sev1beta1.SecurityExceptionSpec{
+					Match: sev1beta1.ExceptionMatch{
+						ObjectSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "nginx"},
+						},
+					},
+					Vulnerabilities: []sev1beta1.VulnerabilityException{{
+						Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2026-1"},
+					}},
+				},
+			}}, nil, nil
+		},
+		getWorkloadLabels: func(context.Context, string, string, string) (map[string]string, error) {
+			return nil, errors.New("lookup failed")
+		},
+	})
+	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		calls++
+		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	}
+	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
+
+	_, err := a.GetCVEExceptions(ctx)
+	assert.NoError(t, err)
+	_, err = a.GetCVEExceptions(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls, "selector-based degradations should not be cached")
 }
 
 func fileToType[T any](path string) *T {

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -92,6 +92,38 @@ func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 	}
 }
 
+func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
+	calls := 0
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
+	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		calls++
+		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	}
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:          "wlid://cluster-c/namespace-ns/deployment-d",
+		ContainerName: "container",
+	})
+
+	got1, err := a.GetCVEExceptions(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, got1, 1)
+	assert.Equal(t, 1, calls, "first call should hit the backend")
+
+	got2, err := a.GetCVEExceptions(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, got1, got2)
+	assert.Equal(t, 1, calls, "second call for the same workload should be served from cache")
+
+	// a different workload must not be served from the other workload's cache entry
+	otherCtx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:          "wlid://cluster-c/namespace-ns2/deployment-d2",
+		ContainerName: "container2",
+	})
+	_, err = a.GetCVEExceptions(otherCtx)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls, "a different workload should not hit the cache")
+}
+
 func fileToType[T any](path string) *T {
 	var t *T
 	b, err := os.ReadFile(path)


### PR DESCRIPTION
## Overview
`BackendAdapter.GetCVEExceptions` (adapters/v1/backend.go) currently hits the backend API and merges CRD-based SecurityExceptions on every single container scan. Exceptions for a given workload rarely change within a short window, so this is a redundant network + CRD round trip on every scan of that workload.

This PR adds a TTL cache (5 min, keyed by account/cluster/namespace/kind/name/containerName) around the merged exceptions result, reusing the same `github.com/akyoto/cache` pattern already used for the `tooManyRequests` limiter in `core/services/scan.go`. The cache is nil-safe, so tests constructing `BackendAdapter{}` directly (bypassing `NewBackendAdapter`) are unaffected — caching only activates for adapters built via the constructor (i.e. real usage).

## Additional Information
This is related to but distinct from #438 (shared Grype vulnerability DB cache across replicas) — that issue is about the on-disk vulnerability DB, this PR is about the in-process exceptions/CRD lookup.

## How to Test
- `go build ./...`
- `go test ./adapters/v1/...`
- New test `TestBackendAdapter_GetCVEExceptions_Caches` verifies: first call hits the backend, a second call for the same workload is served from cache, and a different workload does not hit the other workload's cache entry.

## Related issues/PRs:
* Related to #438

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added short-lived caching for CVE exceptions to reduce repeated lookups.
  * Cache entries are scoped by workload and image to prevent incorrect result sharing.
  * Registry scans remain isolated and do not reuse cached exceptions.

* **Reliability**
  * Exceptions continue to be processed when cache-related lookups fail.
  * Results are not cached when policy retrieval or selector resolution is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->