### PR TITLE
fix: reuse HTTP client and guard channel sends in BackendAdapter (#437)

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -250,7 +250,7 @@ func (a *BackendAdapter) ReportScanFailure(ctx context.Context, failureCase scan
 	}
 
 	url := fmt.Sprintf("%s/k8s/v2/scanFailure", a.eventReceiverRestURL)
-	resp, err := a.httpPostFunc(http.DefaultClient, url, a.getRequestHeaders(), payload, 30*time.Second)
+	resp, err := a.httpPostFunc(a.getHTTPClient(), url, a.getRequestHeaders(), payload, 30*time.Second)
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to send scan failure report",
 			helpers.Error(err),

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -71,7 +71,15 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 		accessKey:             accessKey,
 		securityExceptionRepo: seRepo,
 		exceptionsCache:       cache.New(exceptionsCacheCleaningInterval),
-		httpClient:            &http.Client{},
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 32,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
 	}
 }
 

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -42,6 +42,7 @@ type BackendAdapter struct {
 	accessKey             string
 	securityExceptionRepo ports.SecurityExceptionRepository
 	exceptionsCache       *cache.Cache
+	httpClient            httputils.IHttpClient
 }
 
 var _ ports.Platform = (*BackendAdapter)(nil)
@@ -70,7 +71,15 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 		accessKey:             accessKey,
 		securityExceptionRepo: seRepo,
 		exceptionsCache:       cache.New(exceptionsCacheCleaningInterval),
+		httpClient:            &http.Client{},
 	}
+}
+
+func (a *BackendAdapter) getHTTPClient() httputils.IHttpClient {
+	if a.httpClient == nil {
+		a.httpClient = &http.Client{}
+	}
+	return a.httpClient
 }
 
 const ActionName = "vuln scan"
@@ -180,7 +189,7 @@ func (a *BackendAdapter) ReportError(ctx context.Context, err error) error {
 	report.Errors = append(report.Errors, err.Error())
 	report.Status = sysreport.JobFailed
 
-	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, &http.Client{}, a.getRequestHeaders(), report)
+	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, a.getHTTPClient(), a.getRequestHeaders(), report)
 	a.sendStatusFunc(sender, sysreport.JobFailed, true)
 	return nil
 }
@@ -261,7 +270,7 @@ func (a *BackendAdapter) SendStatus(ctx context.Context, step int) error {
 	report.Details = details[step]
 	report.Status = statuses[step]
 
-	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, &http.Client{}, a.getRequestHeaders(), report)
+	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, a.getHTTPClient(), a.getRequestHeaders(), report)
 	a.sendStatusFunc(sender, statuses[step], true)
 	return nil
 }

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -76,10 +76,10 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 }
 
 func (a *BackendAdapter) getHTTPClient() httputils.IHttpClient {
-	if a.httpClient == nil {
-		a.httpClient = &http.Client{}
+	if a.httpClient != nil {
+		return a.httpClient
 	}
-	return a.httpClient
+	return http.DefaultClient
 }
 
 const ActionName = "vuln scan"

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -836,6 +836,9 @@ func TestBackendAdapter_HTTPClientReuse(t *testing.T) {
 	assert.Equal(t, 3, stub.Calls(), "postResults should use the shared httpClient")
 	assert.Empty(t, errChan, "postResults should not report an error when the shared client succeeds")
 
+	require.NoError(t, a.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration, scanfailure.ReasonSBOMGenerationFailed, nil))
+	assert.Equal(t, 4, stub.Calls(), "ReportScanFailure should use the shared httpClient")
+
 	assert.Same(t, stub, a.getHTTPClient(), "getHTTPClient should keep returning the exact configured instance")
 }
 

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -784,24 +785,103 @@ func TestGetCVEExceptions_ScopesCRDByMatch(t *testing.T) {
 	assert.Empty(t, exceptions, "redis-scoped exception must not apply to an nginx workload")
 }
 
