### PR TITLE
fix(adapters): pass platform to syft GetSource in in-process SBOM path

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -158,9 +157,6 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	domainSBOM.Annotations[helpersv1.ImageTagMetadataKey] = imageTag
 
 	// translate business models into Syft models
-	if options.Platform == "" {
-		options.Platform = runtime.GOARCH
-	}
 	credentials := make([]image.RegistryCredentials, len(options.Credentials))
 	for i, v := range options.Credentials {
 		credentials[i] = image.RegistryCredentials{
@@ -174,6 +170,11 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		InsecureSkipTLSVerify: options.InsecureSkipTLSVerify,
 		InsecureUseHTTP:       options.InsecureUseHTTP,
 		Credentials:           credentials,
+	}
+
+	imgPlatform, err := parseSyftPlatform(options.Platform)
+	if err != nil {
+		return domainSBOM, err
 	}
 
 	// prepare temporary directory for image download
@@ -191,14 +192,14 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 
 	ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, s.maxImageSize)
 	pullRef := rewriteImageRef(imageID, s.proxyRegistryMap)
-	src, err := syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+	src, err := syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
 
 	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
 		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
 			helpers.String("imageTag", imageTag),
 			helpers.String("imageID", imageID))
 		pullRef = rewriteImageRef(imageTag, s.proxyRegistryMap)
-		src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+		src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
 	}
 
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
@@ -210,7 +211,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 					helpers.String("imageID", imageID))
 			} else {
 				registryOptions.Credentials = []image.RegistryCredentials{*gcpCreds}
-				src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+				src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
 			}
 		}
 		// If GCP ADC was not attempted, succeeded in auth but still got 401, or the image is not a GCP registry,
@@ -219,7 +220,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 			logger.L().Debug("retrying without credentials",
 				helpers.String("imageID", imageID))
 			registryOptions.Credentials = nil
-			src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+			src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
 			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
 				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
 			}

--- a/adapters/v1/syft_platform.go
+++ b/adapters/v1/syft_platform.go
@@ -1,0 +1,31 @@
+package v1
+
+import (
+	"runtime"
+	"strings"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/anchore/syft/syft"
+)
+
+// parseSyftPlatform normalizes a platform specifier for multi-arch image resolution.
+// The specifier uses OCI format "os/arch[/variant]" (e.g. "linux/amd64"). When only an
+// architecture is provided (e.g. "amd64"), "linux/" is prepended. An empty string defaults
+// to runtime.GOARCH. This mirrors pkg/sbomscanner/v1/server.go so in-process and sidecar
+// SBOM generation resolve the same manifest.
+func parseSyftPlatform(platformStr string) (*image.Platform, error) {
+	if platformStr == "" {
+		platformStr = runtime.GOARCH
+	}
+	if !strings.Contains(platformStr, "/") {
+		platformStr = "linux/" + platformStr
+	}
+	return image.NewPlatform(platformStr)
+}
+
+func syftGetSourceConfig(registryOptions *image.RegistryOptions, platform *image.Platform) *syft.GetSourceConfig {
+	return syft.DefaultGetSourceConfig().
+		WithRegistryOptions(registryOptions).
+		WithPlatform(platform).
+		WithSources("registry")
+}

