### PR TITLE
feat: add metric for degraded exception fetching 

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -127,6 +127,7 @@ func main() {
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("metrics initialization error", helpers.Error(err))
 	}
+	service.SetMetrics(m)
 	controller, err = controller.WithMetrics(m)
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("metrics registration error", helpers.Error(err))

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
+	"github.com/kubescape/kubevuln/internal/metrics"
 	"github.com/kubescape/kubevuln/internal/tools"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
@@ -55,6 +56,14 @@ type ScanService struct {
 	storage           bool
 	vexGeneration     bool
 	tooManyRequests   *cache.Cache
+	metrics           *metrics.Metrics
+}
+
+// SetMetrics attaches an optional Metrics instance to the service. It is not
+// a constructor parameter so existing callers (including the many test call
+// sites) are unaffected; metric recording is a no-op until this is called.
+func (s *ScanService) SetMetrics(m *metrics.Metrics) {
+	s.metrics = m
 }
 
 var _ ports.ScanService = (*ScanService)(nil)
@@ -832,6 +841,9 @@ func (s *ScanService) applyExceptionsToManifest(ctx context.Context, cve domain.
 	}
 	exceptions, err := s.platform.GetCVEExceptions(ctx)
 	degraded := errors.Is(err, domain.ErrExceptionsDegraded)