-func TestBackendAdapter_HTTPClientReuseAndSendErrorNonBlocking(t *testing.T) {
-	customClient := &http.Client{}
+// recordingHTTPClient counts how many times it served a request, so tests can prove that the
+// exact same client instance was reused across multiple call sites instead of merely asserting
+// that a getter echoes back the field it was handed.
+type recordingHTTPClient struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (c *recordingHTTPClient) Do(_ *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok")), Header: make(http.Header)}, nil
+}
+
+func (c *recordingHTTPClient) Calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+func TestBackendAdapter_HTTPClientReuse(t *testing.T) {
+	stub := &recordingHTTPClient{}
 	a := &BackendAdapter{
-		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
-		httpClient:    customClient,
+		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
+		eventReceiverRestURL: "http://example.invalid",
+		httpClient:           stub,
+		httpPostFunc:         httputils.HttpPostWithRetry,
+		sendStatusFunc: func(sender *beClientV1.BaseReportSender, status string, sendReport bool) {
+			sender.SendStatus(status, sendReport)
+		},
 	}
 
-	assert.Equal(t, customClient, a.getHTTPClient(), "should reuse configured httpClient")
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:          "wlid",
+		ContainerName: "container",
+		ImageTag:      "imageTag",
+		ImageHash:     "imageHash",
+	})
 
-	// Test non-blocking sendError when context is cancelled and channel is full
-	cancelledCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, a.ReportError(ctx, fmt.Errorf("boom")))
+	assert.Equal(t, 1, stub.Calls(), "ReportError should use the shared httpClient")
+
+	require.NoError(t, a.SendStatus(ctx, 0))
+	assert.Equal(t, 2, stub.Calls(), "SendStatus should use the shared httpClient")
+
+	errChan := make(chan error, 1)
+	a.postResults(ctx, v1.ScanResultReport{}, a.eventReceiverRestURL, "imageTag", "wlid", errChan)
+	assert.Equal(t, 3, stub.Calls(), "postResults should use the shared httpClient")
+	assert.Empty(t, errChan, "postResults should not report an error when the shared client succeeds")
+
+	assert.Same(t, stub, a.getHTTPClient(), "getHTTPClient should keep returning the exact configured instance")
+}
+
+func TestSendError_DeliversImmediatelyWhenChannelHasRoom(t *testing.T) {
+	// Realistic shape from the reported bug: a buffered channel with free space, hit while ctx
+	// is already cancelled. The send must still win deterministically instead of racing a
+	// random select against ctx.Done().
+	ch := make(chan error, 10)
+	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	ch := make(chan error, 1)
-	ch <- fmt.Errorf("initial error")
+	sendError(ctx, ch, fmt.Errorf("overflow error"))
 
-	// Must not block even when ch is full because ctx is cancelled
-	sendError(cancelledCtx, ch, fmt.Errorf("overflow error"))
-	assert.Len(t, ch, 1, "channel should still contain only initial error")
+	require.Len(t, ch, 1)
+	assert.EqualError(t, <-ch, "overflow error")
+}
+
+func TestSendError_BlocksOnFullChannelUntilCtxCancelledThenDrops(t *testing.T) {
+	// This is the scenario the PR description actually claims to guard: a full channel with a
+	// live context. sendError must block until either the channel drains or ctx is cancelled,
+	// only dropping the error once that happens.
+	ch := make(chan error, 1)
+	ch <- fmt.Errorf("first error")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		sendError(ctx, ch, fmt.Errorf("second error"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("sendError returned before the channel had room or ctx was cancelled")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sendError did not return after context cancellation")
+	}
+
+	require.Len(t, ch, 1, "second error should have been dropped since the channel stayed full")
+	assert.EqualError(t, <-ch, "first error")
 }
 

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -884,4 +884,3 @@ func TestSendError_BlocksOnFullChannelUntilCtxCancelledThenDrops(t *testing.T) {
 	require.Len(t, ch, 1, "second error should have been dropped since the channel stayed full")
 	assert.EqualError(t, <-ch, "first error")
 }
-

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -783,3 +783,25 @@ func TestGetCVEExceptions_ScopesCRDByMatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, exceptions, "redis-scoped exception must not apply to an nginx workload")
 }
+
+func TestBackendAdapter_HTTPClientReuseAndSendErrorNonBlocking(t *testing.T) {
+	customClient := &http.Client{}
+	a := &BackendAdapter{
+		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
+		httpClient:    customClient,
+	}
+
+	assert.Equal(t, customClient, a.getHTTPClient(), "should reuse configured httpClient")
+
+	// Test non-blocking sendError when context is cancelled and channel is full
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch := make(chan error, 1)
+	ch <- fmt.Errorf("initial error")
+
+	// Must not block even when ch is full because ctx is cancelled
+	sendError(cancelledCtx, ch, fmt.Errorf("overflow error"))
+	assert.Len(t, ch, 1, "channel should still contain only initial error")
+}
+

