### PR TITLE
fix(repositories): cache SecurityException/ClusterSecurityException List() results

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/akyoto/cache"
 	"github.com/armosec/utils-k8s-go/wlid"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -40,11 +41,29 @@ const (
 	vulnSummaryContNameFormat              string = "%s-%s-%s" // "<kind>-<name>-<container-name>"
 )
 
+// securityExceptionListCacheCleaningInterval/TTL bound how stale the raw SecurityException/
+// ClusterSecurityException List() results served by GetSecurityExceptions can be. Unlike
+// BackendAdapter's exceptionsCacheTTL (5m, keyed per workload), this cache sits below the
+// per-workload match/filter step and is keyed per namespace (SecurityException) or cluster-wide
+// (ClusterSecurityException), so every workload sharing that scope reuses the same List() —
+// see #510. 30s keeps the data close to live while still collapsing a burst of many
+// workloads/images scanned back-to-back into a single List() call.
+const (
+	securityExceptionListCacheCleaningInterval = 30 * time.Second
+	securityExceptionListCacheTTL              = 30 * time.Second
+	clusterSecurityExceptionListCacheKey       = "cse"
+)
+
 // APIServerStore implements both CVERepository and SBOMRepository with in-cluster storage (apiserver) to be used for production
 type APIServerStore struct {
 	StorageClient spdxv1beta1.SpdxV1beta1Interface
 	DynamicClient dynamic.Interface
 	Namespace     string
+
+	// securityExceptionListCache caches the raw List() results GetSecurityExceptions reads;
+	// nil is safe (falls back to always listing, e.g. in tests that construct APIServerStore
+	// literals directly instead of through the constructors below).
+	securityExceptionListCache *cache.Cache
 }
 
 var (
@@ -97,9 +116,10 @@ func NewAPIServerStorage(namespace string) (*APIServerStore, error) {
 		return nil, err
 	}
 	return &APIServerStore{
-		StorageClient: clientset.SpdxV1beta1(),
-		DynamicClient: dynClient,
-		Namespace:     namespace,
+		StorageClient:              clientset.SpdxV1beta1(),
+		DynamicClient:              dynClient,
+		Namespace:                  namespace,
+		securityExceptionListCache: cache.New(securityExceptionListCacheCleaningInterval),
 	}, nil
 }
 
@@ -114,7 +134,8 @@ func NewFakeAPIServerStorage(namespace string) *APIServerStore {
 			securityExceptionGVR:        "SecurityExceptionList",
 			clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
 		}),
-		Namespace: namespace,
+		Namespace:                  namespace,
+		securityExceptionListCache: cache.New(securityExceptionListCacheCleaningInterval),
 	}
 }
 
