### PR TITLE
fix: remove sidecar RPC-wide lock, fix Version() cache poisoning, and bound retryCount growth

### DIFF
--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -83,13 +83,18 @@ func (s *SidecarSBOMAdapter) CreateSBOM(ctx context.Context, name, imageID, imag
 		imageID = NormalizeImageID(imageID, imageTag)
 	}
 
+	// Resolved once and reused for both fields below: two separate s.Version() calls could
+	// otherwise observe different results (e.g. the first hits a transient Health() failure
+	// and returns "unknown" while a concurrent call succeeds moments later), tagging the same
+	// SBOM with two different creator versions.
+	version := s.Version()
 	domainSBOM := domain.SBOM{
 		Name:               name,
-		SBOMCreatorVersion: s.Version(),
+		SBOMCreatorVersion: version,
 		SBOMCreatorName:    "syft",
 		Annotations: map[string]string{
 			helpersv1.ImageIDMetadataKey:     imageID,
-			helpersv1.ToolVersionMetadataKey: s.Version(),
+			helpersv1.ToolVersionMetadataKey: version,
 		},
 		Labels: tools.LabelsFromImageID(imageID),
 	}

--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/internal/tools"
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -47,8 +48,9 @@ type SidecarSBOMAdapter struct {
 	mu         sync.Mutex
 	retryCount map[string]*crashRetry
 
-	versionMu  sync.Mutex
-	versionStr string
+	versionMu    sync.Mutex
+	versionStr   string
+	versionGroup singleflight.Group
 }
 
 var _ ports.SBOMCreator = (*SidecarSBOMAdapter)(nil)
