### PR TITLE
fix(core): reconcile cached manifests with the current SecurityException set

### DIFF
--- a/adapters/mockplatform.go
+++ b/adapters/mockplatform.go
@@ -48,12 +48,18 @@ func (m MockPlatform) GetCVEExceptions(ctx context.Context) (domain.CVEException
 	seList, cseList, err := m.securityExceptionRepo.GetSecurityExceptions(ctx, namespace)
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions", helpers.Error(err))
-		return domain.CVEExceptions{}, nil
+		return domain.CVEExceptions{}, domain.ErrExceptionsDegraded
 	}
 
 	if len(seList) > 0 || len(cseList) > 0 {
 		target := v1.BuildExceptionTarget(ctx, workload, seList, cseList, m.securityExceptionRepo)
 		policies := v1.ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
+		// A selector-based exception whose labels failed to resolve fails closed,
+		// making the merged set incomplete (see matchExceptionTarget).
+		if (v1.UsesObjectSelector(seList, cseList) && !target.WorkloadLabelsResolved) ||
+			(v1.UsesNamespaceSelector(cseList) && !target.NamespaceLabelsResolved) {
+			return policies, domain.ErrExceptionsDegraded
+		}
 		return policies, nil
 	}
 
@@ -85,4 +91,3 @@ func (m MockPlatform) SubmitCVE(ctx context.Context, _ domain.CVEManifest, _ dom
 	defer span.End()
 	return nil
 }
-

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -200,12 +201,15 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	}
 
 	// Merge CRD-based exceptions
+	degraded := false
 	seList, cseList, crdErr := a.securityExceptionRepo.GetSecurityExceptions(ctx, namespace)
 	if crdErr != nil {
 		logger.L().Ctx(ctx).Warning("failed to get CRD security exceptions", helpers.Error(crdErr))
-		// This is a best-effort degradation that self-heals on the next scan;
-		// caching it would suppress valid CRD exceptions for the full TTL.
+		// Best-effort degradation that self-heals on the next scan. The set is
+		// incomplete: caching it would suppress valid CRD exceptions for the full
+		// TTL, and callers must not persist "removals" computed from it.
 		cacheable = false
+		degraded = true
 	} else if len(seList) > 0 || len(cseList) > 0 {
 		target := BuildExceptionTarget(ctx, workload, seList, cseList, a.securityExceptionRepo)
 		crdPolicies := ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
@@ -214,14 +218,19 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 		// A selector-based exception whose labels failed to resolve fails closed
 		// (see matchExceptionTarget), which is also a self-healing degradation and
 		// must not be cached as if it were the authoritative result.
-		if (usesObjectSelector(seList, cseList) && !target.WorkloadLabelsResolved) ||
-			(usesNamespaceSelector(cseList) && !target.NamespaceLabelsResolved) {
+		if (UsesObjectSelector(seList, cseList) && !target.WorkloadLabelsResolved) ||
+			(UsesNamespaceSelector(cseList) && !target.NamespaceLabelsResolved) {
 			cacheable = false
+			degraded = true
 		}
 	}
 
 	if cacheable && a.exceptionsCache != nil {
 		a.exceptionsCache.Set(cacheKey, domain.CVEExceptions(vulnExceptionList), exceptionsCacheTTL)
+	}
+
+	if degraded {
+		return vulnExceptionList, domain.ErrExceptionsDegraded
 	}
 
 	return vulnExceptionList, nil
@@ -384,7 +393,7 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 
 	// get exceptions
 	exceptions, err := a.GetCVEExceptions(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, domain.ErrExceptionsDegraded) {
 		return fmt.Errorf("failed to get exceptions: %w", err)
 	}
 	// convert to vulnerabilities

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -234,9 +234,9 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenCRDLookupFails(t *testi
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
 	_, err := a.GetCVEExceptions(ctx)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, domain.ErrExceptionsDegraded, "degraded CRD merges must be reported as incomplete")
 	_, err = a.GetCVEExceptions(ctx)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, domain.ErrExceptionsDegraded, "degraded CRD merges must be reported as incomplete")
 	assert.Equal(t, 2, calls, "degraded CRD merges should not be cached")
 }
 
@@ -268,9 +268,9 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheUnresolvedSelectorLabels(t 
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
 	_, err := a.GetCVEExceptions(ctx)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, domain.ErrExceptionsDegraded, "selector-based degradation must be reported as incomplete")
 	_, err = a.GetCVEExceptions(ctx)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, domain.ErrExceptionsDegraded, "selector-based degradation must be reported as incomplete")
 	assert.Equal(t, 2, calls, "selector-based degradations should not be cached")
 }
 

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -155,6 +155,46 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 	doc.Matches = remaining
 }
 
