### PR TITLE
fix(repositories): include IgnoredMatches in VEX statement generation and updates (#497)

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -673,6 +673,30 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		return err
 	}
 
+	// apply security exceptions
+	filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
+
+	// store filtered CVE
+	if s.storage {
+		err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
+				helpers.String("imageSlug", workload.ImageSlug))
+		}
+		err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
+				helpers.String("imageSlug", workload.ImageSlug))
+		}
+		if s.vexGeneration {
+			err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCve, false)
+			if err != nil {
+				logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
+					helpers.String("imageSlug", workload.ImageSlug))
+			}
+		}
+	}
+
 	// report scan success to platform
 	err = s.platform.SendStatus(ctx, domain.Success)
 	if err != nil {

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -673,11 +673,11 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		return err
 	}
 
-	// apply security exceptions
-	filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
-
 	// store filtered CVE
 	if s.storage {
+		// apply security exceptions
+		filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
+
 		err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
 		if err != nil {
 			logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
@@ -745,6 +745,12 @@ func (s *ScanService) applyExceptionsToManifest(ctx context.Context, cve domain.
 		return cve, !degraded
 	}
 	filtered := cve
+	if cve.Labels != nil {
+		filtered.Labels = maps.Clone(cve.Labels)
+	}
+	if cve.Annotations != nil {
+		filtered.Annotations = maps.Clone(cve.Annotations)
+	}
 	docCopy := cve.Content.DeepCopy()
 	v1.ApplySecurityExceptions(docCopy, exceptions)
 	filtered.Content = docCopy

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -899,11 +899,47 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 		})
 	}
 
+	// Add ignored vulnerabilities as not_affected with SecurityException impact statement
+	if cve.Content != nil {
+		for _, v := range cve.Content.IgnoredMatches {
+			var aliases []string
+			for _, alias := range v.RelatedVulnerabilities {
+				aliases = append(aliases, alias.ID)
+			}
+
+			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
+
+			if err != nil {
+				return err
+			}
+
+			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:          v.Vulnerability.DataSource,
+					Name:        v.Vulnerability.ID,
+					Description: v.Vulnerability.Description,
+					Aliases:     aliases,
+				},
+
+				Products: []v1beta1.Product{
+					*product,
+				},
+
+				Status:          v1beta1.Status(vex.StatusNotAffected),
+				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
+				ImpactStatement: "Vulnerability was ignored by a SecurityException",
+			})
+		}
+	}
+
 	// Now change the status of the filtered vulnerabilities to "Affected"
 	err := markRelevantVulnerabilitiesAsAffectedInVex(&vexDoc, &cvep)
 	if err != nil {
 		return err
 	}
+
+	_ = markIgnoredVulnerabilitiesInVex(&vexDoc, &cve)
+	_ = markIgnoredVulnerabilitiesInVex(&vexDoc, &cvep)
 
 	calculatedId, err := calculateVexCanonicalHash(vexDoc)
 	if err != nil {
@@ -927,6 +963,37 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 	return err
 }
 
