### PR TITLE
test(adapters): add unit tests for syft_utils hash helpers

### DIFF
--- a/adapters/v1/syft_utils_test.go
+++ b/adapters/v1/syft_utils_test.go
@@ -1,0 +1,50 @@
+package v1
+
+import (
+	"crypto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanDigestAlgorithmName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "uppercase with hyphen", input: "SHA-256", want: "sha256"},
+		{name: "already lowercase, no hyphen", input: "md5", want: "md5"},
+		{name: "mixed case with hyphen", input: "Sha-1", want: "sha1"},
+		{name: "multiple hyphens", input: "SHA-512-256", want: "sha512256"},
+		{name: "empty string", input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CleanDigestAlgorithmName(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHashers(t *testing.T) {
+	t.Run("supported algorithms are resolved correctly", func(t *testing.T) {
+		got, err := Hashers("sha-256", "MD5", "Sha-1")
+		assert.NoError(t, err)
+		assert.Equal(t, []crypto.Hash{crypto.SHA256, crypto.MD5, crypto.SHA1}, got)
+	})
+
+	t.Run("no names returns empty result", func(t *testing.T) {
+		got, err := Hashers()
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("unsupported algorithm returns an error", func(t *testing.T) {
+		got, err := Hashers("sha-256", "not-a-real-hash")
+		assert.Error(t, err)
+		assert.Nil(t, got)
+		assert.Contains(t, err.Error(), "unsupported hash algorithm: not-a-real-hash")
+	})
+}


### PR DESCRIPTION
## Summary

Adds dedicated unit tests for `CleanDigestAlgorithmName()` and `Hashers()` in `adapters/v1/syft_utils.go`, the only file in the package without a matching test file.

## Changes

- Tests `CleanDigestAlgorithmName` normalization (uppercase, hyphens, multiple hyphens, empty string)
- Tests `Hashers` resolving multiple valid algorithms with mixed casing/formatting
- Tests `Hashers` with no arguments returning an empty result
- Tests `Hashers` returning an explicit error for an unsupported algorithm

## Testing

- Ran `go test ./adapters/v1/... -run "TestCleanDigestAlgorithmName|TestHashers" -v`
- All 8 subtests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for digest and hash algorithm handling.
  * Verified case-insensitive and hyphen-normalized algorithm names.
  * Added tests for supported, empty, and unsupported algorithm inputs, including expected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->