### PR TITLE
refactor(sbomscanner): make registry auth fallback pluggable

### DIFF
--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -119,10 +119,10 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
 		unauthorizedErr := err
 		for _, provider := range registryAuthProviders {
-			if !provider.Matches(imageID) {
+			if !provider.Matches(pullRef) {
 				continue
 			}
-			if creds, credErr := provider.Credentials(ctx); credErr != nil {
+			if creds, credErr := provider.Credentials(ctx); credErr != nil || creds == nil {
 				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
 					helpers.Error(credErr),
 					helpers.String("imageID", imageID))

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -74,12 +74,37 @@ func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
 // unit-tested without a live GCP environment.
 var gcpCredsFn = gcpCredentials
 
+// registryAuthProvider supplies registry credentials for hosts it recognizes, so
+// resolveSource can consult cloud-specific auth fallbacks without hard-coding each
+// one into its retry logic.
+type registryAuthProvider interface {
+	// Matches reports whether this provider handles the given pull reference.
+	Matches(imageID string) bool
+	// Credentials fetches credentials for a host this provider matches.
+	Credentials(ctx context.Context) (*image.RegistryCredentials, error)
+}
+
+// gcpAuthProvider resolves credentials for GCR/Artifact Registry hosts via
+// Application Default Credentials.
+type gcpAuthProvider struct{}
+
+func (gcpAuthProvider) Matches(imageID string) bool { return isGCPRegistry(imageID) }
+
+func (gcpAuthProvider) Credentials(ctx context.Context) (*image.RegistryCredentials, error) {
+	return gcpCredsFn(ctx)
+}
+
+// registryAuthProviders is the ordered list of cloud registry auth fallbacks resolveSource
+// consults on a 401 Unauthorized, before falling back to anonymous access. Add ECR/ACR
+// providers here as they're implemented.
+var registryAuthProviders = []registryAuthProvider{gcpAuthProvider{}}
+
 // sourceGetter abstracts the syft.GetSource call so the fallback ordering in
 // resolveSource is testable with a scripted implementation.
 type sourceGetter func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error)
 
 // resolveSource downloads an image source, applying the MANIFEST_UNKNOWN and
-// 401/ADC/anonymous fallbacks in order. It mirrors the retry chain in
+// 401/provider/anonymous fallbacks in order. It mirrors the retry chain in
 // adapters/v1/syft.go so the sidecar and in-process adapters behave the same.
 func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag string, opts image.RegistryOptions) (source.Source, error) {
 	pullRef := imageID
@@ -93,18 +118,22 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 	}
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
 		unauthorizedErr := err
-		if isGCPRegistry(imageID) {
-			if gcpCreds, gcpErr := gcpCredsFn(ctx); gcpErr != nil {
-				logger.L().Debug("GCP ADC unavailable, falling back to anonymous",
-					helpers.Error(gcpErr),
+		for _, provider := range registryAuthProviders {
+			if !provider.Matches(imageID) {
+				continue
+			}
+			if creds, credErr := provider.Credentials(ctx); credErr != nil {
+				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
+					helpers.Error(credErr),
 					helpers.String("imageID", imageID))
 			} else {
-				opts.Credentials = []image.RegistryCredentials{*gcpCreds}
+				opts.Credentials = []image.RegistryCredentials{*creds}
 				src, err = get(ctx, pullRef, &opts)
 			}
+			break
 		}
-		// If GCP ADC was not attempted, succeeded in auth but still got 401, or
-		// the image is not a GCP registry, fall back to anonymous access.
+		// If no provider matched, its credentials were unavailable, or it succeeded
+		// in auth but still got 401, fall back to anonymous access.
 		if err != nil {
 			logger.L().Debug("retrying without credentials",
 				helpers.String("imageID", imageID))

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -300,6 +300,63 @@ func TestResolveSource_CustomProvider(t *testing.T) {
 	assert.Equal(t, []image.RegistryCredentials{{Username: "custom", Password: "token"}}, calls[len(calls)-1])
 }
 
+func TestResolveSource_ProviderNilCredentialsFallsBackAnonymous(t *testing.T) {
+	orig := registryAuthProviders
+	defer func() { registryAuthProviders = orig }()
+	registryAuthProviders = []registryAuthProvider{
+		fakeAuthProvider{matchHost: "my-registry.example.com"},
+	}
+
+	err401 := errors.New("401 Unauthorized")
+	err403 := errors.New("403 Forbidden")
+	var calls [][]image.RegistryCredentials
+	callCount := 0
+	results := []error{err401, err403}
+	get := func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		creds := append([]image.RegistryCredentials(nil), opts.Credentials...)
+		calls = append(calls, creds)
+		res := results[callCount]
+		callCount++
+		return nil, res
+	}
+
+	assert.NotPanics(t, func() {
+		_, err := resolveSource(context.Background(), get, "my-registry.example.com/foo/bar", "", image.RegistryOptions{})
+		require.Error(t, err)
+	})
+	assert.Equal(t, 2, callCount)
+	assert.Nil(t, calls[len(calls)-1])
+}
+
+func TestResolveSource_ProviderMatchesUsesPullRef(t *testing.T) {
+	orig := registryAuthProviders
+	defer func() { registryAuthProviders = orig }()
+	registryAuthProviders = []registryAuthProvider{
+		fakeAuthProvider{
+			matchHost: "gcr.io",
+			creds:     &image.RegistryCredentials{Username: "custom", Password: "token"},
+		},
+	}
+
+	manifestUnknownErr := errors.New("MANIFEST_UNKNOWN")
+	err401 := errors.New("401 Unauthorized")
+	var calls [][]image.RegistryCredentials
+	callCount := 0
+	results := []error{manifestUnknownErr, err401, nil}
+	get := func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		creds := append([]image.RegistryCredentials(nil), opts.Credentials...)
+		calls = append(calls, creds)
+		res := results[callCount]
+		callCount++
+		return nil, res
+	}
+
+	_, err := resolveSource(context.Background(), get, "digest-only.example.com/foo@sha256:abc", "gcr.io/foo:latest", image.RegistryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 3, callCount)
+	assert.Equal(t, []image.RegistryCredentials{{Username: "custom", Password: "token"}}, calls[len(calls)-1])
+}
+
 func makeDummyTarGz(fileSize int) ([]byte, string, string, error) {
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/image"
@@ -252,6 +253,51 @@ func TestResolveSource(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeAuthProvider is a scripted registryAuthProvider used to prove
+// resolveSource consults registryAuthProviders generically, not just GCP.
+type fakeAuthProvider struct {
+	matchHost string
+	creds     *image.RegistryCredentials
+	err       error
+}
+
+func (p fakeAuthProvider) Matches(imageID string) bool {
+	host, _, _ := strings.Cut(imageID, "/")
+	return host == p.matchHost
+}
+
+func (p fakeAuthProvider) Credentials(ctx context.Context) (*image.RegistryCredentials, error) {
+	return p.creds, p.err
+}
+
+func TestResolveSource_CustomProvider(t *testing.T) {
+	orig := registryAuthProviders
+	defer func() { registryAuthProviders = orig }()
+	registryAuthProviders = []registryAuthProvider{
+		fakeAuthProvider{
+			matchHost: "my-registry.example.com",
+			creds:     &image.RegistryCredentials{Username: "custom", Password: "token"},
+		},
+	}
+
+	err401 := errors.New("401 Unauthorized")
+	var calls [][]image.RegistryCredentials
+	callCount := 0
+	results := []error{err401, nil}
+	get := func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		creds := append([]image.RegistryCredentials(nil), opts.Credentials...)
+		calls = append(calls, creds)
+		res := results[callCount]
+		callCount++
+		return nil, res
+	}
+
+	_, err := resolveSource(context.Background(), get, "my-registry.example.com/foo/bar", "", image.RegistryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+	assert.Equal(t, []image.RegistryCredentials{{Username: "custom", Password: "token"}}, calls[len(calls)-1])
 }
 
 func makeDummyTarGz(fileSize int) ([]byte, string, string, error) {


### PR DESCRIPTION
## Overview
Extracts the sidecar's GCP-specific 401 auth fallback in `resolveSource` (`pkg/sbomscanner/v1/server.go`) into a small `registryAuthProvider` interface (`Matches(imageID) bool`, `Credentials(ctx) (*image.RegistryCredentials, error)`), with GCP as the first implementation via `registryAuthProviders`. This gives ECR/ACR a clean extension point instead of adding more inline conditionals to `resolveSource`.

Behavior is unchanged: on a 401, the first matching provider's credentials are tried once, then anonymous fallback applies exactly as before.

<!--
## Additional Information

> Any additional information that may be useful for reviewers to know
-->

## How to Test
- `go test ./pkg/sbomscanner/v1/... -run 'TestResolveSource|TestIsGCPRegistry'`

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

Resolved #492

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Registry scanning now supports ordered authentication providers for broader private registry compatibility.
  - Credentials are retrieved and retried automatically after an unauthorized response.
  - Anonymous access is attempted when providers return no credentials and the registry permits it.

- **Bug Fixes**
  - Improved registry source matching when resolving image references by digest or fallback tag.
  - Improved handling of unauthorized registry responses during source resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->