+func markIgnoredVulnerabilitiesInVex(vexDoc *v1beta1.VEX, cve *domain.CVEManifest) error {
+	if cve == nil || cve.Content == nil {
+		return nil
+	}
+	for _, v := range cve.Content.IgnoredMatches {
+		for i, s := range vexDoc.Statements {
+			if s.Vulnerability.Name == v.Vulnerability.ID {
+				foundProduct := false
+				for _, p := range s.Products {
+					for _, sc := range p.Subcomponents {
+						if sc.ID == v.Artifact.PURL {
+							vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
+							vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
+							vexDoc.Statements[i].ImpactStatement = "Vulnerability was ignored by a SecurityException"
+							vexDoc.Statements[i].ActionStatement = ""
+							foundProduct = true
+						}
+						if foundProduct {
+							break
+						}
+					}
+					if foundProduct {
+						break
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, vexContainer *v1beta1.OpenVulnerabilityExchangeContainer) error {
 	_, span := otel.Tracer("").Start(ctx, "APIServerStore.updateVEX")
 	defer span.End()
@@ -946,55 +1013,99 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		}
 	}
 
-	for _, v := range cve.Content.Matches {
-		found := false
-		for _, s := range vexDoc.Statements {
-			if s.Vulnerability.Name != v.Vulnerability.ID {
-				continue
+	if cve.Content != nil {
+		for _, v := range cve.Content.Matches {
+			found := false
+			for _, s := range vexDoc.Statements {
+				if s.Vulnerability.Name != v.Vulnerability.ID {
+					continue
+				}
+				if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
+					continue
+				}
+				if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
+					found = true
+					break
+				}
 			}
-			if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
-				continue
-			}
-			if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
-				found = true
-				break
+			if !found {
+				// Add the vulnerability to the VEX document
+				var aliases []string
+				for _, alias := range v.RelatedVulnerabilities {
+					aliases = append(aliases, alias.ID)
+				}
+
+				product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
+				if err != nil {
+					return err
+				}
+
+				vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
+					Vulnerability: v1beta1.VexVulnerability{
+						ID:          v.Vulnerability.DataSource,
+						Name:        v.Vulnerability.ID,
+						Description: v.Vulnerability.Description,
+						Aliases:     aliases,
+					},
+
+					Products: []v1beta1.Product{
+						*product,
+					},
+
+					Status:          v1beta1.Status(vex.StatusNotAffected),
+					Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
+					ImpactStatement: "Vulnerable component is not loaded into the memory",
+				})
 			}
 		}
-		if !found {
-			// Add the vulnerability to the VEX document
-			var aliases []string
-			for _, alias := range v.RelatedVulnerabilities {
-				aliases = append(aliases, alias.ID)
+
+		for _, v := range cve.Content.IgnoredMatches {
+			found := false
+			for _, s := range vexDoc.Statements {
+				if s.Vulnerability.Name != v.Vulnerability.ID {
+					continue
+				}
+				if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
+					continue
+				}
+				if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
+					found = true
+					break
+				}
 			}
+			if !found {
+				var aliases []string
+				for _, alias := range v.RelatedVulnerabilities {
+					aliases = append(aliases, alias.ID)
+				}
 
-			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
-			if err != nil {
-				return err
+				product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
+				if err != nil {
+					return err
+				}
+
+				vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
+					Vulnerability: v1beta1.VexVulnerability{
+						ID:          v.Vulnerability.DataSource,
+						Name:        v.Vulnerability.ID,
+						Description: v.Vulnerability.Description,
+						Aliases:     aliases,
+					},
+
+					Products: []v1beta1.Product{
+						*product,
+					},
+
+					Status:          v1beta1.Status(vex.StatusNotAffected),
+					Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
+					ImpactStatement: "Vulnerability was ignored by a SecurityException",
+				})
 			}
-
-			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
-				Vulnerability: v1beta1.VexVulnerability{
-					ID:          v.Vulnerability.DataSource,
-					Name:        v.Vulnerability.ID,
-					Description: v.Vulnerability.Description,
-					Aliases:     aliases,
-				},
-
-				Products: []v1beta1.Product{
-					*product,
-				},
-
-				Status:          v1beta1.Status(vex.StatusNotAffected),
-				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-				ImpactStatement: "Vulnerable component is not loaded into the memory",
-			})
 		}
 	}
 
 	// Reset every statement back to the baseline "not affected" status before
