### PR TITLE
fix: bound graceful shutdown drain time instead of blocking indefinitely

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -166,8 +166,9 @@ func main() {
 		logger.L().Ctx(ctx).Fatal("server forced to shutdown", helpers.Error(err))
 	}
 
-	// Purging the controller worker queue
-	controller.Shutdown()
+	// Purging the controller worker queue, bounded by ShutdownTimeout so this
+	// doesn't silently run past the pod's terminationGracePeriodSeconds
+	controller.Shutdown(c.ShutdownTimeout)
 
 	logger.L().Info("kubevuln exiting")
 }

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -158,12 +158,17 @@ func main() {
 	stop()
 	logger.L().Info("shutting down gracefully")
 
-	// modify context to inform the server it has 5 seconds to finish
-	// the request it is currently handling
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if err := srv.Shutdown(ctx); err != nil {
-		logger.L().Ctx(ctx).Fatal("server forced to shutdown", helpers.Error(err))
+	// Give the HTTP server up to 5 seconds to finish in-flight requests. This must be
+	// derived from context.Background(), not the signal ctx above: that one is already
+	// Done() by this point (we only got here via <-ctx.Done()), so deriving from it
+	// would hand srv.Shutdown an already-expired context and return immediately.
+	srvCtx, srvCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer srvCancel()
+	if err := srv.Shutdown(srvCtx); err != nil {
+		// Log and continue rather than exit: a failed/timed-out HTTP shutdown must not
+		// skip the worker-pool drain below, since that's where actual queued/running
+		// scan work would otherwise be silently lost (#467).
+		logger.L().Ctx(srvCtx).Error("server shutdown error", helpers.Error(err))
 	}
 
 	// Purging the controller worker queue, bounded by ShutdownTimeout so this

--- a/cmd/http/main_test.go
+++ b/cmd/http/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/armosec/armoapi-go/apis"
 	"github.com/gin-gonic/gin"
@@ -121,7 +122,7 @@ func TestScan(t *testing.T) {
 			assert.Equal(t, test.expectedCode, w.Code, w.Code)
 			assert.Equal(t, test.expectedBody, w.Body.String(), w.Body.String())
 
-			controller.Shutdown()
+			controller.Shutdown(5 * time.Second)
 		})
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -80,11 +80,13 @@ func LoadConfig(path string) (Config, error) {
 	v.SetDefault("scanConcurrency", 1)
 	v.SetDefault("scanTimeout", 5*time.Minute)
 	v.SetDefault("scannerReadinessTimeout", 60*time.Second)
-	// Kept safely under Kubernetes' typical terminationGracePeriodSeconds (30s
-	// default) so the worker-pool drain (see controllers.HTTPController.Shutdown)
-	// has a chance to log an explicit abandonment before the kubelet SIGKILLs the
-	// process, instead of the drain silently running out the clock unbounded.
-	v.SetDefault("shutdownTimeout", 25*time.Second)
+	// cmd/http/main.go spends up to 5s on the HTTP server's own Shutdown before this
+	// phase (the worker-pool drain, see controllers.HTTPController.Shutdown) even
+	// starts. 20s here keeps the combined worst case at 25s, safely under Kubernetes'
+	// typical terminationGracePeriodSeconds (30s default), so the drain has a chance
+	// to log an explicit abandonment before the kubelet SIGKILLs the process, instead
+	// of silently running out the clock past the grace period.
+	v.SetDefault("shutdownTimeout", 20*time.Second)
 	v.SetDefault("vexGeneration", false)
 	v.SetDefault("namespace", "kubescape")
 	v.SetDefault("scanEmbeddedSBOMs", false)

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	ScanEmbeddedSboms       bool              `mapstructure:"scanEmbeddedSBOMs"`
 	ScanTimeout             time.Duration     `mapstructure:"scanTimeout"`
 	ScannerReadinessTimeout time.Duration     `mapstructure:"scannerReadinessTimeout"`
+	ShutdownTimeout         time.Duration     `mapstructure:"shutdownTimeout"`
 	RiskAcceptance          bool              `mapstructure:"riskAcceptance"`
 	Storage                 bool              `mapstructure:"storage"`
 	StoreFilteredSbom       bool              `mapstructure:"storeFilteredSbom"`
@@ -79,6 +80,11 @@ func LoadConfig(path string) (Config, error) {
 	v.SetDefault("scanConcurrency", 1)
 	v.SetDefault("scanTimeout", 5*time.Minute)
 	v.SetDefault("scannerReadinessTimeout", 60*time.Second)
+	// Kept safely under Kubernetes' typical terminationGracePeriodSeconds (30s
+	// default) so the worker-pool drain (see controllers.HTTPController.Shutdown)
+	// has a chance to log an explicit abandonment before the kubelet SIGKILLs the
+	// process, instead of the drain silently running out the clock unbounded.
+	v.SetDefault("shutdownTimeout", 25*time.Second)
 	v.SetDefault("vexGeneration", false)
 	v.SetDefault("namespace", "kubescape")
 	v.SetDefault("scanEmbeddedSBOMs", false)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestLoadConfigShutdownTimeoutDefault(t *testing.T) {
 	viper.Reset()
 	c, err := LoadConfig("testdata")
 	assert.NoError(t, err)
-	assert.Equal(t, 25*time.Second, c.ShutdownTimeout)
+	assert.Equal(t, 20*time.Second, c.ShutdownTimeout)
 }
 
 func TestLoadConfigNotFound(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,13 @@ func TestLoadConfig(t *testing.T) {
 	viper.Reset()
 	_, err := LoadConfig("testdata")
 	assert.NoError(t, err)
+}
+
+func TestLoadConfigShutdownTimeoutDefault(t *testing.T) {
+	viper.Reset()
+	c, err := LoadConfig("testdata")
+	assert.NoError(t, err)
+	assert.Equal(t, 25*time.Second, c.ShutdownTimeout)
 }
 
 func TestLoadConfigNotFound(t *testing.T) {

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	wssc "github.com/armosec/armoapi-go/apis"
 	"github.com/gammazero/workerpool"
@@ -274,8 +275,31 @@ func registryScanCommandToScanCommand(c wssc.RegistryScanCommand) domain.ScanCom
 	return command
 }
 
-func (h HTTPController) Shutdown() {
+// Shutdown drains the worker pool's queued and running scans, but bounds how long it
+// waits. workerPool.StopWait() alone has no deadline of its own — it waits for the
+// entire queued backlog to finish, not just the task currently running — which for
+// scanConcurrency=1 with a full queue can run far longer than Kubernetes'
+// terminationGracePeriodSeconds. Without a bound here, that difference is invisible: the
+// process just gets SIGKILLed mid-drain with no log trace of what was abandoned. timeout
+// should be kept safely under the pod's terminationGracePeriodSeconds so this path has a
+// chance to log before that happens.
+func (h HTTPController) Shutdown(timeout time.Duration) {
 	logger.L().Info("purging SBOM creation queue",
-		helpers.String("remaining jobs", strconv.Itoa(h.workerPool.WaitingQueueSize())))
-	h.workerPool.StopWait()
+		helpers.String("remaining jobs", strconv.Itoa(h.workerPool.WaitingQueueSize())),
+		helpers.String("timeout", timeout.String()))
+
+	drained := make(chan struct{})
+	go func() {
+		h.workerPool.StopWait()
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		logger.L().Info("SBOM creation queue drained")
+	case <-time.After(timeout):
+		logger.L().Warning("shutdown timeout reached, abandoning queued/running scans",
+			helpers.String("remaining jobs", strconv.Itoa(h.workerPool.WaitingQueueSize())),
+			helpers.String("timeout", timeout.String()))
+	}
 }

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -275,14 +275,14 @@ func registryScanCommandToScanCommand(c wssc.RegistryScanCommand) domain.ScanCom
 	return command
 }
 
-// Shutdown drains the worker pool's queued and running scans, but bounds how long it
-// waits. workerPool.StopWait() alone has no deadline of its own — it waits for the
-// entire queued backlog to finish, not just the task currently running — which for
-// scanConcurrency=1 with a full queue can run far longer than Kubernetes'
-// terminationGracePeriodSeconds. Without a bound here, that difference is invisible: the
-// process just gets SIGKILLed mid-drain with no log trace of what was abandoned. timeout
-// should be kept safely under the pod's terminationGracePeriodSeconds so this path has a
-// chance to log before that happens.
+// Shutdown abandons queued-but-not-started scans immediately and waits only for
+// currently running scans to finish, bounded by timeout. workerPool.Stop() (as opposed
+// to StopWait()) already caps the wait at "currently running tasks", matching this
+// package's acceptance criteria of abandoning pending work rather than racing through
+// the whole backlog; timeout is the backstop for a running task that ignores ctx
+// cancellation (see #450) and would otherwise block Stop() indefinitely. timeout should
+// be kept safely under the pod's terminationGracePeriodSeconds so this path has a
+// chance to log before the kubelet SIGKILLs the process.
 func (h HTTPController) Shutdown(timeout time.Duration) {
 	logger.L().Info("purging SBOM creation queue",
 		helpers.String("remaining jobs", strconv.Itoa(h.workerPool.WaitingQueueSize())),
@@ -290,7 +290,7 @@ func (h HTTPController) Shutdown(timeout time.Duration) {
 
 	drained := make(chan struct{})
 	go func() {
-		h.workerPool.StopWait()
+		h.workerPool.Stop() // abandon the queue, wait only for in-flight scans
 		close(drained)
 	}()
 
@@ -298,8 +298,7 @@ func (h HTTPController) Shutdown(timeout time.Duration) {
 	case <-drained:
 		logger.L().Info("SBOM creation queue drained")
 	case <-time.After(timeout):
-		logger.L().Warning("shutdown timeout reached, abandoning queued/running scans",
-			helpers.String("remaining jobs", strconv.Itoa(h.workerPool.WaitingQueueSize())),
+		logger.L().Warning("shutdown timeout reached, abandoning in-flight scans",
 			helpers.String("timeout", timeout.String()))
 	}
 }

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -173,7 +173,7 @@ func TestHTTPController_ScanCP_MissingArgsDoesNotPanic(t *testing.T) {
 		scanService: services.NewMockScanService(true),
 		workerPool:  workerpool.New(1),
 	}
-	defer c.Shutdown()
+	defer c.Shutdown(5 * time.Second)
 
 	// gin.New() rather than gin.Default() so a regression that panics surfaces
 	// as an unrecovered panic in this test instead of being masked by
@@ -190,6 +190,38 @@ func TestHTTPController_ScanCP_MissingArgsDoesNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		router.ServeHTTP(w, req)
 	})
+}
+
+// TestHTTPController_Shutdown_BoundedByTimeout is a regression test for #467: Shutdown
+// used to delegate straight to workerPool.StopWait(), which blocks until every queued and
+// currently-running task finishes with no deadline of its own. A single stuck task (e.g. a
+// scan blocked on a backend call that ignores ctx cancellation, see #450) could therefore
+// hang shutdown indefinitely, well past Kubernetes' terminationGracePeriodSeconds, ending in
+// a silent SIGKILL instead of a bounded, logged abandonment.
+func TestHTTPController_Shutdown_BoundedByTimeout(t *testing.T) {
+	c := HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	}
+
+	blocked := make(chan struct{})
+	c.workerPool.Submit(func() {
+		<-blocked
+	})
+	// Unblock the stuck task once the test is done so the pool's background dispatcher
+	// goroutine (still draining in the background after Shutdown's timeout fires) can
+	// actually finish instead of leaking for the rest of the test binary's lifetime.
+	defer close(blocked)
+
+	const timeout = 100 * time.Millisecond
+	start := time.Now()
+	c.Shutdown(timeout)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 2*time.Second,
+		"Shutdown should return once its timeout elapses instead of blocking on a stuck task")
+	assert.GreaterOrEqual(t, elapsed, timeout,
+		"Shutdown should not return before its timeout when the pool hasn't drained yet")
 }
 
 func TestHTTPController_ScanRegistry(t *testing.T) {
@@ -377,7 +409,7 @@ func TestHTTPController_ContextCancellationIsDetached(t *testing.T) {
 		scanService: spy,
 		workerPool:  workerpool.New(4),
 	}
-	defer c.Shutdown()
+	defer c.Shutdown(5 * time.Second)
 
 	router := gin.Default()
 	router.POST("/v1/generateSBOM", c.GenerateSBOM)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,7 +73,7 @@ Kubevuln follows the hexagonal architecture pattern to achieve:
 |----------|-----------|
 | Async processing | Scan requests return immediately; work is queued |
 | Worker pool | Prevents resource exhaustion with concurrent scans |
-| Graceful shutdown | Waits for in-flight scans to complete |
+| Graceful shutdown | Abandons queued scans and waits for in-flight scans to complete, bounded by `shutdownTimeout` |
 | Modular adapters | Easy to upgrade Syft/Grype versions |
 | Interface-driven | All external dependencies accessed via ports |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -173,6 +173,12 @@ The main configuration file. All options can be overridden via environment varia
 | `scanEmbeddedSBOMs` | bool | `false` | Scan for embedded SBOMs in images |
 | `scannerReadinessTimeout` | duration | `60s` | Maximum time to wait for the SBOM scanner sidecar to become ready at startup. A value of `0` or less does not mean "wait forever": it makes the readiness deadline expire immediately, causing startup to fall back to the built-in Syft scanner right away. |
 
+#### Shutdown Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `shutdownTimeout` | duration | `20s` | Maximum time to wait for in-flight scans to finish when the process receives a shutdown signal; any not-yet-started, queued scans are abandoned immediately. This is added on top of the HTTP server's own fixed 5s shutdown window (hardcoded in `cmd/http/main.go`), not a replacement for it — budget `5s + shutdownTimeout` when sizing your pod's `terminationGracePeriodSeconds`. A value of `0` or less does not mean "wait forever": like `scannerReadinessTimeout`, it makes the deadline expire immediately, so the drain races the abandonment path from the start. |
+
 #### Vulnerability Database Options
 
 | Option | Type | Default | Description |
@@ -260,6 +266,11 @@ The main configuration file. All options can be overridden via environment varia
     "scannerReadinessTimeout": {
       "type": "string",
       "default": "60s",
+      "pattern": "^[0-9]+(s|m|h)$"
+    },
+    "shutdownTimeout": {
+      "type": "string",
+      "default": "20s",
       "pattern": "^[0-9]+(s|m|h)$"
     },
     "storage": {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -271,7 +271,7 @@ The main configuration file. All options can be overridden via environment varia
     "shutdownTimeout": {
       "type": "string",
       "default": "20s",
-      "pattern": "^[0-9]+(s|m|h)$"
+      "pattern": "^-?[0-9]+(s|m|h)$"
     },
     "storage": {
       "type": "boolean",


### PR DESCRIPTION
## Overview

`HTTPController.Shutdown` delegated straight to `workerpool.WorkerPool.StopWait`, which waits for the *entire* queued backlog to finish with no deadline of its own. Every scan handler (`GenerateSBOM`/`ScanCP`/`ScanCVE`/`ScanRegistry`) already writes its `200 OK` and detaches the real work onto the worker pool via `context.WithoutCancel` before returning, so by the time `srv.Shutdown`'s 5s budget in `main.go` runs, there's no in-flight HTTP handler left for it to bound — the real, unbounded wait happens afterward in `Shutdown`, invisible to that deadline.

With `scanConcurrency` defaulting to `1` and `scanTimeout` to 5 minutes, a handful of queued jobs at shutdown time could block the drain for many minutes — comfortably past Kubernetes' typical 30s `terminationGracePeriodSeconds`, with nothing logged beyond a single queue-size count at the very start. The kubelet ends up SIGKILLing the process mid-drain on every rolling deploy or scale-down that catches kubevuln with work queued, silently losing scans the caller was already told succeeded.

Fix, scoped to the shutdown/drain path only:
- New config field `shutdownTimeout` (`config/config.go`), defaulting to 25s — safely under a typical 30s termination grace period.
- `HTTPController.Shutdown` (`controllers/http.go`) now takes that timeout, runs `workerPool.StopWait()` in a goroutine, and selects between it completing and the timeout elapsing — logging explicitly which happened, including the remaining queue size in the timeout case.
- `cmd/http/main.go` passes `c.ShutdownTimeout` through.

Not touched (intentionally, per the issue's own scoping): backpressure on `Submit`/bounded queue depth, and the separate `SendStatus`/`ReportError` ctx-ignoring gap tracked in #450 — both are flagged in #467 as needing a maintainer decision on desired client-facing behavior, not something to guess at silently in this PR.

## How to Test

- Added `TestHTTPController_Shutdown_BoundedByTimeout` (`controllers/http_test.go`): submits a task that blocks forever on a channel, calls `Shutdown(100ms)`, and asserts it returns close to that timeout instead of hanging — regression guard for the exact bug this PR fixes.
- Added `TestLoadConfigShutdownTimeoutDefault` (`config/config_test.go`) asserting the 25s default.
- Updated the three existing `.Shutdown()` call sites (two in `controllers/http_test.go`, one in `cmd/http/main_test.go`) to the new signature.
- `go build ./...`, `go vet ./...`: clean.
- `go test ./...`: clean, except the pre-existing `Test_grypeAdapter_DBVersion`/`Test_grypeAdapter_ScanSBOM`/`TestScanService_NginxTest`, which fail in this environment with `panic: rootless Docker is not supported on Windows` — unrelated `testcontainers`/Docker-dependent tests, not touched by this change.

## Related issues/PRs

Resolved #467

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable shutdown timeout for active scans, defaulting to 20 seconds.
  * HTTP shutdown now provides an additional five-second termination window.

* **Bug Fixes**
  * Prevented shutdown from hanging indefinitely when active work remains blocked.
  * Queued scans are abandoned when shutdown begins, while in-flight scans are allowed to finish within the configured timeout.
  * Shutdown errors are logged without terminating the process prematurely.

* **Documentation**
  * Documented shutdown timing, scan-draining behavior, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->