+	if degraded && s.metrics != nil {
+		s.metrics.ExceptionsDegradedCounter.Add(ctx, 1)
+	}
 	if err != nil && !degraded {
 		logger.L().Ctx(ctx).Warning("failed to get CVE exceptions for filtering", helpers.Error(err))
 		return cve, false

--- a/core/services/scan_metrics_test.go
+++ b/core/services/scan_metrics_test.go
@@ -1,0 +1,58 @@
+package services
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/armosec/armoapi-go/scanfailure"
+	"github.com/kubescape/kubevuln/core/domain"
+	"github.com/kubescape/kubevuln/internal/metrics"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// degradedPlatform is a minimal ports.Platform stub whose GetCVEExceptions
+// always reports the exception set as degraded.
+type degradedPlatform struct{}
+
+func (degradedPlatform) GetCVEExceptions(ctx context.Context) (domain.CVEExceptions, error) {
+	return nil, domain.ErrExceptionsDegraded
+}
+func (degradedPlatform) ReportError(ctx context.Context, err error) error { return nil }
+func (degradedPlatform) ReportScanFailure(ctx context.Context, failureCase scanfailure.ScanFailureCase, reason string, scanErr error) error {
+	return nil
+}
+func (degradedPlatform) SendStatus(ctx context.Context, step int) error { return nil }
+func (degradedPlatform) SubmitCVE(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest) error {
+	return nil
+}
+
+func TestApplyExceptionsToManifest_NilMetricsDoesNotPanic(t *testing.T) {
+	s := &ScanService{platform: degradedPlatform{}}
+
+	assert.NotPanics(t, func() {
+		_, complete := s.applyExceptionsToManifest(context.Background(), domain.CVEManifest{Content: &v1beta1.GrypeDocument{}})
+		assert.False(t, complete)
+	})
+}
+
+func TestApplyExceptionsToManifest_RecordsDegradedMetric(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	s := &ScanService{platform: degradedPlatform{}}
+	s.SetMetrics(m)
+
+	_, complete := s.applyExceptionsToManifest(context.Background(), domain.CVEManifest{Content: &v1beta1.GrypeDocument{}})
+	assert.False(t, complete)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	m.Handler().ServeHTTP(w, req)
+	body := w.Body.String()
+
+	assert.True(t, strings.Contains(body, "kubevuln_exceptions_degraded_total 1"), body)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -26,9 +26,10 @@ type Metrics struct {
 	provider *sdkmetric.MeterProvider
 	handler  http.Handler
 
-	ScanDuration  metric.Float64Histogram
-	ScanCounter   metric.Int64Counter
-	RejectCounter metric.Int64Counter
+	ScanDuration              metric.Float64Histogram
+	ScanCounter               metric.Int64Counter
+	RejectCounter             metric.Int64Counter
+	ExceptionsDegradedCounter metric.Int64Counter
 }
 
 // New builds a Metrics instance backed by a Prometheus exporter registered
@@ -82,12 +83,21 @@ func New() (*Metrics, error) {
 		return nil, err
 	}
 
+	exceptionsDegradedCounter, err := meter.Int64Counter(
+		"kubevuln_exceptions_degraded_total",
+		metric.WithDescription("Total number of times CVE exception fetching degraded (partially failed) during a scan"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Metrics{
 		provider:      provider,
 		handler:       promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
-		ScanDuration:  scanDuration,
-		ScanCounter:   scanCounter,
-		RejectCounter: rejectCounter,
+		ScanDuration:              scanDuration,
+		ScanCounter:               scanCounter,
+		RejectCounter:             rejectCounter,
+		ExceptionsDegradedCounter: exceptionsDegradedCounter,
 	}, nil
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -19,6 +19,7 @@ func TestNewAndHandler(t *testing.T) {
 	m.ScanCounter.Add(context.Background(), 1, metric.WithAttributes())
 	m.ScanDuration.Record(context.Background(), 0.5, metric.WithAttributes())
 	m.RejectCounter.Add(context.Background(), 1, metric.WithAttributes())
+	m.ExceptionsDegradedCounter.Add(context.Background(), 1, metric.WithAttributes())
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	w := httptest.NewRecorder()
@@ -29,6 +30,7 @@ func TestNewAndHandler(t *testing.T) {
 	assert.True(t, strings.Contains(body, "kubevuln_scans_completed_total"), body)
 	assert.True(t, strings.Contains(body, "kubevuln_scan_duration_seconds"), body)
 	assert.True(t, strings.Contains(body, "kubevuln_scan_rejections_total"), body)
+	assert.True(t, strings.Contains(body, "kubevuln_exceptions_degraded_total"), body)
 }
 
 func TestMeterRegistersObservableGauge(t *testing.T) {


### PR DESCRIPTION
## Overview

`applyExceptionsToManifest` already detects when CVE exception fetching
degrades (via `domain.ErrExceptionsDegraded`) and handles it correctly
at the 3 call sites that check for it (avoiding treating a transient
fetch failure as an actual exception removal). But this degraded state
was never recorded anywhere, so there was no way to tell from metrics
alone whether this is a rare blip or happening on every scan.

## Changes

- Add `ExceptionsDegradedCounter` to `internal/metrics`, following the
  same pattern as the existing `RejectCounter`.
- Add an optional `metrics *metrics.Metrics` field + `SetMetrics()` to
  `ScanService`, rather than a constructor parameter, so the ~18
  existing `NewScanService` call sites (mostly tests) are unaffected.
- Increment the counter inside `applyExceptionsToManifest` when
  exceptions degrade, guarded by a nil check so it's a no-op if
  metrics were never set.
- Wire `SetMetrics()` into `cmd/http/main.go` alongside the existing
  `metrics.New()` call.

## Why this matters

The VEX Ingestion project (kubevuln#387) will add a second, similar
external dependency (fetching VEX feeds), which will need the exact
same kind of "did this degrade" tracking. This establishes the metric
pattern now, on the existing exceptions case, rather than needing to
invent one from scratch later.

## Testing

- `internal/metrics/metrics_test.go`: extended to confirm the new
  counter is exposed via the `/metrics` endpoint.
- `core/services/scan_metrics_test.go` (new): confirms the counter is
  a no-op with no panic when metrics aren't set, and confirms it
  actually increments when exception fetching degrades.
- Full `go test ./...` passes except a pre-existing, unrelated flaky
  test in `adapters/v1` (`Test_syftAdapter_CreateSBOM`) that depends
  on live Docker Hub network access — confirmed via `git stash` that
  this fails identically with these changes removed.

## Related issues/PRs:

* Resolved #507

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for cases where CVE exception retrieval is degraded.
  * Exposed a Prometheus counter for degraded exception handling.

* **Bug Fixes**
  * Improved scan behavior during degraded CVE exception retrieval, including safe operation when metrics are unavailable.

* **Tests**
  * Added coverage confirming degraded processing and metric reporting work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->