### PR TITLE
feat: sweep stale stereoscope temp dirs at startup

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/core/services"
 	"github.com/kubescape/kubevuln/internal/metrics"
+	"github.com/kubescape/kubevuln/internal/tools"
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 	"github.com/kubescape/kubevuln/repositories"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
@@ -129,6 +130,21 @@ func main() {
 	controller, err = controller.WithMetrics(m)
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("metrics registration error", helpers.Error(err))
+	}
+
+	// Best-effort startup sweep: reclaim stereoscope temp dirs orphaned by previous process
+	// invocations killed by SIGKILL (OOM kill, or terminationGracePeriodSeconds exceeded)
+	// before their defer-based cleanup could run. The threshold is ScanTimeout: the main
+	// process and the SBOM-scanner sidecar run in the same Pod on the same machine (same
+	// kernel clock), so no clock-skew margin is needed, and a dir idle longer than
+	// ScanTimeout can only belong to a dead or already-timed-out scan.
+	if removed, err := tools.CleanupStaleTempDirs(os.TempDir(), "stereoscope-", c.ScanTimeout); err != nil {
+		logger.L().Ctx(ctx).Warning("startup temp dir sweep error",
+			helpers.Error(err),
+			helpers.Int("removed", removed))
+	} else if removed > 0 {
+		logger.L().Ctx(ctx).Info("startup temp dir sweep complete",
+			helpers.Int("removed", removed))
 	}
 
 	gin.SetMode(gin.ReleaseMode)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2,11 +2,13 @@ package tools
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"regexp"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 
@@ -103,6 +105,42 @@ func DeleteContents(dir string) error {
 		}
 	}
 	return nil
