### PR TITLE
fix: include SecurityException-suppressed CVEs in generated VEX document

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -301,6 +301,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		}
 
 		// if CVE manifest is not available, create it
+		var filteredCve domain.CVEManifest
 		if cve.Content == nil {
 			// scan for CVE
 			cve, err = s.cveScanner.ScanSBOM(ctx, sbom)
@@ -313,7 +314,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 
 			// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-			filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
+			filteredCve, _ = s.applyExceptionsToManifest(ctx, cve)
 
 			// store filtered CVE
 			if s.storage {
@@ -338,7 +339,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			// unfiltered data a cache miss would produce.
 			prevIgnored := v1.IgnoredMatchKeys(cve.Content)
 			cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-			filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
+			var exceptionsComplete bool
+			filteredCve, exceptionsComplete = s.applyExceptionsToManifest(ctx, cve)
 
 			if s.storage {
 				curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
@@ -421,7 +423,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 					// no continue, storing the CVE summary is not critical
 				}
 				if s.vexGeneration {
-					err = s.cveRepository.StoreVEX(ctx, cve, cvep, true)
+					err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCvep, true)
 					if err != nil {
 						logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
 							helpers.String("imageSlug", slug))

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1118,13 +1118,75 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		}
 	}
 
+	for _, v := range cve.Content.IgnoredMatches {
+		found := false
+		for _, s := range vexDoc.Statements {
+			if s.Vulnerability.Name != v.Vulnerability.ID {
+				continue
+			}
+			if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
+				continue
+			}
+			if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Add the vulnerability to the VEX document
+			var aliases []string
+			for _, alias := range v.RelatedVulnerabilities {
+				aliases = append(aliases, alias.ID)
+			}
+
+			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
+			if err != nil {
+				return err
+			}
+
+			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:          v.Vulnerability.DataSource,
+					Name:        v.Vulnerability.ID,
+					Description: v.Vulnerability.Description,
+					Aliases:     aliases,
+				},
+
+				Products: []v1beta1.Product{
+					*product,
+				},
+
+				Status:          v1beta1.Status(vex.StatusNotAffected),
+				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
+				ImpactStatement: "Vulnerability was ignored by a SecurityException",
+			})
+		}
+	}
+
+	ignoredMap := make(map[string]bool)
+	for _, v := range cve.Content.IgnoredMatches {
+		ignoredMap[v.Vulnerability.ID+v.Artifact.PURL] = true
+	}
+
 	// Reset every statement back to the baseline "not affected" status before
 	// reapplying the current filtered manifest.
 	for i := range vexDoc.Statements {
 		vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
 		vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
-		vexDoc.Statements[i].ImpactStatement = "Vulnerable component is not loaded into the memory"
 		vexDoc.Statements[i].ActionStatement = ""
+		
+		isIgnored := false
+		if len(vexDoc.Statements[i].Products) > 0 && len(vexDoc.Statements[i].Products[0].Subcomponents) > 0 {
+			if ignoredMap[vexDoc.Statements[i].Vulnerability.Name+vexDoc.Statements[i].Products[0].Subcomponents[0].ID] {
+				isIgnored = true
+			}
+		}
+
+		if isIgnored {
+			vexDoc.Statements[i].ImpactStatement = "Vulnerability was ignored by a SecurityException"
+		} else {
+			vexDoc.Statements[i].ImpactStatement = "Vulnerable component is not loaded into the memory"
+		}
 	}
 
 	// Now change the status of the filtered vulnerabilities to "Affected"

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -368,6 +368,85 @@ func TestAPIServerStore_storeVEX(t *testing.T) {
 	assert.Equal(t, relevant+1, relevant2)
 }
 
