### PR TITLE
feat(adapters): surface suppression provenance for security exceptions

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -6,11 +6,22 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
 	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// suppressionSource identifies the CRD object a suppression provenance record originated
+// from, so a suppressed CVE can be traced back to the exception (and its scope) that
+// caused it to be filtered out of scan results.
+type suppressionSource struct {
+	kind      string // "SecurityException" or "ClusterSecurityException"
+	name      string
+	namespace string
+}
 
 // ConvertToVulnerabilityExceptionPolicies converts SecurityException and
 // ClusterSecurityException CRDs into armotypes.VulnerabilityExceptionPolicy
@@ -37,7 +48,11 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 			if !shouldSuppress(vuln) {
 				continue
 			}
-			p := buildPolicy(se.Spec, vuln, namespace)
+			p := buildPolicy(se.Spec, vuln, namespace, suppressionSource{
+				kind:      "SecurityException",
+				name:      se.Name,
+				namespace: se.Namespace,
+			})
 			policies = append(policies, p)
 		}
 	}
@@ -54,7 +69,10 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 			if !shouldSuppress(vuln) {
 				continue
 			}
-			p := buildPolicy(cse.Spec, vuln, "")
+			p := buildPolicy(cse.Spec, vuln, "", suppressionSource{
+				kind: "ClusterSecurityException",
+				name: cse.Name,
+			})
 			policies = append(policies, p)
 		}
 	}
@@ -86,7 +104,7 @@ func shouldSuppress(vuln sev1beta1.VulnerabilityException) bool {
 	}
 }
 
-func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.VulnerabilityException, namespace string) armotypes.VulnerabilityExceptionPolicy {
+func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.VulnerabilityException, namespace string, src suppressionSource) armotypes.VulnerabilityExceptionPolicy {
 	vulnerabilityPolicies := []armotypes.VulnerabilityPolicy{
 		{Name: strings.TrimSpace(vuln.Vulnerability.ID)},
 	}
@@ -97,6 +115,10 @@ func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.Vulnerabil
 	}
 
 	p := armotypes.VulnerabilityExceptionPolicy{
+		// PortalBase.Name identifies the CRD object (the "rule") that produced this policy,
+		// since SecurityException/ClusterSecurityException have no separate rule/statement
+		// ID — the object's own name is the closest thing to one.
+		PortalBase:            armotypes.PortalBase{Name: src.name},
 		PolicyType:            "vulnerabilityExceptionPolicy",
 		Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
 		VulnerabilityPolicies: vulnerabilityPolicies,
@@ -114,8 +136,56 @@ func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.Vulnerabil
 	}
 
 	p.Designatores = buildDesignators(spec.Match.Resources, namespace)
+	p.Attributes = buildSuppressionAttributes(spec, vuln, namespace, src)
 
 	return p
+}
+
+// buildSuppressionAttributes records suppression provenance that has no dedicated field on
+// armotypes.VulnerabilityExceptionPolicy: which kind of exception CRD matched, its scope, and
+// the VEX justification/impact statement behind the suppression. This is surfaced here (rather
+// than on the filtered manifest's IgnoreRule) because the manifest's IgnoreRule schema is owned
+// by github.com/kubescape/storage and has no such fields.
+func buildSuppressionAttributes(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.VulnerabilityException, namespace string, src suppressionSource) map[string]interface{} {
+	attrs := map[string]interface{}{
+		"sourceKind": src.kind,
+	}
+	if src.namespace != "" {
+		attrs["sourceNamespace"] = src.namespace
+	}
+	if j := strings.TrimSpace(vuln.Justification); j != "" {
+		attrs["justification"] = j
+	}
+	if s := strings.TrimSpace(vuln.ImpactStatement); s != "" {
+		attrs["impactStatement"] = s
+	}
+	if t := normalizedTarget(spec.Match.Resources, namespace); t != "" {
+		attrs["normalizedTarget"] = t
+	}
+	return attrs
+}
+
+// normalizedTarget renders a human-readable identifier for what an exception's match criteria
+// targeted, for suppression-provenance reporting.
+func normalizedTarget(resources []sev1beta1.ResourceMatch, namespace string) string {
+	if len(resources) == 0 {
+		if namespace != "" {
+			return "namespace/" + namespace
+		}
+		return "cluster-wide"
+	}
+	parts := make([]string, 0, len(resources))
+	for _, r := range resources {
+		target := r.Kind
+		if r.Name != "" {
+			target += "/" + r.Name
+		}
+		if namespace != "" {
+			target = namespace + "/" + target
+		}
+		parts = append(parts, target)
+	}
+	return strings.Join(parts, ",")
 }
 
 // hasIgnoreAction returns true if any of the matched policies contain the Ignore action.