-	// reapplying the current filtered manifest. Without this, a statement that
-	// was marked "affected" during an earlier update stays "affected" forever,
-	// even after the corresponding CVE/package pair is no longer relevant.
+	// reapplying the current filtered manifest.
 	for i := range vexDoc.Statements {
 		vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
 		vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
@@ -1007,6 +1118,9 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 	if err != nil {
 		return err
 	}
+
+	_ = markIgnoredVulnerabilitiesInVex(&vexDoc, &cve)
+	_ = markIgnoredVulnerabilitiesInVex(&vexDoc, &cvep)
 
 	// Update the VEX document metadata
 	vexDoc.Metadata.LastUpdated = time.Now().Format(time.RFC3339)

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2155,3 +2155,72 @@ func TestCtxCapturingClient_wrappersKeyedByNamespace(t *testing.T) {
 	require.NotSame(t, cp1, cp2)
 	require.Same(t, cp1, cp1Again)
 }
+
+func TestAPIServerStore_storeVEX_ignoredMatches(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	cveManifest.Content.IgnoredMatches = append(cveManifest.Content.IgnoredMatches, v1beta1.IgnoredMatch{
+		Match: v1beta1.Match{
+			Vulnerability: v1beta1.Vulnerability{
+				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+					ID:         "CVE-IGNORE-TEST",
+					DataSource: "GHSA-IGNORE-TEST",
+				},
+			},
+			Artifact: v1beta1.GrypePackage{
+				Name:    "ignored-package",
+				Version: "1.0",
+				PURL:    "pkg:deb/debian/ignored-package@1.0",
+			},
+		},
+	})
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, vexContainer)
+
+	var foundIgnored bool
+	for _, stmt := range vexContainer.Spec.Statements {
+		if stmt.Vulnerability.Name == "CVE-IGNORE-TEST" {
+			foundIgnored = true
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status)
+			assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), stmt.Justification)
+			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement)
+		}
+	}
+	assert.True(t, foundIgnored, "IgnoredMatch should be included in the VEX document")
+
+	// Now test updating VEX container when a match moves into IgnoredMatches
+	cveManifestFiltered.Content.IgnoredMatches = cveManifest.Content.IgnoredMatches
+	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+
+	vexContainerUpdated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	foundIgnored = false
+	for _, stmt := range vexContainerUpdated.Spec.Statements {
+		if stmt.Vulnerability.Name == "CVE-IGNORE-TEST" {
+			foundIgnored = true
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status)
+			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement)
+		}
+	}
+	assert.True(t, foundIgnored, "IgnoredMatch should remain not_affected on VEX update")
+}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2160,21 +2160,27 @@ func TestAPIServerStore_storeVEX_ignoredMatches(t *testing.T) {
 	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
 	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
 
-	cveManifest.Content.IgnoredMatches = append(cveManifest.Content.IgnoredMatches, v1beta1.IgnoredMatch{
-		Match: v1beta1.Match{
-			Vulnerability: v1beta1.Vulnerability{
-				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
-					ID:         "CVE-IGNORE-TEST",
-					DataSource: "GHSA-IGNORE-TEST",
-				},
+	testMatch := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+				ID:         "CVE-TRANSITION-TEST",
+				DataSource: "GHSA-TRANSITION-TEST",
 			},
-			Artifact: v1beta1.GrypePackage{
-				Name:    "ignored-package",
-				Version: "1.0",
-				PURL:    "pkg:deb/debian/ignored-package@1.0",
+			Fix: v1beta1.Fix{
+				State:    "fixed",
+				Versions: []string{"2.0"},
 			},
 		},
-	})
+		Artifact: v1beta1.GrypePackage{
+			Name:    "transition-package",
+			Version: "1.0",
+			PURL:    "pkg:deb/debian/transition-package@1.0",
+		},
+	}
+
+	// Initially, testMatch is in Matches for both cveManifest and cveManifestFiltered (so it starts as affected)
+	cveManifest.Content.Matches = append(cveManifest.Content.Matches, testMatch)
+	cveManifestFiltered.Content.Matches = append(cveManifestFiltered.Content.Matches, testMatch)
 
 	a := NewFakeAPIServerStorage("kubescape")
 
@@ -2188,6 +2194,7 @@ func TestAPIServerStore_storeVEX_ignoredMatches(t *testing.T) {
 	}
 	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
 
+	// First StoreVEX call: testMatch should be created with StatusAffected
 	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
 	require.NoError(t, err)
 
@@ -2195,32 +2202,43 @@ func TestAPIServerStore_storeVEX_ignoredMatches(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, vexContainer)
 
-	var foundIgnored bool
+	var foundInitial bool
 	for _, stmt := range vexContainer.Spec.Statements {
-		if stmt.Vulnerability.Name == "CVE-IGNORE-TEST" {
-			foundIgnored = true
-			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status)
-			assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), stmt.Justification)
-			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement)
+		if stmt.Vulnerability.Name == "CVE-TRANSITION-TEST" {
+			foundInitial = true
+			assert.Equal(t, v1beta1.Status(vex.StatusAffected), stmt.Status)
+			assert.NotEmpty(t, stmt.ActionStatement)
 		}
 	}