+}
+
+// CleanupStaleTempDirs removes directories under dir whose names start with prefix and whose
+// mtime is older than olderThan. It is a best-effort startup sweep to reclaim disk space left
+// by processes killed before their defer-based cleanup could run (e.g. SIGKILL from OOM or
+// Kubernetes terminationGracePeriodSeconds expiry).
+//
+// It returns the number of directories removed and a joined error of all failures encountered.
+// A non-nil error never blocks startup — callers should log and continue.
+func CleanupStaleTempDirs(dir, prefix string, olderThan time.Duration) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, err
+	}
+	cutoff := time.Now().Add(-olderThan)
+	removed := 0
+	var allErrs error
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			allErrs = errors.Join(allErrs, err)
+			continue
+		}
+		if !info.ModTime().Before(cutoff) {
+			continue // young enough — may belong to a live sidecar scan
+		}
+		if err := os.RemoveAll(path.Join(dir, e.Name())); err != nil {
+			allErrs = errors.Join(allErrs, err)
+			continue
+		}
+		removed++
+	}
+	return removed, allErrs
 }
 
 func NormalizeReference(ref string) string {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,10 +1,14 @@
 package tools
 
 import (
+	"os"
+	"path"
 	"testing"
+	"time"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackageVersion(t *testing.T) {
@@ -227,4 +231,84 @@ func TestReferenceMatchForms(t *testing.T) {
 			assert.Equal(t, tt.want, ReferenceMatchForms(tt.ref))
 		})
 	}
+}
+
+func TestCleanupStaleTempDirs(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, dir string)
+		prefix  string
+		age     time.Duration
+		wantN   int
+		wantErr bool
+	}{
+		{
+			name: "old matching dirs removed, fresh and unrelated kept",
+			setup: func(t *testing.T, dir string) {
+				old := time.Now().Add(-2 * time.Hour)
+				for _, d := range []string{"stereoscope-aaa", "stereoscope-bbb"} {
+					require.NoError(t, os.Mkdir(path.Join(dir, d), 0o755))
+					require.NoError(t, os.Chtimes(path.Join(dir, d), old, old))
+				}
+				require.NoError(t, os.Mkdir(path.Join(dir, "stereoscope-new"), 0o755))
+				require.NoError(t, os.Mkdir(path.Join(dir, "other-xyz"), 0o755))
+				require.NoError(t, os.Chtimes(path.Join(dir, "other-xyz"), old, old))
+			},
+			prefix: "stereoscope-",
+			age:    time.Hour,
+			wantN:  2,
+		},
+		{
+			name: "dir clearly younger than threshold is kept",
+			setup: func(t *testing.T, dir string) {
+				// cutoff = now-1h is computed inside CleanupStaleTempDirs, which runs AFTER
+				// this setup, so an exact -1h mtime would already be older than cutoff and be
+				// removed. A clear 5s margin inside the threshold makes the "kept" assertion
+				// deterministic regardless of clock drift.
+				inside := time.Now().Add(-1*time.Hour + 5*time.Second)
+				require.NoError(t, os.Mkdir(path.Join(dir, "stereoscope-edge"), 0o755))
+				require.NoError(t, os.Chtimes(path.Join(dir, "stereoscope-edge"), inside, inside))
+			},
+			prefix: "stereoscope-",
+			age:    time.Hour,
+			wantN:  0,
+		},
+		{
+			name:    "empty dir returns zero and no error",
+			setup:   func(t *testing.T, dir string) {},
+			prefix:  "stereoscope-",
+			age:     time.Hour,
+			wantN:   0,
+			wantErr: false,
+		},
+		{
+			name: "no matching prefix removes nothing",
+			setup: func(t *testing.T, dir string) {
+				old := time.Now().Add(-2 * time.Hour)
+				require.NoError(t, os.Mkdir(path.Join(dir, "other-dir"), 0o755))
+				require.NoError(t, os.Chtimes(path.Join(dir, "other-dir"), old, old))
+			},
+			prefix: "stereoscope-",
+			age:    time.Hour,
+			wantN:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.setup(t, dir)
+			n, err := CleanupStaleTempDirs(dir, tt.prefix, tt.age)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantN, n)
+		})
+	}
+}
+
+func TestCleanupStaleTempDirs_NonexistentDir(t *testing.T) {
+	_, err := CleanupStaleTempDirs(path.Join(t.TempDir(), "does-not-exist"), "stereoscope-", time.Hour)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Closes #483

## Overview
Stereoscope creates a `/tmp/stereoscope-*` temp dir per scan and removes it via
`defer t.Cleanup()` (`adapters/v1/syft.go`, `pkg/sbomscanner/v1/server.go`). SIGKILL
(OOM kill, or Kubernetes termination after `terminationGracePeriodSeconds` expires)
skips deferred cleanup, orphaning these dirs across container restarts in a surviving
pod (`emptyDir` survives) or on PVC-backed `/tmp`.

This PR adds a best-effort startup sweep in `cmd/http/main.go`, before the server
accepts scan requests, that deletes `/tmp` dirs matching `stereoscope-*` whose mtime
is older than `ScanTimeout`.

## Additional Information
- Threshold is `ScanTimeout` (default 5m): the main process and the SBOM-scanner
  sidecar run in the same Pod on the same machine (same kernel clock), so no
  clock-skew margin is needed; a dir idle longer than `ScanTimeout` can only belong
  to a dead or already-timed-out scan.
- One sweep covers both processes: the in-process Syft adapter and the sidecar write
  to the same mounted `/tmp`, so a single sweep in the main process reclaims orphans
  from both.
- Best-effort: on error it logs a warning and startup continues. No config knob, no
  new dependencies.
- Known tradeoff: on a main-only container restart, a surviving sidecar mid-scan (it
  keeps pulling on a detached context, #421) could have its temp dir swept — worst
  case is one failed scan, which is retried.
- Untested-by-design: mid-sweep removal failure aggregation (`errors.Join`) is not
  exercised — portable failure injection would require an fs abstraction.

## How to Test
```bash
go test ./internal/tools/ ./cmd/http/ -v
go build ./...
```

Full suite: 438 passed, 2 failed — both pre-existing Docker/local-registry
environment failures (`Test_syftAdapter_CreateSBOM`, `TestCreateSBOM_ImageTooLarge_LocalRegistry`),
verified to fail on clean `main` as well. No new golangci-lint issues.

## Examples/Screenshots
N/A

## Related issues/PRs
- Resolved #483

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes stale temporary scan directories during service startup.
  * Keeps recent and unrelated temporary directories intact.
  * Logs cleanup warnings when removal errors occur and reports successful cleanup activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->