### PR TITLE
fix: propagate ctx to backend HTTP retries and gate chunk dispatch on summary success (#446)

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 	"github.com/armosec/utils-go/httputils"
 	pkgcautils "github.com/armosec/utils-k8s-go/armometadata"
 	wlidpkg "github.com/armosec/utils-k8s-go/wlid"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/go-multierror"
 	backendClientV1 "github.com/kubescape/backend/pkg/client/v1"
 	sysreport "github.com/kubescape/backend/pkg/server/v1/systemreports"
@@ -37,7 +39,7 @@ type BackendAdapter struct {
 	apiServerRestURL      string
 	clusterConfig         pkgcautils.ClusterConfig
 	getCVEExceptionsFunc  func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
-	httpPostFunc          func(httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error)
+	httpPostFunc          func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error)
 	sendStatusFunc        func(*backendClientV1.BaseReportSender, string, bool)
 	accessKey             string
 	securityExceptionRepo ports.SecurityExceptionRepository
@@ -64,7 +66,7 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 		eventReceiverRestURL: eventReceiverRestURL,
 		apiServerRestURL:     apiServerRestURL,
 		getCVEExceptionsFunc: backendClientV1.GetCVEExceptionByDesignator,
-		httpPostFunc:         httputils.HttpPostWithRetry,
+		httpPostFunc:         httpPostWithContext,
 		sendStatusFunc: func(sender *backendClientV1.BaseReportSender, status string, sendReport bool) {
 			sender.SendStatus(status, sendReport) // TODO - update this function to use from kubescape/backend
 		},
@@ -88,6 +90,47 @@ func (a *BackendAdapter) getHTTPClient() httputils.IHttpClient {
 		return a.httpClient
 	}
 	return http.DefaultClient
+}
+
+// httpPostWithContext is the default httpPostFunc. Unlike httputils.HttpPostWithRetry (which
+// binds context.Background() to the request and retries on a plain, non-cancellable
+// backoff.Retry loop), it threads the caller's ctx through the request AND the retry loop, so
+// cancelling ctx aborts both an in-flight attempt and any further retries promptly instead of
+// running the full retry budget to completion regardless of cancellation (#446).
+func httpPostWithContext(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, maxElapsedTime time.Duration) (*http.Response, error) {
+	bo := backoff.NewExponentialBackOff()
+	return backoff.Retry(ctx, func() (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			defer resp.Body.Close()
+			retryErr := fmt.Errorf("received status code: %d", resp.StatusCode)
+			if !shouldRetryReport(resp) {
+				return nil, backoff.Permanent(retryErr)
+			}
+			return nil, retryErr
+		}
+		return resp, nil
+	}, backoff.WithBackOff(bo), backoff.WithMaxElapsedTime(maxElapsedTime))
+}
+
+// shouldRetryReport mirrors the unexported defaultShouldRetry in armosec/utils-go: retry on any
+// response except the ones that are never going to succeed on a retry.
+func shouldRetryReport(resp *http.Response) bool {
+	return resp.StatusCode != http.StatusUnauthorized &&
+		resp.StatusCode != http.StatusForbidden &&
+		resp.StatusCode != http.StatusNotFound &&
+		resp.StatusCode != http.StatusInternalServerError
 }
 
 const ActionName = "vuln scan"
@@ -197,6 +240,12 @@ func (a *BackendAdapter) ReportError(ctx context.Context, err error) error {
 	report.Errors = append(report.Errors, err.Error())
 	report.Status = sysreport.JobFailed
 
+	// NOTE: unlike postResults/ReportScanFailure, this call is not ctx-cancellation-aware.
+	// backendClientV1.NewBaseReportSender builds its own *http.Request bound to
+	// context.Background() inside armosec/utils-go, before it ever reaches our IHttpClient, so
+	// there's no seam here to inject ctx without either bypassing the sender or a ctx-accepting
+	// constructor upstream in kubescape/backend. Tracked separately (#450) rather than silently
+	// left unaddressed.
 	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, a.getHTTPClient(), a.getRequestHeaders(), report)
 	a.sendStatusFunc(sender, sysreport.JobFailed, true)
 	return nil
