### PR TITLE
fix(services): pass filtered manifests to StoreVEX in ScanCP (#501)

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -301,7 +301,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		}
 
 		filteredCve := domain.CVEManifest{}
-		cveExceptionsComplete := true
+		var cveExceptionsComplete bool
 		// if CVE manifest is not available, create it
 		if cve.Content == nil {
 			// scan for CVE

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -301,6 +301,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		}
 
 		filteredCve := domain.CVEManifest{}
+		cveExceptionsComplete := true
 		// if CVE manifest is not available, create it
 		if cve.Content == nil {
 			// scan for CVE
@@ -314,7 +315,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 
 			// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-			filteredCve, _ = s.applyExceptionsToManifest(ctx, cve)
+			filteredCve, cveExceptionsComplete = s.applyExceptionsToManifest(ctx, cve)
 
 			// store filtered CVE
 			if s.storage {
@@ -339,8 +340,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			// unfiltered data a cache miss would produce.
 			prevIgnored := v1.IgnoredMatchKeys(cve.Content)
 			cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-			var exceptionsComplete bool
-			filteredCve, exceptionsComplete = s.applyExceptionsToManifest(ctx, cve)
+			filteredCve, cveExceptionsComplete = s.applyExceptionsToManifest(ctx, cve)
 
 			if s.storage {
 				curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
@@ -356,7 +356,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 							break
 						}
 					}
-					if exceptionsComplete || !hasRemovals {
+					if cveExceptionsComplete || !hasRemovals {
 						err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
 						if err != nil {
 							logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
@@ -403,7 +403,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 
 			// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-			filteredCvep, _ := s.applyExceptionsToManifest(ctx, cvep)
+			filteredCvep, cvepExceptionsComplete := s.applyExceptionsToManifest(ctx, cvep)
 
 			// store filtered CVE'
 			if s.storage {
@@ -422,7 +422,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 						helpers.String("imageSlug", slug))
 					// no continue, storing the CVE summary is not critical
 				}
-				if s.vexGeneration {
+				if s.vexGeneration && cveExceptionsComplete && cvepExceptionsComplete {
 					err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCvep, true)
 					if err != nil {
 						logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -300,6 +300,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 		}
 
+		filteredCve := domain.CVEManifest{}
 		// if CVE manifest is not available, create it
 		if cve.Content == nil {
 			// scan for CVE
@@ -313,7 +314,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 
 			// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-			filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
+			filteredCve, _ = s.applyExceptionsToManifest(ctx, cve)
 
 			// store filtered CVE
 			if s.storage {
@@ -338,7 +339,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			// unfiltered data a cache miss would produce.
 			prevIgnored := v1.IgnoredMatchKeys(cve.Content)
 			cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-			filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
+			var exceptionsComplete bool
+			filteredCve, exceptionsComplete = s.applyExceptionsToManifest(ctx, cve)
 
 			if s.storage {
 				curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
@@ -421,7 +423,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 					// no continue, storing the CVE summary is not critical
 				}
 				if s.vexGeneration {
-					err = s.cveRepository.StoreVEX(ctx, cve, cvep, true)
+					err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCvep, true)
 					if err != nil {
 						logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
 							helpers.String("imageSlug", slug))


### PR DESCRIPTION
## Overview
This PR resolves **#501** where `ScanCP` (container profile scan flow) passed unfiltered main (`cve`) and relevant (`cvep`) manifests to `StoreVEX`.

**Current behavior**: Because `cvep` (unfiltered relevant manifest) was passed to `StoreVEX`, vulnerabilities suppressed by `SecurityException` policies (moved to `IgnoredMatches`) were still present in `cvep.Content.Matches`. Consequently, `markRelevantVulnerabilitiesAsAffectedInVex` marked ignored vulnerabilities as `status: affected` with remediation action statements in generated OpenVEX documents. Furthermore, `filteredCve` was scoped within `if/else` blocks, preventing the filtered manifest from being passed to `StoreVEX`.

**Future behavior**: `ScanCP` passes `filteredCve` and `filteredCvep` to `StoreVEX`. Suppressed vulnerabilities are correctly recorded as `status: not_affected` with `impact_statement: "Vulnerability was ignored by a SecurityException"`.

## Additional Information
- Updated `ScanCP` in `core/services/scan.go` to declare `filteredCve` at function scope so both new and cached scan paths retain the filtered main manifest.
- Updated `StoreVEX` invocation in `ScanCP` (line 424) to pass `filteredCve` and `filteredCvep`:
  `err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCvep, true)`

## How to Test
1. Run local unit tests in the `core/services` package:
   `go test -v -count=1 -skip "TestScanService_NginxTest" ./core/services/...`
2. Run unit tests in the `repositories` package:
   `go test -v -count=1 ./repositories/...`

## Related issues/PRs:
* Resolved #501

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability exception handling during scans.
  * Ensured cached and newly scanned results apply consistent CVE filtering rules.
  * Corrected stored scan data so excluded vulnerabilities are consistently omitted from displayed and processed results.
  * Prevented VEX data from being stored when exception-filtering results are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->