@@ -148,11 +218,44 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 					{Vulnerability: m.Vulnerability.ID},
 				},
 			})
+			logSuppression(m, matched)
 		} else {
 			remaining = append(remaining, m)
 		}
 	}
 	doc.Matches = remaining
+}
+
+// logSuppression records why a CVE disappeared from scan results: which exception object
+// matched, its scope, and the stated reason/justification. This is logged rather than stored on
+// the manifest because the filtered manifest's IgnoreRule (github.com/kubescape/storage) has no
+// fields for this provenance; see buildSuppressionAttributes for where it is captured.
+func logSuppression(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionPolicy) {
+	for _, p := range matched {
+		fields := []helpers.IDetails{
+			helpers.String("cve", m.Vulnerability.ID),
+			helpers.String("package", m.Artifact.Name),
+		}
+		if p.Name != "" {
+			fields = append(fields, helpers.String("sourceName", p.Name))
+		}
+		if p.Reason != "" {
+			fields = append(fields, helpers.String("reason", p.Reason))
+		}
+		if kind, ok := p.Attributes["sourceKind"].(string); ok && kind != "" {
+			fields = append(fields, helpers.String("sourceKind", kind))
+		}
+		if ns, ok := p.Attributes["sourceNamespace"].(string); ok && ns != "" {
+			fields = append(fields, helpers.String("sourceNamespace", ns))
+		}
+		if just, ok := p.Attributes["justification"].(string); ok && just != "" {
+			fields = append(fields, helpers.String("justification", just))
+		}
+		if target, ok := p.Attributes["normalizedTarget"].(string); ok && target != "" {
+			fields = append(fields, helpers.String("normalizedTarget", target))
+		}
+		logger.L().Info("CVE suppressed by security exception", fields...)
+	}
 }
 
 // RestoreSuppressedMatches is the inverse of ApplySecurityExceptions: it returns a copy of doc

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -149,6 +149,7 @@ func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.Vulnerabil
 func buildSuppressionAttributes(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.VulnerabilityException, namespace string, src suppressionSource) map[string]interface{} {
 	attrs := map[string]interface{}{
 		"sourceKind": src.kind,
+		"ruleId":     suppressionRuleID(src),
 	}
 	if src.namespace != "" {
 		attrs["sourceNamespace"] = src.namespace
@@ -163,6 +164,16 @@ func buildSuppressionAttributes(spec sev1beta1.SecurityExceptionSpec, vuln sev1b
 		attrs["normalizedTarget"] = t
 	}
 	return attrs
+}
+
+// suppressionRuleID renders a stable, structured identifier for the CRD object that produced a
+// suppression, distinct from both its bare name and the human-authored reason: kind/namespace/name
+// for a namespaced SecurityException, kind/name for a cluster-scoped one.
+func suppressionRuleID(src suppressionSource) string {
+	if src.namespace != "" {
+		return src.kind + "/" + src.namespace + "/" + src.name
+	}
+	return src.kind + "/" + src.name
 }
 
 // normalizedTarget renders a human-readable identifier for what an exception's match criteria
@@ -226,12 +237,26 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 	doc.Matches = remaining
 }
 
