### PR TITLE
ci: add arm64 test lane to pull request workflow

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -40,9 +40,22 @@ jobs:
         with:
           platforms: arm64
 
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build-arm64
+            ~/go/pkg/mod-arm64
+          key: ${{ runner.os }}-arm64-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-go-
+
       - name: Run go test ./... on linux/arm64
         run: |
+          mkdir -p ~/.cache/go-build-arm64 ~/go/pkg/mod-arm64
           docker run --rm --platform linux/arm64 \
             -v "${{ github.workspace }}:/workspace" -w /workspace \
+            -v ~/.cache/go-build-arm64:/root/.cache/go-build \
+            -v ~/go/pkg/mod-arm64:/root/go/pkg/mod \
             -e CGO_ENABLED=0 \
             golang:1.25 go test ./...

--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -25,3 +25,24 @@ jobs:
       CGO_ENABLED: 0
       GO_VERSION: "1.25"
     secrets: inherit
+
+  # Runs the unit test suite under QEMU arm64 emulation so platform-specific
+  # regressions (e.g. in adapters/v1, pkg/sbomscanner/v1) are caught before
+  # merge, matching the linux/arm64 image published by pr-merged.yaml.
+  arm64-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Run go test ./... on linux/arm64
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            -e CGO_ENABLED=0 \
+            golang:1.25 go test ./...


### PR DESCRIPTION
## Overview
Adds an arm64 test lane to `.github/workflows/pr-created.yaml`. Pull requests now run `go test ./...` inside a QEMU-emulated `linux/arm64` container, in addition to the existing shared pr-created workflow, so platform-specific regressions are caught before merge instead of only after an arm64 image has been built and released.

## Additional Information
`pr-merged.yaml` already builds and publishes `linux/amd64,linux/arm64` images (`BUILD_PLATFORM: linux/amd64,linux/arm64`), but `pr-created.yaml` had no arm64 test step, so pull requests only validated on the runner's native amd64 architecture.

## How to Test
The new `arm64-test` job runs on every pull request via `.github/workflows/pr-created.yaml`. It can be reviewed by opening this PR and checking the Actions run for the `arm64-test` job.

## Related issues/PRs:
Resolved #489

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated ARM64 test coverage using Go 1.25.
  * The test suite now runs in a Linux ARM64 environment with CGO disabled, helping identify platform-specific issues before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->