@@ -250,7 +299,7 @@ func (a *BackendAdapter) ReportScanFailure(ctx context.Context, failureCase scan
 	}
 
 	url := fmt.Sprintf("%s/k8s/v2/scanFailure", a.eventReceiverRestURL)
-	resp, err := a.httpPostFunc(a.getHTTPClient(), url, a.getRequestHeaders(), payload, 30*time.Second)
+	resp, err := a.httpPostFunc(ctx, a.getHTTPClient(), url, a.getRequestHeaders(), payload, 30*time.Second)
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to send scan failure report",
 			helpers.Error(err),
@@ -278,6 +327,8 @@ func (a *BackendAdapter) SendStatus(ctx context.Context, step int) error {
 	report.Details = details[step]
 	report.Status = statuses[step]
 
+	// NOTE: see the same comment on ReportError above — this call has the same ctx-cancellation
+	// gap for the same reason.
 	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, a.getHTTPClient(), a.getRequestHeaders(), report)
 	a.sendStatusFunc(sender, statuses[step], true)
 	return nil
@@ -430,7 +481,19 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 	firstVulnerabilitiesChunk := <-chunksChan
 	firstChunkVulnerabilitiesCount := len(firstVulnerabilitiesChunk)
 	// send the summary and the first chunk in one or two reports according to the size
