### PR TITLE
fix: classify gRPC codes.DeadlineExceeded as ReasonScanTimeout

### DIFF
--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -101,6 +101,9 @@ func (c *sbomScannerClient) CreateSBOM(ctx context.Context, req ScanRequest) (*S
 		if ok && (st.Code() == codes.Unavailable || st.Code() == codes.Aborted) {
 			return nil, fmt.Errorf("%w: %v", ErrScannerCrashed, err)
 		}
+		if ok && st.Code() == codes.DeadlineExceeded {
+			return nil, fmt.Errorf("scan timeout: %w: %v", context.DeadlineExceeded, err)
+		}
 		return nil, err
 	}
 

--- a/pkg/sbomscanner/v1/client_test.go
+++ b/pkg/sbomscanner/v1/client_test.go
@@ -1,0 +1,67 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type mockPBScannerClient struct {
+	createSBOMErr error
+}
+
+func (m *mockPBScannerClient) CreateSBOM(_ context.Context, _ *pb.CreateSBOMRequest, _ ...grpc.CallOption) (*pb.CreateSBOMResponse, error) {
+	return nil, m.createSBOMErr
+}
+
+func (m *mockPBScannerClient) Health(_ context.Context, _ *pb.HealthRequest, _ ...grpc.CallOption) (*pb.HealthResponse, error) {
+	return &pb.HealthResponse{Ready: true}, nil
+}
+
+func TestCreateSBOM_WrapsGRPCDeadlineExceeded(t *testing.T) {
+	c := &sbomScannerClient{client: &mockPBScannerClient{createSBOMErr: status.Error(codes.DeadlineExceeded, "context deadline exceeded")}}
+
+	_, err := c.CreateSBOM(context.Background(), ScanRequest{})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrScannerCrashed)
+}
+
+func TestCreateSBOM_PassesThroughPlainDeadlineExceeded(t *testing.T) {
+	c := &sbomScannerClient{client: &mockPBScannerClient{createSBOMErr: context.DeadlineExceeded}}
+
+	_, err := c.CreateSBOM(context.Background(), ScanRequest{})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrScannerCrashed)
+}
+
+func TestCreateSBOM_WrapsGRPCCrashCodes(t *testing.T) {
+	for _, code := range []codes.Code{codes.Unavailable, codes.Aborted} {
+		c := &sbomScannerClient{client: &mockPBScannerClient{
+			createSBOMErr: status.Error(code, "scanner crashed"),
+		}}
+		_, err := c.CreateSBOM(context.Background(), ScanRequest{})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrScannerCrashed)
+		assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	}
+}
+
+func TestCreateSBOM_PassesThroughUnrelatedError(t *testing.T) {
+	unrelated := errors.New("some other error")
+	c := &sbomScannerClient{client: &mockPBScannerClient{
+		createSBOMErr: unrelated,
+	}}
+
+	_, err := c.CreateSBOM(context.Background(), ScanRequest{})
+	assert.ErrorIs(t, err, unrelated)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrScannerCrashed)
+}


### PR DESCRIPTION
## Overview

`sbomScannerClient.CreateSBOM` wraps gRPC `Unavailable`/`Aborted` errors as `ErrScannerCrashed` but lets `codes.DeadlineExceeded` escape as a raw gRPC status error. That raw error never satisfies `errors.Is(err, context.DeadlineExceeded)` in `classifySBOMError` (`core/services/scan_failure_reasons.go:29`), so a sidecar scan that times out on the caller's deadline is reported as `ReasonSBOMGenerationFailed` instead of `ReasonScanTimeout`.

This adds the missing sibling wrap so the `scanfailure` taxonomy holds regardless of caller. See #441 for the full analysis and scope note.

## How to Test

```bash
TMPDIR=/tmp go test ./pkg/sbomscanner/v1/ -run 'TestCreateSBOM_' -v
```

- `TestCreateSBOM_WrapsGRPCDeadlineExceeded` - asserts `errors.Is(err, context.DeadlineExceeded)` and that it stays distinct from `ErrScannerCrashed`.
- `TestCreateSBOM_WrapsGRPCCrashCodes` - confirms `Unavailable`/`Aborted` behavior is unchanged.
- `TestCreateSBOM_PassesThroughPlainDeadlineExceeded` / `TestCreateSBOM_PassesThroughUnrelatedError` - confirms no double-wrapping and pass-through of unrelated errors.

Note: `TMPDIR=/tmp` is only needed locally (this machine's temp path exceeds the Unix-socket 104-byte limit - a pre-existing, environment-only issue affecting the package's other socket tests). CI uses `/tmp`, so it's green there.

## Files changed

- `pkg/sbomscanner/v1/client.go` - add `codes.DeadlineExceeded` wrap (+3 lines)
- `pkg/sbomscanner/v1/client_test.go` - new, mock-based regression tests

Resolves #441