### PR TITLE
fix: fetch the full summary in StoreCVESummaryStub so the data-preservation guard works

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -664,7 +664,7 @@ func (a *APIServerStore) StoreCVESummaryStub(ctx context.Context, status string)
 				return err
 			}
 			// retrieve the latest version before attempting update
-			result, getErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Get(ctx, manifest.Name, metav1.GetOptions{ResourceVersion: "metadata"})
+			result, getErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Get(ctx, manifest.Name, metav1.GetOptions{})
 			if getErr != nil {
 				return getErr
 			}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -757,6 +757,49 @@ func TestAPIServerStore_StoreCVESummaryStub(t *testing.T) {
 	})
 }
 
+// TestAPIServerStore_StoreCVESummaryStub_DoesNotUseMetadataGet guards the
+// data-preservation guard in StoreCVESummaryStub: its retry-path Get must fetch
+// the full object, not request ResourceVersion "metadata" (which kubescape/
+// storage returns as an ObjectMeta-only object with a zeroed Spec). The fake
+// clientset ignores GetOptions, so a behavioral test cannot reproduce the
+// resulting data loss; only an assertion on the requested GetOptions can.
+func TestAPIServerStore_StoreCVESummaryStub_DoesNotUseMetadataGet(t *testing.T) {
+	workload := domain.ScanCommand{
+		Wlid:          "wlid://cluster-kind/namespace-local-path-storage/deployment-local-path-provisioner",
+		ContainerName: "local-path-provisioner",
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	clientset := fake.NewSimpleClientset()
+	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}
+	a := &APIServerStore{StorageClient: wrapped, Namespace: "kubescape"}
+
+	ns, err := GetCVESummaryK8sResourceNamespace(ctx)
+	require.NoError(t, err)
+	resourceName, err := GetCVESummaryK8sResourceName(ctx)
+	require.NoError(t, err)
+
+	// Seed a real summary so the stub's Create returns AlreadyExists and the
+	// retry-path Get executes.
+	real := &v1beta1.VulnerabilityManifestSummary{
+		ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+		Spec: v1beta1.VulnerabilityManifestSummarySpec{
+			Severities: v1beta1.SeveritySummary{
+				High: v1beta1.VulnerabilityCounters{All: 3, Relevant: 1},
+			},
+		},
+	}
+	_, err = wrapped.VulnerabilityManifestSummaries(ns).Create(context.Background(), real, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, a.StoreCVESummaryStub(ctx, helpersv1.Incomplete))
+
+	require.NotNil(t, wrapped.vulnSummaries[ns], "summary sub-client must have been exercised")
+	require.Empty(t, wrapped.vulnSummaries[ns].getResourceVersion,
+		"StoreCVESummaryStub must not request the metadata-only Get")
+}
+
 func TestAPIServerStore_enrichSummaryManifestObjectLabels(t *testing.T) {
 	ctx := context.Background()
 
@@ -1555,11 +1598,13 @@ func (w *ctxCapturingOVECs) Update(ctx context.Context, obj *v1beta1.OpenVulnera
 
 type ctxCapturingVulnerabilityManifestSummaries struct {
 	spdxv1beta1.VulnerabilityManifestSummaryInterface
-	getCtx context.Context
+	getCtx             context.Context
+	getResourceVersion string
 }
 
 func (w *ctxCapturingVulnerabilityManifestSummaries) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1beta1.VulnerabilityManifestSummary, error) {
 	w.getCtx = ctx
+	w.getResourceVersion = opts.ResourceVersion
 	return w.VulnerabilityManifestSummaryInterface.Get(ctx, name, opts)
 }
 


### PR DESCRIPTION
Fixes #475

## Overview

`StoreCVESummaryStub` (`repositories/apiserver.go:626-701`) is meant to never overwrite a real summary's `Spec` — `summaryHasVulnerabilityData` (`:672`) and the "keep any existing Spec" intent (`:675`). The retry-path `Get` (`:667`) used `metav1.GetOptions{ResourceVersion: "metadata"}`, which the pinned storage backend (`kubescape/storage@v0.0.258`) returns as an `ObjectMeta`-only object with a zeroed `Spec` (`pkg/registry/file/storage.go:422-436`; `ResourceVersionMetadata = "metadata"`, `pkg/apis/softwarecomposition/register.go:27`). The guard therefore sees an empty `Spec` and never fires, and the subsequent `Update` writes the zeroed `Spec` back — silently erasing a real summary's `Severities`/`Vulnerabilities`.

The siblings are safe with the metadata-`Get` only because they overwrite `Spec` wholesale (`StoreCVE:339`, `StoreCVESummary:580`, `StoreSBOM:1224/:1261`, e.g. `result.Spec = manifest.Spec` at `StoreCVESummary:587`). `StoreVEX` documents this exact pitfall (`:756-763`) and deliberately uses plain `GetOptions{}` (`:765`) because it merges into `Spec`. `StoreCVESummaryStub` is the one method that both uses the metadata-`Get` and preserves the fetched `Spec`. This change is correct-by-construction regardless of storage-server behavior.

---

## Change

`repositories/apiserver.go:667`:

```go
result, getErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Get(ctx, manifest.Name, metav1.GetOptions{})
```

One-token change: `{ResourceVersion: "metadata"}` → `{}`, matching the `StoreVEX` pattern (`:765`). The guard now sees the real `Spec` (real data → skip update); with no real data, the update preserves the existing `Spec`. Only cost is a slightly heavier read on the `AlreadyExists` path.

---

## Tests

`TestAPIServerStore_StoreCVESummaryStub_DoesNotUseMetadataGet` (`repositories/apiserver_test.go`).

**Why a mechanism test:** The existing behavioral test ("update over a real summary preserves Spec", `apiserver_test.go:730-757`) passes on both the buggy and the fixed code, because the fake clientset ignores `GetOptions` and always returns the full object. Only an assertion on the requested `GetOptions.ResourceVersion` can catch the regression. The test seeds a real summary (forcing the `AlreadyExists` → retry-path `Get`) and asserts the stub's `Get` uses an empty `ResourceVersion`.

Red on `main` / green with this change (verified by reverting the fix):

```text
# fix reverted (buggy code):
[FAIL] TestAPIServerStore_StoreCVESummaryStub_DoesNotUseMetadataGet
  Should be empty, but was metadata

# fix applied:
Go test: 1 passed in 1 packages
```

---

## Verification

- `go build ./...` — clean
- `go vet ./repositories/` — no issues
- `gofmt -l repositories/apiserver.go repositories/apiserver_test.go` — clean
- `go test ./repositories/ -run 'TestAPIServerStore_StoreCVESummaryStub' -count=1` — 5 passed (4 existing + new)
- `go test ./repositories/... -count=1` — 34 passed

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] DCO signed off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vulnerability summary retrieval to use complete resource data when updating existing summaries.
  * Existing vulnerability summaries are now preserved correctly during retries and updates.

* **Tests**
  * Added regression coverage to verify correct resource retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->