-	nextPartNum := a.sendSummaryAndVulnerabilities(ctx, &finalReport, a.eventReceiverRestURL, totalVulnerabilities, scanID, firstVulnerabilitiesChunk, errChan, sendWG)
+	nextPartNum, summaryErr := a.sendSummaryAndVulnerabilities(ctx, &finalReport, a.eventReceiverRestURL, totalVulnerabilities, scanID, firstVulnerabilitiesChunk, errChan, sendWG)
+	if summaryErr != nil {
+		// Nothing was sent, so no chunk goroutine was dispatched and nothing will ever drain
+		// chunksChan or close errChan on its own. Drain chunksChan ourselves so the producer
+		// goroutine started by SplitSlice2Chunks doesn't block forever trying to hand off the
+		// remaining chunks (#446), and return directly instead of ranging over an errChan
+		// nothing will close.
+		go func() {
+			for range chunksChan {
+			}
+		}()
+		return summaryErr
+	}
 	// if not all vulnerabilities got into the first chunk
 	if totalVulnerabilities != firstChunkVulnerabilitiesCount {
 		//send the rest of the vulnerabilities - error channel will be closed when all vulnerabilities are sent

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -324,7 +325,7 @@ func TestBackendAdapter_SubmitCVE(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mu := &sync.Mutex{}
 			seenCVE := map[string]struct{}{}
-			httpPostFunc := func(httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, timeOut time.Duration) (*http.Response, error) {
+			httpPostFunc := func(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, timeOut time.Duration) (*http.Response, error) {
 				var report v1.ScanResultReport
 				err := json.Unmarshal(body, &report)
 				if err != nil {
@@ -522,7 +523,7 @@ func TestBackendAdapter_ReportScanFailure_WorkloadScan(t *testing.T) {
 	var capturedURL string
 	var capturedReport scanfailure.ScanFailureReport
 
-	mockHTTP := func(_ httputils.IHttpClient, fullURL string, _ map[string]string, body []byte, _ time.Duration) (*http.Response, error) {
+	mockHTTP := func(_ context.Context, _ httputils.IHttpClient, fullURL string, _ map[string]string, body []byte, _ time.Duration) (*http.Response, error) {
 		capturedURL = fullURL
 		require.NoError(t, json.Unmarshal(body, &capturedReport))
 		return &http.Response{
@@ -570,7 +571,7 @@ func TestBackendAdapter_ReportScanFailure_WorkloadScan(t *testing.T) {
 func TestBackendAdapter_ReportScanFailure_RegistryScan(t *testing.T) {
 	var capturedReport scanfailure.ScanFailureReport
 
-	mockHTTP := func(_ httputils.IHttpClient, _ string, _ map[string]string, body []byte, _ time.Duration) (*http.Response, error) {
+	mockHTTP := func(_ context.Context, _ httputils.IHttpClient, _ string, _ map[string]string, body []byte, _ time.Duration) (*http.Response, error) {
 		require.NoError(t, json.Unmarshal(body, &capturedReport))
 		return &http.Response{
 			StatusCode: 200,
@@ -615,7 +616,7 @@ func TestBackendAdapter_ReportScanFailure_NoWorkloadInContext(t *testing.T) {
 }
 
 func TestBackendAdapter_ReportScanFailure_HTTPError(t *testing.T) {
-	mockHTTP := func(_ httputils.IHttpClient, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+	mockHTTP := func(_ context.Context, _ httputils.IHttpClient, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
 		return nil, assert.AnError
 	}
 
@@ -636,7 +637,7 @@ func TestBackendAdapter_ReportScanFailure_HTTPError(t *testing.T) {
 }
 
 func TestBackendAdapter_ReportScanFailure_HTTPNon2xx(t *testing.T) {
-	mockHTTP := func(_ httputils.IHttpClient, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+	mockHTTP := func(_ context.Context, _ httputils.IHttpClient, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 500,
 			Body:       io.NopCloser(bytes.NewBufferString("internal server error")),
@@ -663,7 +664,7 @@ func TestBackendAdapter_ReportScanFailure_HTTPNon2xx(t *testing.T) {
 func TestBackendAdapter_ReportScanFailure_NilError(t *testing.T) {
 	var capturedReport scanfailure.ScanFailureReport
 
-	mockHTTP := func(_ httputils.IHttpClient, _ string, _ map[string]string, body []byte, _ time.Duration) (*http.Response, error) {
+	mockHTTP := func(_ context.Context, _ httputils.IHttpClient, _ string, _ map[string]string, body []byte, _ time.Duration) (*http.Response, error) {
 		require.NoError(t, json.Unmarshal(body, &capturedReport))
 		return &http.Response{
 			StatusCode: 200,
@@ -812,7 +813,7 @@ func TestBackendAdapter_HTTPClientReuse(t *testing.T) {
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
 		eventReceiverRestURL: "http://example.invalid",
 		httpClient:           stub,
-		httpPostFunc:         httputils.HttpPostWithRetry,
+		httpPostFunc:         httpPostWithContext,
 		sendStatusFunc: func(sender *beClientV1.BaseReportSender, status string, sendReport bool) {
 			sender.SendStatus(status, sendReport)
 		},
@@ -832,7 +833,7 @@ func TestBackendAdapter_HTTPClientReuse(t *testing.T) {
 	assert.Equal(t, 2, stub.Calls(), "SendStatus should use the shared httpClient")
 
 	errChan := make(chan error, 1)
-	a.postResults(ctx, v1.ScanResultReport{}, a.eventReceiverRestURL, "imageTag", "wlid", errChan)
+	require.NoError(t, a.postResults(ctx, v1.ScanResultReport{}, a.eventReceiverRestURL, "imageTag", "wlid", errChan))
 	assert.Equal(t, 3, stub.Calls(), "postResults should use the shared httpClient")
 	assert.Empty(t, errChan, "postResults should not report an error when the shared client succeeds")
 
@@ -886,4 +887,114 @@ func TestSendError_BlocksOnFullChannelUntilCtxCancelledThenDrops(t *testing.T) {
 
 	require.Len(t, ch, 1, "second error should have been dropped since the channel stayed full")
 	assert.EqualError(t, <-ch, "first error")
+}
+
+// blockingHTTPClient's Do blocks until the request's own context is done, simulating how a real
+// net/http.Transport aborts an in-flight request once its context is cancelled. It lets tests
+// prove that cancelling the caller's ctx actually reaches the request (and the retry loop around
+// it), instead of the call quietly running to completion regardless (#446).
+type blockingHTTPClient struct {
+	calls int32
+}
+
+func (c *blockingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	atomic.AddInt32(&c.calls, 1)
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func (c *blockingHTTPClient) Calls() int32 {
+	return atomic.LoadInt32(&c.calls)
+}
+
+func TestBackendAdapter_PostResultsAbortsPromptlyOnCtxCancellation(t *testing.T) {
+	client := &blockingHTTPClient{}
+	a := &BackendAdapter{
+		eventReceiverRestURL: "http://example.invalid",
+		httpClient:           client,
+		httpPostFunc:         httpPostWithContext,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errChan := make(chan error, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.postResults(ctx, v1.ScanResultReport{}, a.eventReceiverRestURL, "imageTag", "wlid", errChan)
+	}()
+
+	// give postResults time to reach the (blocking) HTTP call before cancelling
+	require.Eventually(t, func() bool { return client.Calls() > 0 }, time.Second, time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "postResults should return an error once the request is aborted by ctx cancellation")
+	case <-time.After(2 * time.Second):
+		t.Fatal("postResults did not return promptly after ctx was cancelled; the retry loop is not ctx-aware")
+	}
+}
+
+func TestBackendAdapter_ReportScanFailureAbortsPromptlyOnCtxCancellation(t *testing.T) {
+	client := &blockingHTTPClient{}
+	a := &BackendAdapter{
+		eventReceiverRestURL: "http://example.invalid",
+		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
+		httpClient:           client,
+		httpPostFunc:         httpPostWithContext,
+	}
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:               "wlid://cluster-prod/namespace-default/deployment-nginx",
+		ImageTagNormalized: "nginx:latest",
+	}))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost, scanfailure.ReasonResultUploadFailed, fmt.Errorf("connection refused"))
+	}()
+
+	require.Eventually(t, func() bool { return client.Calls() > 0 }, time.Second, time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "ReportScanFailure should return an error once the request is aborted by ctx cancellation")
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReportScanFailure did not return promptly after ctx was cancelled; the retry loop is not ctx-aware")
+	}
+}
+
+func TestBackendAdapter_SubmitCVE_SkipsChunksWhenSummaryFails(t *testing.T) {
+	var chunkPosts int32
+	httpPostFunc := func(_ context.Context, _ httputils.IHttpClient, _ string, _ map[string]string, body []byte, _ time.Duration) (*http.Response, error) {
+		var report v1.ScanResultReport
+		require.NoError(t, json.Unmarshal(body, &report))
+		if report.Summary != nil {
+			// this is the summary report (possibly combined with the first chunk) - fail it
+			return nil, fmt.Errorf("simulated summary post failure")
+		}
+		atomic.AddInt32(&chunkPosts, 1)
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBuffer(nil)),
+		}, nil
+	}
+
+	a := &BackendAdapter{
+		clusterConfig: armometadata.ClusterConfig{},
+		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
+		httpPostFunc:          httpPostFunc,
+		securityExceptionRepo: &repositories.NoOpSecurityExceptionRepository{},
+	}
+	ctx := context.TODO()
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, time.Now().Unix())
+	ctx = context.WithValue(ctx, domain.ScanIDKey{}, uuid.New().String())
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
+
+	cve := *fileToType[domain.CVEManifest]("testdata/nginx-cve.json")
+	err := a.SubmitCVE(ctx, cve, domain.CVEManifest{})
+
+	require.Error(t, err, "SubmitCVE should surface the summary post failure")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&chunkPosts), "no vulnerability chunk should be posted once the summary failed")
 }

--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -49,7 +49,13 @@ func sendError(ctx context.Context, errorChan chan<- error, err error) {
 	}
 }
 
-func (a *BackendAdapter) sendSummaryAndVulnerabilities(ctx context.Context, report *v1.ScanResultReport, eventReceiverURL string, totalVulnerabilities int, scanID string, firstVulnerabilitiesChunk []containerscan.CommonContainerVulnerabilityResult, errChan chan<- error, sendWG *sync.WaitGroup) (nextPartNum int) {
+// sendSummaryAndVulnerabilities posts the summary report synchronously so it always reaches the
+// backend before any chunk report (preventing the "missing summary for containerScanID"
+// rejection, #437). If the summary post fails, no chunk is dispatched here: the backend would
+// reject every one of them anyway without a summary on file, so there is nothing to gain by
+// sending them (#446). Callers must treat a non-nil error as "nothing was sent" and must not
+// dispatch the remaining chunks either.
+func (a *BackendAdapter) sendSummaryAndVulnerabilities(ctx context.Context, report *v1.ScanResultReport, eventReceiverURL string, totalVulnerabilities int, scanID string, firstVulnerabilitiesChunk []containerscan.CommonContainerVulnerabilityResult, errChan chan<- error, sendWG *sync.WaitGroup) (nextPartNum int, err error) {
 	//get the first chunk
 	firstChunkVulnerabilitiesCount := len(firstVulnerabilitiesChunk)
 	//if size of summary + first chunk does not exceed max size
@@ -64,10 +70,10 @@ func (a *BackendAdapter) sendSummaryAndVulnerabilities(ctx context.Context, repo
 		//first chunk is not included in the summary, so if there are vulnerabilities to send set the last part to false
 		report.PaginationInfo.IsLastReport = firstChunkVulnerabilitiesCount == 0
 	}
-	//send the summary report synchronously so it is always received before any chunk report,
-	//preventing the backend from rejecting a chunk that arrives before its summary (#437)
-	a.postResults(ctx, *report, eventReceiverURL, report.Summary.ImageTag, report.Summary.WLID, errChan)
-	nextPartNum++
+	if err := a.postResults(ctx, *report, eventReceiverURL, report.Summary.ImageTag, report.Summary.WLID, errChan); err != nil {
+		return 0, fmt.Errorf("failed to send summary report: %w", err)
+	}
+	nextPartNum = 1
 	//send the first chunk if it was not sent yet (because of summary size)
 	if firstVulnerabilitiesChunk != nil {
 		a.postResultsAsGoroutine(ctx,
@@ -80,14 +86,16 @@ func (a *BackendAdapter) sendSummaryAndVulnerabilities(ctx context.Context, repo
 			}, eventReceiverURL, report.Summary.ImageTag, report.Summary.WLID, errChan, sendWG)
 		nextPartNum++
 	}
-	return nextPartNum
+	return nextPartNum, nil
 }
 
 func (a *BackendAdapter) postResultsAsGoroutine(ctx context.Context, report *v1.ScanResultReport, eventReceiverURL, imagetag string, wlid string, errorChan chan<- error, wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func(report v1.ScanResultReport, eventReceiverURL, imagetag string, wlid string, errorChan chan<- error, wg *sync.WaitGroup) {
 		defer wg.Done()
-		a.postResults(ctx, report, eventReceiverURL, imagetag, wlid, errorChan)
+		// failure is reported to the caller via errorChan, not the return value, for chunks
+		// sent from a goroutine
+		_ = a.postResults(ctx, report, eventReceiverURL, imagetag, wlid, errorChan)
 	}(*report, eventReceiverURL, imagetag, wlid, errorChan, wg)
 }
 
@@ -98,13 +106,17 @@ func (a *BackendAdapter) getRequestHeaders() map[string]string {
 	}
 }
 
-func (a *BackendAdapter) postResults(ctx context.Context, report v1.ScanResultReport, eventReceiverURL, imagetag, wlid string, errorChan chan<- error) {
+// postResults posts a single report and returns the failure, if any, so a synchronous caller
+// (sendSummaryAndVulnerabilities, for the summary report) can react to it. Goroutine-wrapped
+// callers (postResultsAsGoroutine, for chunk reports) additionally get the same failure via
+// errorChan, since nothing is synchronously waiting on their return value.
+func (a *BackendAdapter) postResults(ctx context.Context, report v1.ScanResultReport, eventReceiverURL, imagetag, wlid string, errorChan chan<- error) error {
 	payload, err := json.Marshal(report)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed to convert to json", helpers.Error(err),
 			helpers.String("wlid", wlid))
 		sendError(ctx, errorChan, err)
-		return
+		return err
 	}
 
 	urlBase, err := beClient.GetVulnerabilitiesReportURL(eventReceiverURL, report.Designators.Attributes[identifiers.AttributeCustomerGUID])
@@ -112,16 +124,16 @@ func (a *BackendAdapter) postResults(ctx context.Context, report v1.ScanResultRe
 		logger.L().Ctx(ctx).Error("failed to get vulnerabilities report url", helpers.Error(err),
 			helpers.String("wlid", wlid))
 		sendError(ctx, errorChan, err)
-		return
+		return err
 	}
 
-	resp, err := a.httpPostFunc(a.getHTTPClient(), urlBase.String(), a.getRequestHeaders(), payload, 60*time.Second)
+	resp, err := a.httpPostFunc(ctx, a.getHTTPClient(), urlBase.String(), a.getRequestHeaders(), payload, 60*time.Second)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("failed posting to event", helpers.Error(err),
 			helpers.String("image", imagetag),
 			helpers.String("wlid", wlid))
 		sendError(ctx, errorChan, err)
-		return
+		return err
 	}
 	defer resp.Body.Close()
 	body, err := httputils.HttpRespToString(resp)
@@ -132,9 +144,10 @@ func (a *BackendAdapter) postResults(ctx context.Context, report v1.ScanResultRe
 			logger.L().Ctx(ctx).Error("failed sending vulnerabilities report", helpers.Error(err), helpers.String("body", body))
 		}
 		sendError(ctx, errorChan, err)
-		return
+		return err
 	}
 	logger.L().Debug(fmt.Sprintf("posting to event receiver image %s wlid %s finished successfully response body: %s", imagetag, wlid, body)) // systest dependent
+	return nil
 }
 
 func (a *BackendAdapter) sendVulnerabilitiesRoutine(ctx context.Context, chunksChan <-chan []containerscan.CommonContainerVulnerabilityResult, eventReceiverURL string, scanID string, finalReport v1.ScanResultReport, errChan chan error, sendWG *sync.WaitGroup, totalVulnerabilities int, firstChunkVulnerabilitiesCount int, nextPartNum int) {

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -667,7 +667,7 @@ func Test_sendSummaryAndVulnerabilities(t *testing.T) {
 			sendWG.Add(len(tc.expectedPaginationMarks))
 			var reports []v1.ScanResultReport
 			mu := &sync.Mutex{}
-			httpPostFunc := func(httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, timeOut time.Duration) (*http.Response, error) {
+			httpPostFunc := func(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, timeOut time.Duration) (*http.Response, error) {
 				mu.Lock()
 				var report v1.ScanResultReport
 				err := json.Unmarshal(body, &report)
@@ -697,7 +697,8 @@ func Test_sendSummaryAndVulnerabilities(t *testing.T) {
 				httpPostFunc:  httpPostFunc,
 			}
 			report.Vulnerabilities = []containerscan.CommonContainerVulnerabilityResult{}
-			actualNextPartNum := a.sendSummaryAndVulnerabilities(ctx, report, "", tc.totalVulnerabilities, "1234", tc.firstVulnerabilitiesChunk, errChan, sendWG)
+			actualNextPartNum, err := a.sendSummaryAndVulnerabilities(ctx, report, "", tc.totalVulnerabilities, "1234", tc.firstVulnerabilitiesChunk, errChan, sendWG)
+			assert.NoError(t, err)
 			sendWG.Wait()
 			assert.Equal(t, tc.expectedNextPartNum, actualNextPartNum)
 			assert.Equal(t, len(tc.expectedPaginationMarks), len(reports))


### PR DESCRIPTION
## Overview

`BackendAdapter`'s platform-reporting layer (`adapters/v1/backend.go`, `adapters/v1/backend_utils.go`) had two related gaps left over after #437/#440: the caller's `ctx` never reached the network layer at any of the four reporting entry points, and a failed summary POST didn't stop the vulnerability chunks that depend on it from going out anyway. Both were flagged during review of #440 but never turned into a tracked issue until #446.

## What changed

1. **`ctx` now reaches the HTTP retry loop, not just the request.** `httpPostFunc`'s signature gained a `context.Context` parameter. The new default implementation, `httpPostWithContext`, builds each request via `http.NewRequestWithContext(ctx, ...)` and drives retries through `cenkalti/backoff/v5`'s `Retry(ctx, ...)` (already a dependency — used the same way in `pkg/sbomscanner/v1/client.go`), which checks `ctx` both before each retry attempt and while sleeping between attempts. This replaces `httputils.HttpPostWithRetry`, which binds `context.Background()` to the request and retries on a plain, non-cancellable `backoff.Retry` loop — so even passing `ctx` through wouldn't have been enough on its own. `postResults` and `ReportScanFailure` now pass `ctx` through.
2. **A failed summary POST now stops the chunks.** `postResults` returns an `error`. `sendSummaryAndVulnerabilities` checks it before dispatching the first chunk, and `SubmitCVE` skips `sendVulnerabilitiesRoutine` for the rest when the summary failed — draining the (now-abandoned) `chunksChan` itself so `SplitSlice2Chunks`' producer goroutine doesn't block forever trying to hand off chunks nobody reads. A permanently-failed summary no longer lets every chunk ship and get rejected with `missing summary for containerScanID`.
3. **`ReportError`/`SendStatus` are documented, not silently left half-fixed.** Both still go through `backendClientV1.NewBaseReportSender`, which builds its own request bound to `context.Background()` inside `armosec/utils-go` before it ever reaches our `IHttpClient` — there's no seam here to inject `ctx` without either bypassing the sender or a change to `kubescape/backend`. That's a real design decision affecting a shared dependency, so it's called out in a code comment on both functions and tracked separately in #450 rather than assumed or silently dropped.

## Tests

- `TestBackendAdapter_PostResultsAbortsPromptlyOnCtxCancellation` / `TestBackendAdapter_ReportScanFailureAbortsPromptlyOnCtxCancellation`: a blocking mock `IHttpClient` that only unblocks when the request's own context is cancelled, proving the call returns promptly once `ctx` is cancelled instead of running the full retry budget.
- `TestBackendAdapter_SubmitCVE_SkipsChunksWhenSummaryFails`: fails the mocked summary POST and asserts zero chunk POSTs occur, using the same large fixture (`testdata/nginx-cve.json`) that exercises the multi-chunk `chunksChan` drain path.
- `Test_sendSummaryAndVulnerabilities` and the `httpPostFunc` mocks across `backend_test.go`/`backend_utils_test.go` updated for the new ctx-aware signature and `postResults`' new return value.

## How to Test

```bash
go test -v -count=1 -run "TestBackendAdapter|TestSendError|Test_sendSummaryAndVulnerabilities" ./adapters/v1/...
```

## Related issues/PRs:

* Resolved #446
* Follow-up tracked in #450 (ReportError/SendStatus ctx propagation, needs a maintainer call on `kubescape/backend`)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
