### PR TITLE
perf: index dynamic paths in filterSBOM by segment count

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -784,11 +784,13 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 	addedFileIDs := mapset.NewSet[string]()
 	addedRelationshipIDs := mapset.NewSet[string]()
 
-	// filter relevant files with dynamic paths
-	var dynamicPaths []string
+	// filter relevant files with dynamic paths, indexed by segment count since
+	// CompareDynamic only ever matches paths with the same number of segments
+	dynamicPathsBySegmentCount := make(map[int][]string)
 	relevantFiles.Each(func(file string) bool {
 		if strings.Contains(file, dynamicpathdetector.DynamicIdentifier) {
-			dynamicPaths = append(dynamicPaths, file)
+			segmentCount := strings.Count(file, "/")
+			dynamicPathsBySegmentCount[segmentCount] = append(dynamicPathsBySegmentCount[segmentCount], file)
 		}
 		return false
 	})
@@ -803,8 +805,8 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 				filteredSBOM.Content.Files = append(filteredSBOM.Content.Files, f)
 				continue
 			}
-			// then try dynamic match (expensive lookup)
-			for _, dynamicPath := range dynamicPaths {
+			// then try dynamic match (expensive lookup), limited to candidates with a matching segment count
+			for _, dynamicPath := range dynamicPathsBySegmentCount[strings.Count(f.Location.RealPath, "/")] {
 				if dynamicpathdetector.CompareDynamic(dynamicPath, f.Location.RealPath) {
 					addedFileIDs.Add(f.ID)
 					filteredSBOM.Content.Files = append(filteredSBOM.Content.Files, f)

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1074,6 +1074,41 @@ func Test_filterSBOM(t *testing.T) {
 	}
 }
 
+func BenchmarkFilterSBOM(b *testing.B) {
+	nginxSBOM := domain.SBOM{
+		Name: "nginx-sbom",
+		Annotations: map[string]string{
+			helpersv1.ImageIDMetadataKey:  "docker.io/library/nginx@sha256:04ba374043ccd2fc5c593885c0eacddebabd5ca375f9323666f28dfd5a9710e3",
+			helpersv1.ImageTagMetadataKey: "nginx:1.14.1",
+			helpersv1.StatusMetadataKey:   helpersv1.Learning,
+		},
+		Content: fileToSyftDocument("../../adapters/v1/testdata/nginx-sbom.json"),
+	}
+	instanceID, err := instanceidhandlerv1.GenerateInstanceIDFromString(
+		"apiVersion-apps/v1/namespace-default/kind-Deployment/name-nginx/containerName-nginx",
+	)
+	require.NoError(b, err)
+	labels := map[string]string{
+		helpersv1.ContainerNameMetadataKey: "nginx",
+	}
+	wlid := "wlid://cluster-test/namespace-default/deployment-nginx"
+
+	for _, dynamicPathCount := range []int{10, 100, 1000} {
+		dynamicPathCount := dynamicPathCount
+		b.Run(fmt.Sprintf("dynamicPaths=%d", dynamicPathCount), func(b *testing.B) {
+			relevantFiles := mapset.NewSet[string]()
+			for i := 0; i < dynamicPathCount; i++ {
+				relevantFiles.Add(fmt.Sprintf("/var/lib/%s/segment-%d/data", dynamicpathdetector.DynamicIdentifier, i))
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := filterSBOM(nginxSBOM, instanceID, wlid, relevantFiles, labels, helpersv1.Full)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
 func TestOptionsFromWorkload(t *testing.T) {
 	tests := []struct {
 		name                string


### PR DESCRIPTION
## Overview
`filterSBOM` in `core/services/scan.go` falls back to a linear scan over all collected `dynamicPaths` for every SBOM file that isn't an exact match in `relevantFiles`, calling `dynamicpathdetector.CompareDynamic` for each pair. This is O(files x dynamicPaths). `CompareDynamic` only ever matches paths with an identical number of `/`-separated segments, so most of those comparisons can never succeed.

This PR indexes the collected dynamic paths by segment count, so the per-file fallback loop only compares against the bucket of dynamic paths with a matching segment count, instead of the full set. Matching behavior is unchanged since a differing segment count can never match under `CompareDynamic`.

## Related issues/PRs:
Resolved #447

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM path filtering by matching dynamic paths with the same directory depth, reducing incorrect matches while preserving direct path matching.

* **Tests**
  * Added benchmark coverage for SBOM filtering across small, medium, and large path sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->