### PR TITLE
fix(adapters): key relevancy merge by (cve, package)

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -407,16 +407,8 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 		if err != nil {
 			return fmt.Errorf("failed to convert filtered vulnerabilities to report: %w", err)
 		}
-		// index relevantVulnerabilities
-		cvepIndices := map[string]struct{}{}
-		for _, v := range relevantVulnerabilities {
-			cvepIndices[v.Name] = struct{}{}
-		}
 		// mark common vulnerabilities as relevant
-		for i, v := range vulnerabilities {
-			_, isRelevant := cvepIndices[v.Name]
-			vulnerabilities[i].IsRelevant = &isRelevant
-		}
+		markRelevantVulnerabilities(vulnerabilities, relevantVulnerabilities)
 	}
 
 	finalReport := v1.ScanResultReport{
@@ -519,4 +511,20 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 func httpPostDebug(httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte) (*http.Response, error) {
 	logger.L().Debug("httpPostDebug", helpers.String("fullURL", fullURL), helpers.Interface("headers", headers), helpers.String("body", string(body)))
 	return httputils.HttpPostWithContext(context.Background(), httpClient, fullURL, headers, body, -1, func(resp *http.Response) bool { return true })
+}
+
+// markRelevantVulnerabilities annotates each vulnerability with IsRelevant=true iff the same
+// (CVE, package) pair also appeared in the relevancy (CVEp) scan. Keying by CVE id alone would
+// mark a CVE relevant on every package it affects even when only one of those packages was
+// executed; the pair is the record identity (see RelatedPackageName in DomainToArmo and the
+// uniqueness assertion in backend_test.go).
+func markRelevantVulnerabilities(vulnerabilities, relevantVulnerabilities []cs.CommonContainerVulnerabilityResult) {
+	cvepIndices := make(map[string]struct{}, len(relevantVulnerabilities))
+	for _, v := range relevantVulnerabilities {
+		cvepIndices[v.Name+"+"+v.RelatedPackageName] = struct{}{}
+	}
+	for i, v := range vulnerabilities {
+		_, isRelevant := cvepIndices[v.Name+"+"+v.RelatedPackageName]
+		vulnerabilities[i].IsRelevant = &isRelevant
+	}
 }

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -385,6 +386,173 @@ func TestBackendAdapter_SubmitCVE(t *testing.T) {
 			ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
 			if err := a.SubmitCVE(ctx, tt.cve, tt.cvep); (err != nil) != tt.wantErr {
 				t.Errorf("SubmitCVE() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBackendAdapter_SubmitCVE_RelevancySubset(t *testing.T) {
+	// minimal valid image source so ParseImageManifest succeeds; the config is stored
+	// base64-encoded (the []byte JSON field forces base64), matching real syft output
+	config := base64.StdEncoding.EncodeToString([]byte(`{"architecture":"amd64","os":"linux","history":[],"rootfs":{"type":"layers","diff_ids":[]}}`))
+	imageTarget := fmt.Sprintf(`{"userInput":"","imageID":"","manifestDigest":"","mediaType":"","tags":null,"imageSize":0,"layers":[{"mediaType":"","digest":"dummyLayer","size":0}],"manifest":null,"config":%q,"repoDigests":null,"architecture":"","os":""}`, config)
+
+	match := func(id, pkg string) v1beta1.Match {
+		return v1beta1.Match{
+			Vulnerability: v1beta1.Vulnerability{
+				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: id},
+			},
+			Artifact: v1beta1.GrypePackage{Name: pkg},
+		}
+	}
+	full := domain.CVEManifest{
+		Content: &v1beta1.GrypeDocument{
+			Source: &v1beta1.Source{Target: json.RawMessage(imageTarget)},
+			Matches: []v1beta1.Match{
+				match("CVE-2024-0001", "libssl1.1"),
+				match("CVE-2024-0001", "openssl"),
+				match("CVE-2024-0002", "zlib1g"),
+			},
+		},
+	}
+	cvep := domain.CVEManifest{
+		Content: &v1beta1.GrypeDocument{
+			Source: &v1beta1.Source{Target: json.RawMessage(imageTarget)},
+			Matches: []v1beta1.Match{
+				match("CVE-2024-0001", "libssl1.1"),
+			},
+		},
+	}
+
+	var gotReport v1.ScanResultReport
+	httpPostFunc := func(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, timeOut time.Duration) (*http.Response, error) {
+		var report v1.ScanResultReport
+		if err := json.Unmarshal(body, &report); err != nil {
+			t.Errorf("failed to unmarshal report: %v", err)
+		}
+		gotReport = report
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBuffer([]byte{})),
+		}, nil
+	}
+
+	a := &BackendAdapter{
+		getCVEExceptionsFunc: func(s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
+		httpPostFunc:          httpPostFunc,
+		securityExceptionRepo: &repositories.NoOpSecurityExceptionRepository{},
+	}
+	ctx := context.TODO()
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, time.Now().Unix())
+	ctx = context.WithValue(ctx, domain.ScanIDKey{}, uuid.New().String())
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
+
+	require.NoError(t, a.SubmitCVE(ctx, full, cvep))
+
+	require.Len(t, gotReport.Vulnerabilities, 3)
+	wantRelevant := map[string]bool{
+		"CVE-2024-0001+libssl1.1": true,
+		"CVE-2024-0001+openssl":   false,
+		"CVE-2024-0002+zlib1g":    false,
+	}
+	for _, v := range gotReport.Vulnerabilities {
+		id := v.Name + "+" + v.RelatedPackageName
+		want, ok := wantRelevant[id]
+		require.True(t, ok, "unexpected vulnerability %s", id)
+		require.NotNil(t, v.IsRelevant, "IsRelevant should be set for %s", id)
+		assert.Equal(t, want, *v.IsRelevant, "IsRelevant mismatch for %s", id)
+	}
+	require.NotNil(t, gotReport.Summary)
+	assert.Equal(t, int64(1), gotReport.Summary.RelevantCount)
+}
+
+func TestMarkRelevantVulnerabilities(t *testing.T) {
+	vuln := func(name, pkg string) containerscan.CommonContainerVulnerabilityResult {
+		return containerscan.CommonContainerVulnerabilityResult{
+			Vulnerability: containerscan.Vulnerability{Name: name, RelatedPackageName: pkg},
+		}
+	}
+	tests := []struct {
+		name                string
+		vulnerabilities     []containerscan.CommonContainerVulnerabilityResult
+		relevantVulns       []containerscan.CommonContainerVulnerabilityResult
+		wantRelevantVulnIDs map[string]bool // key: name+"+"+relatedPackageName
+	}{
+		{
+			name: "same cve on multiple packages, only one executed",
+			vulnerabilities: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "libssl1.1"),
+				vuln("CVE-2024-0001", "openssl"),
+			},
+			relevantVulns: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "libssl1.1"),
+			},
+			wantRelevantVulnIDs: map[string]bool{
+				"CVE-2024-0001+libssl1.1": true,
+				"CVE-2024-0001+openssl":   false,
+			},
+		},
+		{
+			name: "single cve single package present in both scans",
+			vulnerabilities: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "libssl1.1"),
+			},
+			relevantVulns: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "libssl1.1"),
+			},
+			wantRelevantVulnIDs: map[string]bool{
+				"CVE-2024-0001+libssl1.1": true,
+			},
+		},
+		{
+			name: "disjoint cves",
+			vulnerabilities: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "libssl1.1"),
+			},
+			relevantVulns: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0002", "openssl"),
+			},
+			wantRelevantVulnIDs: map[string]bool{
+				"CVE-2024-0001+libssl1.1": false,
+			},
+		},
+		{
+			name: "empty relevancy scan marks nothing relevant",
+			vulnerabilities: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "libssl1.1"),
+			},
+			wantRelevantVulnIDs: map[string]bool{
+				"CVE-2024-0001+libssl1.1": false,
+			},
+		},
+		{
+			name: "mixed cves on multiple packages",
+			vulnerabilities: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "p1"),
+				vuln("CVE-2024-0001", "p2"),
+				vuln("CVE-2024-0002", "p3"),
+			},
+			relevantVulns: []containerscan.CommonContainerVulnerabilityResult{
+				vuln("CVE-2024-0001", "p1"),
+			},
+			wantRelevantVulnIDs: map[string]bool{
+				"CVE-2024-0001+p1": true,
+				"CVE-2024-0001+p2": false,
+				"CVE-2024-0002+p3": false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			markRelevantVulnerabilities(tt.vulnerabilities, tt.relevantVulns)
+			for _, v := range tt.vulnerabilities {
+				id := v.Name + "+" + v.RelatedPackageName
+				want, ok := tt.wantRelevantVulnIDs[id]
+				require.True(t, ok, "unexpected vulnerability %s", id)
+				require.NotNil(t, v.IsRelevant, "IsRelevant should be set for %s", id)
+				assert.Equal(t, want, *v.IsRelevant, "IsRelevant mismatch for %s", id)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #478

## Overview

Fixed the relevancy merge in `SubmitCVE` that marked a CVE as relevant on every package it affects, even when the relevancy (CVEp) scan only found it on a single executed package.

The merge was keyed by CVE ID only (`cvepIndices[v.Name]`), dropping `RelatedPackageName` — even though `(CVE, package)` is the record identity: `DomainToArmo` emits `RelatedPackageName`, and the uniqueness assertion in `backend_test.go` keys by `Name + "+" + RelatedPackageName`.

The merge is now extracted into `markRelevantVulnerabilities`, keyed by the composite `Name + "+" + RelatedPackageName` on both build and lookup. The key is lossless: CVE/GHSA/EUVD IDs never contain `+`, so the separator is unambiguous even when a package name does (e.g., `libstdc++6`).

**Impact (scoped):** Report data accuracy — wrong package attribution and inflated `RelevantCount`/`RelevancyScanCount`. Not a security exposure; the CVE is still genuinely relevant via the executed package.

---

## Additional Information

- **Why this went unnoticed:** The integration fixtures (`testdata/nginx-cve.json` vs `testdata/nginx-filtered-cve.json`) are content-identical at the `(CVE, package)` level, so the golden test cannot observe a subset divergence. A proper subset is the normal case in production — the CVEp scan is produced from the executed-files-filtered SBOM (`filterSBOM`, `core/services/scan.go:842`).
- **Testing approach:** A new end-to-end test (`TestBackendAdapter_SubmitCVE_RelevancySubset`) reproduces the exact scenario through `SubmitCVE` — `CVE-2024-0001` on `libssl1.1` + `openssl`, with CVEp containing only `libssl1.1`. It failed before the fix (`openssl` marked relevant) and passes after. A focused unit test (`TestMarkRelevantVulnerabilities`) covers the merge logic (same-CVE multi-package, disjoint, empty CVEp, mixed).

---

## How to Test

```bash
go test ./adapters/v1/ -run 'TestMarkRelevantVulnerabilities|TestBackendAdapter_SubmitCVE' -v
go build ./...
```

Full suite: 438 passed, 2 failed — both pre-existing Docker/local-registry environment failures (`Test_grypeAdapter_DBVersion`, `TestCreateSBOM_ImageTooLarge_LocalRegistry`), verified to fail on clean `main` as well. `golangci-lint` reports 18 issues, identical to the clean baseline (0 new).

---

## Examples/Screenshots

N/A

---

## Related Issues/PRs

- Resolved #478

---

## Checklist Before Requesting a Review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes