### PR TITLE
fix: resolve TOCTOU race condition in sidecar version cache

### DIFF
--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -250,14 +250,14 @@ func (s *SidecarSBOMAdapter) Version() string {
 		if err != nil {
 			return "", err
 		}
-		
+
 		s.versionMu.Lock()
 		defer s.versionMu.Unlock()
 		s.versionStr = version
-		
+
 		return version, nil
 	})
-	
+
 	if err != nil {
 		logger.L().Warning("failed to get scanner version", helpers.Error(err))
 		return "unknown"

--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -234,24 +234,36 @@ func (s *SidecarSBOMAdapter) Version() string {
 	s.versionMu.Unlock()
 
 	v, err, _ := s.versionGroup.Do("version", func() (any, error) {
+		// Another goroutine may have populated versionStr after the
+		// singleflight key was released but before this closure executes.
+		// Recheck the cache to avoid issuing a redundant Health() request.
+		s.versionMu.Lock()
+		if s.versionStr != "" {
+			s.versionMu.Unlock()
+			return s.versionStr, nil
+		}
+		s.versionMu.Unlock()
+
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		version, _, err := s.client.Health(ctx)
 		if err != nil {
 			return "", err
 		}
+		
+		s.versionMu.Lock()
+		defer s.versionMu.Unlock()
+		s.versionStr = version
+		
 		return version, nil
 	})
+	
 	if err != nil {
 		logger.L().Warning("failed to get scanner version", helpers.Error(err))
 		return "unknown"
 	}
 
-	version := v.(string)
-	s.versionMu.Lock()
-	s.versionStr = version
-	s.versionMu.Unlock()
-	return version
+	return v.(string)
 }
 
 func (s *SidecarSBOMAdapter) GetMaxImageSize() int64 {

--- a/adapters/v1/sidecar_race_test.go
+++ b/adapters/v1/sidecar_race_test.go
@@ -1,0 +1,63 @@
+package v1
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
+)
+
+type mockScannerClientRace struct {
+	sbomscanner.SBOMScannerClient
+	healthCalls int32
+}
+
+func (m *mockScannerClientRace) Health(ctx context.Context) (string, bool, error) {
+	atomic.AddInt32(&m.healthCalls, 1)
+	return "test-version", true, nil
+}
+
+func TestSidecarVersion_CachingUnderConcurrency(t *testing.T) {
+	mockClient := &mockScannerClientRace{}
+	
+	adapter := &SidecarSBOMAdapter{
+		client: mockClient,
+	}
+
+	var wg sync.WaitGroup
+	var readyWg sync.WaitGroup
+	startCh := make(chan struct{})
+	workers := 100
+	
+	// Launch many goroutines that constantly call Version() to hit the tiny race window
+	// between singleflight.Do returning and versionMu being locked.
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		readyWg.Add(1)
+		go func() {
+			defer wg.Done()
+			readyWg.Done()
+			<-startCh
+			
+			for j := 0; j < 1000; j++ {
+				version := adapter.Version()
+				if version != "test-version" {
+					t.Errorf("expected test-version, got %s", version)
+				}
+			}
+		}()
+	}
+
+	readyWg.Wait()
+	close(startCh)
+	wg.Wait()
+
+	calls := atomic.LoadInt32(&mockClient.healthCalls)
+	if calls > 1 {
+		t.Fatalf("expected Health to be called exactly 1 time due to caching, but was called %d times", calls)
+	} else {
+		t.Logf("Success! Health was called exactly 1 time.")
+	}
+}

--- a/adapters/v1/sidecar_race_test.go
+++ b/adapters/v1/sidecar_race_test.go
@@ -21,7 +21,7 @@ func (m *mockScannerClientRace) Health(ctx context.Context) (string, bool, error
 
 func TestSidecarVersion_CachingUnderConcurrency(t *testing.T) {
 	mockClient := &mockScannerClientRace{}
-	
+
 	adapter := &SidecarSBOMAdapter{
 		client: mockClient,
 	}
@@ -30,7 +30,7 @@ func TestSidecarVersion_CachingUnderConcurrency(t *testing.T) {
 	var readyWg sync.WaitGroup
 	startCh := make(chan struct{})
 	workers := 100
-	
+
 	// Launch many goroutines that constantly call Version() to hit the tiny race window
 	// between singleflight.Do returning and versionMu being locked.
 	for i := 0; i < workers; i++ {
@@ -40,7 +40,7 @@ func TestSidecarVersion_CachingUnderConcurrency(t *testing.T) {
 			defer wg.Done()
 			readyWg.Done()
 			<-startCh
-			
+
 			for j := 0; j < 1000; j++ {
 				version := adapter.Version()
 				if version != "test-version" {


### PR DESCRIPTION
## Overview

**Current behavior:** The `SidecarSBOMAdapter.Version()` method uses `singleflight.Group` to coalesce concurrent requests. However, there is a time-of-check to time-of-use (TOCTOU) race condition: when `singleflight.Do` completes, it removes its internal key before the executing goroutine writes the result to `s.versionStr`. A new concurrent caller entering during this small window can observe an empty cache, bypass `singleflight`, and trigger a redundant `Health()` request.

**New behavior:** A standard double-checked locking pattern has been added inside the `singleflight.Do` closure. Before issuing a `Health()` request, the closure now rechecks `s.versionStr` under `versionMu`. If another goroutine has already populated the cache, the cached value is returned immediately, eliminating redundant network calls under concurrent access.

---

## Additional Information

A new concurrency-focused unit test, `TestSidecarVersion_CachingUnderConcurrency`, has been added to verify that the cached scanner version is shared correctly across concurrent callers and to guard against future regressions.

---

## How to Test

1. Run the new unit test from the repository root:

   ```bash
   go test -v -run TestSidecarVersion_CachingUnderConcurrency ./adapters/v1
   ```

2. Verify that the test passes, confirming that `Health()` is invoked only once even under heavy concurrent access.

---

## Example Output

```text
=== RUN   TestSidecarVersion_CachingUnderConcurrency
--- PASS: TestSidecarVersion_CachingUnderConcurrency (0.01s)
PASS
ok      github.com/kubescape/kubevuln/adapters/v1    1.338s
```

---

## Related Issues

- Closes #493

---

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have commented on my code where appropriate.
- [x] I have performed a self-review of my code.
- [x] I have added tests to cover the change.
- [x] New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection during concurrent requests.
  * Prevented redundant health checks when version information is already being retrieved or cached.
  * Preserved the fallback behavior when health checks fail.

* **Tests**
  * Added coverage for high-concurrency version requests and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->