--- a/adapters/v1/syft_platform_test.go
+++ b/adapters/v1/syft_platform_test.go
@@ -1,0 +1,75 @@
+package v1
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSyftPlatform(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform string
+		wantOS   string
+		wantArch string
+		wantErr  bool
+	}{
+		{
+			name:     "empty defaults to GOARCH with linux prefix",
+			platform: "",
+			wantOS:   "linux",
+			wantArch: runtime.GOARCH,
+		},
+		{
+			name:     "architecture only gets linux prefix",
+			platform: "arm64",
+			wantOS:   "linux",
+			wantArch: "arm64",
+		},
+		{
+			name:     "full OCI platform is preserved",
+			platform: "linux/amd64",
+			wantOS:   "linux",
+			wantArch: "amd64",
+		},
+		{
+			name:     "platform with variant",
+			platform: "linux/arm64/v8",
+			wantOS:   "linux",
+			wantArch: "arm64",
+		},
+		{
+			name:     "invalid platform is rejected",
+			platform: "not-a-valid-platform-spec",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSyftPlatform(tt.platform)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantOS, got.OS)
+			assert.Equal(t, tt.wantArch, got.Architecture)
+		})
+	}
+}
+
+func TestSyftGetSourceConfig_usesPlatform(t *testing.T) {
+	platform, err := parseSyftPlatform("linux/arm64")
+	require.NoError(t, err)
+
+	cfg := syftGetSourceConfig(&image.RegistryOptions{}, platform)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.SourceProviderConfig)
+	require.NotNil(t, cfg.SourceProviderConfig.Platform)
+	assert.Equal(t, "linux", cfg.SourceProviderConfig.Platform.OS)
+	assert.Equal(t, "arm64", cfg.SourceProviderConfig.Platform.Architecture)
+}

--- a/adapters/v1/testdata/alpine-sbom.format.json
+++ b/adapters/v1/testdata/alpine-sbom.format.json
@@ -2241,7 +2241,7 @@
         "index.docker.io/library/alpine@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501"
       ],
       "architecture": "<<PRESENCE>>",
-      "os": ""
+      "os": "linux"
     }
   },
   "distro": {


### PR DESCRIPTION
Fixes https://github.com/kubescape/kubevuln/issues/505
## Overview
This PR resolves #505 where the in-process SBOM path accepted `options.Platform` but never passed it to `syft.GetSource()`, while the sidecar scanner already normalized the platform and called `.WithPlatform(imgPlatform)` on every registry pull.
**Current behavior:**
- `SyftAdapter.CreateSBOM` in `adapters/v1/syft.go` sets/defaults `options.Platform` but calls `syft.GetSource` with only `WithRegistryOptions(...).WithSources("registry")` — no platform passed.
- The sidecar path in `pkg/sbomscanner/v1/server.go` (lines 157–203) builds `imgPlatform` via `image.NewPlatform(...)` and passes `.WithPlatform(imgPlatform)` on every pull.
- For multi-arch images, the two scan modes can resolve different manifests; the in-process path often falls back to the pod's `GOARCH` instead of the requested platform, so SBOM and CVE results can disagree for the same workload.
**Future behavior:**
- In-process and sidecar SBOM generation use the same platform normalization (`amd64` → `linux/amd64`, empty → `runtime.GOARCH`).
- All four `GetSource` calls in `CreateSBOM` pass `.WithPlatform()` — initial pull plus MANIFEST_UNKNOWN, auth, and anonymous retries.
- Multi-arch images resolve the same manifest when given the same `Platform` option.
## Additional Information
- Added `parseSyftPlatform` and `syftGetSourceConfig` helpers in `adapters/v1/syft_platform.go` (mirrors `pkg/sbomscanner/v1/server.go`).
- Updated `SyftAdapter.CreateSBOM` in `adapters/v1/syft.go` to use the shared config on every registry pull attempt.
- Added unit tests `TestParseSyftPlatform` and `TestSyftGetSourceConfig_usesPlatform` in `adapters/v1/syft_platform_test.go`.
## How to Test
Run local unit tests in the `adapters/v1` package:
```bash
go test ./adapters/v1/... -run 'TestParseSyftPlatform|TestSyftGetSourceConfig' -count=1 -v
```
```
=== RUN   TestParseSyftPlatform
--- PASS: TestParseSyftPlatform (0.00s)
=== RUN   TestSyftGetSourceConfig_usesPlatform
--- PASS: TestSyftGetSourceConfig_usesPlatform (0.00s)
PASS
ok  	github.com/kubescape/kubevuln/adapters/v1	0.104s
```
## Related issues/PRs
* Resolved #505
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image handling across platforms, including architecture-only and full OCI platform specifications.
  * Platform settings are now consistently applied when retrieving image sources.
  * Added clearer validation for invalid platform specifications.
  * Fixed generated SBOM metadata to correctly identify Linux-based images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->