+// RestoreSuppressedMatches is the inverse of ApplySecurityExceptions: it returns a copy of doc
+// with every ignored match moved back into Matches and IgnoredMatches cleared, reconstructing the
+// original unfiltered manifest so a cached (filtered) manifest can be re-evaluated against the
+// current SecurityException set. The input document is not mutated, mirroring
+// ApplySecurityExceptions' copy semantics.
+//
+// Restoring every ignored match is safe: grype produces no ignored matches here (GrypeAdapter
+// sets neither VulnerabilityMatcher.IgnoreRules nor VexProcessor — grype vulnerability_matcher.go
+// applyIgnoreRules/findVEXMatches), so each stored ignored match is exception-applied. It is also
+// the fail-open direction for a security tool: if that assumption ever breaks, findings surface
+// rather than stay hidden. Reconstruction is lossless because IgnoredMatch embeds the full Match.
+func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument {
+	if doc == nil {
+		return nil
+	}
+	restored := doc.DeepCopy()
+	for _, im := range restored.IgnoredMatches {
+		restored.Matches = append(restored.Matches, im.Match)
+	}
+	restored.IgnoredMatches = nil
+	return restored
+}
+
+// IgnoredVulnIDs returns the set of vulnerability IDs in a manifest's ignored matches. Keyed by
+// ID because SecurityException policies match on vulnerability name only
+// (getCVEExceptionMatchCVENameFromList), so a policy suppresses every match of that CVE or none —
+// an ID set is sufficient to detect exception-set changes on cache hits.
+func IgnoredVulnIDs(doc *v1beta1.GrypeDocument) map[string]struct{} {
+	ids := map[string]struct{}{}
+	if doc == nil {
+		return ids
+	}
+	for _, im := range doc.IgnoredMatches {
+		if im.Match.Vulnerability.ID != "" {
+			ids[im.Match.Vulnerability.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
 func buildDesignators(resources []sev1beta1.ResourceMatch, namespace string) []identifiers.PortalDesignator {
 	if len(resources) == 0 {
 		// No specific resource match — create a namespace-only designator

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -156,43 +156,67 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 }
 
 // RestoreSuppressedMatches is the inverse of ApplySecurityExceptions: it returns a copy of doc
-// with every ignored match moved back into Matches and IgnoredMatches cleared, reconstructing the
-// original unfiltered manifest so a cached (filtered) manifest can be re-evaluated against the
-// current SecurityException set. The input document is not mutated, mirroring
-// ApplySecurityExceptions' copy semantics.
+// with exception-applied ignored matches moved back into Matches, reconstructing the original
+// unfiltered manifest so a cached (filtered) manifest can be re-evaluated against the current
+// SecurityException set. The input document is not mutated, mirroring ApplySecurityExceptions'
+// copy semantics. When there is nothing to restore, the input document is returned unchanged —
+// the only caller hands the result to applyExceptionsToManifest, which copies before mutating,
+// so the shared stored object is never modified.
 //
-// Restoring every ignored match is safe: grype produces no ignored matches here (GrypeAdapter
-// sets neither VulnerabilityMatcher.IgnoreRules nor VexProcessor — grype vulnerability_matcher.go
-// applyIgnoreRules/findVEXMatches), so each stored ignored match is exception-applied. It is also
-// the fail-open direction for a security tool: if that assumption ever breaks, findings surface
-// rather than stay hidden. Reconstruction is lossless because IgnoredMatch embeds the full Match.
+// Only ignored matches carrying the signature ApplySecurityExceptions writes (a single ignore
+// rule with only the vulnerability ID set) are restored. Any other entry (e.g. one that would be
+// produced if GrypeAdapter ever wired up IgnoreRules/VexProcessor) is preserved, so the helper is
+// self-guarding instead of relying on an assumption. Reconstruction is lossless because
+// IgnoredMatch embeds the full Match.
 func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument {
 	if doc == nil {
 		return nil
 	}
-	restored := doc.DeepCopy()
-	for _, im := range restored.IgnoredMatches {
-		restored.Matches = append(restored.Matches, im.Match)
+	if len(doc.IgnoredMatches) == 0 {
+		return doc
 	}
-	restored.IgnoredMatches = nil
+	restored := doc.DeepCopy()
+	var kept []v1beta1.IgnoredMatch
+	for _, im := range restored.IgnoredMatches {
+		if isExceptionSourcedIgnore(im) {
+			restored.Matches = append(restored.Matches, im.Match)
+		} else {
+			kept = append(kept, im)
+		}
+	}
+	restored.IgnoredMatches = kept
 	return restored
 }
 
-// IgnoredVulnIDs returns the set of vulnerability IDs in a manifest's ignored matches. Keyed by
-// ID because SecurityException policies match on vulnerability name only
-// (getCVEExceptionMatchCVENameFromList), so a policy suppresses every match of that CVE or none —
-// an ID set is sufficient to detect exception-set changes on cache hits.
-func IgnoredVulnIDs(doc *v1beta1.GrypeDocument) map[string]struct{} {
-	ids := map[string]struct{}{}
+// isExceptionSourcedIgnore reports whether an ignored match carries the AppliedIgnoreRules
+// signature ApplySecurityExceptions writes: exactly one rule whose only field is the
+// vulnerability ID.
+func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
+	if len(im.AppliedIgnoreRules) != 1 {
+		return false
+	}
+	r := im.AppliedIgnoreRules[0]
+	return r.FixState == "" && r.Package == nil
+}
+
+// IgnoredMatchKeys returns the set of match-identity keys for a manifest's ignored matches.
+// Keyed by vulnerability ID + artifact name + version (via \x00 separators) rather than CVE ID
+// alone, because an ExpiredOnFix policy suppresses only the matches of a CVE whose
+// Fix.State != "fixed" (getCVEExceptionMatchCVENameFromList), so two matches of the same CVE can
+// have different suppression states. The manifest content is fixed across a cache hit, so these
+// keys are stable and detect both ID- and fix-state-driven changes to the ignored set.
+func IgnoredMatchKeys(doc *v1beta1.GrypeDocument) map[string]struct{} {
+	keys := map[string]struct{}{}
 	if doc == nil {
-		return ids
+		return keys
 	}
 	for _, im := range doc.IgnoredMatches {
-		if im.Match.Vulnerability.ID != "" {
-			ids[im.Match.Vulnerability.ID] = struct{}{}
+		m := im.Match
+		if m.Vulnerability.ID != "" {
+			keys[m.Vulnerability.ID+"\x00"+m.Artifact.Name+"\x00"+m.Artifact.Version] = struct{}{}
 		}
 	}
-	return ids
+	return keys
 }
 
 func buildDesignators(resources []sev1beta1.ResourceMatch, namespace string) []identifiers.PortalDesignator {

--- a/adapters/v1/securityexception_match.go
+++ b/adapters/v1/securityexception_match.go
@@ -188,7 +188,7 @@ func BuildExceptionTarget(ctx context.Context, workload domain.ScanCommand, exce
 	// Labels are resolved only when a selector actually needs them. A failed
 	// resolution leaves the corresponding *Resolved flag false so the selector
 	// fails closed in matchExceptionTarget.
-	if usesObjectSelector(exceptions, clusterExceptions) && namespace != "" && kind != "" && name != "" {
+	if UsesObjectSelector(exceptions, clusterExceptions) && namespace != "" && kind != "" && name != "" {
 		if lbls, err := repo.GetWorkloadLabels(ctx, namespace, kind, name); err != nil {
 			logger.L().Ctx(ctx).Warning("failed to resolve workload labels for SecurityException objectSelector; exception will not apply to this workload",
 				helpers.Error(err), helpers.String("namespace", namespace), helpers.String("kind", kind), helpers.String("name", name))
@@ -198,7 +198,7 @@ func BuildExceptionTarget(ctx context.Context, workload domain.ScanCommand, exce
 		}
 	}
 
-	if usesNamespaceSelector(clusterExceptions) && namespace != "" {
+	if UsesNamespaceSelector(clusterExceptions) && namespace != "" {
 		if lbls, err := repo.GetNamespaceLabels(ctx, namespace); err != nil {
 			logger.L().Ctx(ctx).Warning("failed to resolve namespace labels for ClusterSecurityException namespaceSelector; exception will not apply to this namespace",
 				helpers.Error(err), helpers.String("namespace", namespace))
@@ -211,7 +211,10 @@ func BuildExceptionTarget(ctx context.Context, workload domain.ScanCommand, exce
 	return target
 }
 
-func usesObjectSelector(exceptions []sev1beta1.SecurityException, clusterExceptions []sev1beta1.ClusterSecurityException) bool {
+// UsesObjectSelector reports whether any of the given exceptions targets workloads by
+// objectSelector. Such exceptions fail closed when the workload's labels cannot be
+// resolved, making the merged exception set incomplete.
+func UsesObjectSelector(exceptions []sev1beta1.SecurityException, clusterExceptions []sev1beta1.ClusterSecurityException) bool {
 	for i := range exceptions {
 		if exceptions[i].Spec.Match.ObjectSelector != nil {
 			return true
@@ -225,7 +228,10 @@ func usesObjectSelector(exceptions []sev1beta1.SecurityException, clusterExcepti
 	return false
 }
 
-func usesNamespaceSelector(clusterExceptions []sev1beta1.ClusterSecurityException) bool {
+// UsesNamespaceSelector reports whether any of the given cluster exceptions targets
+// namespaces by namespaceSelector. Such exceptions fail closed when the namespace's
+// labels cannot be resolved, making the merged exception set incomplete.
+func UsesNamespaceSelector(clusterExceptions []sev1beta1.ClusterSecurityException) bool {
 	for i := range clusterExceptions {
 		if clusterExceptions[i].Spec.Match.NamespaceSelector != nil {
 			return true

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -499,7 +499,7 @@ func TestApplySecurityExceptions_MatchesByAlias(t *testing.T) {
 }
 
 func TestRestoreSuppressedMatches(t *testing.T) {
-	t.Run("restores every ignored match and clears IgnoredMatches", func(t *testing.T) {
+	t.Run("restores exception-applied ignored matches and clears IgnoredMatches", func(t *testing.T) {
 		doc := &v1beta1.GrypeDocument{
 			Matches: []v1beta1.Match{
 				{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-KEEP"}}},
@@ -523,7 +523,7 @@ func TestRestoreSuppressedMatches(t *testing.T) {
 		assert.Len(t, doc.IgnoredMatches, 2, "input document must not be mutated")
 
 		require.NotNil(t, restored)
-		assert.Len(t, restored.IgnoredMatches, 0, "all ignored matches are restored")
+		assert.Len(t, restored.IgnoredMatches, 0, "all exception-applied ignored matches are restored")
 		require.Len(t, restored.Matches, 3)
 		// existing matches are preserved first, restored matches appended after
 		assert.Equal(t, "CVE-KEEP", restored.Matches[0].Vulnerability.ID)
@@ -535,7 +535,7 @@ func TestRestoreSuppressedMatches(t *testing.T) {
 		assert.Nil(t, RestoreSuppressedMatches(nil))
 	})
 
-	t.Run("no ignored matches returns a copy with Matches intact", func(t *testing.T) {
+	t.Run("no ignored matches returns the input document unchanged (no copy)", func(t *testing.T) {
 		doc := &v1beta1.GrypeDocument{
 			Matches: []v1beta1.Match{
 				{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-1"}}},
@@ -545,13 +545,38 @@ func TestRestoreSuppressedMatches(t *testing.T) {
 		restored := RestoreSuppressedMatches(doc)
 
 		require.NotNil(t, restored)
+		assert.Same(t, doc, restored, "no ignored matches must not trigger a deep copy")
 		assert.Len(t, restored.Matches, 1)
 		assert.Len(t, restored.IgnoredMatches, 0)
 	})
+
+	t.Run("preserves non-exception-applied ignored matches", func(t *testing.T) {
+		doc := &v1beta1.GrypeDocument{
+			IgnoredMatches: []v1beta1.IgnoredMatch{
+				{
+					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-A"}}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-A"}},
+				},
+				{
+					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-NATIVE"}}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-NATIVE", FixState: "not-fixed"}},
+				},
+			},
+		}
+
+		restored := RestoreSuppressedMatches(doc)
+
+		require.NotNil(t, restored)
+		// only the exception-shaped entry is restored; the other is preserved
+		assert.Len(t, restored.Matches, 1)
+		assert.Equal(t, "CVE-A", restored.Matches[0].Vulnerability.ID)
+		require.Len(t, restored.IgnoredMatches, 1)
+		assert.Equal(t, "CVE-NATIVE", restored.IgnoredMatches[0].Match.Vulnerability.ID)
+	})
 }
 
-func TestIgnoredVulnIDs(t *testing.T) {
-	t.Run("collects non-empty ignored vulnerability IDs", func(t *testing.T) {
+func TestIgnoredMatchKeys(t *testing.T) {
+	t.Run("collects match-identity keys for non-empty ignored IDs", func(t *testing.T) {
 		doc := &v1beta1.GrypeDocument{
 			IgnoredMatches: []v1beta1.IgnoredMatch{
 				{Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-A"}}}},
@@ -559,25 +584,37 @@ func TestIgnoredVulnIDs(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, map[string]struct{}{"CVE-A": {}}, IgnoredVulnIDs(doc))
+		assert.Equal(t, map[string]struct{}{"CVE-A\x00\x00": {}}, IgnoredMatchKeys(doc))
 	})
 
 	t.Run("nil document returns an empty set", func(t *testing.T) {
-		assert.Empty(t, IgnoredVulnIDs(nil))
+		assert.Empty(t, IgnoredMatchKeys(nil))
 	})
 }
 
-func TestIgnoredVulnIDs_MultiPackageSameCVE(t *testing.T) {
-	// Pins the match-by-CVE invariant: a SecurityException policy matches on vulnerability
-	// name only, so it suppresses every match of that CVE or none. Multiple packages sharing
-	// a CVE therefore collapse into a single set entry, which is sufficient to detect
-	// exception-set changes on cache hits.
+func TestIgnoredMatchKeys_DistinctKeysPerPackage(t *testing.T) {
+	// Keys include artifact name and version so that ExpiredOnFix transitions, which can
+	// suppress only some matches of a CVE, are detected (see IgnoredMatchKeys doc).
 	doc := &v1beta1.GrypeDocument{
 		IgnoredMatches: []v1beta1.IgnoredMatch{
-			{Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}}},
-			{Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}}},
+			{Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}},
+				Artifact:      v1beta1.GrypePackage{Name: "log4j-api", Version: "2.17.0"},
+			}},
+			{Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}},
+				Artifact:      v1beta1.GrypePackage{Name: "log4j-core", Version: "2.17.0"},
+			}},
+			{Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}},
+				Artifact:      v1beta1.GrypePackage{Name: "log4j-api", Version: "2.15.0"},
+			}},
 		},
 	}
 
-	assert.Equal(t, map[string]struct{}{"CVE-2021-44228": {}}, IgnoredVulnIDs(doc))
+	assert.Equal(t, map[string]struct{}{
+		"CVE-2021-44228\x00log4j-api\x002.17.0":  {},
+		"CVE-2021-44228\x00log4j-core\x002.17.0": {},
+		"CVE-2021-44228\x00log4j-api\x002.15.0":  {},
+	}, IgnoredMatchKeys(doc))
 }

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -9,6 +9,7 @@ import (
 	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -495,4 +496,88 @@ func TestApplySecurityExceptions_MatchesByAlias(t *testing.T) {
 	assert.Equal(t, "CVE-2023-9999", doc.Matches[0].Vulnerability.ID)
 	assert.Len(t, doc.IgnoredMatches, 1)
 	assert.Equal(t, "GHSA-jfh8-c2jp-5v3q", doc.IgnoredMatches[0].Vulnerability.ID)
+}
+
+func TestRestoreSuppressedMatches(t *testing.T) {
+	t.Run("restores every ignored match and clears IgnoredMatches", func(t *testing.T) {
+		doc := &v1beta1.GrypeDocument{
+			Matches: []v1beta1.Match{
+				{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-KEEP"}}},
+			},
+			IgnoredMatches: []v1beta1.IgnoredMatch{
+				{
+					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-A"}}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-A"}},
+				},
+				{
+					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-B"}}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-B"}},
+				},
+			},
+		}
+
+		restored := RestoreSuppressedMatches(doc)
+
+		// the input document is not mutated
+		assert.Len(t, doc.Matches, 1, "input document must not be mutated")
+		assert.Len(t, doc.IgnoredMatches, 2, "input document must not be mutated")
+
+		require.NotNil(t, restored)
+		assert.Len(t, restored.IgnoredMatches, 0, "all ignored matches are restored")
+		require.Len(t, restored.Matches, 3)
+		// existing matches are preserved first, restored matches appended after
+		assert.Equal(t, "CVE-KEEP", restored.Matches[0].Vulnerability.ID)
+		assert.Equal(t, "CVE-A", restored.Matches[1].Vulnerability.ID)
+		assert.Equal(t, "CVE-B", restored.Matches[2].Vulnerability.ID)
+	})
+
+	t.Run("nil document returns nil", func(t *testing.T) {
+		assert.Nil(t, RestoreSuppressedMatches(nil))
+	})
+
+	t.Run("no ignored matches returns a copy with Matches intact", func(t *testing.T) {
+		doc := &v1beta1.GrypeDocument{
+			Matches: []v1beta1.Match{
+				{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-1"}}},
+			},
+		}
+
+		restored := RestoreSuppressedMatches(doc)
+
+		require.NotNil(t, restored)
+		assert.Len(t, restored.Matches, 1)
+		assert.Len(t, restored.IgnoredMatches, 0)
+	})
+}
+
+func TestIgnoredVulnIDs(t *testing.T) {
+	t.Run("collects non-empty ignored vulnerability IDs", func(t *testing.T) {
+		doc := &v1beta1.GrypeDocument{
+			IgnoredMatches: []v1beta1.IgnoredMatch{
+				{Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-A"}}}},
+				{Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: ""}}}},
+			},
+		}
+
+		assert.Equal(t, map[string]struct{}{"CVE-A": {}}, IgnoredVulnIDs(doc))
+	})
+
+	t.Run("nil document returns an empty set", func(t *testing.T) {
+		assert.Empty(t, IgnoredVulnIDs(nil))
+	})
+}
+
+func TestIgnoredVulnIDs_MultiPackageSameCVE(t *testing.T) {
+	// Pins the match-by-CVE invariant: a SecurityException policy matches on vulnerability
+	// name only, so it suppresses every match of that CVE or none. Multiple packages sharing
+	// a CVE therefore collapse into a single set entry, which is sufficient to detect
+	// exception-set changes on cache hits.
+	doc := &v1beta1.GrypeDocument{
+		IgnoredMatches: []v1beta1.IgnoredMatch{
+			{Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}}},
+			{Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}}},
+		},
+	}
+
+	assert.Equal(t, map[string]struct{}{"CVE-2021-44228": {}}, IgnoredVulnIDs(doc))
 }

--- a/core/domain/scan.go
+++ b/core/domain/scan.go
@@ -30,6 +30,10 @@ var (
 	ErrCastingWorkload          = errors.New("casting workload")
 	ErrMockError                = errors.New("mock error")
 	ErrTooManyRequests          = errors.New("too many requests")
+	// ErrExceptionsDegraded indicates the SecurityException set is incomplete
+	// (e.g. the CRD list failed). Callers must not treat missing exceptions as
+	// deletions.
+	ErrExceptionsDegraded = errors.New("exception set is incomplete")
 )
 
 type ScanIDKey struct{}

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -312,7 +313,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 
 			// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-			filteredCve := s.applyExceptionsToManifest(ctx, cve)
+			filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
 
 			// store filtered CVE
 			if s.storage {
@@ -330,9 +331,16 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 				}
 			}
 		} else {
-			filteredCve := s.applyExceptionsToManifest(ctx, cve)
+			// A cached manifest was filtered against the exception set at store time.
+			// Reconstruct the unfiltered manifest so the CURRENT exception set is
+			// re-evaluated (deleted exceptions un-suppress findings) and
+			// SubmitCVE/StoreVEX receive the same unfiltered data a cache miss would
+			// produce.
+			prevIgnored := v1.IgnoredVulnIDs(cve.Content)
+			cve.Content = v1.RestoreSuppressedMatches(cve.Content)
+			filteredCve, exceptionsFetched := s.applyExceptionsToManifest(ctx, cve)
 
-			if s.storage && len(filteredCve.Content.IgnoredMatches) > len(cve.Content.IgnoredMatches) {
+			if s.storage && exceptionsFetched && !maps.Equal(prevIgnored, v1.IgnoredVulnIDs(filteredCve.Content)) {
 				err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
 				if err != nil {
 					logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
@@ -377,7 +385,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 
 			// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-			filteredCvep := s.applyExceptionsToManifest(ctx, cvep)
+			filteredCvep, _ := s.applyExceptionsToManifest(ctx, cvep)
 
 			// store filtered CVE'
 			if s.storage {
@@ -521,7 +529,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 		}
 
 		// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-		filteredCve := s.applyExceptionsToManifest(ctx, cve)
+		filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
 
 		// store filtered CVE
 		if s.storage {
@@ -537,9 +545,15 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 			}
 		}
 	} else {
-		filteredCve := s.applyExceptionsToManifest(ctx, cve)
+		// A cached manifest was filtered against the exception set at store time.
+		// Reconstruct the unfiltered manifest so the CURRENT exception set is
+		// re-evaluated (deleted exceptions un-suppress findings) and SubmitCVE
+		// receives the same unfiltered data a cache miss would produce.
+		prevIgnored := v1.IgnoredVulnIDs(cve.Content)
+		cve.Content = v1.RestoreSuppressedMatches(cve.Content)
+		filteredCve, exceptionsFetched := s.applyExceptionsToManifest(ctx, cve)
 
-		if s.storage && len(filteredCve.Content.IgnoredMatches) > len(cve.Content.IgnoredMatches) {
+		if s.storage && exceptionsFetched && !maps.Equal(prevIgnored, v1.IgnoredVulnIDs(filteredCve.Content)) {
 			err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
 			if err != nil {
 				logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
@@ -654,24 +668,28 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 
 // applyExceptionsToManifest returns a filtered copy of the CVE manifest with
 // SecurityException policies applied. The original manifest is not mutated,
-// so callers can still use it for SubmitCVE (cloud reporting).
-func (s *ScanService) applyExceptionsToManifest(ctx context.Context, cve domain.CVEManifest) domain.CVEManifest {
+// so callers can still use it for SubmitCVE (cloud reporting). The returned
+// bool reports whether the current exception set was fetched successfully;
+// cache-hit callers must not persist the result on a failed fetch, so a
+// transient error cannot wipe previously applied exceptions from the stored
+// manifest.
+func (s *ScanService) applyExceptionsToManifest(ctx context.Context, cve domain.CVEManifest) (domain.CVEManifest, bool) {
 	if cve.Content == nil {
-		return cve
+		return cve, false
 	}
 	exceptions, err := s.platform.GetCVEExceptions(ctx)
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to get CVE exceptions for filtering", helpers.Error(err))
-		return cve
+		return cve, false
 	}
 	if len(exceptions) == 0 {
-		return cve
+		return cve, true
 	}
 	filtered := cve
 	docCopy := cve.Content.DeepCopy()
 	v1.ApplySecurityExceptions(docCopy, exceptions)
 	filtered.Content = docCopy
-	return filtered
+	return filtered, true
 }
 
 func addTimestamp(ctx context.Context) context.Context {

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -333,23 +333,39 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		} else {
 			// A cached manifest was filtered against the exception set at store time.
 			// Reconstruct the unfiltered manifest so the CURRENT exception set is
-			// re-evaluated (deleted exceptions un-suppress findings) and
-			// SubmitCVE/StoreVEX receive the same unfiltered data a cache miss would
-			// produce.
-			prevIgnored := v1.IgnoredVulnIDs(cve.Content)
+			// re-evaluated (deleted exceptions and ExpiredOnFix transitions
+			// un-suppress findings) and SubmitCVE/StoreVEX receive the same
+			// unfiltered data a cache miss would produce.
+			prevIgnored := v1.IgnoredMatchKeys(cve.Content)
 			cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-			filteredCve, exceptionsFetched := s.applyExceptionsToManifest(ctx, cve)
+			filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
 
-			if s.storage && exceptionsFetched && !maps.Equal(prevIgnored, v1.IgnoredVulnIDs(filteredCve.Content)) {
-				err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-				if err != nil {
-					logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
-						helpers.String("imageSlug", slug))
-				}
-				err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-				if err != nil {
-					logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
-						helpers.String("imageSlug", slug))
+			if s.storage {
+				curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
+				if !maps.Equal(prevIgnored, curIgnored) {
+					// Persist additions freely, but never persist removals when the
+					// exception set is incomplete: a transient SecurityException CRD
+					// list failure must not look like a deletion and wipe suppression
+					// from the stored manifest.
+					hasRemovals := false
+					for k := range prevIgnored {
+						if _, ok := curIgnored[k]; !ok {
+							hasRemovals = true
+							break
+						}
+					}
+					if exceptionsComplete || !hasRemovals {
+						err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
+						if err != nil {
+							logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
+								helpers.String("imageSlug", slug))
+						}
+						err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
+						if err != nil {
+							logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
+								helpers.String("imageSlug", slug))
+						}
+					}
 				}
 			}
 		}
@@ -547,22 +563,39 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 	} else {
 		// A cached manifest was filtered against the exception set at store time.
 		// Reconstruct the unfiltered manifest so the CURRENT exception set is
-		// re-evaluated (deleted exceptions un-suppress findings) and SubmitCVE
-		// receives the same unfiltered data a cache miss would produce.
-		prevIgnored := v1.IgnoredVulnIDs(cve.Content)
+		// re-evaluated (deleted exceptions and ExpiredOnFix transitions
+		// un-suppress findings) and SubmitCVE receives the same unfiltered data a
+		// cache miss would produce.
+		prevIgnored := v1.IgnoredMatchKeys(cve.Content)
 		cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-		filteredCve, exceptionsFetched := s.applyExceptionsToManifest(ctx, cve)
+		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
 
-		if s.storage && exceptionsFetched && !maps.Equal(prevIgnored, v1.IgnoredVulnIDs(filteredCve.Content)) {
-			err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-			if err != nil {
-				logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
-					helpers.String("imageSlug", workload.ImageSlug))
-			}
-			err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-			if err != nil {
-				logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
-					helpers.String("imageSlug", workload.ImageSlug))
+		if s.storage {
+			curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
+			if !maps.Equal(prevIgnored, curIgnored) {
+				// Persist additions freely, but never persist removals when the
+				// exception set is incomplete: a transient SecurityException CRD
+				// list failure must not look like a deletion and wipe suppression
+				// from the stored manifest.
+				hasRemovals := false
+				for k := range prevIgnored {
+					if _, ok := curIgnored[k]; !ok {
+						hasRemovals = true
+						break
+					}
+				}
+				if exceptionsComplete || !hasRemovals {
+					err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
+					if err != nil {
+						logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
+							helpers.String("imageSlug", workload.ImageSlug))
+					}
+					err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
+					if err != nil {
+						logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
+							helpers.String("imageSlug", workload.ImageSlug))
+					}
+				}
 			}
 		}
 	}
@@ -669,27 +702,29 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 // applyExceptionsToManifest returns a filtered copy of the CVE manifest with
 // SecurityException policies applied. The original manifest is not mutated,
 // so callers can still use it for SubmitCVE (cloud reporting). The returned
-// bool reports whether the current exception set was fetched successfully;
-// cache-hit callers must not persist the result on a failed fetch, so a
-// transient error cannot wipe previously applied exceptions from the stored
-// manifest.
+// bool reports whether the current exception set is known complete. A hard
+// fetch failure returns the manifest unfiltered with complete=false; a degraded
+// fetch (ErrExceptionsDegraded) still applies the partial set but reports
+// complete=false, so callers never persist "removals" computed from an
+// incomplete set.
 func (s *ScanService) applyExceptionsToManifest(ctx context.Context, cve domain.CVEManifest) (domain.CVEManifest, bool) {
 	if cve.Content == nil {
 		return cve, false
 	}
 	exceptions, err := s.platform.GetCVEExceptions(ctx)
-	if err != nil {
+	degraded := errors.Is(err, domain.ErrExceptionsDegraded)
+	if err != nil && !degraded {
 		logger.L().Ctx(ctx).Warning("failed to get CVE exceptions for filtering", helpers.Error(err))
 		return cve, false
 	}
 	if len(exceptions) == 0 {
-		return cve, true
+		return cve, !degraded
 	}
 	filtered := cve
 	docCopy := cve.Content.DeepCopy()
 	v1.ApplySecurityExceptions(docCopy, exceptions)
 	filtered.Content = docCopy
-	return filtered, true
+	return filtered, !degraded
 }
 
 func addTimestamp(ctx context.Context) context.Context {

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1436,10 +1436,7 @@ type recordingPlatform struct {
 var _ ports.Platform = (*recordingPlatform)(nil)
 
 func (p *recordingPlatform) GetCVEExceptions(context.Context) (domain.CVEExceptions, error) {
-	if p.getExceptionsErr != nil {
-		return nil, p.getExceptionsErr
-	}
-	return p.exceptions, nil
+	return p.exceptions, p.getExceptionsErr
 }
 
 func (p *recordingPlatform) SubmitCVE(_ context.Context, cve domain.CVEManifest, _ domain.CVEManifest) error {
@@ -1622,6 +1619,124 @@ func TestScanService_ScanCVE_CacheHit_ExceptionFetchFailureDoesNotWipe(t *testin
 	assert.Equal(t, "CVE-A", stored.Content.IgnoredMatches[0].Match.Vulnerability.ID)
 }
 
+// TestScanService_ScanCVE_CacheHit_ExpiredOnFixRestoresFixedMatch is the reproduction matthyx
+// provided during review: an ExpiredOnFix policy suppresses only the matches of a CVE whose
+// Fix.State != "fixed". When one CVE hits two packages with different fix states, the ignored-ID
+// set stays identical while the ignored-match set changes, so change detection must be keyed by
+// match identity, not CVE ID.
+func TestScanService_ScanCVE_CacheHit_ExpiredOnFixRestoresFixedMatch(t *testing.T) {
+	fixedMatch := matchForTest("CVE-X")
+	fixedMatch.Artifact = v1beta1.GrypePackage{Name: "pkgA", Version: "1.0.0"}
+	fixedMatch.Vulnerability.Fix = v1beta1.Fix{State: "fixed", Versions: []string{"1.0.1"}}
+
+	unfixedMatch := matchForTest("CVE-X")
+	unfixedMatch.Artifact = v1beta1.GrypePackage{Name: "pkgB", Version: "2.0.0"}
+	unfixedMatch.Vulnerability.Fix = v1beta1.Fix{State: "not-fixed"}
+
+	expiredOnFix := true
+	platform := &recordingPlatform{exceptions: domain.CVEExceptions{{
+		PolicyType:            "vulnerabilityExceptionPolicy",
+		Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+		VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-X"}},
+		ExpiredOnFix:          &expiredOnFix,
+	}}}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, repo, nil)
+
+	// cached: both matches suppressed by the earlier, wider policy (no ExpiredOnFix)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		IgnoredMatches: []v1beta1.IgnoredMatch{
+			{Match: fixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X"}}},
+			{Match: unfixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X"}}},
+		},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.Matches, 1, "pkgA (fixed) must be restored into Matches")
+	assert.Equal(t, "pkgA", stored.Content.Matches[0].Artifact.Name)
+	require.Len(t, stored.Content.IgnoredMatches, 1)
+	assert.Equal(t, "pkgB", stored.Content.IgnoredMatches[0].Match.Artifact.Name)
+}
+
+// TestScanService_ScanCVE_CacheHit_ExpiredOnFixWideningPersistsSuppression is the mirror case:
+// widening the exception (dropping ExpiredOnFix) must suppress the previously-visible fixed match.
+func TestScanService_ScanCVE_CacheHit_ExpiredOnFixWideningPersistsSuppression(t *testing.T) {
+	fixedMatch := matchForTest("CVE-X")
+	fixedMatch.Artifact = v1beta1.GrypePackage{Name: "pkgA", Version: "1.0.0"}
+	fixedMatch.Vulnerability.Fix = v1beta1.Fix{State: "fixed", Versions: []string{"1.0.1"}}
+
+	unfixedMatch := matchForTest("CVE-X")
+	unfixedMatch.Artifact = v1beta1.GrypePackage{Name: "pkgB", Version: "2.0.0"}
+	unfixedMatch.Vulnerability.Fix = v1beta1.Fix{State: "not-fixed"}
+
+	// new, wider policy: no ExpiredOnFix → both pkgA and pkgB suppressed
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-X")}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, repo, nil)
+
+	// cached: only pkgB was suppressed under the earlier ExpiredOnFix policy
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{fixedMatch},
+		IgnoredMatches: []v1beta1.IgnoredMatch{
+			{Match: unfixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X"}}},
+		},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	assert.Empty(t, stored.Content.Matches, "widening the exception must suppress pkgA too")
+	require.Len(t, stored.Content.IgnoredMatches, 2)
+}
+
+// TestScanService_ScanCVE_CacheHit_DegradedFetchDoesNotPersistRemoval verifies Blocker 1: a
+// transient SecurityException CRD list failure (ErrExceptionsDegraded, partial set) must not be
+// mistaken for an exception deletion and wipe suppression from the stored manifest.
+func TestScanService_ScanCVE_CacheHit_DegradedFetchDoesNotPersistRemoval(t *testing.T) {
+	platform := &recordingPlatform{
+		exceptions:       domain.CVEExceptions{}, // partial set: CVE-A exception missing (CRD list failed)
+		getExceptionsErr: domain.ErrExceptionsDegraded,
+	}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, repo, nil)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches:        []v1beta1.Match{matchForTest("CVE-B")},
+		IgnoredMatches: []v1beta1.IgnoredMatch{ignoredMatchForTest("CVE-A")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.IgnoredMatches, 1, "a degraded fetch must not persist an apparent removal")
+	assert.Equal(t, "CVE-A", stored.Content.IgnoredMatches[0].Match.Vulnerability.ID)
+}
+
+// TestScanService_ScanCVE_CacheHit_DegradedFetchPersistsAddition verifies that a purely additive
+// change is persisted even when the exception set is incomplete.
+func TestScanService_ScanCVE_CacheHit_DegradedFetchPersistsAddition(t *testing.T) {
+	platform := &recordingPlatform{
+		exceptions:       exceptionPolicyForTest("CVE-A"), // partial set still includes CVE-A
+		getExceptionsErr: domain.ErrExceptionsDegraded,
+	}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, repo, nil)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{matchForTest("CVE-A"), matchForTest("CVE-B")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.IgnoredMatches, 1, "a purely additive change must be persisted even when degraded")
+	assert.Equal(t, "CVE-A", stored.Content.IgnoredMatches[0].Match.Vulnerability.ID)
+}
+
 // TestScanService_ScanCVE_CacheMiss_UnfilteredToBackend guards the primary path: a fresh scan
 // stores the exception-filtered manifest but submits the unfiltered original to the backend.
 func TestScanService_ScanCVE_CacheMiss_UnfilteredToBackend(t *testing.T) {
@@ -1640,9 +1755,11 @@ func TestScanService_ScanCVE_CacheMiss_UnfilteredToBackend(t *testing.T) {
 }
 
 // TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch is the ScanCP mirror of
-// the ScanCVE regression test. The manifest handed to StoreVEX is the same object passed to
-// SubmitCVE (scan.go), so the unfiltered submission assertion covers the VEX consequence
-// transitively (createVEX builds statements from cve.Content.Matches).
+// the ScanCVE regression test, run with vexGeneration enabled so the StoreVEX path is exercised.
+// The manifest handed to StoreVEX is the same object passed to SubmitCVE (scan.go), so the
+// unfiltered submission assertion covers the VEX consequence transitively; that VEX statements
+// are built from cve.Content.Matches (i.e. the restored manifest) is asserted directly by
+// TestAPIServerStore_storeVEX (repositories/apiserver_test.go).
 func TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch(t *testing.T) {
 	wlid := "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy"
 	imageID := "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
@@ -1657,7 +1774,7 @@ func TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch(t *
 	storageCP := repositories.NewMemoryStorage(false, false)
 	storageSBOM := repositories.NewMemoryStorage(false, false)
 	storageCVE := repositories.NewMemoryStorage(false, false)
-	s := NewScanService(sbomAdapter, storageSBOM, cveAdapter, storageCVE, platform, v1.NewContainerProfileAdapter(storageCP), true, false, true, false, false)
+	s := NewScanService(sbomAdapter, storageSBOM, cveAdapter, storageCVE, platform, v1.NewContainerProfileAdapter(storageCP), true, true, true, false, false)
 	ctx := context.TODO()
 	s.Ready(ctx)
 

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -9,16 +9,20 @@ import (
 	"os"
 	"testing"
 
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/scanfailure"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/k8s-interface/instanceidhandler"
 	instanceidhandlerv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/k8s-interface/names"
 	"github.com/kubescape/kubevuln/adapters"
 	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
+	"github.com/kubescape/kubevuln/internal/tools"
 	"github.com/kubescape/kubevuln/repositories"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
@@ -592,7 +596,7 @@ func (schemaUnsupportedSBOMAdapter) CreateSBOM(_ context.Context, _, _, _ string
 func (schemaUnsupportedSBOMAdapter) Version() string { return "schema-unsupported-mock" }
 
 func (schemaUnsupportedSBOMAdapter) GetMaxImageSize() int64 { return 0 }
-func (schemaUnsupportedSBOMAdapter) GetMaxSBOMSize() int { return 0 }
+func (schemaUnsupportedSBOMAdapter) GetMaxSBOMSize() int    { return 0 }
 func (schemaUnsupportedSBOMAdapter) GetMemoryLimit() string { return "" }
 
 func TestScanService_ScanCVE_SchemaUnsupportedStub(t *testing.T) {
@@ -1335,9 +1339,9 @@ func TestOptionsFromWorkload(t *testing.T) {
 
 type mockSBOMRepository struct {
 	ports.SBOMRepository
-	getSBOMSBOM domain.SBOM
-	getSBOMErr  error
-	deleteErr   error
+	getSBOMSBOM  domain.SBOM
+	getSBOMErr   error
+	deleteErr    error
 	deleteCalled bool
 }
 
@@ -1352,13 +1356,13 @@ func (m *mockSBOMRepository) DeleteSBOM(ctx context.Context, name string) error 
 
 func TestScanService_getSBOM_Outdated(t *testing.T) {
 	tests := []struct {
-		name          string
-		sbom          domain.SBOM
-		getErr        error
-		deleteErr     error
-		wantDelete    bool
-		wantSBOM      domain.SBOM
-		wantErr       error
+		name       string
+		sbom       domain.SBOM
+		getErr     error
+		deleteErr  error
+		wantDelete bool
+		wantSBOM   domain.SBOM
+		wantErr    error
 	}{
 		{
 			name: "outdated, too large, delete succeeds",
@@ -1418,4 +1422,287 @@ func TestScanService_getSBOM_Outdated(t *testing.T) {
 			assert.Equal(t, tt.wantDelete, repo.deleteCalled)
 		})
 	}
+}
+
+// recordingPlatform implements ports.Platform for tests: it returns a configurable exception
+// set (or error) and captures every manifest passed to SubmitCVE so cache-hit vs cache-miss
+// telemetry can be asserted.
+type recordingPlatform struct {
+	exceptions       domain.CVEExceptions
+	getExceptionsErr error
+	submitted        []domain.CVEManifest
+}
+
+var _ ports.Platform = (*recordingPlatform)(nil)
+
+func (p *recordingPlatform) GetCVEExceptions(context.Context) (domain.CVEExceptions, error) {
+	if p.getExceptionsErr != nil {
+		return nil, p.getExceptionsErr
+	}
+	return p.exceptions, nil
+}
+
+func (p *recordingPlatform) SubmitCVE(_ context.Context, cve domain.CVEManifest, _ domain.CVEManifest) error {
+	p.submitted = append(p.submitted, cve)
+	return nil
+}
+
+func (p *recordingPlatform) ReportError(context.Context, error) error { return nil }
+func (p *recordingPlatform) ReportScanFailure(context.Context, scanfailure.ScanFailureCase, string, error) error {
+	return nil
+}
+func (p *recordingPlatform) SendStatus(context.Context, int) error { return nil }
+
+// countingCVERepository wraps a CVERepository and counts StoreCVE calls, so tests can assert a
+// cached manifest was (or wasn't) rewritten without depending on the stored content alone.
+type countingCVERepository struct {
+	ports.CVERepository
+	storeCVECalls int
+}
+
+func (c *countingCVERepository) StoreCVE(ctx context.Context, cve domain.CVEManifest, withRelevancy bool) error {
+	c.storeCVECalls++
+	return c.CVERepository.StoreCVE(ctx, cve, withRelevancy)
+}
+
+// fakeCVEScanner is a CVEScanner whose ScanSBOM output is fully controlled, used to exercise the
+// cache-miss path with a real vulnerability ID (the shared MockCVEAdapter emits an empty-ID match
+// that no SecurityException can target).
+type fakeCVEScanner struct{}
+
+func (fakeCVEScanner) ScanSBOM(_ context.Context, sbom domain.SBOM) (domain.CVEManifest, error) {
+	return domain.CVEManifest{
+		Name:               sbom.Name,
+		SBOMCreatorVersion: sbom.SBOMCreatorVersion,
+		CVEScannerVersion:  "fake-cve",
+		CVEDBVersion:       "fake-db",
+		Content: &v1beta1.GrypeDocument{
+			Matches: []v1beta1.Match{matchForTest("CVE-A"), matchForTest("CVE-B")},
+		},
+	}, nil
+}
+
+func (fakeCVEScanner) Version() string                  { return "fake-cve" }
+func (fakeCVEScanner) DBVersion(context.Context) string { return "fake-db" }
+func (fakeCVEScanner) Ready(context.Context) bool       { return true }
+
+func matchForTest(id string) v1beta1.Match {
+	return v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: id}}}
+}
+
+func ignoredMatchForTest(id string) v1beta1.IgnoredMatch {
+	return v1beta1.IgnoredMatch{
+		Match:              matchForTest(id),
+		AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: id}},
+	}
+}
+
+func exceptionPolicyForTest(id string) domain.CVEExceptions {
+	return domain.CVEExceptions{{
+		PolicyType:            "vulnerabilityExceptionPolicy",
+		Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+		VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: id}},
+	}}
+}
+
+// newScanCVETestService builds a ScanService over in-memory storage with a configurable platform
+// and CVE repository/scanner, returning the service, the version strings needed to seed/read a
+// CVE manifest, and a validated context.
+func newScanCVETestService(t *testing.T, platform ports.Platform, cveRepo ports.CVERepository, cveScanner ports.CVEScanner) (*ScanService, string, string, string, context.Context) {
+	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
+	if cveScanner == nil {
+		cveScanner = adapters.NewMockCVEAdapter()
+	}
+	s := NewScanService(sbomAdapter, repositories.NewMemoryStorage(false, false), cveScanner, cveRepo, platform, adapters.NewMockRelevancyAdapter(), true, false, true, false, false)
+	ctx := context.TODO()
+	s.Ready(ctx)
+	workload := domain.ScanCommand{
+		ImageSlug:     "imageSlug",
+		ContainerName: "kube-proxy",
+		ImageHash:     "k8s.gcr.io/kube-proxy@sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+		Wlid:          "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy",
+	}
+	var err error
+	ctx, err = s.ValidateScanCVE(ctx, workload)
+	require.NoError(t, err)
+	return s, sbomAdapter.Version(), cveScanner.Version(), cveScanner.DBVersion(ctx), ctx
+}
+
+func seedCachedCVEManifest(t *testing.T, repo ports.CVERepository, name, sbomCreatorVersion, cveScannerVersion, cveDBVersion string, ctx context.Context, content *v1beta1.GrypeDocument) {
+	require.NoError(t, repo.StoreCVE(ctx, domain.CVEManifest{
+		Name:               name,
+		SBOMCreatorVersion: sbomCreatorVersion,
+		CVEScannerVersion:  cveScannerVersion,
+		CVEDBVersion:       cveDBVersion,
+		Content:            content,
+	}, false))
+}
+
+func matchIDs(matches []v1beta1.Match) []string {
+	var ids []string
+	for _, m := range matches {
+		ids = append(ids, m.Vulnerability.ID)
+	}
+	return ids
+}
+
+// TestScanService_ScanCVE_CacheHit_DeletedExceptionRestoresSuppressedMatch is a regression test
+// for the cached-manifest poisoning bug: deleting a SecurityException must un-suppress the
+// finding on the next cache hit, and the backend must receive the unfiltered manifest.
+func TestScanService_ScanCVE_CacheHit_DeletedExceptionRestoresSuppressedMatch(t *testing.T) {
+	platform := &recordingPlatform{}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, repo, nil)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches:        []v1beta1.Match{matchForTest("CVE-B")},
+		IgnoredMatches: []v1beta1.IgnoredMatch{ignoredMatchForTest("CVE-A")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.NotNil(t, stored.Content)
+	assert.Contains(t, matchIDs(stored.Content.Matches), "CVE-A", "deleted exception must restore the suppressed match")
+	assert.Len(t, stored.Content.IgnoredMatches, 0)
+
+	require.Len(t, platform.submitted, 1, "cache hit must still submit the manifest to the backend")
+	assert.Contains(t, matchIDs(platform.submitted[0].Content.Matches), "CVE-A", "backend must receive the unfiltered manifest on a cache hit")
+}
+
+func TestScanService_ScanCVE_CacheHit_AddedExceptionSuppresses(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, repo, nil)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{matchForTest("CVE-A"), matchForTest("CVE-B")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.IgnoredMatches, 1)
+	assert.Equal(t, "CVE-A", stored.Content.IgnoredMatches[0].Match.Vulnerability.ID)
+}
+
+func TestScanService_ScanCVE_CacheHit_UnchangedExceptionSkipsRewrite(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	inner := repositories.NewMemoryStorage(false, false)
+	counting := &countingCVERepository{CVERepository: inner}
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, counting, nil)
+	seedCachedCVEManifest(t, inner, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches:        []v1beta1.Match{matchForTest("CVE-B")},
+		IgnoredMatches: []v1beta1.IgnoredMatch{ignoredMatchForTest("CVE-A")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	assert.Zero(t, counting.storeCVECalls, "an unchanged exception set must not rewrite the cached manifest")
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.IgnoredMatches, 1)
+	assert.Equal(t, "CVE-A", stored.Content.IgnoredMatches[0].Match.Vulnerability.ID)
+}
+
+func TestScanService_ScanCVE_CacheHit_ExceptionFetchFailureDoesNotWipe(t *testing.T) {
+	platform := &recordingPlatform{getExceptionsErr: errors.New("backend unreachable")}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestService(t, platform, repo, nil)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches:        []v1beta1.Match{matchForTest("CVE-B")},
+		IgnoredMatches: []v1beta1.IgnoredMatch{ignoredMatchForTest("CVE-A")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.IgnoredMatches, 1, "a failed exception fetch must not wipe filtering from the stored manifest")
+	assert.Equal(t, "CVE-A", stored.Content.IgnoredMatches[0].Match.Vulnerability.ID)
+}
+
+// TestScanService_ScanCVE_CacheMiss_UnfilteredToBackend guards the primary path: a fresh scan
+// stores the exception-filtered manifest but submits the unfiltered original to the backend.
+func TestScanService_ScanCVE_CacheMiss_UnfilteredToBackend(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	repo := repositories.NewMemoryStorage(false, false)
+	s, _, _, _, ctx := newScanCVETestService(t, platform, repo, fakeCVEScanner{})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.IgnoredMatches, 1)
+
+	require.Len(t, platform.submitted, 1)
+	assert.Contains(t, matchIDs(platform.submitted[0].Content.Matches), "CVE-A", "backend must receive the unfiltered manifest on a cache miss")
+}
+
+// TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch is the ScanCP mirror of
+// the ScanCVE regression test. The manifest handed to StoreVEX is the same object passed to
+// SubmitCVE (scan.go), so the unfiltered submission assertion covers the VEX consequence
+// transitively (createVEX builds statements from cve.Content.Matches).
+func TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch(t *testing.T) {
+	wlid := "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy"
+	imageID := "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+	imageTag := "k8s.gcr.io/kube-proxy:v1.24.3"
+	// the full CVE manifest is keyed by the image slug ScanCP computes itself
+	slug, err := names.ImageInfoToSlug(tools.NormalizeReference(imageTag), imageID)
+	require.NoError(t, err)
+
+	platform := &recordingPlatform{}
+	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
+	cveAdapter := adapters.NewMockCVEAdapter()
+	storageCP := repositories.NewMemoryStorage(false, false)
+	storageSBOM := repositories.NewMemoryStorage(false, false)
+	storageCVE := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(sbomAdapter, storageSBOM, cveAdapter, storageCVE, platform, v1.NewContainerProfileAdapter(storageCP), true, false, true, false, false)
+	ctx := context.TODO()
+	s.Ready(ctx)
+
+	workload := domain.ScanCommand{
+		Args: map[string]interface{}{
+			domain.ArgsName:      "daemonset-kube-proxy",
+			domain.ArgsNamespace: "kube-system",
+		},
+		Wlid: wlid,
+	}
+	ctx, err = s.ValidateScanCP(ctx, workload)
+	require.NoError(t, err)
+
+	ap := v1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "daemonset-kube-proxy",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: helpersv1.Full,
+				helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-kube-system/kind-DaemonSet/name-kube-proxy/containerName-kube-proxy",
+				helpersv1.StatusMetadataKey:     helpersv1.Learning,
+				helpersv1.WlidMetadataKey:       wlid,
+			},
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Spec: v1beta1.ContainerProfileSpec{
+			ImageID:  imageID,
+			ImageTag: imageTag,
+		},
+	}
+	require.NoError(t, storageCP.StoreContainerProfile(ctx, ap))
+
+	seedCachedCVEManifest(t, storageCVE, slug, sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx), ctx, &v1beta1.GrypeDocument{
+		Matches:        []v1beta1.Match{matchForTest("CVE-B")},
+		IgnoredMatches: []v1beta1.IgnoredMatch{ignoredMatchForTest("CVE-A")},
+	})
+
+	require.NoError(t, s.ScanCP(ctx))
+
+	stored, err := storageCVE.GetCVE(ctx, slug, sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx))
+	require.NoError(t, err)
+	require.NotNil(t, stored.Content)
+	assert.Contains(t, matchIDs(stored.Content.Matches), "CVE-A", "deleted exception must restore the suppressed match on a ScanCP cache hit")
+	assert.Len(t, stored.Content.IgnoredMatches, 0)
+
+	require.Len(t, platform.submitted, 1, "ScanCP cache hit must still submit the manifest to the backend")
+	assert.Contains(t, matchIDs(platform.submitted[0].Content.Matches), "CVE-A", "backend must receive the unfiltered manifest on a ScanCP cache hit")
 }

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"crypto/sha256"
+	stderrors "errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -117,12 +118,14 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 	defer cancel()
 
 	var exceptions []sev1beta1.SecurityException
+	var listErr error
 
 	// Only list namespaced exceptions when namespace is provided
 	if namespace != "" {
 		seList, err := a.DynamicClient.Resource(securityExceptionGVR).Namespace(namespace).List(listCtx, metav1.ListOptions{})
 		if err != nil {
 			logger.L().Ctx(ctx).Warning("failed to list SecurityExceptions", helpers.Error(err), helpers.String("namespace", namespace))
+			listErr = stderrors.Join(listErr, err)
 		} else {
 			for i := range seList.Items {
 				var se sev1beta1.SecurityException
@@ -140,6 +143,7 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 	cseList, err := a.DynamicClient.Resource(clusterSecurityExceptionGVR).List(listCtx, metav1.ListOptions{})
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to list ClusterSecurityExceptions", helpers.Error(err))
+		listErr = stderrors.Join(listErr, err)
 	} else {
 		for i := range cseList.Items {
 			var cse sev1beta1.ClusterSecurityException
@@ -151,7 +155,7 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 		}
 	}
 
-	return exceptions, clusterExceptions, nil
+	return exceptions, clusterExceptions, listErr
 }
 
 // GetWorkloadLabels resolves the labels of a workload so that a


### PR DESCRIPTION
Fixes #469

## Overview

On a cache hit, `ScanCVE`/`ScanCP` loaded the previously exception-filtered `VulnerabilityManifest` and re-applied the current `SecurityException` set. Since `ApplySecurityExceptions` (`adapters/v1/securityexception.go`) only ever moves matches `Matches` → `IgnoredMatches` — it never restores them — and the cache-hit store guard (`len(filteredCve.Content.IgnoredMatches) > len(cve.Content.IgnoredMatches)` in `core/services/scan.go`) could only detect a *growing* ignore set, deleting an exception never un-suppressed the finding. Because a rescan of the same image is itself a cache hit, the suppression was effectively permanent, and the backend received **filtered** data on cache hits vs. **unfiltered** data on cache misses (VEX had the same split: `createVEX` builds statements from `cve.Content.Matches`, `repositories/apiserver.go:799`).

This makes cache hits behave like cache misses: reconstruct the unfiltered manifest, re-evaluate the current exception set, and persist only when the exception-derived ignore set actually changed.

---

## Changes

### adapters/v1/securityexception.go
- `RestoreSuppressedMatches` — the inverse of `ApplySecurityExceptions`: returns a copy of the document with every ignored match moved back into `Matches` and `IgnoredMatches` cleared; the input is not mutated, mirroring `ApplySecurityExceptions`' copy semantics.
- Restoring every ignored match is safe, not heuristic: `GrypeAdapter.ScanSBOM` builds `VulnerabilityMatcher` with neither `IgnoreRules` nor `VexProcessor` (`adapters/v1/grype.go`), and grype emits ignored matches only from those two inputs (`applyIgnoreRules` short-circuits on an empty rule set, `findVEXMatches` short-circuits on a nil processor — grype `vulnerability_matcher.go:236,214`). Every stored ignored match is therefore exception-applied. It is also the fail-open direction: if that assumption ever breaks, findings surface rather than stay hidden. Lossless because `IgnoredMatch` embeds the full `Match`.
- `IgnoredVulnIDs` — the set of ignored vulnerability IDs used by the change comparison, valid because SecurityException policies match on vulnerability name only (`getCVEExceptionMatchCVENameFromList`), so a policy suppresses every match of that CVE or none.

### core/services/scan.go
- `ScanCVE`/`ScanCP` cache-hit branches: capture the cached ignored-ID set, restore suppressed matches, re-filter against the current exception set, and re-store only when the ignored-ID set changed (`maps.Equal`) — persisting both additions **and removals**, and skipping redundant writes when nothing changed.
- `applyExceptionsToManifest` now reports whether the exception fetch succeeded; on a failed fetch the cache-hit re-store is skipped, so a transient error cannot wipe previously applied exceptions from the stored manifest. The three cache-miss/`cvep` call sites are signature-only (`filteredCve, _ :=`).
- Cache-miss, `cvep`, and `ScanRegistry` paths are unchanged.

### adapters/v1/securityexception_test.go
- `TestRestoreSuppressedMatches` — restores all ignored matches (order-preserving), leaves the input document untouched, and no-ops on nil / empty documents.
- `TestIgnoredVulnIDs` — correct ID set, empty document → empty set.
- `TestIgnoredVulnIDs_MultiPackageSameCVE` — pins the match-by-CVE invariant: multiple packages sharing a CVE collapse to one entry, so the ID set is sufficient.

### core/services/scan_test.go
- New test doubles: `recordingPlatform` (configurable exceptions / fetch error, captures `SubmitCVE` input), `countingCVERepository` (counts `StoreCVE`), `fakeCVEScanner` (deterministic cache-miss output, since the shared mock emits an empty-ID match no exception can target).
- Regression tests (verified to fail on `main`): deleted-exception restore (ScanCVE and ScanCP), added-exception suppress, unchanged-exception no-rewrite, exception-fetch-failure no-wipe, cache-miss unfiltered-to-backend parity. VEX is covered transitively — the manifest handed to `StoreVEX` is the same object passed to `SubmitCVE`.

---

## Verification

- `go build ./...` — clean
- `go vet ./adapters/v1/ ./core/services/` — clean
- `gofmt -l` on the changed files — clean
- `go test ./adapters/v1/... ./core/services/...` — pass (168 tests; only the pre-existing Docker-dependent `Test_grypeAdapter_DBVersion` / `TestScanService_NginxTest` fail on a machine without Docker, identical to `main`)
- The two deleted-exception regression tests fail on the unpatched `scan.go` and pass with this change, so they are true regression tests rather than snapshots of existing behavior.

---

## Follow-up Option

`ExpiredOnFix` changes still cannot self-heal on a cache hit: a cached match's fix-state is a scan-time snapshot, so a fix published after the manifest was stored is invisible until a cache miss. That is the same stale-snapshot root cause as #449 and is intentionally out of scope here — happy to take it on in a follow-up if desired.

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored previously suppressed vulnerability findings when exceptions are removed or expire.
  * Improved handling of cached vulnerability results when exception retrieval is incomplete or findings remain unchanged.
  * Prevented incomplete exception data from being treated as removed exceptions.
  * Ensured consistent exception filtering across full scans and filtered vulnerability scans.
  * Improved rate-limit and unsupported SBOM schema handling.
  * Allowed report generation to continue when exception data is temporarily incomplete.

* **Tests**
  * Added comprehensive coverage for exception restoration, caching, suppression, degraded retrieval, and scan submission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->