### PR TITLE
fix: copy container profile labels before enriching the relevancy scan

### DIFF
--- a/adapters/v1/container_profile.go
+++ b/adapters/v1/container_profile.go
@@ -56,6 +56,12 @@ func (a *ContainerProfileAdapter) GetContainerRelevancyScans(ctx context.Context
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate instance ID: %w", err)
 	}
+	// copy labels map so we never mutate the repository-owned profile and nil labels scan cleanly
+	scanLabels := make(map[string]string, len(containerProfile.Labels)+1)
+	for k, v := range containerProfile.Labels {
+		scanLabels[k] = v
+	}
+	scanLabels[helpersv1.ContainerNameMetadataKey] = instanceID.GetContainerName()
 	scan := ports.ContainerRelevancyScan{
 		Completion:       completionStatus,
 		ContainerName:    instanceID.GetContainerName(),
@@ -63,7 +69,7 @@ func (a *ContainerProfileAdapter) GetContainerRelevancyScans(ctx context.Context
 		ImageTag:         containerProfile.Spec.ImageTag,
 		InstanceID:       instanceID,
 		InstanceIDString: instanceIDString,
-		Labels:           containerProfile.Labels,
+		Labels:           scanLabels,
 		RelevantFiles:    mapset.NewSet[string](),
 		Wlid:             wlid,
 	}
@@ -74,8 +80,6 @@ func (a *ContainerProfileAdapter) GetContainerRelevancyScans(ctx context.Context
 	for _, f := range containerProfile.Spec.Opens {
 		scan.RelevantFiles.Add(f.Path)
 	}
-	// add container name to labels
-	scan.Labels[helpersv1.ContainerNameMetadataKey] = instanceID.GetContainerName()
 	scans = append(scans, scan)
 	return scans, nil
 }

--- a/adapters/v1/container_profile_test.go
+++ b/adapters/v1/container_profile_test.go
@@ -1,0 +1,61 @@
+package v1
+
+import (
+	"context"
+	"testing"
+
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/kubevuln/repositories"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func validContainerProfile(name, namespace string, labels map[string]string) v1beta1.ContainerProfile {
+	return v1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: helpersv1.Full,
+				helpersv1.StatusMetadataKey:     helpersv1.Learning,
+				helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-kube-system/kind-DaemonSet/name-kube-proxy/containerName-kube-proxy",
+				helpersv1.WlidMetadataKey:       "wlid/cluster-test/namespace-kube-system/kind-DaemonSet/name-kube-proxy",
+			},
+			Labels: labels,
+		},
+		Spec: v1beta1.ContainerProfileSpec{
+			Execs:    []v1beta1.ExecCalls{{Path: "/usr/local/bin/kube-proxy"}},
+			Opens:    []v1beta1.OpenCalls{{Path: "/etc/kubernetes/kube-proxy.conf"}},
+			ImageID:  "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+			ImageTag: "k8s.gcr.io/kube-proxy:v1.24.3",
+		},
+	}
+}
+
+func TestGetContainerRelevancyScans_NilLabels(t *testing.T) {
+	repo := repositories.NewMemoryStorage(false, false)
+	require.NoError(t, repo.StoreContainerProfile(context.TODO(), validContainerProfile("daemonset-kube-proxy", "kube-system", nil)))
+
+	scans, err := NewContainerProfileAdapter(repo).GetContainerRelevancyScans(context.TODO(), "kube-system", "daemonset-kube-proxy", true)
+	require.NoError(t, err)
+
+	require.Len(t, scans, 1)
+	assert.Equal(t, "kube-proxy", scans[0].Labels[helpersv1.ContainerNameMetadataKey])
+}
+
+func TestGetContainerRelevancyScans_DoesNotMutateStoredProfile(t *testing.T) {
+	repo := repositories.NewMemoryStorage(false, false)
+	require.NoError(t, repo.StoreContainerProfile(context.TODO(), validContainerProfile("daemonset-kube-proxy", "kube-system", map[string]string{"foo": "bar"})))
+
+	scans, err := NewContainerProfileAdapter(repo).GetContainerRelevancyScans(context.TODO(), "kube-system", "daemonset-kube-proxy", true)
+	require.NoError(t, err)
+
+	require.Len(t, scans, 1)
+	assert.Equal(t, "kube-proxy", scans[0].Labels[helpersv1.ContainerNameMetadataKey])
+
+	stored, err := repo.GetContainerProfile(context.TODO(), "kube-system", "daemonset-kube-proxy")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"foo": "bar"}, stored.Labels)
+}


### PR DESCRIPTION
Fixes #465

## Overview

`GetContainerRelevancyScans` wrote `kubescape.io/workload-container-name` into a `labels` map taken by reference from the repository object (`adapters/v1/container_profile.go:66,78`).

- **Process crash:** A `ContainerProfile` with no `metadata.labels` decodes to a `nil` map — `kubescape-storage` never initializes `Labels` (`ContainerProfileProcessor.PreSave` only guards `Annotations`), and `kubevuln` never writes container profiles (only `MemoryStore.StoreContainerProfile` exists). The write at `:78` panicked with `assignment to entry in nil map`. `ScanCP` runs inside a `workerPool.Submit` goroutine (`controllers/http.go:123-124`); the `gammazero` workerpool does not recover panics (`workerpool.go:235-241`) and `gin.Recovery()` only covers the handler goroutine, so the panic was unrecovered and terminated the whole `kubevuln` process, dropping all in-flight scans. The same aliased map was written again downstream in `filterSBOM` (`scan.go:768`).
- **Stored-state pollution:** With a reference-returning repository (`MemoryStore`, tests/local), the write mutated the stored profile — subsequent reads returned runtime labels.

---

## Change

`adapters/v1/container_profile.go`: Build a shallow copy of `Labels` (`len+1` capacity) and set the container-name key on the copy, so repository-owned state is never modified and `nil` labels scan cleanly. The label remains available to `filterSBOM` for the filtered-SBOM annotation (`scan.go:750`). No new imports; no behavior change for the normal (non-nil) path.

---

## Tests

New `adapters/v1/container_profile_test.go` (the adapter had no direct unit tests):

- `TestGetContainerRelevancyScans_NilLabels` — a labels-less profile scans without panicking, and the returned scan carries the container-name label.
- `TestGetContainerRelevancyScans_DoesNotMutateStoredProfile` — stored profile labels stay `{"foo":"bar"}` after a scan.

Both fail on `main` and pass with this change.

---

## Verification

Red (unfixed `main`):

```text
[FAIL] TestGetContainerRelevancyScans_NilLabels
  panic: assignment to entry in nil map

[FAIL] TestGetContainerRelevancyScans_DoesNotMutateStoredProfile
  expected: map[string]string{"foo":"bar"}
  actual  : map[string]string{"foo":"bar", "kubescape.io/workload-container-name":"kube-proxy"}
```

Green (with fix):

```text
go test: 2 passed
```

- `go build ./...` — clean
- `go vet ./adapters/v1/` — clean (no findings in touched files)
- `gofmt -l adapters/v1/container_profile.go adapters/v1/container_profile_test.go` — clean
- `go test ./adapters/v1/...` — 60 passed, 1 failed: `Test_grypeAdapter_DBVersion` (Docker/testcontainers-dependent, passes when the Docker daemon is up; fails on clean `main` identically otherwise)
- `go test ./repositories/...` — 33 passed
- `go test ./core/services/ -run TestScanService_ScanCP` — 13 passed (no regression in the indirect integration path)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] DCO signed off