### PR TITLE
test: key ctxCapturing sub-client wrappers by namespace

### DIFF
--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1558,9 +1558,9 @@ func (w *ctxCapturingVulnerabilityManifestSummaries) Get(ctx context.Context, na
 // everything else untouched.
 type ctxCapturingClient struct {
 	spdxv1beta1.SpdxV1beta1Interface
-	vulnManifests *ctxCapturingVulnerabilityManifests
-	sbomSyfts     *ctxCapturingSBOMSyfts
-	ovecs         *ctxCapturingOVECs
+	vulnManifests map[string]*ctxCapturingVulnerabilityManifests
+	sbomSyfts     map[string]*ctxCapturingSBOMSyfts
+	ovecs         map[string]*ctxCapturingOVECs
 	vulnSummaries map[string]*ctxCapturingVulnerabilityManifestSummaries
 }
 
@@ -1571,23 +1571,32 @@ type ctxCapturingClient struct {
 
 func (c *ctxCapturingClient) VulnerabilityManifests(namespace string) spdxv1beta1.VulnerabilityManifestInterface {
 	if c.vulnManifests == nil {
-		c.vulnManifests = &ctxCapturingVulnerabilityManifests{VulnerabilityManifestInterface: c.SpdxV1beta1Interface.VulnerabilityManifests(namespace)}
+		c.vulnManifests = map[string]*ctxCapturingVulnerabilityManifests{}
 	}
-	return c.vulnManifests
+	if _, ok := c.vulnManifests[namespace]; !ok {
+		c.vulnManifests[namespace] = &ctxCapturingVulnerabilityManifests{VulnerabilityManifestInterface: c.SpdxV1beta1Interface.VulnerabilityManifests(namespace)}
+	}
+	return c.vulnManifests[namespace]
 }
 
 func (c *ctxCapturingClient) SBOMSyfts(namespace string) spdxv1beta1.SBOMSyftInterface {
 	if c.sbomSyfts == nil {
-		c.sbomSyfts = &ctxCapturingSBOMSyfts{SBOMSyftInterface: c.SpdxV1beta1Interface.SBOMSyfts(namespace)}
+		c.sbomSyfts = map[string]*ctxCapturingSBOMSyfts{}
 	}
-	return c.sbomSyfts
+	if _, ok := c.sbomSyfts[namespace]; !ok {
+		c.sbomSyfts[namespace] = &ctxCapturingSBOMSyfts{SBOMSyftInterface: c.SpdxV1beta1Interface.SBOMSyfts(namespace)}
+	}
+	return c.sbomSyfts[namespace]
 }
 
 func (c *ctxCapturingClient) OpenVulnerabilityExchangeContainers(namespace string) spdxv1beta1.OpenVulnerabilityExchangeContainerInterface {
 	if c.ovecs == nil {
-		c.ovecs = &ctxCapturingOVECs{OpenVulnerabilityExchangeContainerInterface: c.SpdxV1beta1Interface.OpenVulnerabilityExchangeContainers(namespace)}
+		c.ovecs = map[string]*ctxCapturingOVECs{}
 	}
-	return c.ovecs
+	if _, ok := c.ovecs[namespace]; !ok {
+		c.ovecs[namespace] = &ctxCapturingOVECs{OpenVulnerabilityExchangeContainerInterface: c.SpdxV1beta1Interface.OpenVulnerabilityExchangeContainers(namespace)}
+	}
+	return c.ovecs[namespace]
 }
 
 func (c *ctxCapturingClient) VulnerabilityManifestSummaries(namespace string) spdxv1beta1.VulnerabilityManifestSummaryInterface {
@@ -1620,7 +1629,7 @@ func TestAPIServerStore_GetCVE_ctxPropagated(t *testing.T) {
 	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}
 	a := &APIServerStore{StorageClient: wrapped, Namespace: "kubescape"}
 	_, _ = a.GetCVE(canaryCtx(), name, "", "", "")
-	requireCanaryCtx(t, wrapped.vulnManifests.getCtx)
+	requireCanaryCtx(t, wrapped.vulnManifests[a.Namespace].getCtx)
 }
 
 func TestAPIServerStore_GetSBOM_ctxPropagated(t *testing.T) {
@@ -1628,7 +1637,7 @@ func TestAPIServerStore_GetSBOM_ctxPropagated(t *testing.T) {
 	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}
 	a := &APIServerStore{StorageClient: wrapped, Namespace: "kubescape"}
 	_, _ = a.GetSBOM(canaryCtx(), name, "")
-	requireCanaryCtx(t, wrapped.sbomSyfts.getCtx)
+	requireCanaryCtx(t, wrapped.sbomSyfts[a.Namespace].getCtx)
 }
 
 func TestAPIServerStore_GetCVESummary_ctxPropagated(t *testing.T) {
@@ -1671,7 +1680,7 @@ func TestAPIServerStore_StoreCVE_ctxPropagated(t *testing.T) {
 	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}
 	a := &APIServerStore{StorageClient: wrapped, Namespace: "kubescape"}
 	require.NoError(t, a.StoreCVE(canaryCtx(), domain.CVEManifest{Name: name}, false))
-	requireCanaryCtx(t, wrapped.vulnManifests.createCtx)
+	requireCanaryCtx(t, wrapped.vulnManifests[a.Namespace].createCtx)
 }
 
 func TestAPIServerStore_StoreSBOM_ctxPropagated(t *testing.T) {
@@ -1679,7 +1688,7 @@ func TestAPIServerStore_StoreSBOM_ctxPropagated(t *testing.T) {
 	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}
 	a := &APIServerStore{StorageClient: wrapped, Namespace: "kubescape"}
 	require.NoError(t, a.StoreSBOM(canaryCtx(), domain.SBOM{Name: name}, false))
-	requireCanaryCtx(t, wrapped.sbomSyfts.createCtx)
+	requireCanaryCtx(t, wrapped.sbomSyfts[a.Namespace].createCtx)
 }
 
 func TestAPIServerStore_StoreVEX_ctxPropagated(t *testing.T) {
@@ -1688,6 +1697,6 @@ func TestAPIServerStore_StoreVEX_ctxPropagated(t *testing.T) {
 	a := &APIServerStore{StorageClient: wrapped, Namespace: "kubescape"}
 	cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
 	require.NoError(t, a.StoreVEX(canaryCtx(), cve, cve, false))
-	requireCanaryCtx(t, wrapped.ovecs.getCtx)
-	requireCanaryCtx(t, wrapped.ovecs.createCtx)
+	requireCanaryCtx(t, wrapped.ovecs[a.Namespace].getCtx)
+	requireCanaryCtx(t, wrapped.ovecs[a.Namespace].createCtx)
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1700,3 +1700,30 @@ func TestAPIServerStore_StoreVEX_ctxPropagated(t *testing.T) {
 	requireCanaryCtx(t, wrapped.ovecs[a.Namespace].getCtx)
 	requireCanaryCtx(t, wrapped.ovecs[a.Namespace].createCtx)
 }
+
+func TestCtxCapturingClient_wrappersKeyedByNamespace(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}
+
+	// VulnerabilityManifests: different namespaces must return different wrappers,
+	// repeated access to one namespace must return the same wrapper.
+	vm1 := wrapped.VulnerabilityManifests("ns-a")
+	vm2 := wrapped.VulnerabilityManifests("ns-b")
+	vm1Again := wrapped.VulnerabilityManifests("ns-a")
+	require.NotSame(t, vm1, vm2, "different namespaces must return different wrappers")
+	require.Same(t, vm1, vm1Again, "same namespace must return the memoized wrapper")
+
+	// SBOMSyfts
+	ss1 := wrapped.SBOMSyfts("ns-a")
+	ss2 := wrapped.SBOMSyfts("ns-b")
+	ss1Again := wrapped.SBOMSyfts("ns-a")
+	require.NotSame(t, ss1, ss2)
+	require.Same(t, ss1, ss1Again)
+
+	// OpenVulnerabilityExchangeContainers
+	ov1 := wrapped.OpenVulnerabilityExchangeContainers("ns-a")
+	ov2 := wrapped.OpenVulnerabilityExchangeContainers("ns-b")
+	ov1Again := wrapped.OpenVulnerabilityExchangeContainers("ns-a")
+	require.NotSame(t, ov1, ov2)
+	require.Same(t, ov1, ov1Again)
+}


### PR DESCRIPTION
Key `vulnManifests`, `sbomSyfts`, and `ovecs` wrappers by namespace in `ctxCapturingClient`, matching the existing `VulnerabilityManifestSummaries` pattern. This prevents a future wrapper (e.g. `ContainerProfiles`) from silently binding to the wrong namespace's sub-client.

Existing assertions are updated to use `wrapped.field[a.Namespace].ctx` syntax, consistent with the summaries wrapper.

Fixes #435

## Overview

**Current behavior:** Three of the four `ctxCapturing*` sub-client wrappers (`vulnManifests`, `sbomSyfts`, `ovecs`) memoize on a single pointer field, ignoring the `namespace` argument. They bind to whichever namespace is requested first and silently return that same sub-client for every subsequent namespace. As noted in #435, this means a wrapper added for `ContainerProfiles` — where `GetContainerProfile(ctx, namespace, name)` takes a caller-supplied namespace unrelated to `a.Namespace` — would let a ctx assertion pass vacuously against the wrong sub-client.

**New behavior:** All three wrappers are keyed by namespace using `map[string]*ctxCapturing...`, matching the pattern `VulnerabilityManifestSummaries` already uses. Each accessor lazy-inits the map and keys by the `namespace` argument. Memoization is preserved — a single storage operation that calls the accessor more than once (e.g. `StoreVEX` for its `Get` and then again for its `Update`) still gets the same wrapper instance.

## How to Test

```bash
go test -v ./repositories -run ctxPropagated
```

All 7 existing `_ctxPropagated` tests pass with the updated assertions.

## Related issues/PRs:

* Resolved #435
* Prerequisite for #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for context propagation across CVE, SBOM, and VEX operations.
  * Added namespace-specific context tracking for retrieval, creation, and update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->