@@ -125,51 +146,101 @@ func NewFakeAPIServerStorage(namespace string) *APIServerStore {
 // conversion failure on an individual item is still only logged and skipped, since that's a
 // malformed single object rather than a listing-wide failure, and skipping it doesn't risk
 // masking a systemic API problem the way swallowing a List() error would.
+//
+// Both lists are served from securityExceptionListCache when available and fresh: the raw
+// List() results are the same for every workload in a given namespace (SecurityException) or
+// in the whole cluster (ClusterSecurityException), but without this cache each distinct
+// workload/image scanned re-triggers its own List() call — see #510. A List() failure is
+// never cached, so a transient apiserver hiccup self-heals on the next call instead of being
+// pinned for the TTL.
 func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
 	// Use a detached context with timeout — the scan context may be canceled
 	// before the CRD listing completes due to rate limiting.
 	listCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 
-	var exceptions []sev1beta1.SecurityException
 	var listErrs []error
 
 	// Only list namespaced exceptions when namespace is provided
+	var exceptions []sev1beta1.SecurityException
 	if namespace != "" {
-		seList, err := a.DynamicClient.Resource(securityExceptionGVR).Namespace(namespace).List(listCtx, metav1.ListOptions{})
+		var err error
+		exceptions, err = a.listSecurityExceptions(ctx, listCtx, namespace)
 		if err != nil {
-			logger.L().Ctx(ctx).Warning("failed to list SecurityExceptions", helpers.Error(err), helpers.String("namespace", namespace))
-			listErrs = append(listErrs, fmt.Errorf("failed to list SecurityExceptions: %w", err))
-		} else {
-			for i := range seList.Items {
-				var se sev1beta1.SecurityException
-				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(seList.Items[i].Object, &se); err != nil {
-					logger.L().Ctx(ctx).Warning("failed to convert SecurityException", helpers.Error(err))
-					continue
-				}
-				exceptions = append(exceptions, se)
-			}
+			listErrs = append(listErrs, err)
 		}
 	}
 
-	// List cluster-scoped exceptions
-	var clusterExceptions []sev1beta1.ClusterSecurityException
-	cseList, err := a.DynamicClient.Resource(clusterSecurityExceptionGVR).List(listCtx, metav1.ListOptions{})
+	clusterExceptions, err := a.listClusterSecurityExceptions(ctx, listCtx)
 	if err != nil {
-		logger.L().Ctx(ctx).Warning("failed to list ClusterSecurityExceptions", helpers.Error(err))
-		listErrs = append(listErrs, fmt.Errorf("failed to list ClusterSecurityExceptions: %w", err))
-	} else {
-		for i := range cseList.Items {
-			var cse sev1beta1.ClusterSecurityException
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(cseList.Items[i].Object, &cse); err != nil {
-				logger.L().Ctx(ctx).Warning("failed to convert ClusterSecurityException", helpers.Error(err))
-				continue
-			}
-			clusterExceptions = append(clusterExceptions, cse)
-		}
+		listErrs = append(listErrs, err)
 	}
 
 	return exceptions, clusterExceptions, stderrors.Join(listErrs...)
+}
+
+// listSecurityExceptions returns the namespaced SecurityExceptions for namespace, from
+// securityExceptionListCache when a fresh entry exists.
+func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, namespace string) ([]sev1beta1.SecurityException, error) {
+	cacheKey := "se/" + namespace
+	if a.securityExceptionListCache != nil {
+		if cached, ok := a.securityExceptionListCache.Get(cacheKey); ok {
+			return cached.([]sev1beta1.SecurityException), nil
+		}
+	}
+
+	seList, err := a.DynamicClient.Resource(securityExceptionGVR).Namespace(namespace).List(listCtx, metav1.ListOptions{})
+	if err != nil {
+		logger.L().Ctx(ctx).Warning("failed to list SecurityExceptions", helpers.Error(err), helpers.String("namespace", namespace))
+		return nil, fmt.Errorf("failed to list SecurityExceptions: %w", err)
+	}
+
+	var exceptions []sev1beta1.SecurityException
+	for i := range seList.Items {
+		var se sev1beta1.SecurityException
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(seList.Items[i].Object, &se); err != nil {
+			logger.L().Ctx(ctx).Warning("failed to convert SecurityException", helpers.Error(err))
+			continue
+		}
+		exceptions = append(exceptions, se)
+	}
+
+	if a.securityExceptionListCache != nil {
+		a.securityExceptionListCache.Set(cacheKey, exceptions, securityExceptionListCacheTTL)
+	}
+	return exceptions, nil
+}
+
+// listClusterSecurityExceptions returns every ClusterSecurityException in the cluster, from
+// securityExceptionListCache when a fresh entry exists. The result is the same regardless of
+// which workload/namespace triggered the call, so it is cached under a single cluster-wide key.
+func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Context) ([]sev1beta1.ClusterSecurityException, error) {
+	if a.securityExceptionListCache != nil {
+		if cached, ok := a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey); ok {
+			return cached.([]sev1beta1.ClusterSecurityException), nil
+		}
+	}
+
+	cseList, err := a.DynamicClient.Resource(clusterSecurityExceptionGVR).List(listCtx, metav1.ListOptions{})
+	if err != nil {
+		logger.L().Ctx(ctx).Warning("failed to list ClusterSecurityExceptions", helpers.Error(err))
+		return nil, fmt.Errorf("failed to list ClusterSecurityExceptions: %w", err)
+	}
+
+	var clusterExceptions []sev1beta1.ClusterSecurityException
+	for i := range cseList.Items {
+		var cse sev1beta1.ClusterSecurityException
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(cseList.Items[i].Object, &cse); err != nil {
+			logger.L().Ctx(ctx).Warning("failed to convert ClusterSecurityException", helpers.Error(err))
+			continue
+		}
+		clusterExceptions = append(clusterExceptions, cse)
+	}
+
+	if a.securityExceptionListCache != nil {
+		a.securityExceptionListCache.Set(clusterSecurityExceptionListCacheKey, clusterExceptions, securityExceptionListCacheTTL)
+	}
+	return clusterExceptions, nil
 }
 
 // GetWorkloadLabels resolves the labels of a workload so that a
@@ -1174,7 +1245,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
 		vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
 		vexDoc.Statements[i].ActionStatement = ""