+func TestAPIServerStore_storeVEX_ignoredMatches_append(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	// Inject an IgnoredMatch into the original cveManifest
+	cveManifest.Content.IgnoredMatches = append(cveManifest.Content.IgnoredMatches, v1beta1.IgnoredMatch{
+		Match: v1beta1.Match{
+			Vulnerability: v1beta1.Vulnerability{
+				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+					ID:         "CVE-IGNORE-TEST",
+					DataSource: "GHSA-IGNORE-TEST",
+				},
+			},
+			Artifact: v1beta1.GrypePackage{
+				Name:    "ignored-package",
+				Version: "1.0",
+			},
+		},
+	})
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	assert.NoError(t, err)
+
+	// Inject a second IgnoredMatch to trigger updateVEX and verify it correctly handles new ignored matches
+	// and preserves existing ones
+	cveManifest.Content.IgnoredMatches = append(cveManifest.Content.IgnoredMatches, v1beta1.IgnoredMatch{
+		Match: v1beta1.Match{
+			Vulnerability: v1beta1.Vulnerability{
+				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+					ID:         "CVE-IGNORE-TEST-2",
+					DataSource: "GHSA-IGNORE-TEST-2",
+				},
+			},
+			Artifact: v1beta1.GrypePackage{
+				Name:    "ignored-package-2",
+				Version: "2.0",
+			},
+		},
+	})
+
+	// Second call triggers the updateVEX path
+	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	assert.NoError(t, err)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, vexContainer)
+
+	var foundIgnored1, foundIgnored2 bool
+	for _, stmt := range vexContainer.Spec.Statements {
+		if stmt.Vulnerability.Name == "CVE-IGNORE-TEST" {
+			foundIgnored1 = true
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status)
+			assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), stmt.Justification)
+			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement)
+		}
+		if stmt.Vulnerability.Name == "CVE-IGNORE-TEST-2" {
+			foundIgnored2 = true
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status)
+			assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), stmt.Justification)
+			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement)
+		}
+	}
+	assert.True(t, foundIgnored1, "First IgnoredMatch should be preserved in the VEX document during update")
+	assert.True(t, foundIgnored2, "Second IgnoredMatch should be included in the VEX document during update")
+}
+
 // TestAPIServerStore_storeVEX_updateRestoresNotAffected guards against a regression where
 // updateVEX only ever promoted statements to "affected" and never reset them back to
 // "not_affected" once the corresponding CVE/package pair stopped being relevant.


### PR DESCRIPTION
## Overview
This PR fixes a bug where CVEs suppressed by a `SecurityException` were completely omitted from the generated VEX document, instead of being marked as `not_affected`.

**Current behavior**: If a CVE is marked as ignored via a SecurityException, it disappears from the VEX document, leaving no provenance that it was triaged.
**Future behavior**: Ignored CVEs correctly appear in the VEX document with a status of `not_affected`, a justification of `VulnerableCodeNotPresent`, and a statement noting that it was suppressed by a SecurityException.

## Additional Information
The fix consists of two changes:
1. In `core/services/scan.go`, the hoisted `filteredCve` manifest is passed to `StoreVEX()` instead of the raw `cve` manifest.
2. In `repositories/apiserver.go`, the `createVEX()` function iterates through `cve.Content.IgnoredMatches` and explicitly appends them to the VEX document.

## How to Test
1. Deploy `kubevuln` with `vexGeneration: true` enabled in your configuration.
2. Create a `SecurityException` targeting a specific CVE (e.g., CVE-2021-44228) for a workload.
3. Trigger a vulnerability scan for that workload.
4. Retrieve the generated VEX document:
   `kubectl get openvulnerabilityexchangecontainers -n <your-namespace> -o yaml`
5. Inspect the `.spec.statements` array. You should now see the ignored CVE listed with `status: not_affected` and a matching justification.

## Related issues/PRs:
* Resolved #481

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vulnerability exception handling so filtered results are applied consistently when generating VEX reports.
  - Ignored vulnerability matches are now included in VEX documents as **Not Affected**, with clear explanations that the vulnerable code is not present and the match was suppressed by a security exception.
  - Prevented duplicate ignored entries during VEX updates while preserving existing exception findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->