### PR TITLE
fix: skip grype offline-db tests instead of panicking when Docker is unavailable

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -104,7 +105,59 @@ func buildTrustedVendorSet(vendors []string) map[distro.Type]bool {
 	return set
 }
 
+// ErrDockerUnavailable is returned (wrapped) when no usable container runtime
+// could be reached. Callers that only want to skip on environment unavailability
+// -- as opposed to failing on genuine container setup errors (bad image, registry,
+// port mapping, ...) -- should check for it with errors.Is.
+var ErrDockerUnavailable = errors.New("container runtime unavailable")
+
+// probeDockerAvailable checks whether a usable container runtime is reachable
+// before attempting to start a testcontainers-go container. testcontainers-go's
+// docker host detection can panic (instead of returning an error) in some
+// misconfigured environments (e.g. rootless Docker it fails to detect), so a
+// recover is also in place as a defense in depth. Every error returned here
+// wraps ErrDockerUnavailable.
+func probeDockerAvailable(ctx context.Context) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("docker runtime probe panicked: %v: %w", r, ErrDockerUnavailable)
+		}
+	}()
+
+	provider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		return fmt.Errorf("docker provider unavailable: %w: %w", err, ErrDockerUnavailable)
+	}
+	defer provider.Close()
+
+	if err := provider.Health(ctx); err != nil {
+		return fmt.Errorf("docker daemon not healthy: %w: %w", err, ErrDockerUnavailable)
+	}
+	return nil
+}
+
 func startGrypeOfflineDBContainer(ctx context.Context) (port string, terminate func(), err error) {
+	terminate = func() {}
+
+	if probeErr := probeDockerAvailable(ctx); probeErr != nil {
+		return "", terminate, fmt.Errorf("container runtime not available: %w", probeErr)
+	}
+
+	// Panics past this point happen while actually starting the container (bad
+	// image, registry, port mapping, ...) rather than because the runtime itself
+	// is unavailable -- the availability probe above already ruled that out.
+	// Recover so callers get a normal error instead of an unrecovered panic
+	// crashing the whole test binary, but deliberately do NOT wrap
+	// ErrDockerUnavailable here so callers still fail on these instead of skipping.
+	// Note: if the panic happens after the container started, that container is
+	// leaked since we have no reference to it here to terminate.
+	defer func() {
+		if r := recover(); r != nil {
+			port = ""
+			err = fmt.Errorf("starting grype offline db container panicked: %v", r)
+		}
+	}()
+
 	req := testcontainers.ContainerRequest{
 		Image:        "quay.io/kubescape/grype-offline-db:v6-ci-only",
 		ExposedPorts: []string{"8080/tcp"},
@@ -115,12 +168,12 @@ func startGrypeOfflineDBContainer(ctx context.Context) (port string, terminate f
 		Started:          true,
 	})
 	if err != nil {
-		return "", nil, err
+		return "", terminate, err
 	}
 
 	mappedPort, err := container.MappedPort(ctx, "8080")
 	if err != nil {
-		return "", nil, err
+		return "", terminate, err
 	}
 
 	terminate = func() {
@@ -138,7 +191,7 @@ func NewGrypeAdapterFixedDB() (*GrypeAdapter, func(), error) {
 func NewGrypeAdapterFixedDBWithMatchers(matchingMode config.CVEMatchingMode, trustedVendors []string) (*GrypeAdapter, func(), error) {
 	port, terminate, err := startGrypeOfflineDBContainer(context.Background())
 	if err != nil {
-		return nil, nil, err
+		return nil, terminate, err
 	}
 	distCfg := distribution.DefaultConfig()
 	distCfg.LatestURL = fmt.Sprintf("http://localhost:%s/databases", port)

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -25,6 +25,9 @@ import (
 func Test_grypeAdapter_DBVersion(t *testing.T) {
 	ctx := context.TODO()
 	g, terminate, err := NewGrypeAdapterFixedDB()
+	if errors.Is(err, ErrDockerUnavailable) {
+		t.Skipf("skipping: grype offline db container unavailable (container runtime not usable): %v", err)
+	}
 	require.NoError(t, err)
 	defer terminate()
 	g.Ready(ctx) // need to call ready to load the DB
@@ -65,6 +68,9 @@ func Test_grypeAdapter_ScanSBOM(t *testing.T) {
 		},
 	}
 	g, terminate, err := NewGrypeAdapterFixedDB()
+	if errors.Is(err, ErrDockerUnavailable) {
+		t.Skipf("skipping: grype offline db container unavailable (container runtime not usable): %v", err)
+	}
 	require.NoError(t, err)
 	defer terminate()
 	ctx := context.TODO()

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -666,6 +666,9 @@ func TestScanService_NginxTest(t *testing.T) {
 	ctx := context.TODO()
 	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
 	cveAdapter, terminate, err := v1.NewGrypeAdapterFixedDB()
+	if errors.Is(err, v1.ErrDockerUnavailable) {
+		t.Skipf("skipping: grype offline db container unavailable (container runtime not usable): %v", err)
+	}
 	require.NoError(t, err)
 	defer terminate()
 	storageCP := repositories.NewMemoryStorage(false, false)


### PR DESCRIPTION
## Overview
`TestScanService_NginxTest` called `v1.NewGrypeAdapterFixedDB()` unconditionally. That constructor spins up a `quay.io/kubescape/grype-offline-db:v6-ci-only` container via testcontainers-go. When the local Docker environment does not match what testcontainers-go's internal docker host detection expects (e.g. rootless Docker not found), testcontainers-go panics internally, crashing the whole test binary instead of failing or skipping just the one test.

This PR adds a Docker-availability probe in `startGrypeOfflineDBContainer` (adapters/v1/grype.go) that returns a normal error instead of letting a panic escape, and updates `TestScanService_NginxTest` to call `t.Skip(...)` with a clear message when that error occurs.

<!--
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

## Related issues/PRs:

* Resolved #471

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/metrics` endpoint exposing scan performance, request, rejection, and worker-queue metrics.
  * Added instrumentation for SBOM, CP, CVE, and registry scans.
  * Metrics remain optional when not configured.

* **Bug Fixes**
  * Docker-dependent scans now fail gracefully with descriptive errors when Docker is unavailable.
  * Prevented container startup panics from crashing the service.

* **Tests**
  * Added coverage for metrics collection and graceful handling of unavailable Docker environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->