--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -24,6 +24,11 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 )
 
+// sendError delivers err to errorChan. It always wins the send when the channel has room,
+// even if ctx is already cancelled, so a cancelled context never causes a real error to be
+// dropped in favor of a stale one already sitting in the channel. Only once the channel is
+// actually saturated do we fall back to waiting for room or for ctx cancellation, logging a
+// warning if we ultimately have to give up.
 func sendError(ctx context.Context, errorChan chan<- error, err error) {
 	if errorChan == nil || err == nil {
 		return
@@ -33,8 +38,14 @@ func sendError(ctx context.Context, errorChan chan<- error, err error) {
 	}
 	select {
 	case errorChan <- err:
+		return
+	default:
+	}
+	// only now consider giving up
+	select {
+	case errorChan <- err:
 	case <-ctx.Done():
-		logger.L().Ctx(ctx).Warning("context cancelled while sending error to channel", helpers.Error(err))
+		logger.L().Ctx(ctx).Warning("dropping error, context cancelled", helpers.Error(err))
 	}
 }
 
@@ -53,8 +64,9 @@ func (a *BackendAdapter) sendSummaryAndVulnerabilities(ctx context.Context, repo
 		//first chunk is not included in the summary, so if there are vulnerabilities to send set the last part to false
 		report.PaginationInfo.IsLastReport = firstChunkVulnerabilitiesCount == 0
 	}
-	//send the summary report
-	a.postResultsAsGoroutine(ctx, report, eventReceiverURL, report.Summary.ImageTag, report.Summary.WLID, errChan, sendWG)
+	//send the summary report synchronously so it is always received before any chunk report,
+	//preventing the backend from rejecting a chunk that arrives before its summary (#437)
+	a.postResults(ctx, *report, eventReceiverURL, report.Summary.ImageTag, report.Summary.WLID, errChan)
 	nextPartNum++
 	//send the first chunk if it was not sent yet (because of summary size)
 	if firstVulnerabilitiesChunk != nil {

--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -28,6 +28,9 @@ func sendError(ctx context.Context, errorChan chan<- error, err error) {
 	if errorChan == nil || err == nil {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	select {
 	case errorChan <- err:
 	case <-ctx.Done():

--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -24,6 +24,17 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 )
 
+func sendError(ctx context.Context, errorChan chan<- error, err error) {
+	if errorChan == nil || err == nil {
+		return
+	}
+	select {
+	case errorChan <- err:
+	case <-ctx.Done():
+		logger.L().Ctx(ctx).Warning("context cancelled while sending error to channel", helpers.Error(err))
+	}
+}
+
 func (a *BackendAdapter) sendSummaryAndVulnerabilities(ctx context.Context, report *v1.ScanResultReport, eventReceiverURL string, totalVulnerabilities int, scanID string, firstVulnerabilitiesChunk []containerscan.CommonContainerVulnerabilityResult, errChan chan<- error, sendWG *sync.WaitGroup) (nextPartNum int) {
 	//get the first chunk
 	firstChunkVulnerabilitiesCount := len(firstVulnerabilitiesChunk)
@@ -77,7 +88,7 @@ func (a *BackendAdapter) postResults(ctx context.Context, report v1.ScanResultRe
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to convert to json", helpers.Error(err),
 			helpers.String("wlid", wlid))
-		errorChan <- err
+		sendError(ctx, errorChan, err)
 		return
 	}
 
@@ -85,16 +96,16 @@ func (a *BackendAdapter) postResults(ctx context.Context, report v1.ScanResultRe
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to get vulnerabilities report url", helpers.Error(err),
 			helpers.String("wlid", wlid))
-		errorChan <- err
+		sendError(ctx, errorChan, err)
 		return
 	}
 
-	resp, err := a.httpPostFunc(http.DefaultClient, urlBase.String(), a.getRequestHeaders(), payload, 60*time.Second)
+	resp, err := a.httpPostFunc(a.getHTTPClient(), urlBase.String(), a.getRequestHeaders(), payload, 60*time.Second)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed posting to event", helpers.Error(err),
 			helpers.String("image", imagetag),
 			helpers.String("wlid", wlid))
-		errorChan <- err
+		sendError(ctx, errorChan, err)
 		return
 	}
 	defer resp.Body.Close()
@@ -105,7 +116,7 @@ func (a *BackendAdapter) postResults(ctx context.Context, report v1.ScanResultRe
 		} else {
 			logger.L().Ctx(ctx).Error("failed sending vulnerabilities report", helpers.Error(err), helpers.String("body", body))
 		}
-		errorChan <- err
+		sendError(ctx, errorChan, err)
 		return
 	}
 	logger.L().Debug(fmt.Sprintf("posting to event receiver image %s wlid %s finished successfully response body: %s", imagetag, wlid, body)) // systest dependent