-		
+
 		isIgnored := false
 		if len(vexDoc.Statements[i].Products) > 0 && len(vexDoc.Statements[i].Products[0].Subcomponents) > 0 {
 			if ignoredMap[vexDoc.Statements[i].Vulnerability.Name+vexDoc.Statements[i].Products[0].Subcomponents[0].ID] {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/akyoto/cache"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/tools"
@@ -1960,6 +1962,84 @@ func TestAPIServerStore_GetSecurityExceptions_NoErrorOnSuccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, se)
 	assert.Empty(t, cse)
+}
+
+// TestAPIServerStore_GetSecurityExceptions_CachesAcrossWorkloads is a regression test for
+// #510: GetSecurityExceptions used to issue a fresh List() call for both CRD types on every
+// invocation, even though the raw list is identical for every workload sharing the same
+// namespace (SecurityException) or the same cluster (ClusterSecurityException). List() call
+// counters prove the cache collapses repeated calls within the TTL into a single List(), and
+// that a genuinely new namespace still gets its own namespaced list while reusing the
+// already-cached cluster-scoped one.
+func TestAPIServerStore_GetSecurityExceptions_CachesAcrossWorkloads(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+
+	var seListCalls, cseListCalls int32
+	dynClient.PrependReactor("list", "securityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&seListCalls, 1)
+		return false, nil, nil
+	})
+	dynClient.PrependReactor("list", "clustersecurityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&cseListCalls, 1)
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient:              dynClient,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	// Two calls for the same namespace, simulating two distinct workloads/images scanned in it.
+	_, _, err := a.GetSecurityExceptions(context.TODO(), "ns-a")
+	require.NoError(t, err)
+	_, _, err = a.GetSecurityExceptions(context.TODO(), "ns-a")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&seListCalls), "second call for the same namespace should be served from cache")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&cseListCalls), "second call should also reuse the cached cluster-scoped list")
+
+	// A different namespace needs its own namespaced list, but the cluster-scoped list is
+	// shared across every namespace and must still come from cache.
+	_, _, err = a.GetSecurityExceptions(context.TODO(), "ns-b")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&seListCalls), "a new namespace is a cache miss for the namespaced list")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&cseListCalls), "ClusterSecurityExceptions are cluster-wide and must not be re-listed per namespace")
+}
+
+// TestAPIServerStore_GetSecurityExceptions_DoesNotCacheListFailures guards the self-healing
+// property #477 relies on: a List() failure must never populate the cache, or a transient
+// apiserver hiccup would be pinned as "no exceptions" for the full cache TTL instead of being
+// retried on the next call.
+func TestAPIServerStore_GetSecurityExceptions_DoesNotCacheListFailures(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+
+	var calls int32
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	dynClient.PrependReactor("list", "clustersecurityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return true, nil, injectedErr
+		}
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient:              dynClient,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	_, _, err := a.GetSecurityExceptions(context.TODO(), "")
+	require.Error(t, err)
+
+	_, _, err = a.GetSecurityExceptions(context.TODO(), "")
+	require.NoError(t, err, "a failed List() must not be cached, so the next call retries instead of replaying the failure")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
 }
 
 func TestAPIServerStore_GetContainerProfile_ctxPropagated(t *testing.T) {


### PR DESCRIPTION
## Overview

`GetSecurityExceptions` issued a fresh, uncached `List()` call to the K8s API for both `SecurityException` and `ClusterSecurityException` on every invocation. The result is identical for every workload sharing a namespace (SecurityException) or the whole cluster (ClusterSecurityException), but registry scans skip the outer per-workload policy cache entirely, and distinct workloads in the same namespace each miss it too - so List() traffic scaled with scan volume instead of with how often the exceptions actually change, all sharing one QPS=50/Burst=100 dynamic client.

This adds a lower-level cache inside `GetSecurityExceptions` itself: the namespaced list is cached per namespace, and the cluster-scoped list is cached once for the whole cluster, so every workload/image in that scope reuses the same List() instead of triggering its own.

## Additional Information

- `securityExceptionListCache` is a 30s-TTL `*cache.Cache` on `APIServerStore`. That's short enough to keep exception data close to live, but long enough to collapse a burst of many workloads/images scanned back-to-back into a single List().
- A failed List() is never cached, so a transient apiserver hiccup still self-heals on the next call instead of being pinned as "no exceptions" for the TTL - this preserves the behavior #477 relies on.
- The cache field is nil-safe, so it falls back to always listing if unset. That matters because several existing tests construct `APIServerStore{}` literals directly instead of going through the constructors.
- `GetSecurityExceptions`'s signature, matching semantics, and error propagation are unchanged - this is purely a caching/fetch-path change.

## How to Test

```
go test ./repositories/... -run GetSecurityExceptions -v
```

New tests:
- `TestAPIServerStore_GetSecurityExceptions_CachesAcrossWorkloads` - two calls for the same namespace collapse into one List() call; a new namespace still triggers its own namespaced list, but the cluster-scoped list stays shared across all of them.
- `TestAPIServerStore_GetSecurityExceptions_DoesNotCacheListFailures` - a failed List() is never cached, so the next call retries instead of replaying the failure.

`go build ./...`, `go vet ./repositories/...`, and the full `repositories`/`adapters`/`core` suites all pass.

## Related issues/PRs:

* Resolved #510

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved SecurityException listing performance by caching recent namespaced and cluster-wide results.
  * Reduced repeated data retrieval while keeping results current through time-based expiration.

* **Reliability**
  * Failed SecurityException list operations are not cached, allowing subsequent requests to retry normally.
  * Preserved handling for individual items that cannot be converted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->