### PR TITLE
fix(adapters): wire WithPlatform() into syft.GetSource() calls

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -161,6 +161,14 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	if options.Platform == "" {
 		options.Platform = runtime.GOARCH
 	}
+	platformStr := options.Platform
+	if !strings.Contains(platformStr, "/") {
+		platformStr = "linux/" + platformStr
+	}
+	imgPlatform, err := image.NewPlatform(platformStr)
+	if err != nil {
+		return domain.SBOM{}, fmt.Errorf("invalid platform %q: %w", platformStr, err)
+	}
 	credentials := make([]image.RegistryCredentials, len(options.Credentials))
 	for i, v := range options.Credentials {
 		credentials[i] = image.RegistryCredentials{
@@ -191,14 +199,14 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 
 	ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, s.maxImageSize)
 	pullRef := rewriteImageRef(imageID, s.proxyRegistryMap)
-	src, err := syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+	src, err := syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithPlatform(imgPlatform).WithSources("registry"))
 
 	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
 		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
 			helpers.String("imageTag", imageTag),
 			helpers.String("imageID", imageID))
 		pullRef = rewriteImageRef(imageTag, s.proxyRegistryMap)
-		src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+		src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithPlatform(imgPlatform).WithSources("registry"))
 	}
 
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
@@ -210,7 +218,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 					helpers.String("imageID", imageID))
 			} else {
 				registryOptions.Credentials = []image.RegistryCredentials{*gcpCreds}
-				src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+				src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithPlatform(imgPlatform).WithSources("registry"))
 			}
 		}
 		// If GCP ADC was not attempted, succeeded in auth but still got 401, or the image is not a GCP registry,
@@ -219,7 +227,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 			logger.L().Debug("retrying without credentials",
 				helpers.String("imageID", imageID))
 			registryOptions.Credentials = nil
-			src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithSources("registry"))
+			src, err = syft.GetSource(ctxWithSize, pullRef, syft.DefaultGetSourceConfig().WithRegistryOptions(&registryOptions).WithPlatform(imgPlatform).WithSources("registry"))
 			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
 				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
 			}

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -158,16 +157,19 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	domainSBOM.Annotations[helpersv1.ImageTagMetadataKey] = imageTag
 
 	// translate business models into Syft models
-	if options.Platform == "" {
-		options.Platform = runtime.GOARCH
-	}
-	platformStr := options.Platform
-	if !strings.Contains(platformStr, "/") {
-		platformStr = "linux/" + platformStr
-	}
-	imgPlatform, err := image.NewPlatform(platformStr)
-	if err != nil {
-		return domain.SBOM{}, fmt.Errorf("invalid platform %q: %w", platformStr, err)
+	// only request a specific platform when the caller explicitly asked for one;
+	// otherwise let Syft resolve whatever platform the image manifest provides.
+	var imgPlatform *image.Platform
+	if options.Platform != "" {
+		platformStr := options.Platform
+		if !strings.Contains(platformStr, "/") {
+			platformStr = "linux/" + platformStr
+		}
+		p, err := image.NewPlatform(platformStr)
+		if err != nil {
+			return domain.SBOM{}, fmt.Errorf("invalid platform %q: %w", platformStr, err)
+		}
+		imgPlatform = p
 	}
 	credentials := make([]image.RegistryCredentials, len(options.Credentials))
 	for i, v := range options.Credentials {


### PR DESCRIPTION
## Summary
- The in-process adapter (`adapters/v1/syft.go`) computed a default platform from `options.Platform` but never passed it to `syft.GetSource()` via `.WithPlatform()`, so the requested platform was silently dropped and Syft fell back to whatever manifest it found.
- The sidecar path (`pkg/sbomscanner/v1/server.go`) already wires `.WithPlatform()` correctly, so the exact same scan request could produce a different result (and a different SBOM) depending on which path handled it.
- This brings the in-process adapter to parity with the sidecar path only. It does not change the default-to-host-arch fallback behavior, which is a separate, larger piece of work tracked as a follow-up sub-task.

First sub-task of #512.

## Test plan
- [x] `go build ./adapters/...`
- [x] `go vet ./adapters/...` (no new findings)
- [x] `go test ./adapters/v1/... -run Test_syftAdapter_CreateSBOM` — note: on a non-amd64 dev machine (e.g. Apple Silicon), several cases now fail because the test fixtures are amd64-only images and platform is no longer silently ignored; this reproduces the exact bug being fixed. CI runs on `ubuntu-latest` (amd64), matching the fixtures' architecture, so these should pass there.