@@ -139,8 +150,8 @@ func (a *BackendAdapter) sendVulnerabilities(ctx context.Context, chunksChan <-c
 
 	//verify that all vulnerabilities received and sent
 	if chunksVulnerabilitiesCount != expectedVulnerabilitiesSum {
-		errorChan <- fmt.Errorf("error while splitting vulnerabilities chunks, expected %s vulnerabilities but received %d",
-			strconv.Itoa(expectedVulnerabilitiesSum), chunksVulnerabilitiesCount)
+		sendError(ctx, errorChan, fmt.Errorf("error while splitting vulnerabilities chunks, expected %s vulnerabilities but received %d",
+			strconv.Itoa(expectedVulnerabilitiesSum), chunksVulnerabilitiesCount))
 	}
 }
 


### PR DESCRIPTION
## Overview

`BackendAdapter` in `adapters/v1/backend.go` and `adapters/v1/backend_utils.go` handles vulnerability report transmission, scan status reporting, and scan failure notifications. This PR addresses all three items from #437:

1. **Unpooled `http.Client`**: `&http.Client{}` with no `Transport` falls back to the shared package-level `http.DefaultTransport`, so it was not actually creating a new connection pool per call. The real gap was configuration: no request `Timeout`, and only `net/http`'s default `MaxIdleConnsPerHost` (2), which under heavy concurrent `postResults` traffic to a single host causes idle connections to get closed and re-opened constantly (visible as `TIME_WAIT` churn). `NewBackendAdapter` now configures the shared `httpClient` with an explicit `Timeout` and a `Transport` with a raised `MaxIdleConnsPerHost`.
2. **Out-of-order summary/chunk reports**: `sendSummaryAndVulnerabilities` now sends the summary report synchronously before dispatching the first vulnerability chunk, so the backend always receives the summary first.
3. **`errorChan` writes and context cancellation**: added a `sendError` helper that always wins the send when the channel has room (even under a cancelled `ctx`), and only falls back to a blocking `select` on `errorChan <- err` / `<-ctx.Done()` once the channel is genuinely saturated, logging and dropping the error only in that case.

## Additional Information

- **HTTP Client Reuse**: `BackendAdapter.httpClient` is configured once in `NewBackendAdapter` with `Timeout: 60s` and a `Transport` (`MaxIdleConns: 100`, `MaxIdleConnsPerHost: 32`, `IdleConnTimeout: 90s`), and reused via `a.getHTTPClient()` across `ReportError`, `SendStatus`, `postResults`, and `ReportScanFailure` — all four call sites.
- **Deterministic Error Delivery**: `sendError` no longer races a `select` between `errorChan <- err` and `<-ctx.Done()` when both are ready (which previously dropped ~50% of real errors on a cancelled context). It now attempts a non-blocking send first, and only contends with `ctx.Done()` once the channel is full.
- **Summary-Before-Chunk Ordering**: the summary report is posted synchronously ahead of the first vulnerability chunk in `sendSummaryAndVulnerabilities`, closing the ordering race described in #437.
- **Unit Test Coverage**: `adapters/v1/backend_test.go` now has `TestBackendAdapter_HTTPClientReuse` (drives `ReportError`/`SendStatus`/`postResults`/`ReportScanFailure` through a recording `httputils.IHttpClient` stub and asserts the same instance served all four calls), `TestSendError_DeliversImmediatelyWhenChannelHasRoom` (buffered channel with room, cancelled ctx — error must be delivered, not randomly dropped), and `TestSendError_BlocksOnFullChannelUntilCtxCancelledThenDrops` (full channel, live ctx — send blocks until the channel drains or ctx is cancelled).

## How to Test

Run unit tests for `adapters/v1`:
```bash
go test -v -count=1 -run "TestBackendAdapter_HTTPClientReuse|TestSendError_|TestBackendAdapter_SubmitCVE" ./adapters/v1/...
```

## Related issues/PRs:

* Resolved #437

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
