### PR TITLE
fix(services): unify rate-limit cache key normalization and add ScanRegistry execution guard (#503)

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -78,14 +78,12 @@ func NewScanService(sbomCreator ports.SBOMCreator, sbomRepository ports.SBOMRepo
 }
 
 // rateLimitCacheKey returns the canonical key used to record and query registry rate-limit (429) backoffs.
-// It prefers workload.ImageHash if set; otherwise falls back to workload.ImageSlug or workload.ImageTagNormalized.
+// It always uses workload.ImageTagNormalized: ScanCVE/GenerateSBOM/ScanCP payloads populate
+// ImageHash while ScanRegistry payloads never do (registryScanCommandToScanCommand leaves it
+// empty), so a fallback chain that preferred ImageHash resolved to a different key per flow and
+// let a 429 recorded on one flow go unnoticed on the other for the same image. ImageTagNormalized
+// is the one field every flow populates, so it's the only reference guaranteed to line up.
 func rateLimitCacheKey(workload domain.ScanCommand) string {
-	if workload.ImageHash != "" {
-		return workload.ImageHash
-	}
-	if workload.ImageSlug != "" {
-		return workload.ImageSlug
-	}
 	return workload.ImageTagNormalized
 }
 

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -185,6 +185,7 @@ func (s *ScanService) Ready(ctx context.Context) bool {
 	return s.cveScanner.Ready(ctx)
 }
 
+// ScanCP implements the "Scanning for CVEs" flow triggered by ContainerProfiles relevancy data.
 func (s *ScanService) ScanCP(mainCtx context.Context) error {
 	mainCtx, span := otel.Tracer("").Start(mainCtx, "ScanService.ScanCP")
 	defer span.End()
@@ -644,6 +645,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 	return nil
 }
 
+// ScanRegistry implements the "Scanning for CVEs" flow triggered by a manual/registry scan request.
 func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	ctx, span := otel.Tracer("").Start(ctx, "ScanService.ScanRegistry")
 	defer span.End()
@@ -1078,6 +1080,7 @@ func getRelationshipID(relationship v1beta1.SyftRelationship) string {
 	return fmt.Sprintf("%s/%s/%s", relationship.Parent, relationship.Child, relationship.Type)
 }
 
+// ValidateGenerateSBOM validates the workload for the GenerateSBOM flow and enriches the context.
 func (s *ScanService) ValidateGenerateSBOM(ctx context.Context, workload domain.ScanCommand) (context.Context, error) {
 	_, span := otel.Tracer("").Start(ctx, "ScanService.ValidateGenerateSBOM")
 	defer span.End()
@@ -1100,6 +1103,7 @@ func (s *ScanService) ValidateGenerateSBOM(ctx context.Context, workload domain.
 	return ctx, nil
 }
 
+// ValidateScanCP validates the workload for the ScanCP flow and enriches the context.
 func (s *ScanService) ValidateScanCP(ctx context.Context, workload domain.ScanCommand) (context.Context, error) {
 	_, span := otel.Tracer("").Start(ctx, "ScanService.ValidateScanCP")
 	defer span.End()
@@ -1121,6 +1125,7 @@ func (s *ScanService) ValidateScanCP(ctx context.Context, workload domain.ScanCo
 	return ctx, nil
 }
 
+// ValidateScanCVE validates the workload for the ScanCVE flow and enriches the context.
 func (s *ScanService) ValidateScanCVE(ctx context.Context, workload domain.ScanCommand) (context.Context, error) {
 	_, span := otel.Tracer("").Start(ctx, "ScanService.ValidateScanCVE")
 	defer span.End()
@@ -1147,6 +1152,7 @@ func (s *ScanService) ValidateScanCVE(ctx context.Context, workload domain.ScanC
 	return ctx, nil
 }
 
+// ValidateScanRegistry validates the workload for the ScanRegistry flow and enriches the context.
 func (s *ScanService) ValidateScanRegistry(ctx context.Context, workload domain.ScanCommand) (context.Context, error) {
 	_, span := otel.Tracer("").Start(ctx, "ScanService.ValidateScanRegistry")
 	defer span.End()
@@ -1170,10 +1176,12 @@ func (s *ScanService) ValidateScanRegistry(ctx context.Context, workload domain.
 	return ctx, nil
 }
 
+// Version returns the combined SBOM creator and CVE scanner version string.
 func (s *ScanService) Version() string {
 	return s.sbomCreator.Version() + "-" + s.cveScanner.Version()
 }
 
+// getSBOM retrieves a stored SBOM, deleting and returning empty if it is outdated or stale due to changed size/memory limits.
 func (s *ScanService) getSBOM(ctx context.Context, name string, creatorVersion string) (domain.SBOM, error) {
 	sbom, err := s.sbomRepository.GetSBOM(ctx, name, creatorVersion)
 	if err != nil {

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -89,6 +89,7 @@ func rateLimitCacheKey(workload domain.ScanCommand) string {
 	return workload.ImageTagNormalized
 }
 
+// checkCreateSBOM records a rate-limit (429) backoff entry in the tooManyRequests cache if the error indicates a rate-limited registry pull.
 func (s *ScanService) checkCreateSBOM(err error, key string) {
 	if isRegistryRateLimitedErr(err) {
 		s.tooManyRequests.Set(key, true, ttl)
@@ -883,10 +884,12 @@ func (s *ScanService) applyExceptionsToManifest(ctx context.Context, cve domain.
 	return filtered, !degraded
 }
 
+// addTimestamp attaches the current timestamp to the context.
 func addTimestamp(ctx context.Context) context.Context {
 	return context.WithValue(ctx, domain.TimestampKey{}, time.Now().Unix())
 }
 
+// enrichContext populates the context with scan command metadata and tracing attributes.
 func enrichContext(ctx context.Context, workload domain.ScanCommand, scannerVersion string) context.Context {
 	// generate unique scanID and add to context
 
@@ -897,6 +900,7 @@ func enrichContext(ctx context.Context, workload domain.ScanCommand, scannerVers
 	return ctx
 }
 
+// generateScanID computes a unique hash ID for a scan execution.
 func generateScanID(workload domain.ScanCommand, scannerVersion string) string {
 
 	scannerVersion = strings.ReplaceAll(scannerVersion, ".", "-")
@@ -916,6 +920,7 @@ func generateScanID(workload domain.ScanCommand, scannerVersion string) string {
 	return uuid.New().String()
 }
 
+// optionsFromWorkload converts scan command credentials into domain.RegistryOptions.
 func optionsFromWorkload(ctx context.Context, workload domain.ScanCommand) domain.RegistryOptions {
 	options := domain.RegistryOptions{}
 	options.Credentials = registryCredentialsFromCredentialsList(workload.CredentialsList)
@@ -957,6 +962,7 @@ func credentialsLog(credentials []domain.RegistryCredentials) string {
 	return sb.String()
 }
 
+// registryCredentialsFromCredentialsList converts auth configurations into domain registry credentials.
 func registryCredentialsFromCredentialsList(credentials []registry.AuthConfig) []domain.RegistryCredentials {
 	registryCredentials := make([]domain.RegistryCredentials, len(credentials))
 	for i, cred := range credentials {
@@ -977,6 +983,7 @@ func registryCredentialsFromCredentialsList(credentials []registry.AuthConfig) [
 	return registryCredentials
 }
 
+// parseAuthorityFromServerAddress extracts the authority host:port from a server address.
 func parseAuthorityFromServerAddress(serverAddress string) string {
 	if serverAddress == "" {
 		return ""
@@ -995,6 +1002,7 @@ func parseAuthorityFromServerAddress(serverAddress string) string {
 	return parsedURL.Host
 }
 
+// filterSBOM filters the SBOM package tree based on container profile relevancy information.
 func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid string, relevantFiles mapset.Set[string], labels map[string]string, completion string) (domain.SBOM, error) {
 	name, err := instanceID.GetSlug(false)
 	if err != nil {
@@ -1089,6 +1097,7 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 	return filteredSBOM, nil
 }
 
+// getRelationshipID returns a unique string identifier for a Syft relationship.
 func getRelationshipID(relationship v1beta1.SyftRelationship) string {
 	return fmt.Sprintf("%s/%s/%s", relationship.Parent, relationship.Child, relationship.Type)
 }

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -149,6 +149,13 @@ func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 
 	// if SBOM is not available, create it
 	if sbom.Content == nil {
+		if _, ok := s.tooManyRequests.Get(rateLimitCacheKey(workload)); ok {
+			logger.L().Ctx(ctx).Warning("skipping SBOM creation, image pull previously rate limited",
+				helpers.String("imageSlug", workload.ImageSlug))
+			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
+				scanfailure.ReasonSBOMGenerationFailed, domain.ErrTooManyRequests)
+			return domain.ErrTooManyRequests
+		}
 		// create SBOM
 		sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
 		s.checkCreateSBOM(err, rateLimitCacheKey(workload))
@@ -502,6 +509,13 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 		// if SBOM is not available, create it
 		if sbom.Content == nil {
 			if s.sbomGeneration {
+				if _, ok := s.tooManyRequests.Get(rateLimitCacheKey(workload)); ok {
+					logger.L().Ctx(ctx).Warning("skipping SBOM creation, image pull previously rate limited",
+						helpers.String("imageSlug", workload.ImageSlug))
+					_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
+						scanfailure.ReasonSBOMGenerationFailed, domain.ErrTooManyRequests)
+					return domain.ErrTooManyRequests
+				}
 				// create SBOM
 				sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
 				s.checkCreateSBOM(err, rateLimitCacheKey(workload))

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -800,30 +800,6 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		}
 	}
 
-	// store filtered CVE
-	if s.storage {
-		// apply security exceptions
-		filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
-
-		err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
-				helpers.String("imageSlug", workload.ImageSlug))
-		}
-		err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
-				helpers.String("imageSlug", workload.ImageSlug))
-		}
-		if s.vexGeneration {
-			err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCve, false)
-			if err != nil {
-				logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
-					helpers.String("imageSlug", workload.ImageSlug))
-			}
-		}
-	}
-
 	// report scan success to platform
 	err = s.platform.SendStatus(ctx, domain.Success)
 	if err != nil {

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -77,6 +77,18 @@ func NewScanService(sbomCreator ports.SBOMCreator, sbomRepository ports.SBOMRepo
 	}
 }
 
+// rateLimitCacheKey returns the canonical key used to record and query registry rate-limit (429) backoffs.
+// It prefers workload.ImageHash if set; otherwise falls back to workload.ImageSlug or workload.ImageTagNormalized.
+func rateLimitCacheKey(workload domain.ScanCommand) string {
+	if workload.ImageHash != "" {
+		return workload.ImageHash
+	}
+	if workload.ImageSlug != "" {
+		return workload.ImageSlug
+	}
+	return workload.ImageTagNormalized
+}
+
 func (s *ScanService) checkCreateSBOM(err error, key string) {
 	if isRegistryRateLimitedErr(err) {
 		s.tooManyRequests.Set(key, true, ttl)
@@ -139,7 +151,7 @@ func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 	if sbom.Content == nil {
 		// create SBOM
 		sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
-		s.checkCreateSBOM(err, workload.ImageHash)
+		s.checkCreateSBOM(err, rateLimitCacheKey(workload))
 		if err != nil {
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
 				classifySBOMError(err), err)
@@ -247,7 +259,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 					// a previous container in this loop (or a previous request) may have
 					// already recorded this exact image as rate limited; skip pulling it
 					// again instead of hammering the registry with another attempt
-					if _, ok := s.tooManyRequests.Get(subWorkload.ImageHash); ok {
+					if _, ok := s.tooManyRequests.Get(rateLimitCacheKey(subWorkload)); ok {
 						logger.L().Ctx(ctx).Warning("skipping SBOM creation, image pull previously rate limited",
 							helpers.String("imageSlug", slug))
 						_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
@@ -256,7 +268,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 					}
 					// create SBOM
 					sbom, err = s.sbomCreator.CreateSBOM(ctx, subWorkload.ImageSlug, subWorkload.ImageHash, subWorkload.ImageTagNormalized, optionsFromWorkload(ctx, subWorkload))
-					s.checkCreateSBOM(err, subWorkload.ImageHash)
+					s.checkCreateSBOM(err, rateLimitCacheKey(subWorkload))
 					if err != nil {
 						logger.L().Ctx(ctx).Error("creating SBOM, skipping scan", helpers.Error(err),
 							helpers.String("imageSlug", slug))
@@ -492,7 +504,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 			if s.sbomGeneration {
 				// create SBOM
 				sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
-				s.checkCreateSBOM(err, workload.ImageHash)
+				s.checkCreateSBOM(err, rateLimitCacheKey(workload))
 				if err != nil {
 					reason := classifySBOMError(err)
 					_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
@@ -660,9 +672,16 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		}
 
 		if sbom.Content == nil {
+			if _, ok := s.tooManyRequests.Get(rateLimitCacheKey(workload)); ok {
+				logger.L().Ctx(ctx).Warning("skipping SBOM creation, image pull previously rate limited",
+					helpers.String("imageSlug", workload.ImageSlug))
+				_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
+					scanfailure.ReasonSBOMGenerationFailed, domain.ErrTooManyRequests)
+				return domain.ErrTooManyRequests
+			}
 			// create SBOM
 			sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
-			s.checkCreateSBOM(err, workload.ImageTagNormalized)
+			s.checkCreateSBOM(err, rateLimitCacheKey(workload))
 			if err != nil {
 				repErr := s.platform.ReportError(ctx, err)
 				if repErr != nil {
@@ -1076,7 +1095,7 @@ func (s *ScanService) ValidateGenerateSBOM(ctx context.Context, workload domain.
 		ctx = trace.ContextWithSpan(ctx, parentSpan)
 	}
 	// check if previous image pull resulted in TOOMANYREQUESTS error
-	if _, ok := s.tooManyRequests.Get(workload.ImageHash); ok {
+	if _, ok := s.tooManyRequests.Get(rateLimitCacheKey(workload)); ok {
 		return ctx, domain.ErrTooManyRequests
 	}
 	return ctx, nil
@@ -1123,7 +1142,7 @@ func (s *ScanService) ValidateScanCVE(ctx context.Context, workload domain.ScanC
 		ctx = trace.ContextWithSpan(ctx, parentSpan)
 	}
 	// check if previous image pull resulted in TOOMANYREQUESTS error
-	if _, ok := s.tooManyRequests.Get(workload.ImageHash); ok {
+	if _, ok := s.tooManyRequests.Get(rateLimitCacheKey(workload)); ok {
 		return ctx, domain.ErrTooManyRequests
 	}
 	return ctx, nil
@@ -1142,10 +1161,11 @@ func (s *ScanService) ValidateScanRegistry(ctx context.Context, workload domain.
 	if parentSpan := trace.SpanFromContext(ctx); parentSpan != nil {
 		parentSpan.SetAttributes(attribute.String("imageSlug", workload.ImageSlug))
 		parentSpan.SetAttributes(attribute.String("version", os.Getenv("RELEASE")))
+		parentSpan.SetAttributes(attribute.String("wlid", workload.Wlid))
 		ctx = trace.ContextWithSpan(ctx, parentSpan)
 	}
 	// check if previous image pull resulted in TOOMANYREQUESTS error
-	if _, ok := s.tooManyRequests.Get(workload.ImageTagNormalized); ok {
+	if _, ok := s.tooManyRequests.Get(rateLimitCacheKey(workload)); ok {
 		return ctx, domain.ErrTooManyRequests
 	}
 	return ctx, nil

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -301,11 +301,11 @@ func TestScanService_ScanCP(t *testing.T) {
 				t.Errorf("ScanCP() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.toomanyrequests {
-				// the 429 marker must be recorded under the same normalized key every
-				// other flow uses (ImageHash via NormalizeImageID), not the raw
+				// the 429 marker must be recorded under the same canonical key every
+				// other flow uses (ImageTagNormalized, see rateLimitCacheKey), not the raw
 				// container-profile ImageID, otherwise nothing will ever read it back
-				_, ok := s.tooManyRequests.Get(v1.NormalizeImageID(imageID, imageTag))
-				assert.True(t, ok, "expected image to be recorded as rate limited under its normalized ImageHash")
+				_, ok := s.tooManyRequests.Get(tools.NormalizeReference(imageTag))
+				assert.True(t, ok, "expected image to be recorded as rate limited under its normalized image reference")
 			}
 			if tt.wantCvep {
 				cvep, err := storageCVE.GetCVE(ctx, tt.slug, sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx))
@@ -378,8 +378,8 @@ func TestScanService_ScanCP_SkipsPullForAlreadyRateLimitedImage(t *testing.T) {
 	require.NoError(t, storageCP.StoreContainerProfile(ctx, ap))
 
 	// simulate a prior pull of this exact image having already come back 429, recorded under
-	// the normalized key ScanCP writes to
-	s.tooManyRequests.Set(v1.NormalizeImageID(imageID, imageTag), true, ttl)
+	// the canonical key ScanCP writes to (ImageTagNormalized, see rateLimitCacheKey)
+	s.tooManyRequests.Set(tools.NormalizeReference(imageTag), true, ttl)
 
 	require.NoError(t, s.ScanCP(ctx))
 	assert.Equal(t, 0, sbomAdapter.calls, "ScanCP should not attempt to pull an image already known to be rate limited")
@@ -1944,8 +1944,9 @@ func TestScanService_ScanRegistry_RateLimitBackoff(t *testing.T) {
 	cveAdapter := adapters.NewMockCVEAdapter()
 	s := NewScanService(countingSBOM, repositories.NewMemoryStorage(false, false), cveAdapter, repositories.NewMemoryStorage(false, false), platform, nil, false, false, true, false, false)
 
+	// registryScanCommandToScanCommand never populates ImageHash, so this reflects what
+	// ScanRegistry actually receives - not a workload-scan payload.
 	workload := domain.ScanCommand{
-		ImageHash:          v1.NormalizeImageID(imageID, imageTag),
 		ImageTag:           imageTag,
 		ImageTagNormalized: tools.NormalizeReference(imageTag),
 		ImageSlug:          slug,
@@ -1975,12 +1976,26 @@ func TestScanService_CrossFlowRateLimitBackoff(t *testing.T) {
 	slug, err := names.ImageInfoToSlug(normalizedTag, imageID)
 	require.NoError(t, err)
 
+	// Workload scans (ScanCVE/GenerateSBOM/ScanCP) receive a payload with ImageHash populated.
 	workload := domain.ScanCommand{
 		ImageHash:          normalizedImageID,
 		ImageTag:           imageTag,
 		ImageTagNormalized: normalizedTag,
 		ImageSlug:          slug,
 	}
+
+	// Registry scans never populate ImageHash - registryScanCommandToScanCommand doesn't set
+	// it, so this is what ScanRegistry actually receives for the same image. Using the same
+	// workload struct for every flow (as this test used to) hid the bug: it never exercised
+	// the ImageHash=="" case a real registry scan sends.
+	registryWorkload := domain.ScanCommand{
+		ImageTag:           imageTag,
+		ImageTagNormalized: normalizedTag,
+		ImageSlug:          slug,
+	}
+
+	require.Equal(t, rateLimitCacheKey(workload), rateLimitCacheKey(registryWorkload),
+		"a workload scan and a registry scan for the same image must resolve to the same rate-limit cache key")
 
 	key := rateLimitCacheKey(workload)
 
@@ -1999,14 +2014,15 @@ func TestScanService_CrossFlowRateLimitBackoff(t *testing.T) {
 	_, errValCVE := s.ValidateScanCVE(context.TODO(), workload)
 	assert.ErrorIs(t, errValCVE, domain.ErrTooManyRequests)
 
-	_, errValReg := s.ValidateScanRegistry(context.TODO(), workload)
+	_, errValReg := s.ValidateScanRegistry(context.TODO(), registryWorkload)
 	assert.ErrorIs(t, errValReg, domain.ErrTooManyRequests)
 
 	ctx := enrichContext(context.TODO(), workload, s.Version())
+	registryCtx := enrichContext(context.TODO(), registryWorkload, s.Version())
 
 	// Execution paths must also abort and return ErrTooManyRequests without calling CreateSBOM
 	assert.ErrorIs(t, s.GenerateSBOM(ctx), domain.ErrTooManyRequests)
 	assert.ErrorIs(t, s.ScanCVE(ctx), domain.ErrTooManyRequests)
-	assert.ErrorIs(t, s.ScanRegistry(ctx), domain.ErrTooManyRequests)
+	assert.ErrorIs(t, s.ScanRegistry(registryCtx), domain.ErrTooManyRequests)
 	assert.Equal(t, 0, countingSBOM.calls, "No execution path should attempt CreateSBOM when rate limited")
 }

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1932,3 +1932,73 @@ func TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch(t *
 	require.Len(t, platform.submitted, 1, "ScanCP cache hit must still submit the manifest to the backend")
 	assert.Contains(t, matchIDs(platform.submitted[0].Content.Matches), "CVE-A", "backend must receive the unfiltered manifest on a ScanCP cache hit")
 }
+
+func TestScanService_ScanRegistry_RateLimitBackoff(t *testing.T) {
+	imageID := "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+	imageTag := "docker.io/library/nginx:1.25"
+	slug, err := names.ImageInfoToSlug(tools.NormalizeReference(imageTag), imageID)
+	require.NoError(t, err)
+
+	platform := &recordingPlatform{}
+	countingSBOM := &countingSBOMCreator{SBOMCreator: adapters.NewMockSBOMAdapter(false, false, false)}
+	cveAdapter := adapters.NewMockCVEAdapter()
+	s := NewScanService(countingSBOM, repositories.NewMemoryStorage(false, false), cveAdapter, repositories.NewMemoryStorage(false, false), platform, nil, false, false, true, false, false)
+
+	workload := domain.ScanCommand{
+		ImageHash:          v1.NormalizeImageID(imageID, imageTag),
+		ImageTag:           imageTag,
+		ImageTagNormalized: tools.NormalizeReference(imageTag),
+		ImageSlug:          slug,
+		JobID:              "job-registry",
+	}
+	ctx := enrichContext(context.TODO(), workload, s.Version())
+
+	// Simulate a prior 429 rate limit recorded for this image
+	key := rateLimitCacheKey(workload)
+	s.tooManyRequests.Set(key, true, ttl)
+
+	// ValidateScanRegistry must return ErrTooManyRequests
+	_, valErr := s.ValidateScanRegistry(ctx, workload)
+	assert.ErrorIs(t, valErr, domain.ErrTooManyRequests)
+
+	// ScanRegistry execution path must also abort and return ErrTooManyRequests
+	scanErr := s.ScanRegistry(ctx)
+	assert.ErrorIs(t, scanErr, domain.ErrTooManyRequests)
+	assert.Equal(t, 0, countingSBOM.calls, "ScanRegistry must not attempt CreateSBOM when rate limited")
+}
+
+func TestScanService_CrossFlowRateLimitBackoff(t *testing.T) {
+	imageID := "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+	imageTag := "k8s.gcr.io/kube-proxy:v1.24.3"
+	normalizedTag := tools.NormalizeReference(imageTag)
+	normalizedImageID := v1.NormalizeImageID(imageID, imageTag)
+	slug, err := names.ImageInfoToSlug(normalizedTag, imageID)
+	require.NoError(t, err)
+
+	workload := domain.ScanCommand{
+		ImageHash:          normalizedImageID,
+		ImageTag:           imageTag,
+		ImageTagNormalized: normalizedTag,
+		ImageSlug:          slug,
+	}
+
+	key := rateLimitCacheKey(workload)
+
+	platform := &recordingPlatform{}
+	countingSBOM := &countingSBOMCreator{SBOMCreator: adapters.NewMockSBOMAdapter(false, false, false)}
+	cveAdapter := adapters.NewMockCVEAdapter()
+	s := NewScanService(countingSBOM, repositories.NewMemoryStorage(false, false), cveAdapter, repositories.NewMemoryStorage(false, false), platform, nil, false, false, true, false, false)
+
+	// Record rate limit under canonical key
+	s.tooManyRequests.Set(key, true, ttl)
+
+	// All validation entry points must recognize the rate limit
+	_, errValGen := s.ValidateGenerateSBOM(context.TODO(), workload)
+	assert.ErrorIs(t, errValGen, domain.ErrTooManyRequests)
+
+	_, errValCVE := s.ValidateScanCVE(context.TODO(), workload)
+	assert.ErrorIs(t, errValCVE, domain.ErrTooManyRequests)
+
+	_, errValReg := s.ValidateScanRegistry(context.TODO(), workload)
+	assert.ErrorIs(t, errValReg, domain.ErrTooManyRequests)
+}

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2001,4 +2001,12 @@ func TestScanService_CrossFlowRateLimitBackoff(t *testing.T) {
 
 	_, errValReg := s.ValidateScanRegistry(context.TODO(), workload)
 	assert.ErrorIs(t, errValReg, domain.ErrTooManyRequests)
+
+	ctx := enrichContext(context.TODO(), workload, s.Version())
+
+	// Execution paths must also abort and return ErrTooManyRequests without calling CreateSBOM
+	assert.ErrorIs(t, s.GenerateSBOM(ctx), domain.ErrTooManyRequests)
+	assert.ErrorIs(t, s.ScanCVE(ctx), domain.ErrTooManyRequests)
+	assert.ErrorIs(t, s.ScanRegistry(ctx), domain.ErrTooManyRequests)
+	assert.Equal(t, 0, countingSBOM.calls, "No execution path should attempt CreateSBOM when rate limited")
 }


### PR DESCRIPTION
## Overview
This PR resolves **#503** where registry rate-limit (HTTP 429) backoffs were recorded under disjoint cache keys across scan flows (`ImageHash` vs `ImageTagNormalized`), and `ScanRegistry` lacked an execution-path read check before calling `CreateSBOM`.

**Current behavior**: 
- `ScanCVE`, `ScanCP`, `GenerateSBOM`, `ValidateScanCP`, and `ValidateGenerateSBOM` read and write `s.tooManyRequests` using `workload.ImageHash`.
- `ScanRegistry` and `ValidateScanRegistry` read and write `s.tooManyRequests` using `workload.ImageTagNormalized`.
- Because `ImageHash` and `ImageTagNormalized` are distinct string keys for the same underlying image, a 429 rate limit recorded by a registry scan is ignored by workload scans and vice versa. Furthermore, `ScanRegistry` lacks an execution-path `s.tooManyRequests` check when `cve.Content` and `sbom.Content` are nil.

**Future behavior**: 
- `ScanService` uses a canonical `rateLimitCacheKey` helper across all validation guards (`ValidateScanCVE`, `ValidateScanCP`, `ValidateScanRegistry`, `ValidateGenerateSBOM`) and execution paths (`ScanCVE`, `ScanCP`, `ScanRegistry`, `GenerateSBOM`).
- `ScanRegistry` checks `s.tooManyRequests` before attempting `s.sbomCreator.CreateSBOM` in its execution path, returning `domain.ErrTooManyRequests` immediately if the image is rate limited.

## Additional Information
- Added `rateLimitCacheKey(workload domain.ScanCommand) string` in `core/services/scan.go` to select the canonical cache key (`ImageHash` > `ImageSlug` > `ImageTagNormalized`).
- Updated `checkCreateSBOM` call sites in `GenerateSBOM`, `ScanCVE`, `ScanCP`, and `ScanRegistry` to use `rateLimitCacheKey`.
- Added execution-path rate-limit read check to `ScanRegistry` before calling `s.sbomCreator.CreateSBOM`.
- Added unit tests `TestScanService_ScanRegistry_RateLimitBackoff` and `TestScanService_CrossFlowRateLimitBackoff` in `core/services/scan_test.go`.

## How to Test
1. Run local unit tests in the `core/services` package:
   `go test -v -count=1 -skip "TestScanService_NginxTest" ./core/services/...`

## Related issues/PRs:
* Resolved #503

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registry scans now consistently honor rate-limit backoffs across validation, SBOM generation, and vulnerability scanning.
  * Previously rate-limited image pulls are skipped and return a clear “Too Many Requests” result.
  * Prevented unnecessary SBOM creation when an image is already subject to a rate-limit backoff.
  * Improved tracing by associating registry validation with the relevant workload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->