-	assert.True(t, foundIgnored, "IgnoredMatch should be included in the VEX document")
+	assert.True(t, foundInitial, "Initial match should be recorded as affected in VEX document")
 
-	// Now test updating VEX container when a match moves into IgnoredMatches
-	cveManifestFiltered.Content.IgnoredMatches = cveManifest.Content.IgnoredMatches
+	// Now move testMatch from Matches to IgnoredMatches (simulating a SecurityException rule applied)
+	var filteredMatches []v1beta1.Match
+	for _, m := range cveManifestFiltered.Content.Matches {
+		if m.Vulnerability.ID != "CVE-TRANSITION-TEST" {
+			filteredMatches = append(filteredMatches, m)
+		}
+	}
+	cveManifestFiltered.Content.Matches = filteredMatches
+	cveManifestFiltered.Content.IgnoredMatches = append(cveManifestFiltered.Content.IgnoredMatches, v1beta1.IgnoredMatch{Match: testMatch})
+	cveManifest.Content.IgnoredMatches = append(cveManifest.Content.IgnoredMatches, v1beta1.IgnoredMatch{Match: testMatch})
+
+	// Second StoreVEX call: testMatch should transition from affected to not_affected
 	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
 	require.NoError(t, err)
 
 	vexContainerUpdated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
-	foundIgnored = false
+	var foundTransitioned bool
 	for _, stmt := range vexContainerUpdated.Spec.Statements {
-		if stmt.Vulnerability.Name == "CVE-IGNORE-TEST" {
-			foundIgnored = true
+		if stmt.Vulnerability.Name == "CVE-TRANSITION-TEST" {
+			foundTransitioned = true
 			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status)
+			assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), stmt.Justification)
 			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement)
+			assert.Empty(t, stmt.ActionStatement, "ActionStatement should be cleared on transition to not_affected")
 		}
 	}
-	assert.True(t, foundIgnored, "IgnoredMatch should remain not_affected on VEX update")
+	assert.True(t, foundTransitioned, "Transitioned match should be updated to not_affected with SecurityException impact statement")
 }


### PR DESCRIPTION
## Overview
This PR resolves **#497** where vulnerabilities suppressed by `SecurityException` policies (`IgnoredMatches`) were omitted from generated OpenVEX documents (`OpenVulnerabilityExchangeContainer`) during initial creation and subsequent updates.

**Current behavior**: When `ApplySecurityExceptions` moves triaged/suppressed vulnerabilities from `Matches` to `IgnoredMatches`, `createVEX` and `updateVEX` iterate exclusively over `Matches`. As a result, triaged vulnerabilities disappear from generated VEX documents, leaving no provenance that they were triaged. Additionally, during VEX container updates, existing statements for ignored matches were reset back to `"Vulnerable component is not loaded into the memory"`.

**Future behavior**: `IgnoredMatches` are properly included in generated OpenVEX documents during both creation (`createVEX`) and updates (`updateVEX`). Suppressed vulnerabilities are recorded with `status: not_affected`, `justification: VulnerableCodeNotPresent`, and `impact_statement: "Vulnerability was ignored by a SecurityException"`.

## Additional Information
- Extended `createVEX` and `updateVEX` in `repositories/apiserver.go` to process `cve.Content.IgnoredMatches` in addition to `cve.Content.Matches`.
- Introduced `markIgnoredVulnerabilitiesInVex` helper to preserve SecurityException status and impact statements across VEX container updates.
- Added unit test coverage `TestAPIServerStore_storeVEX_ignoredMatches` in `repositories/apiserver_test.go`.

## How to Test
1. Run local unit tests in the `repositories` package:
   `go test -v -count=1 -run "TestAPIServerStore_storeVEX" ./repositories/...`
2. Run all unit tests to confirm zero regressions:
   `go test -v -count=1 ./repositories/...`

## Related issues/PRs:
* Resolved #497

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VEX documents now include ignored vulnerabilities as `not_affected` entries.
  * Ignored vulnerability entries include security exception details and remain preserved during VEX updates.
  * Existing matching vulnerability statements are updated to reflect ignored status.
  * Stored scan results and summaries now reflect applicable security exceptions, with optional VEX output generated from the filtered results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->