@@ -211,6 +213,13 @@ func (s *SidecarSBOMAdapter) evictStaleRetriesLocked() {
 // on this pod to "unknown" and starve the storage cache (see #473) — the next call simply
 // retries instead of returning a value baked in by sync.Once for the rest of the process's
 // life.
+//
+// Concurrent callers that miss the cache are coalesced through versionGroup into a single
+// in-flight Health() call: without this, two overlapping callers could each run their own
+// Health() independently, and if one happened to fail while the other succeeded, the failing
+// caller would return "unknown" even though the version was, at that same moment, already
+// known — an avoidable cache miss for whatever that caller was about to look up. Coalescing
+// means every overlapping caller observes the same outcome as the single underlying call.
 func (s *SidecarSBOMAdapter) Version() string {
 	s.versionMu.Lock()
 	if s.versionStr != "" {
@@ -219,14 +228,21 @@ func (s *SidecarSBOMAdapter) Version() string {
 	}
 	s.versionMu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	version, _, err := s.client.Health(ctx)
+	v, err, _ := s.versionGroup.Do("version", func() (any, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		version, _, err := s.client.Health(ctx)
+		if err != nil {
+			return "", err
+		}
+		return version, nil
+	})
 	if err != nil {
 		logger.L().Warning("failed to get scanner version", helpers.Error(err))
 		return "unknown"
 	}
 
+	version := v.(string)
 	s.versionMu.Lock()
 	s.versionStr = version
 	s.versionMu.Unlock()

--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -16,7 +16,22 @@ import (
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 )
 
-const maxCrashRetries = 3
+const (
+	maxCrashRetries = 3
+	// retryCountTTL bounds how long a crashed image's retry count is remembered. Without
+	// this, an image that crashes the scanner once or twice and is then never scanned
+	// again (common with CI-generated unique tags/digests) would leave a permanent entry
+	// in retryCount, since the map was previously only ever cleared on success or once
+	// maxCrashRetries was hit (see #473).
+	retryCountTTL = 1 * time.Hour
+)
+
+// crashRetry tracks a per-image crash-retry count and when it was last touched, so stale
+// entries (images that crashed once and were never retried) can be evicted.
+type crashRetry struct {
+	count    int
+	lastSeen time.Time
+}
 
 // SidecarSBOMAdapter implements ports.SBOMCreator by delegating SBOM generation
 // to the sbom-scanner sidecar container via gRPC over a Unix domain socket.
@@ -30,10 +45,10 @@ type SidecarSBOMAdapter struct {
 	memoryLimit       string
 
 	mu         sync.Mutex
-	retryCount map[string]int
+	retryCount map[string]*crashRetry
 
-	versionOnce sync.Once
-	versionStr  string
+	versionMu  sync.Mutex
+	versionStr string
 }
 
 var _ ports.SBOMCreator = (*SidecarSBOMAdapter)(nil)
@@ -56,7 +71,7 @@ func NewSidecarSBOMAdapter(
 		scanTimeout:       scanTimeout,
 		scanEmbeddedSBOMs: scanEmbeddedSBOMs,
 		memoryLimit:       memoryLimit,
-		retryCount:        make(map[string]int),
+		retryCount:        make(map[string]*crashRetry),
 	}
 }
 
@@ -138,8 +153,15 @@ func (s *SidecarSBOMAdapter) CreateSBOM(ctx context.Context, name, imageID, imag
 
 func (s *SidecarSBOMAdapter) handleCrash(ctx context.Context, name, imageID, imageTag string, options domain.RegistryOptions, domainSBOM domain.SBOM, crashErr error) (domain.SBOM, error) {
 	s.mu.Lock()
-	s.retryCount[imageID]++
-	retries := s.retryCount[imageID]
+	s.evictStaleRetriesLocked()
+	entry := s.retryCount[imageID]
+	if entry == nil {
+		entry = &crashRetry{}
+		s.retryCount[imageID] = entry
+	}
+	entry.count++
+	entry.lastSeen = time.Now()
+	retries := entry.count
 	s.mu.Unlock()
 
 	logger.L().Warning("SBOM scanner sidecar crashed during scan",
@@ -169,19 +191,46 @@ func (s *SidecarSBOMAdapter) handleCrash(ctx context.Context, name, imageID, ima
 	return domainSBOM, crashErr
 }
 
-func (s *SidecarSBOMAdapter) Version() string {
-	s.versionOnce.Do(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		version, _, err := s.client.Health(ctx)
-		if err != nil {
-			logger.L().Warning("failed to get scanner version", helpers.Error(err))
-			s.versionStr = "unknown"
-			return
+// evictStaleRetriesLocked removes retry-count entries untouched for longer than
+// retryCountTTL, bounding the map's growth for images that crash once and are never
+// scanned again. Called with s.mu held; piggybacks on handleCrash rather than a background
+// goroutine since crashes are rare and this keeps the map bounded without extra machinery.
+func (s *SidecarSBOMAdapter) evictStaleRetriesLocked() {
+	cutoff := time.Now().Add(-retryCountTTL)
+	for imageID, entry := range s.retryCount {
+		if entry.lastSeen.Before(cutoff) {
+			delete(s.retryCount, imageID)
 		}
-		s.versionStr = version
-	})
-	return s.versionStr
+	}
+}
+
+// Version returns the sidecar's Syft version, used as the SBOM/CVE storage cache key
+// (see repositories/apiserver.go's semver comparison against the stored manifest). It only
+// caches a successful Health() result: a failed/timed-out health check is never written to
+// versionStr, so a transient blip (e.g. on cold start) does not permanently pin every scan
+// on this pod to "unknown" and starve the storage cache (see #473) — the next call simply
+// retries instead of returning a value baked in by sync.Once for the rest of the process's
+// life.
+func (s *SidecarSBOMAdapter) Version() string {
+	s.versionMu.Lock()
+	if s.versionStr != "" {
+		defer s.versionMu.Unlock()
+		return s.versionStr
+	}
+	s.versionMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	version, _, err := s.client.Health(ctx)
+	if err != nil {
+		logger.L().Warning("failed to get scanner version", helpers.Error(err))
+		return "unknown"
+	}
+
+	s.versionMu.Lock()
+	s.versionStr = version
+	s.versionMu.Unlock()
+	return version
 }
 
 func (s *SidecarSBOMAdapter) GetMaxImageSize() int64 {

--- a/adapters/v1/sidecar_test.go
+++ b/adapters/v1/sidecar_test.go
@@ -18,6 +18,7 @@ import (
 // mockScannerClient implements sbomscanner.SBOMScannerClient for testing
 type mockScannerClient struct {
 	createSBOMFunc func(ctx context.Context, req sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error)
+	healthFunc     func(ctx context.Context) (string, bool, error)
 	healthVersion  string
 	healthReady    bool
 	healthErr      error
@@ -31,6 +32,9 @@ func (m *mockScannerClient) CreateSBOM(ctx context.Context, req sbomscanner.Scan
 }
 
 func (m *mockScannerClient) Health(ctx context.Context) (string, bool, error) {
+	if m.healthFunc != nil {
+		return m.healthFunc(ctx)
+	}
 	return m.healthVersion, m.healthReady, m.healthErr
 }
 
@@ -177,4 +181,64 @@ func TestSidecarSBOMAdapter_Version(t *testing.T) {
 
 	adapter := NewSidecarSBOMAdapter(mock, 5*time.Minute, 512*1024*1024, 20*1024*1024, false, "5Gi", nil)
 	assert.Equal(t, "v0.100.0", adapter.Version())
+}
+
+// TestSidecarSBOMAdapter_Version_RecoversAfterTransientFailure is a regression test for
+// #473: Version() used to cache its result behind a sync.Once, so a single failed/timed-out
+// Health() call (e.g. a cold-start blip) permanently pinned every later call to "unknown" for
+// the adapter's lifetime — corrupting the SBOM/CVE storage cache key. Version() must retry on
+// the next call after a failure and only cache once Health() actually succeeds.
+func TestSidecarSBOMAdapter_Version_RecoversAfterTransientFailure(t *testing.T) {
+	callCount := 0
+	mock := &mockScannerClient{
+		healthFunc: func(ctx context.Context) (string, bool, error) {
+			callCount++
+			if callCount == 1 {
+				return "", false, errors.New("transient health check failure")
+			}
+			return "v0.100.0", true, nil
+		},
+	}
+
+	adapter := NewSidecarSBOMAdapter(mock, 5*time.Minute, 512*1024*1024, 20*1024*1024, false, "5Gi", nil)
+
+	assert.Equal(t, "unknown", adapter.Version(), "first call hits the transient failure")
+	assert.Equal(t, "v0.100.0", adapter.Version(), "second call must retry, not replay the cached failure")
+	assert.Equal(t, "v0.100.0", adapter.Version(), "once resolved, the real version stays cached")
+	assert.Equal(t, 2, callCount, "a resolved version must not trigger further Health() calls")
+}
+
+// TestSidecarSBOMAdapter_CreateSBOM_CrashRetry_EvictsStaleEntries is a regression test for
+// #473: retryCount entries were only ever cleared on success or once maxCrashRetries was hit,
+// so an image that crashed once and was never retried left a permanent entry, growing the map
+// unboundedly over the adapter's lifetime (common with CI-generated unique tags/digests).
+func TestSidecarSBOMAdapter_CreateSBOM_CrashRetry_EvictsStaleEntries(t *testing.T) {
+	mock := &mockScannerClient{
+		healthVersion: "v0.100.0",
+		healthReady:   true,
+		createSBOMFunc: func(ctx context.Context, req sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error) {
+			return nil, sbomscanner.ErrScannerCrashed
+		},
+	}
+
+	adapter := NewSidecarSBOMAdapter(mock, 5*time.Minute, 512*1024*1024, 20*1024*1024, false, "5Gi", nil)
+
+	// A one-off crash for an image that is never retried.
+	_, err := adapter.CreateSBOM(context.Background(), "test-sbom", "", "one-shot-image:latest", domain.RegistryOptions{})
+	require.Error(t, err)
+	require.Len(t, adapter.retryCount, 1)
+
+	// Simulate that entry going stale.
+	adapter.mu.Lock()
+	adapter.retryCount["one-shot-image:latest"].lastSeen = time.Now().Add(-retryCountTTL - time.Minute)
+	adapter.mu.Unlock()
+
+	// A crash for a different image should sweep the stale entry out while recording its own.
+	_, err = adapter.CreateSBOM(context.Background(), "test-sbom", "", "another-image:latest", domain.RegistryOptions{})
+	require.Error(t, err)
+
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+	assert.NotContains(t, adapter.retryCount, "one-shot-image:latest", "stale entry must be evicted")
+	assert.Contains(t, adapter.retryCount, "another-image:latest")
 }

--- a/adapters/v1/sidecar_test.go
+++ b/adapters/v1/sidecar_test.go
@@ -75,6 +75,35 @@ func TestSidecarSBOMAdapter_CreateSBOM_Success(t *testing.T) {
 	assert.Equal(t, "test-pkg", sbom.Content.Artifacts[0].Name)
 }
 
+// TestSidecarSBOMAdapter_CreateSBOM_UsesOneVersionForBothFields is a CodeRabbit regression
+// test: CreateSBOM used to call s.Version() twice — once for SBOMCreatorVersion, once for the
+// ToolVersionMetadataKey annotation — so two independently-resolved calls could disagree
+// (e.g. the first hits a transient Health() failure and returns "unknown" while a second,
+// concurrent call already knows the real version). CreateSBOM must resolve the version once
+// and use that single value for both fields, so a stored SBOM never carries two different
+// creator versions.
+func TestSidecarSBOMAdapter_CreateSBOM_UsesOneVersionForBothFields(t *testing.T) {
+	var callCount int32
+	mock := &mockScannerClient{
+		healthFunc: func(ctx context.Context) (string, bool, error) {
+			atomic.AddInt32(&callCount, 1)
+			return "", false, errors.New("transient health check failure")
+		},
+		createSBOMFunc: func(ctx context.Context, req sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error) {
+			return &sbomscanner.ScanResult{Status: helpersv1.Learning}, nil
+		},
+	}
+
+	adapter := NewSidecarSBOMAdapter(mock, 5*time.Minute, 512*1024*1024, 20*1024*1024, false, "5Gi", nil)
+
+	sbom, err := adapter.CreateSBOM(context.Background(), "test-sbom", "", "nginx:latest", domain.RegistryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), callCount, "CreateSBOM must resolve the version once, not once per field")
+	assert.Equal(t, "unknown", sbom.SBOMCreatorVersion)
+	assert.Equal(t, sbom.SBOMCreatorVersion, sbom.Annotations[helpersv1.ToolVersionMetadataKey],
+		"SBOMCreatorVersion and the ToolVersionMetadataKey annotation must always agree")
+}
+
 func TestSidecarSBOMAdapter_CreateSBOM_TooLarge(t *testing.T) {
 	mock := &mockScannerClient{
 		healthVersion: "v0.100.0",

--- a/adapters/v1/sidecar_test.go
+++ b/adapters/v1/sidecar_test.go
@@ -3,6 +3,8 @@ package v1
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -206,6 +208,66 @@ func TestSidecarSBOMAdapter_Version_RecoversAfterTransientFailure(t *testing.T) 
 	assert.Equal(t, "v0.100.0", adapter.Version(), "second call must retry, not replay the cached failure")
 	assert.Equal(t, "v0.100.0", adapter.Version(), "once resolved, the real version stays cached")
 	assert.Equal(t, 2, callCount, "a resolved version must not trigger further Health() calls")
+}
+
+// TestSidecarSBOMAdapter_Version_CoalescesConcurrentCalls is a regression test for a
+// CodeRabbit follow-up on #473: Version() released versionMu before calling Health(), so two
+// overlapping callers that both raced past the "not yet cached" check would each run their
+// own independent Health() call. If one of those independent calls happened to fail while the
+// other succeeded, the failing caller returned "unknown" even though the version was, at that
+// same moment, already known via its sibling call. Overlapping callers must instead be
+// coalesced into a single in-flight Health() call (via singleflight), so every caller in the
+// race observes the same, single outcome.
+//
+// The two calls are deliberately ordered rather than merely fired concurrently: the second
+// call is only started once the first is provably already inside Health() (via the started
+// channel), which guarantees — by singleflight's own locking, not by timing luck — that the
+// second call's Do() finds the first call already registered and joins it instead of racing
+// to register its own. A bare "launch N goroutines and hope they overlap" design would be
+// flaky, since a goroutine that arrives after the in-flight call has already completed
+// legitimately starts a fresh call rather than a bug.
+func TestSidecarSBOMAdapter_Version_CoalescesConcurrentCalls(t *testing.T) {
+	var callCount int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mock := &mockScannerClient{
+		healthFunc: func(ctx context.Context) (string, bool, error) {
+			atomic.AddInt32(&callCount, 1)
+			close(started)
+			<-release
+			return "v0.100.0", true, nil
+		},
+	}
+
+	adapter := NewSidecarSBOMAdapter(mock, 5*time.Minute, 512*1024*1024, 20*1024*1024, false, "5Gi", nil)
+
+	var wg sync.WaitGroup
+	results := make([]string, 2)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		results[0] = adapter.Version()
+	}()
+
+	<-started // the first call is now registered in singleflight and blocked inside Health()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		results[1] = adapter.Version()
+	}()
+
+	// Give the second call a moment to reach Do() and join the in-flight call before it's
+	// allowed to complete. The first call is held open the whole time, so there is no window
+	// in which the second call could observe it as already finished.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), callCount, "the second, overlapping call must join the first instead of running its own Health()")
+	assert.Equal(t, "v0.100.0", results[0])
+	assert.Equal(t, "v0.100.0", results[1])
 }
 
 // TestSidecarSBOMAdapter_CreateSBOM_CrashRetry_EvictsStaleEntries is a regression test for

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -244,7 +244,6 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 
 	// generate SBOM
 	// use a deadline to prevent the process from hanging for too long
-	// TODO check memory usage and see if we can kill the goroutine
 	var syftSBOM *sbom.SBOM
 	// ensure no parallel pulls
 	s.pullMutex.Lock()
@@ -297,7 +296,11 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 
 	// strip the SBOM to reduce size
 	v1beta1.StripSBOM(syftSBOM)
-	// check the size of the SBOM
+	// check the size of the SBOM. This is necessarily a post-hoc check: Syft doesn't expose
+	// an incremental/streaming size hook to check maxSBOMSize during cataloging, only once
+	// syft.CreateSBOM above has already returned a complete result (see #473 and the
+	// maxSBOMSize caveat in docs/CONFIGURATION.md). Memory used while generating is bounded
+	// by the process's memory limit, not by maxSBOMSize.
 	sz := size.Of(syftSBOM)
 	domainSBOM.Annotations[helpersv1.ResourceSizeMetadataKey] = fmt.Sprintf("%d", sz)
 	if sz > s.maxSBOMSize {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -167,7 +167,7 @@ The main configuration file. All options can be overridden via environment varia
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `maxImageSize` | int | `536870912` | Maximum image size to scan in bytes (default: 512 MB) |
-| `maxSBOMSize` | int | `20971520` | Maximum SBOM size in bytes (default: 20 MB) |
+| `maxSBOMSize` | int | `20971520` | Maximum SBOM size in bytes (default: 20 MB). Enforced after SBOM generation completes, not during it — Syft doesn't expose an incremental size hook, so an oversized SBOM is rejected only once it has already been built in memory. During generation, actual memory use is bounded by the scanner container's memory limit, not by this value. |
 | `scanConcurrency` | int | `1` | Number of concurrent scans |
 | `scanTimeout` | duration | `5m` | Timeout for SBOM generation |
 | `scanEmbeddedSBOMs` | bool | `false` | Scan for embedded SBOMs in images |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -167,7 +167,7 @@ The main configuration file. All options can be overridden via environment varia
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `maxImageSize` | int | `536870912` | Maximum image size to scan in bytes (default: 512 MB) |
-| `maxSBOMSize` | int | `20971520` | Maximum SBOM size in bytes (default: 20 MB). Enforced after SBOM generation completes, not during it — Syft doesn't expose an incremental size hook, so an oversized SBOM is rejected only once it has already been built in memory. During generation, actual memory use is bounded by the scanner container's memory limit, not by this value. |
+| `maxSBOMSize` | int | `20971520` | Maximum SBOM size in bytes (default: 20 MB). Enforced after SBOM generation completes, not during it — Syft doesn't expose an incremental size hook, so an oversized SBOM is rejected only once it has already been built in memory. During generation, actual memory use is bounded by the memory limit of whichever container runs Syft, not by this value: the `sbom-scanner` sidecar container when `SBOM_SCANNER_SOCKET` is configured, or the main kubevuln container otherwise (in-process `SyftAdapter`). |
 | `scanConcurrency` | int | `1` | Number of concurrent scans |
 | `scanTimeout` | duration | `5m` | Timeout for SBOM generation |
 | `scanEmbeddedSBOMs` | bool | `false` | Scan for embedded SBOMs in images |

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/mod v0.35.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	k8s.io/apimachinery v0.35.0
@@ -424,7 +425,6 @@ require (
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/DmitriyVTitov/size"
@@ -121,7 +120,6 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 
 type scannerServer struct {
 	pb.UnimplementedSBOMScannerServer
-	mu      sync.Mutex
 	version string
 }
 
@@ -132,10 +130,14 @@ func NewScannerServer() pb.SBOMScannerServer {
 	}
 }
 
+// CreateSBOM handles one scan per call, with no state shared across concurrent calls: each
+// invocation downloads into its own temp dir (via its own file.NewTempDirGenerator) and builds
+// its own SBOM from its own source. s.version is set once in NewScannerServer and never
+// mutated, so it's safe to read concurrently without a lock. Do not add a mutex/semaphore
+// around this method — a previous version serialized the whole RPC (pull + generation) behind
+// a single process-wide lock, which defeated the caller's scanConcurrency entirely regardless
+// of its configured value (see #473); concurrency is bounded by the caller instead.
 func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMRequest) (*pb.CreateSBOMResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	// imageID is already the final, normalized pull reference. The SidecarSBOMAdapter
 	// normalizes it (NormalizeImageID) before sending the request - that is the single
 	// normalization point. Do not normalize again here: re-normalizing an
@@ -275,7 +277,11 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// Strip the SBOM to reduce size
 	v1beta1.StripSBOM(syftSBOM)
 
-	// Check in-memory size
+	// Check in-memory size. This is necessarily a post-hoc check: Syft doesn't expose an
+	// incremental/streaming size hook to check MaxSbomSize during cataloging, only once
+	// syft.CreateSBOM above has already returned a complete result (see #473 and the
+	// maxSBOMSize caveat in docs/CONFIGURATION.md). Memory used while generating is bounded
+	// by the scanner container's memory limit, not by MaxSbomSize.
 	sz := size.Of(syftSBOM)
 	if sz > int(req.MaxSbomSize) {
 		logger.L().Warning("SBOM exceeds size limit",

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -136,7 +136,15 @@ func NewScannerServer() pb.SBOMScannerServer {
 // mutated, so it's safe to read concurrently without a lock. Do not add a mutex/semaphore
 // around this method — a previous version serialized the whole RPC (pull + generation) behind
 // a single process-wide lock, which defeated the caller's scanConcurrency entirely regardless
-// of its configured value (see #473); concurrency is bounded by the caller instead.
+// of its configured value (see #473); the number of concurrent in-flight RPCs is bounded by
+// the caller instead, matching scanConcurrency.
+//
+// That bound is on in-flight RPCs, not on actual Syft resource usage: syft.CreateSBOM below
+// runs on context.Background() and Syft's catalogers don't support cancellation, so when
+// dl.Run times out and this RPC returns Incomplete, the abandoned Syft goroutine can keep
+// consuming CPU/memory in the background after the caller already considers that slot free
+// and starts another scan. scanConcurrency therefore bounds concurrent requests, not peak
+// concurrent Syft memory/CPU use, on this path.
 func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMRequest) (*pb.CreateSBOMResponse, error) {
 	// imageID is already the final, normalized pull reference. The SidecarSBOMAdapter
 	// normalizes it (NormalizeImageID) before sending the request - that is the single


### PR DESCRIPTION
## Overview

The sidecar SBOM-scanner path (used whenever `SBOM_SCANNER_SOCKET` is set) never got the concurrency/robustness hardening the in-process Syft adapter was meant to get. Three problems in that subsystem compounded each other; this PR fixes all three plus a small related cleanup in the same file.

## What changed

1. **Removed the whole-RPC mutex serializing every sidecar scan.** `scannerServer.CreateSBOM` (`pkg/sbomscanner/v1/server.go`) held `s.mu` around the *entire* handler — registry pull and full Syft cataloging — so `scanConcurrency` had no effect once the sidecar was in the loop; every concurrent scan queued behind whichever one was currently running. Each RPC already downloads into its own temp dir (`file.NewTempDirGenerator`) and builds its own SBOM, and `s.version` is set once at construction and never mutated — nothing shared actually needed guarding. The lock is gone; left a comment explaining why so it doesn't get silently reintroduced.
2. **Fixed `SidecarSBOMAdapter.Version()`'s cache poisoning.** It used `sync.Once` around a single, no-retry, 5s `Health()` call. One transient gRPC hiccup (e.g. right after the sidecar starts) permanently cached `"unknown"` as the version for the rest of the pod's life. That's not just a cosmetic string: `Version()` is the SBOM/CVE storage cache key, and `repositories/apiserver.go` compares it via `semver.Compare`, which treats an invalid version string as always older than a valid one — so a poisoned replica writes manifests tagged `"unknown"`, and every replica (including healthy ones) then discards them as outdated and regenerates on every read. Replaced `sync.Once` with a cache that only sticks on a successful `Health()` call; a failure just means the next call retries instead of latching forever.
3. **Documented the `maxSBOMSize` enforcement-timing limitation.** It's checked only after `syft.CreateSBOM` finishes building the full in-memory catalog, in both the sidecar (`server.go`) and in-process (`syft.go`) paths. Syft doesn't expose an incremental size hook, so this was already the best available check — it just wasn't written down as a post-hoc check backed by the scanner container's memory limit rather than a hard pre-emptive bound. Added that caveat to `docs/CONFIGURATION.md` (same pattern as the existing `scannerReadinessTimeout` note) and inline at both call sites.
4. **Bounded `retryCount` growth.** Crash-retry entries were only ever cleared on success or once `maxCrashRetries` was hit, so an image that crashed the scanner once and was never scanned again (common with CI-generated unique tags/digests) left a permanent entry — slow, unbounded map growth over the adapter's lifetime. Added a `crashRetry{count, lastSeen}` struct and an opportunistic TTL sweep (`retryCountTTL = 1h`) that runs each time `handleCrash` touches the map.

## Tests

- `TestSidecarSBOMAdapter_Version_RecoversAfterTransientFailure` (new): asserts `Version()` returns `"unknown"` on a failed `Health()` call, then recovers to the real version on the next call instead of staying pinned to `"unknown"`.
- `TestSidecarSBOMAdapter_CreateSBOM_CrashRetry_EvictsStaleEntries` (new): asserts a stale `retryCount` entry gets swept out the next time the map is touched by a different image's crash.
- Existing `TestSidecarSBOMAdapter_*` suite in `adapters/v1/sidecar_test.go` — unchanged behavior, all still pass.
- Full `pkg/sbomscanner/v1` package (unit + integration tests over the real gRPC/Unix-socket path) passes with the mutex removed.

## How to Test

```bash
go build ./...
go vet ./adapters/... ./pkg/sbomscanner/...
go test ./adapters/v1/... -run TestSidecarSBOMAdapter -v
go test ./pkg/sbomscanner/...
```

Not touched by this PR: `Test_grypeAdapter_DBVersion` in `adapters/v1` fails locally on Windows with a `testcontainers`/Docker panic (`rootless Docker is not supported on Windows`) — that's pre-existing and unrelated, tracked separately in #471.

## Related issues/PRs:

* Resolved #473

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version checks now retry after temporary health-check failures and cache only successful results.
  * Concurrent version checks are consolidated to avoid redundant health requests.
  * Crash-retry records expire after one hour, preventing stale entries from affecting processing.

* **Performance**
  * SBOM generation can now process multiple requests concurrently.

* **Documentation**
  * Clarified that SBOM size limits are checked after generation and memory usage is governed by the scanner’s container limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->