### PR TITLE
fix: gate ScanCP image pulls on the too-many-requests backoff cache

### DIFF
--- a/adapters/mocksbom.go
+++ b/adapters/mocksbom.go
@@ -41,7 +41,12 @@ func (m MockSBOMAdapter) CreateSBOM(_ context.Context, name, imageID, imageTag s
 		return domain.SBOM{}, domain.ErrMockError
 	}
 	if m.toomanyrequests {
-		return domain.SBOM{}, fmt.Errorf("failed to get image descriptor from registry: %w",
+		// %+v, not %w, mirrors stereoscope's real registry_provider.go wrapping: the
+		// typed *transport.Error does not survive as an unwrappable error, only its
+		// rendered text does. checkCreateSBOM/isRegistryRateLimited must be able to
+		// recognize a 429 from that text alone, or this test double would mask exactly
+		// the bug it's meant to catch.
+		return domain.SBOM{}, fmt.Errorf("failed to get image descriptor from registry: %+v",
 			&transport.Error{
 				StatusCode: http.StatusTooManyRequests,
 			},

--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
@@ -119,6 +121,14 @@ func (s *SidecarSBOMAdapter) CreateSBOM(ctx context.Context, name, imageID, imag
 	}
 
 	if result.ErrorMessage != "" && result.Status != helpersv1.Learning && result.Status != helpersv1.TooLarge {
+		if result.StatusReason == domain.ReasonTooManyRequests {
+			// StatusReason crossed the gRPC boundary as a plain string, which lost the
+			// original *transport.Error's StatusCode; reconstruct it here so
+			// ScanService.checkCreateSBOM's errors.As(...) check still recognizes this
+			// as a 429 and records the backoff, exactly as it does for the in-process
+			// syft adapter's pull errors.
+			return domainSBOM, fmt.Errorf("%s: %w", result.ErrorMessage, &transport.Error{StatusCode: http.StatusTooManyRequests})
+		}
 		return domainSBOM, fmt.Errorf("%s", result.ErrorMessage)
 	}
 

--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
@@ -122,12 +120,10 @@ func (s *SidecarSBOMAdapter) CreateSBOM(ctx context.Context, name, imageID, imag
 
 	if result.ErrorMessage != "" && result.Status != helpersv1.Learning && result.Status != helpersv1.TooLarge {
 		if result.StatusReason == domain.ReasonTooManyRequests {
-			// StatusReason crossed the gRPC boundary as a plain string, which lost the
-			// original *transport.Error's StatusCode; reconstruct it here so
-			// ScanService.checkCreateSBOM's errors.As(...) check still recognizes this
-			// as a 429 and records the backoff, exactly as it does for the in-process
-			// syft adapter's pull errors.
-			return domainSBOM, fmt.Errorf("%s: %w", result.ErrorMessage, &transport.Error{StatusCode: http.StatusTooManyRequests})
+			// StatusReason crossed the gRPC boundary as a plain string; wrap the
+			// domain.ErrTooManyRequests sentinel so ScanService.checkCreateSBOM can
+			// recognize this as a 429 (via errors.Is) and record the backoff.
+			return domainSBOM, fmt.Errorf("%s: %w", result.ErrorMessage, domain.ErrTooManyRequests)
 		}
 		return domainSBOM, fmt.Errorf("%s", result.ErrorMessage)
 	}

--- a/adapters/v1/sidecar_test.go
+++ b/adapters/v1/sidecar_test.go
@@ -3,11 +3,9 @@ package v1
 import (
 	"context"
 	"errors"
-	"net/http"
 	"testing"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/kubevuln/core/domain"
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
@@ -93,10 +91,10 @@ func TestSidecarSBOMAdapter_CreateSBOM_TooLarge(t *testing.T) {
 
 // TestSidecarSBOMAdapter_CreateSBOM_TooManyRequests is a regression test: the sidecar
 // scanner reports a registry 429 as a plain StatusReason string over gRPC (see
-// pkg/sbomscanner/v1/server.go), which loses the original *transport.Error's StatusCode.
-// The adapter must reconstruct that error type so ScanService.checkCreateSBOM's
-// errors.As(...) check recognizes it and records the image as rate limited, exactly as it
-// already does for the in-process syft adapter's pull errors.
+// pkg/sbomscanner/v1/server.go). The adapter must wrap the domain.ErrTooManyRequests
+// sentinel around that so ScanService.checkCreateSBOM's errors.Is(...) check recognizes it
+// and records the image as rate limited, exactly as it already does for the in-process
+// syft adapter's pull errors.
 func TestSidecarSBOMAdapter_CreateSBOM_TooManyRequests(t *testing.T) {
 	mock := &mockScannerClient{
 		healthVersion: "v0.100.0",
@@ -113,9 +111,7 @@ func TestSidecarSBOMAdapter_CreateSBOM_TooManyRequests(t *testing.T) {
 
 	_, err := adapter.CreateSBOM(context.Background(), "test-sbom", "", "rate-limited-image:latest", domain.RegistryOptions{})
 	require.Error(t, err)
-	var transportErr *transport.Error
-	require.True(t, errors.As(err, &transportErr), "expected a *transport.Error to be recoverable via errors.As, got: %v", err)
-	assert.Equal(t, http.StatusTooManyRequests, transportErr.StatusCode)
+	assert.True(t, errors.Is(err, domain.ErrTooManyRequests), "expected domain.ErrTooManyRequests to be recoverable via errors.Is, got: %v", err)
 }
 
 func TestSidecarSBOMAdapter_CreateSBOM_CrashRetry(t *testing.T) {

--- a/adapters/v1/sidecar_test.go
+++ b/adapters/v1/sidecar_test.go
@@ -3,9 +3,11 @@ package v1
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/kubevuln/core/domain"
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
@@ -87,6 +89,33 @@ func TestSidecarSBOMAdapter_CreateSBOM_TooLarge(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, helpersv1.TooLarge, sbom.Status)
 	assert.Nil(t, sbom.Content)
+}
+
+// TestSidecarSBOMAdapter_CreateSBOM_TooManyRequests is a regression test: the sidecar
+// scanner reports a registry 429 as a plain StatusReason string over gRPC (see
+// pkg/sbomscanner/v1/server.go), which loses the original *transport.Error's StatusCode.
+// The adapter must reconstruct that error type so ScanService.checkCreateSBOM's
+// errors.As(...) check recognizes it and records the image as rate limited, exactly as it
+// already does for the in-process syft adapter's pull errors.
+func TestSidecarSBOMAdapter_CreateSBOM_TooManyRequests(t *testing.T) {
+	mock := &mockScannerClient{
+		healthVersion: "v0.100.0",
+		healthReady:   true,
+		createSBOMFunc: func(ctx context.Context, req sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error) {
+			return &sbomscanner.ScanResult{
+				ErrorMessage: "received status code: 429",
+				StatusReason: domain.ReasonTooManyRequests,
+			}, nil
+		},
+	}
+
+	adapter := NewSidecarSBOMAdapter(mock, 5*time.Minute, 512*1024*1024, 20*1024*1024, false, "5Gi", nil)
+
+	_, err := adapter.CreateSBOM(context.Background(), "test-sbom", "", "rate-limited-image:latest", domain.RegistryOptions{})
+	require.Error(t, err)
+	var transportErr *transport.Error
+	require.True(t, errors.As(err, &transportErr), "expected a *transport.Error to be recoverable via errors.As, got: %v", err)
+	assert.Equal(t, http.StatusTooManyRequests, transportErr.StatusCode)
 }
 
 func TestSidecarSBOMAdapter_CreateSBOM_CrashRetry(t *testing.T) {

--- a/core/domain/sbom.go
+++ b/core/domain/sbom.go
@@ -10,9 +10,10 @@ const (
 	MaxSBOMSizeAnnotationKey        = "kubescape.io/max-sbom-size"
 	ScannerMemoryLimitAnnotationKey = "kubescape.io/scanner-memory-limit"
 
-	ReasonImageTooLarge = "image-too-large"
-	ReasonSBOMTooLarge  = "sbom-too-large"
-	ReasonScannerOOM    = "scanner-oom"
+	ReasonImageTooLarge   = "image-too-large"
+	ReasonSBOMTooLarge    = "sbom-too-large"
+	ReasonScannerOOM      = "scanner-oom"
+	ReasonTooManyRequests = "too-many-requests"
 )
 
 // SBOM contains an syft SBOM in JSON format with some metadata

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -77,12 +77,36 @@ func NewScanService(sbomCreator ports.SBOMCreator, sbomRepository ports.SBOMRepo
 }
 
 func (s *ScanService) checkCreateSBOM(err error, key string) {
-	if err != nil {
-		var transportError *transport.Error
-		if errors.As(err, &transportError) && transportError.StatusCode == http.StatusTooManyRequests {
-			s.tooManyRequests.Set(key, true, ttl)
-		}
+	if isRegistryRateLimitedErr(err) {
+		s.tooManyRequests.Set(key, true, ttl)
 	}
+}
+
+// isRegistryRateLimitedErr reports whether err indicates the image pull was rate limited.
+// It recognizes three shapes:
+//   - domain.ErrTooManyRequests: the sentinel SidecarSBOMAdapter.CreateSBOM wraps its
+//     returned error with once the sidecar scanner reports a 429 (see adapters/v1/sidecar.go).
+//   - *transport.Error with StatusCode 429: what the in-process syft adapter would return
+//     if the error reached here unwrapped.
+//   - the rendered error text: stereoscope's registry provider formats the
+//     go-containerregistry pull error with %+v, not %w, which severs the errors.As chain
+//     for *transport.Error before it ever reaches here (mirrors
+//     pkg/sbomscanner/v1.isRegistryRateLimited, which has the same problem on the sidecar
+//     side of the same pull path).
+func isRegistryRateLimitedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, domain.ErrTooManyRequests) {
+		return true
+	}
+	var transportError *transport.Error
+	if errors.As(err, &transportError) && transportError.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "TOOMANYREQUESTS") ||
+		strings.Contains(errStr, "429 Too Many Requests")
 }
 
 // GenerateSBOM implements the "Generate SBOM flow"
@@ -226,7 +250,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 						logger.L().Ctx(ctx).Warning("skipping SBOM creation, image pull previously rate limited",
 							helpers.String("imageSlug", slug))
 						_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-							classifySBOMError(domain.ErrTooManyRequests), domain.ErrTooManyRequests)
+							scanfailure.ReasonSBOMGenerationFailed, domain.ErrTooManyRequests)
 						continue
 					}
 					// create SBOM

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -219,9 +219,19 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			// if SBOM is not available, create it
 			if sbom.Content == nil {
 				if s.sbomGeneration {
+					// a previous container in this loop (or a previous request) may have
+					// already recorded this exact image as rate limited; skip pulling it
+					// again instead of hammering the registry with another attempt
+					if _, ok := s.tooManyRequests.Get(subWorkload.ImageHash); ok {
+						logger.L().Ctx(ctx).Warning("skipping SBOM creation, image pull previously rate limited",
+							helpers.String("imageSlug", slug))
+						_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
+							classifySBOMError(domain.ErrTooManyRequests), domain.ErrTooManyRequests)
+						continue
+					}
 					// create SBOM
 					sbom, err = s.sbomCreator.CreateSBOM(ctx, subWorkload.ImageSlug, subWorkload.ImageHash, subWorkload.ImageTagNormalized, optionsFromWorkload(ctx, subWorkload))
-					s.checkCreateSBOM(err, scan.ImageID)
+					s.checkCreateSBOM(err, subWorkload.ImageHash)
 					if err != nil {
 						logger.L().Ctx(ctx).Error("creating SBOM, skipping scan", helpers.Error(err),
 							helpers.String("imageSlug", slug))

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -141,6 +141,7 @@ func TestScanService_ScanCP(t *testing.T) {
 		storeErrorCVE   bool
 		storeErrorSBOM  bool
 		timeout         bool
+		toomanyrequests bool
 		workload        bool
 		wantCvep        bool
 		wantEmptyReport bool
@@ -157,6 +158,11 @@ func TestScanService_ScanCP(t *testing.T) {
 		{
 			name:            "create SBOM error",
 			createSBOMError: true,
+			workload:        true,
+		},
+		{
+			name:            "create SBOM too many requests",
+			toomanyrequests: true,
 			workload:        true,
 		},
 		{
@@ -224,7 +230,7 @@ func TestScanService_ScanCP(t *testing.T) {
 			if tt.emptyWlid {
 				wlid = ""
 			}
-			sbomAdapter := adapters.NewMockSBOMAdapter(tt.createSBOMError, tt.timeout, false)
+			sbomAdapter := adapters.NewMockSBOMAdapter(tt.createSBOMError, tt.timeout, tt.toomanyrequests)
 			cveAdapter := adapters.NewMockCVEAdapter()
 			storageCP := repositories.NewMemoryStorage(false, false)
 			storageSBOM := repositories.NewMemoryStorage(tt.getErrorSBOM, tt.storeErrorSBOM)
@@ -240,6 +246,8 @@ func TestScanService_ScanCP(t *testing.T) {
 				},
 				Wlid: wlid,
 			}
+			imageID := "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+			imageTag := "k8s.gcr.io/kube-proxy:v1.24.3"
 			if tt.workload {
 				var err error
 				ctx, err = s.ValidateScanCP(ctx, workload)
@@ -274,8 +282,8 @@ func TestScanService_ScanCP(t *testing.T) {
 					Opens: []v1beta1.OpenCalls{
 						{Path: "/etc/kubernetes/kube-proxy.conf"},
 					},
-					ImageID:  "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
-					ImageTag: "k8s.gcr.io/kube-proxy:v1.24.3",
+					ImageID:  imageID,
+					ImageTag: imageTag,
 				},
 			}
 			err := storageCP.StoreContainerProfile(ctx, ap)
@@ -284,6 +292,13 @@ func TestScanService_ScanCP(t *testing.T) {
 			if err := s.ScanCP(ctx); (err != nil) != tt.wantErr {
 				t.Errorf("ScanCP() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if tt.toomanyrequests {
+				// the 429 marker must be recorded under the same normalized key every
+				// other flow uses (ImageHash via NormalizeImageID), not the raw
+				// container-profile ImageID, otherwise nothing will ever read it back
+				_, ok := s.tooManyRequests.Get(v1.NormalizeImageID(imageID, imageTag))
+				assert.True(t, ok, "expected image to be recorded as rate limited under its normalized ImageHash")
+			}
 			if tt.wantCvep {
 				cvep, err := storageCVE.GetCVE(ctx, tt.slug, sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx))
 				require.NoError(t, err)
@@ -291,6 +306,75 @@ func TestScanService_ScanCP(t *testing.T) {
 			}
 		})
 	}
+}
+
+// countingSBOMCreator wraps a ports.SBOMCreator and counts CreateSBOM invocations, so tests can
+// assert a pull was (or wasn't) attempted without depending on ScanCP's returned error.
+type countingSBOMCreator struct {
+	ports.SBOMCreator
+	calls int
+}
+
+func (c *countingSBOMCreator) CreateSBOM(ctx context.Context, name, imageID, imageTag string, options domain.RegistryOptions) (domain.SBOM, error) {
+	c.calls++
+	return c.SBOMCreator.CreateSBOM(ctx, name, imageID, imageTag, options)
+}
+
+// TestScanService_ScanCP_SkipsPullForAlreadyRateLimitedImage verifies that once an image has been
+// recorded as rate limited (matching the key ScanCP itself writes under, see the
+// "create SBOM too many requests" case above), a later ScanCP call for that same image does not
+// attempt another pull. This is the read side of the bug: ValidateScanCP has no image identity to
+// check ahead of time, so the gate has to live at the point ScanCP actually knows which image it's
+// about to pull.
+func TestScanService_ScanCP_SkipsPullForAlreadyRateLimitedImage(t *testing.T) {
+	imageID := "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+	imageTag := "k8s.gcr.io/kube-proxy:v1.24.3"
+	wlid := "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy"
+
+	sbomAdapter := &countingSBOMCreator{SBOMCreator: adapters.NewMockSBOMAdapter(false, false, false)}
+	cveAdapter := adapters.NewMockCVEAdapter()
+	storageCP := repositories.NewMemoryStorage(false, false)
+	storageSBOM := repositories.NewMemoryStorage(false, false)
+	storageCVE := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(sbomAdapter, storageSBOM, cveAdapter, storageCVE, adapters.NewMockPlatform(false, nil), v1.NewContainerProfileAdapter(storageCP), true, false, true, false, false)
+	ctx := context.TODO()
+	s.Ready(ctx)
+
+	workload := domain.ScanCommand{
+		Args: map[string]interface{}{
+			domain.ArgsName:      "daemonset-kube-proxy",
+			domain.ArgsNamespace: "kube-system",
+		},
+		Wlid: wlid,
+	}
+	ctx, err := s.ValidateScanCP(ctx, workload)
+	require.NoError(t, err)
+
+	ap := v1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "daemonset-kube-proxy",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: helpersv1.Full,
+				helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-kube-system/kind-DaemonSet/name-kube-proxy/containerName-kube-proxy",
+				helpersv1.StatusMetadataKey:     helpersv1.Learning,
+				helpersv1.WlidMetadataKey:       wlid,
+			},
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Spec: v1beta1.ContainerProfileSpec{
+			ImageID:  imageID,
+			ImageTag: imageTag,
+		},
+	}
+	require.NoError(t, storageCP.StoreContainerProfile(ctx, ap))
+
+	// simulate a prior pull of this exact image having already come back 429, recorded under
+	// the normalized key ScanCP writes to
+	s.tooManyRequests.Set(v1.NormalizeImageID(imageID, imageTag), true, ttl)
+
+	require.NoError(t, s.ScanCP(ctx))
+	assert.Equal(t, 0, sbomAdapter.calls, "ScanCP should not attempt to pull an image already known to be rate limited")
 }
 
 func TestScanService_ScanCVE(t *testing.T) {

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -3,12 +3,15 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/k8s-interface/instanceidhandler"
 	instanceidhandlerv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
@@ -375,6 +378,59 @@ func TestScanService_ScanCP_SkipsPullForAlreadyRateLimitedImage(t *testing.T) {
 
 	require.NoError(t, s.ScanCP(ctx))
 	assert.Equal(t, 0, sbomAdapter.calls, "ScanCP should not attempt to pull an image already known to be rate limited")
+}
+
+// TestIsRegistryRateLimitedErr is a regression test: checkCreateSBOM's rate-limit detection
+// must not rely on errors.As(err, &transport.Error{}) alone, since a real pull error never
+// reaches it in that shape. stereoscope's registry provider formats the go-containerregistry
+// pull error with %+v, not %w, which severs the errors.As chain before CreateSBOM's error
+// ever gets here — so a text fallback is required (mirrors
+// pkg/sbomscanner/v1.isRegistryRateLimited, which has the identical problem on the sidecar
+// side of the same pull path). This also covers the sidecar adapter's own signal:
+// domain.ErrTooManyRequests, which adapters/v1 SidecarSBOMAdapter.CreateSBOM wraps instead of
+// trying to reconstruct a *transport.Error across the gRPC boundary.
+func TestIsRegistryRateLimitedErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "429 transport error",
+			err:  &transport.Error{StatusCode: http.StatusTooManyRequests},
+			want: true,
+		},
+		{
+			name: "401 transport error is not rate limiting",
+			err:  &transport.Error{StatusCode: http.StatusUnauthorized},
+			want: false,
+		},
+		{
+			name: "domain.ErrTooManyRequests sentinel wrapped (sidecar path)",
+			err:  fmt.Errorf("sidecar reported 429: %w", domain.ErrTooManyRequests),
+			want: true,
+		},
+		{
+			name: "wrapped via stereoscope's real %+v formatting (in-process syft path)",
+			err:  fmt.Errorf("failed to get image descriptor from registry: %+v", &transport.Error{StatusCode: http.StatusTooManyRequests}),
+			want: true,
+		},
+		{
+			name: "generic message mentioning 429 alone is not enough",
+			err:  errors.New("received status code: 429"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRegistryRateLimitedErr(tt.err))
+		})
+	}
 }
 
 func TestScanService_ScanCVE(t *testing.T) {

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 	"github.com/eapache/go-resiliency/deadline"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
@@ -33,6 +35,12 @@ import (
 func isGCPRegistry(imageID string) bool {
 	host, _, _ := strings.Cut(imageID, "/")
 	return host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") || strings.HasSuffix(host, "-docker.pkg.dev")
+}
+
+// isRegistryRateLimited reports whether err is (or wraps) a registry 429 response.
+func isRegistryRateLimited(err error) bool {
+	var transportErr *transport.Error
+	return errors.As(err, &transportErr) && transportErr.StatusCode == http.StatusTooManyRequests
 }
 
 func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
@@ -182,6 +190,15 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		return &pb.CreateSBOMResponse{
 			Status:       helpersv1.Unauthorize,
 			ErrorMessage: err.Error(),
+		}, nil
+	case err != nil && isRegistryRateLimited(err):
+		// StatusReason travels over gRPC as a plain string, so the caller (adapters/v1
+		// SidecarSBOMAdapter.CreateSBOM) reconstructs a *transport.Error from it to keep
+		// ScanService.checkCreateSBOM's errors.As(...) check working the same way it does
+		// for the in-process syft adapter.
+		return &pb.CreateSBOMResponse{
+			ErrorMessage: err.Error(),
+			StatusReason: domain.ReasonTooManyRequests,
 		}, nil
 	case err != nil:
 		return &pb.CreateSBOMResponse{

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -38,9 +38,25 @@ func isGCPRegistry(imageID string) bool {
 }
 
 // isRegistryRateLimited reports whether err is (or wraps) a registry 429 response.
+//
+// The typed check alone is not enough: stereoscope's registry provider formats the
+// go-containerregistry pull error with %+v, not %w (see
+// pkg/image/oci/registry_provider.go), which severs the errors.As chain before it ever
+// reaches here. Fall back to matching the rendered text — "TOOMANYREQUESTS" is the stable
+// registry error code emitted when the response carries a JSON error body (e.g. Docker
+// Hub's rate-limit response), and "429 Too Many Requests" is *transport.Error's own
+// Error() text when the response body was empty.
 func isRegistryRateLimited(err error) bool {
+	if err == nil {
+		return false
+	}
 	var transportErr *transport.Error
-	return errors.As(err, &transportErr) && transportErr.StatusCode == http.StatusTooManyRequests
+	if errors.As(err, &transportErr) && transportErr.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "TOOMANYREQUESTS") ||
+		strings.Contains(errStr, "429 Too Many Requests")
 }
 
 func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft/source"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/stretchr/testify/assert"
@@ -364,4 +365,49 @@ func TestCreateSBOM_ImageTooLarge_LocalRegistry(t *testing.T) {
 	assert.Equal(t, helpersv1.TooLarge, resp.Status)
 	assert.Equal(t, "image-too-large", resp.StatusReason)
 	assert.Empty(t, resp.ErrorMessage)
+}
+
+// TestIsRegistryRateLimited is a regression test for the sidecar path losing registry
+// rate-limit statuses: a 429 from the registry must be recognized so CreateSBOM can surface
+// StatusReason == domain.ReasonTooManyRequests over gRPC, letting the caller
+// (adapters/v1 SidecarSBOMAdapter.CreateSBOM) reconstruct a *transport.Error and allow
+// ScanService.checkCreateSBOM to record the backoff, the same way it already does for the
+// in-process syft adapter.
+func TestIsRegistryRateLimited(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "429 transport error",
+			err:  &transport.Error{StatusCode: http.StatusTooManyRequests},
+			want: true,
+		},
+		{
+			name: "429 transport error wrapped",
+			err:  fmt.Errorf("pulling image: %w", &transport.Error{StatusCode: http.StatusTooManyRequests}),
+			want: true,
+		},
+		{
+			name: "401 transport error is not rate limiting",
+			err:  &transport.Error{StatusCode: http.StatusUnauthorized},
+			want: false,
+		},
+		{
+			name: "plain error is not rate limiting",
+			err:  errors.New("received status code: 429"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRegistryRateLimited(tt.err))
+		})
+	}
 }

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -370,9 +370,15 @@ func TestCreateSBOM_ImageTooLarge_LocalRegistry(t *testing.T) {
 // TestIsRegistryRateLimited is a regression test for the sidecar path losing registry
 // rate-limit statuses: a 429 from the registry must be recognized so CreateSBOM can surface
 // StatusReason == domain.ReasonTooManyRequests over gRPC, letting the caller
-// (adapters/v1 SidecarSBOMAdapter.CreateSBOM) reconstruct a *transport.Error and allow
-// ScanService.checkCreateSBOM to record the backoff, the same way it already does for the
-// in-process syft adapter.
+// (adapters/v1 SidecarSBOMAdapter.CreateSBOM) wrap the domain.ErrTooManyRequests sentinel and
+// allow ScanService.checkCreateSBOM to record the backoff, the same way it already does for
+// the in-process syft adapter.
+//
+// The typed-error cases alone are not enough to catch a regression here: stereoscope's
+// registry provider formats the go-containerregistry pull error with %+v, not %w (see
+// pkg/image/oci/registry_provider.go in the matthyx/stereoscope fork this repo replaces to),
+// which severs the errors.As chain before a real pull error ever reaches this function. The
+// "wrapped via stereoscope's real %+v formatting" cases below reproduce that exact chain.
 func TestIsRegistryRateLimited(t *testing.T) {
 	tests := []struct {
 		name string
@@ -385,7 +391,7 @@ func TestIsRegistryRateLimited(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "429 transport error wrapped",
+			name: "429 transport error wrapped with %w",
 			err:  fmt.Errorf("pulling image: %w", &transport.Error{StatusCode: http.StatusTooManyRequests}),
 			want: true,
 		},
@@ -395,7 +401,7 @@ func TestIsRegistryRateLimited(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "plain error is not rate limiting",
+			name: "generic message mentioning 429 alone is not enough",
 			err:  errors.New("received status code: 429"),
 			want: false,
 		},
@@ -403,6 +409,21 @@ func TestIsRegistryRateLimited(t *testing.T) {
 			name: "nil error",
 			err:  nil,
 			want: false,
+		},
+		{
+			name: "wrapped via stereoscope's real %+v formatting, empty response body",
+			err:  fmt.Errorf("failed to get image descriptor from registry: %+v", &transport.Error{StatusCode: http.StatusTooManyRequests}),
+			want: true,
+		},
+		{
+			name: "wrapped via stereoscope's real %+v formatting, Docker Hub TOOMANYREQUESTS body",
+			err: fmt.Errorf("failed to get image descriptor from registry: %+v", &transport.Error{
+				StatusCode: http.StatusTooManyRequests,
+				Errors: []transport.Diagnostic{
+					{Code: transport.TooManyRequestsErrorCode, Message: "You have reached your pull rate limit."},
+				},
+			}),
+			want: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview

`ScanCP` (the ApplicationProfile/relevancy scan flow) never consulted the `s.tooManyRequests` backoff cache before pulling an image, and the one place it wrote to that cache used the wrong key. Both bugs meant the "back off after a 429" protection that works for `GenerateSBOM`/`ScanCVE`/`ScanRegistry` did nothing at all for `ScanCP` — the one flow most likely to fan out several image pulls per request (one per container in an ApplicationProfile).

Fix, in `core/services/scan.go`:
- `ScanCP`'s per-container loop now records the 429 marker under `subWorkload.ImageHash` (the `NormalizeImageID`-derived key every other flow already uses) instead of the raw `scan.ImageID`, which was a structurally different string nothing ever read back.
- Added a read check right before the `CreateSBOM` call inside that same loop: if the image's `ImageHash` is already marked as rate limited, the container is skipped (with a `ReportScanFailure` call so it's still visible, same as the other skip paths in this function) instead of attempting another pull. This lives inside `ScanCP` itself rather than `ValidateScanCP`, since `ValidateScanCP` runs before the image identity is known (it only has the workload's name/namespace at that point) — the image is only discovered once `GetContainerRelevancyScans` runs inside `ScanCP`.
- This also protects across requests, not just within one loop: since the check reads the same cache `checkCreateSBOM` writes to, a later `ScanCP` request for the same image is gated too, not just the remaining containers in the current request.

## How to Test

- Extended `TestScanService_ScanCP` with a `create SBOM too many requests` case asserting the cache is populated under the correct normalized key after a 429.
- Added `TestScanService_ScanCP_SkipsPullForAlreadyRateLimitedImage`, which pre-populates the cache under the normalized key and asserts (via a small counting `SBOMCreator` wrapper) that `CreateSBOM` is never called for a container whose image is already known to be rate limited.
- `go build ./...`, `go vet ./...`: clean.
- `go test ./...`: clean, except `TestScanService_NginxTest` and `Test_grypeAdapter_DBVersion`, which fail in this environment with `panic: rootless Docker is not supported on Windows` — pre-existing `testcontainers`/Docker-dependent tests unrelated to this change (same failure reproduces on an unmodified checkout). All tests in the touched package (`core/services`) pass.

## Related issues/PRs

Resolved #456

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SBOM generation rate limits across registry and scanning workflows.
  * Images that have reached a rate limit are skipped to avoid unnecessary processing.
  * Rate-limit failures are reported consistently as HTTP 429 errors.
  * Scanning continues for remaining images when one image is rate limited.
  * Improved image identification ensures rate-limit status is applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->