### PR TITLE
fix: propagate SecurityException aliases into vulnerability exception…

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -87,13 +87,20 @@ func shouldSuppress(vuln sev1beta1.VulnerabilityException) bool {
 }
 
 func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.VulnerabilityException, namespace string) armotypes.VulnerabilityExceptionPolicy {
+	vulnerabilityPolicies := []armotypes.VulnerabilityPolicy{
+		{Name: strings.TrimSpace(vuln.Vulnerability.ID)},
+	}
+	for _, alias := range vuln.Vulnerability.Aliases {
+		if a := strings.TrimSpace(alias); a != "" {
+			vulnerabilityPolicies = append(vulnerabilityPolicies, armotypes.VulnerabilityPolicy{Name: a})
+		}
+	}
+
 	p := armotypes.VulnerabilityExceptionPolicy{
-		PolicyType: "vulnerabilityExceptionPolicy",
-		Actions:    []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
-		VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
-			{Name: strings.TrimSpace(vuln.Vulnerability.ID)},
-		},
-		Reason: spec.Reason,
+		PolicyType:            "vulnerabilityExceptionPolicy",
+		Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+		VulnerabilityPolicies: vulnerabilityPolicies,
+		Reason:                spec.Reason,
 	}
 
 	if spec.ExpiresAt != nil {

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -335,7 +335,6 @@ func TestApplySecurityExceptions_NoExceptions(t *testing.T) {
 func TestConvertMixedStatusException(t *testing.T) {
 	const underInvestigationID = "CVE-2023-11111"
 	const notAffectedID = "CVE-2023-22222"
-
 	exceptions := []sev1beta1.SecurityException{
 		{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
@@ -433,4 +432,67 @@ func TestUnderInvestigationDoesNotSuppress(t *testing.T) {
 			assert.Empty(t, doc.IgnoredMatches, "under_investigation CVE must not appear in IgnoredMatches")
 		})
 	}
+}
+
+func TestConvertVulnerabilityExceptions_Aliases(t *testing.T) {
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{
+						Vulnerability: sev1beta1.VulnerabilityRef{
+							ID:      "CVE-2021-44228",
+							Aliases: []string{"GHSA-jfh8-c2jp-5v3q", "  GHSA-xxxx-xxxx-xxxx  ", ""},
+						},
+						Status: sev1beta1.VulnerabilityStatusNotAffected,
+					},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+
+	assert.Len(t, policies, 1)
+	names := make([]string, 0, len(policies[0].VulnerabilityPolicies))
+	for _, vp := range policies[0].VulnerabilityPolicies {
+		names = append(names, vp.Name)
+	}
+	assert.Equal(t, []string{"CVE-2021-44228", "GHSA-jfh8-c2jp-5v3q", "GHSA-xxxx-xxxx-xxxx"}, names)
+}
+
+func TestApplySecurityExceptions_MatchesByAlias(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "GHSA-jfh8-c2jp-5v3q"}}},
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2023-9999"}}},
+		},
+	}
+
+	// CRD declares the CVE as primary ID and the GHSA grype reports as an alias
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{
+						Vulnerability: sev1beta1.VulnerabilityRef{
+							ID:      "CVE-2021-44228",
+							Aliases: []string{"GHSA-jfh8-c2jp-5v3q"},
+						},
+						Status: sev1beta1.VulnerabilityStatusNotAffected,
+					},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+	ApplySecurityExceptions(doc, domain.CVEExceptions(policies))
+
+	assert.Len(t, doc.Matches, 1)
+	assert.Equal(t, "CVE-2023-9999", doc.Matches[0].Vulnerability.ID)
+	assert.Len(t, doc.IgnoredMatches, 1)
+	assert.Equal(t, "GHSA-jfh8-c2jp-5v3q", doc.IgnoredMatches[0].Vulnerability.ID)
 }


### PR DESCRIPTION
Fixes #463

## Overview

`SecurityException` / `ClusterSecurityException` CRDs declare an `aliases` list (`pkg/securityexception/v1beta1/types.go:91-94`, documented in `docs/security-exception-design.md:122`) so one exception can target both the NVD ID and the GitHub Advisory ID of the same flaw. 

`buildPolicy` (`adapters/v1/securityexception.go:69-92`) copied only `vuln.Vulnerability.ID` into `VulnerabilityPolicies`, dropping the aliases entirely. Since `getCVEExceptionMatchCVENameFromList` (`adapters/v1/backend_utils.go:275-293`) matches solely on `VulnerabilityPolicies[].Name`, an exception configured as `id: CVE-2021-44228` + `aliases: [GHSA-jfh8-c2jp-hdph]` silently failed to suppress a finding Grype reports as `GHSA-jfh8-c2jp-hdph` — in both the in-cluster filter (`ApplySecurityExceptions`, `securityexception.go:116`) and the backend report (`DomainToArmo`, `domain_to_armo.go:173`).

---

## Change

`adapters/v1/securityexception.go` — `buildPolicy`
- Build `VulnerabilityPolicies` from the primary ID plus each trimmed, non-empty alias.
- `armotypes.VulnerabilityPolicy` has no dedicated `aliases` field (verified in `armoapi-go v0.0.718`), so expanding the name list is the only mechanism; matching is already `EqualFold`-based (post-#353).
- No changes to `backend_utils.go`; no new imports; no existing test declares aliases, so no existing assertions change.

---

## Tests

Added in `adapters/v1/securityexception_test.go`:
- `TestConvertVulnerabilityExceptions_Aliases` — ID + padded/empty aliases → one policy name per alias, empties skipped.
- `TestApplySecurityExceptions_MatchesByAlias` — end-to-end `ConvertToVulnerabilityExceptionPolicies` → `ApplySecurityExceptions`: a Grype match reported as `GHSA-…` is moved to `IgnoredMatches` when the CRD lists it as an alias of a CVE.

Both fail on `main` (alias dropped) and pass with this change. The `DomainToArmo` backend path is covered transitively: it consumes the same converted policy slice and the same matching function exercised by the conversion test.

---

## Verification

Red (unfixed main, aliases dropped):

[FAIL] TestConvertVulnerabilityExceptions_Aliases
  expected: []string{"CVE-2021-44228", "GHSA-jfh8-c2jp-5v3q", "GHSA-xxxx-xxxx-xxxx"}
  actual  : []string{"CVE-2021-44228"}
[FAIL] TestApplySecurityExceptions_MatchesByAlias

Green (with fix):

go test: 2 passed
- go build ./... — clean
- go vet ./adapters/v1/ — clean (pre-existing findings in backend_test.go, present on main)
- gofmt -l adapters/v1/securityexception.go adapters/v1/securityexception_test.go — clean
- go test ./adapters/v1/... — full package passes (with Docker running; the only otherwise-failing test, Test_grypeAdapter_DBVersion, is a Docker/testcontainers test that also fails on clean main)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] DCO signed off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security exceptions now recognize vulnerability aliases in addition to the main vulnerability ID.
  * Findings reported under an alias can now be matched and ignored by the corresponding exception.

* **Bug Fixes**
  * Improved matching so trimmed, non-empty alias values are handled consistently.
  * Unrelated findings continue to remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->