+// suppressingPolicies filters matched down to the policies that actually cause suppression,
+// mirroring the hasIgnoreAction(matched) condition ApplySecurityExceptions uses to decide
+// whether to suppress at all. Without this, a non-Ignore policy passed alongside an Ignore one
+// would be misreported by logSuppression as a suppression source.
+func suppressingPolicies(matched []armotypes.VulnerabilityExceptionPolicy) []armotypes.VulnerabilityExceptionPolicy {
+	var out []armotypes.VulnerabilityExceptionPolicy
+	for _, p := range matched {
+		if hasIgnoreAction([]armotypes.VulnerabilityExceptionPolicy{p}) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // logSuppression records why a CVE disappeared from scan results: which exception object
 // matched, its scope, and the stated reason/justification. This is logged rather than stored on
 // the manifest because the filtered manifest's IgnoreRule (github.com/kubescape/storage) has no
 // fields for this provenance; see buildSuppressionAttributes for where it is captured.
 func logSuppression(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionPolicy) {
-	for _, p := range matched {
+	for _, p := range suppressingPolicies(matched) {
 		fields := []helpers.IDetails{
 			helpers.String("cve", m.Vulnerability.ID),
 			helpers.String("package", m.Artifact.Name),
@@ -245,11 +270,17 @@ func logSuppression(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionP
 		if kind, ok := p.Attributes["sourceKind"].(string); ok && kind != "" {
 			fields = append(fields, helpers.String("sourceKind", kind))
 		}
+		if ruleID, ok := p.Attributes["ruleId"].(string); ok && ruleID != "" {
+			fields = append(fields, helpers.String("ruleId", ruleID))
+		}
 		if ns, ok := p.Attributes["sourceNamespace"].(string); ok && ns != "" {
 			fields = append(fields, helpers.String("sourceNamespace", ns))
 		}
 		if just, ok := p.Attributes["justification"].(string); ok && just != "" {
 			fields = append(fields, helpers.String("justification", just))
+		}
+		if impact, ok := p.Attributes["impactStatement"].(string); ok && impact != "" {
+			fields = append(fields, helpers.String("impactStatement", impact))
 		}
 		if target, ok := p.Attributes["normalizedTarget"].(string); ok && target != "" {
 			fields = append(fields, helpers.String("normalizedTarget", target))

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -104,6 +104,7 @@ func TestConvertVulnerabilityExceptions_SuppressionProvenance(t *testing.T) {
 	nsPolicy := policies[0]
 	assert.Equal(t, "allow-log4shell", nsPolicy.Name)
 	assert.Equal(t, "SecurityException", nsPolicy.Attributes["sourceKind"])
+	assert.Equal(t, "SecurityException/prod/allow-log4shell", nsPolicy.Attributes["ruleId"])
 	assert.Equal(t, "prod", nsPolicy.Attributes["sourceNamespace"])
 	assert.Equal(t, "vulnerable code path is unreachable", nsPolicy.Attributes["justification"])
 	assert.Equal(t, "no network exposure", nsPolicy.Attributes["impactStatement"])
@@ -112,6 +113,7 @@ func TestConvertVulnerabilityExceptions_SuppressionProvenance(t *testing.T) {
 	clusterPolicy := policies[1]
 	assert.Equal(t, "allow-cluster-wide", clusterPolicy.Name)
 	assert.Equal(t, "ClusterSecurityException", clusterPolicy.Attributes["sourceKind"])
+	assert.Equal(t, "ClusterSecurityException/allow-cluster-wide", clusterPolicy.Attributes["ruleId"])
 	_, hasNamespace := clusterPolicy.Attributes["sourceNamespace"]
 	assert.False(t, hasNamespace, "cluster-scoped exceptions have no source namespace")
 	assert.Equal(t, "cluster-wide", clusterPolicy.Attributes["normalizedTarget"])
@@ -671,4 +673,20 @@ func TestIgnoredMatchKeys_DistinctKeysPerPackage(t *testing.T) {
 		"CVE-2021-44228\x00log4j-core\x002.17.0": {},
 		"CVE-2021-44228\x00log4j-api\x002.15.0":  {},
 	}, IgnoredMatchKeys(doc))
+}
+
+func TestSuppressingPolicies_FiltersNonIgnoreActions(t *testing.T) {
+	ignorePolicy := armotypes.VulnerabilityExceptionPolicy{
+		PortalBase: armotypes.PortalBase{Name: "allow-log4shell"},
+		Actions:    []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+	}
+	alertOnlyPolicy := armotypes.VulnerabilityExceptionPolicy{
+		PortalBase: armotypes.PortalBase{Name: "alert-only"},
+		Actions:    []armotypes.VulnerabilityExceptionPolicyActions{"alertOnly"},
+	}
+
+	out := suppressingPolicies([]armotypes.VulnerabilityExceptionPolicy{alertOnlyPolicy, ignorePolicy})
+
+	require.Len(t, out, 1)
+	assert.Equal(t, "allow-log4shell", out[0].Name)
 }

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -63,6 +63,60 @@ func TestConvertVulnerabilityExceptions(t *testing.T) {
 	assert.Nil(t, policies[1].Designatores)
 }
 
+func TestConvertVulnerabilityExceptions_SuppressionProvenance(t *testing.T) {
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "allow-log4shell", Namespace: "prod"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Reason: "accepted risk",
+				Match: sev1beta1.ExceptionMatch{
+					Resources: []sev1beta1.ResourceMatch{{Kind: "Deployment", Name: "web"}},
+				},
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{
+						Vulnerability:   sev1beta1.VulnerabilityRef{ID: "CVE-2021-44228"},
+						Status:          sev1beta1.VulnerabilityStatusNotAffected,
+						Justification:   "vulnerable code path is unreachable",
+						ImpactStatement: "no network exposure",
+					},
+				},
+			},
+		},
+	}
+	clusterExceptions := []sev1beta1.ClusterSecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "allow-cluster-wide"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Reason: "cluster-wide",
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{
+						Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2022-12345"},
+						Status:        sev1beta1.VulnerabilityStatusNotAffected,
+					},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, clusterExceptions, ExceptionTarget{Kind: "Deployment", Name: "web"})
+	require.Len(t, policies, 2)
+
+	nsPolicy := policies[0]
+	assert.Equal(t, "allow-log4shell", nsPolicy.Name)
+	assert.Equal(t, "SecurityException", nsPolicy.Attributes["sourceKind"])
+	assert.Equal(t, "prod", nsPolicy.Attributes["sourceNamespace"])
+	assert.Equal(t, "vulnerable code path is unreachable", nsPolicy.Attributes["justification"])
+	assert.Equal(t, "no network exposure", nsPolicy.Attributes["impactStatement"])
+	assert.Equal(t, "prod/Deployment/web", nsPolicy.Attributes["normalizedTarget"])
+
+	clusterPolicy := policies[1]
+	assert.Equal(t, "allow-cluster-wide", clusterPolicy.Name)
+	assert.Equal(t, "ClusterSecurityException", clusterPolicy.Attributes["sourceKind"])
+	_, hasNamespace := clusterPolicy.Attributes["sourceNamespace"]
+	assert.False(t, hasNamespace, "cluster-scoped exceptions have no source namespace")
+	assert.Equal(t, "cluster-wide", clusterPolicy.Attributes["normalizedTarget"])
+}
+
 func TestConvertExpiredOnFix(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Overview
Today `ApplySecurityExceptions` only records a minimal ignore rule with the CVE ID, so there is no way to tell why a CVE disappeared from scan results. This PR surfaces suppression provenance (which exception matched, its scope, and the stated reason/justification) on each `VulnerabilityExceptionPolicy` produced from a `SecurityException`/`ClusterSecurityException`, and logs that provenance at the moment a CVE is suppressed.

Note on scope: the filtered manifest's `IgnoredMatch`/`IgnoreRule` type is owned by `github.com/kubescape/storage` and has no fields for this provenance (only `Vulnerability`, `FixState`, `Package`). Adding new fields there is outside this repository. This PR surfaces the provenance at the layer kubevuln owns instead: `armotypes.VulnerabilityExceptionPolicy.Name`/`.Attributes` (already generic fields), plus a structured audit log line.

<!--
## Additional Information

> Any additional information that may be useful for reviewers to know
-->

Fields added per suppressed CVE:
- `Name`: the matching `SecurityException`/`ClusterSecurityException` object name (acts as the rule identifier, since the CRD has no separate rule/statement ID)
- `Attributes["sourceKind"]`: `SecurityException` or `ClusterSecurityException`
- `Attributes["sourceNamespace"]`: set for namespaced `SecurityException` objects
- `Attributes["justification"]` / `Attributes["impactStatement"]`: from the matched `VulnerabilityException` entry, when set
- `Attributes["normalizedTarget"]`: human-readable target the exception's match criteria scoped to (e.g. `prod/Deployment/web`, `namespace/default`, `cluster-wide`)

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

## How to Test
- `go test ./adapters/v1/... -run 'TestConvertVulnerabilityExceptions|TestApplySecurityExceptions|TestRestoreSuppressedMatches|TestIgnoredMatchKeys'`

## Related issues/PRs:

Resolved #488

<!--
## Checklist before requesting a review
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security exception policies now retain suppression provenance, including source, namespace, justification, impact, and normalized target details.
  * Suppressed vulnerability findings now include source and reason information in logs.

* **Tests**
  * Added coverage verifying provenance for both namespaced and cluster-scoped suppression policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->