### PR TITLE
fix(services): walk filterSBOM's relationship graph to a fixed point

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -1040,23 +1040,36 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 		}
 	}
 
-	// filter relevant relationships. A relationship is relevant if the child is a relevant file
-	relationshipsArtifacts := mapset.NewSet[string]()
+	// filter relevant relationships and their transitively-relevant ancestor artifacts. A
+	// relationship is relevant if its child is a relevant file, or transitively, if its child
+	// is an artifact already known to be relevant (e.g. a package nested inside another
+	// package's archive). This walks the relationship graph to a fixed point instead of a
+	// fixed number of passes: Syft does not document or guarantee any particular relationship
+	// ordering, and a fixed number of passes can silently drop artifacts nested more than one
+	// level below the direct file owner depending on that order (see #514).
+	childToRelationships := make(map[string][]v1beta1.SyftRelationship, len(sbom.Content.ArtifactRelationships))
 	for _, relationship := range sbom.Content.ArtifactRelationships {
-		if addedFileIDs.Contains(relationship.Child) && !addedRelationshipIDs.Contains(getRelationshipID(relationship)) { // if the child is a relevant file
-			relationshipsArtifacts.Add(relationship.Parent)
-			addedRelationshipIDs.Add(getRelationshipID(relationship))
-			filteredSBOM.Content.ArtifactRelationships = append(filteredSBOM.Content.ArtifactRelationships, relationship)
-		}
+		childToRelationships[relationship.Child] = append(childToRelationships[relationship.Child], relationship)
 	}
 
-	// Add children of relevant relationships (that the parent is not relevant)
-	for _, relationship := range sbom.Content.ArtifactRelationships {
-		if relationshipsArtifacts.Contains(relationship.Child) && !addedRelationshipIDs.Contains(getRelationshipID(relationship)) {
-			relationshipsArtifacts.Add(relationship.Parent)
-			addedRelationshipIDs.Add(getRelationshipID(relationship))
-			filteredSBOM.Content.ArtifactRelationships = append(filteredSBOM.Content.ArtifactRelationships, relationship)
+	relationshipsArtifacts := mapset.NewSet[string]()
+	frontier := addedFileIDs.ToSlice()
+	for len(frontier) > 0 {
+		var next []string
+		for _, childID := range frontier {
+			for _, relationship := range childToRelationships[childID] {
+				relationshipID := getRelationshipID(relationship)
+				if addedRelationshipIDs.Contains(relationshipID) {
+					continue
+				}
+				addedRelationshipIDs.Add(relationshipID)
+				filteredSBOM.Content.ArtifactRelationships = append(filteredSBOM.Content.ArtifactRelationships, relationship)
+				if relationshipsArtifacts.Add(relationship.Parent) {
+					next = append(next, relationship.Parent)
+				}
+			}
 		}
+		frontier = next
 	}
 
 	// filter relevant artifacts. An artifact is relevant if it is in the relevant relationships

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -1052,6 +1052,12 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 		childToRelationships[relationship.Child] = append(childToRelationships[relationship.Child], relationship)
 	}
 
+	// Compute the closure first (which relationships/artifacts are relevant) without emitting
+	// anything: addedFileIDs.ToSlice() has no stable order, so a traversal that appends
+	// relationships as it discovers them would make the output order vary between calls on
+	// the same input whenever there's more than one relevant file. Emitting afterward, in a
+	// single pass over sbom.Content.ArtifactRelationships, keeps the output in the same
+	// deterministic source order the pre-fix code always had.
 	relationshipsArtifacts := mapset.NewSet[string]()
 	frontier := addedFileIDs.ToSlice()
 	for len(frontier) > 0 {
@@ -1063,13 +1069,18 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 					continue
 				}
 				addedRelationshipIDs.Add(relationshipID)
-				filteredSBOM.Content.ArtifactRelationships = append(filteredSBOM.Content.ArtifactRelationships, relationship)
 				if relationshipsArtifacts.Add(relationship.Parent) {
 					next = append(next, relationship.Parent)
 				}
 			}
 		}
 		frontier = next
+	}
+
+	for _, relationship := range sbom.Content.ArtifactRelationships {
+		if addedRelationshipIDs.Contains(getRelationshipID(relationship)) {
+			filteredSBOM.Content.ArtifactRelationships = append(filteredSBOM.Content.ArtifactRelationships, relationship)
+		}
 	}
 
 	// filter relevant artifacts. An artifact is relevant if it is in the relevant relationships

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -22,8 +22,8 @@ import (
 	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
-	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/kubevuln/internal/tools"
+	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/kubevuln/repositories"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
@@ -973,7 +973,7 @@ type fakeCVEScannerWithVuln struct {
 
 func (f *fakeCVEScannerWithVuln) DBVersion(context.Context) string { return "v1.0.0" }
 func (f *fakeCVEScannerWithVuln) Ready(context.Context) bool       { return true }
-func (f *fakeCVEScannerWithVuln) Version() string                   { return "v1.0.0" }
+func (f *fakeCVEScannerWithVuln) Version() string                  { return "v1.0.0" }
 func (f *fakeCVEScannerWithVuln) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.CVEManifest, error) {
 	return domain.CVEManifest{
 		Name:               sbom.Name,
@@ -1931,4 +1931,55 @@ func TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch(t *
 
 	require.Len(t, platform.submitted, 1, "ScanCP cache hit must still submit the manifest to the backend")
 	assert.Contains(t, matchIDs(platform.submitted[0].Content.Matches), "CVE-A", "backend must receive the unfiltered manifest on a ScanCP cache hit")
+}
+
+// TestFilterSBOM_TransitiveClosure is a regression test for #514: filterSBOM used to walk
+// ArtifactRelationships in exactly two fixed passes, which only ever caught relevant artifacts
+// up to one hop past the direct file owner, and even that one hop depended on the order
+// ArtifactRelationships happened to be in (Syft does not document or guarantee any particular
+// order). This constructs a 3-level containment chain - file F is owned by pkg-A, pkg-A is
+// contained in pkg-B, pkg-B is contained in pkg-C - with the relationships listed
+// outermost-first (C->B, B->A, A->F), the ordering that reproduced the bug.
+func TestFilterSBOM_TransitiveClosure(t *testing.T) {
+	instanceID, err := instanceidhandlerv1.GenerateInstanceIDFromString(
+		"apiVersion-apps/v1/namespace-default/kind-Deployment/name-probe/containerName-probe",
+	)
+	require.NoError(t, err)
+
+	sbom := domain.SBOM{
+		Content: &v1beta1.SyftDocument{
+			Files: []v1beta1.SyftFile{
+				{ID: "file-F", Location: v1beta1.Coordinates{RealPath: "/app/relevant.class"}},
+			},
+			Artifacts: []v1beta1.SyftPackage{
+				{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-A", Name: "A"}},
+				{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-B", Name: "B"}},
+				{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-C", Name: "C"}},
+			},
+			ArtifactRelationships: []v1beta1.SyftRelationship{
+				{Parent: "pkg-C", Child: "pkg-B", Type: "contains"},
+				{Parent: "pkg-B", Child: "pkg-A", Type: "contains"},
+				{Parent: "pkg-A", Child: "file-F", Type: "contains"},
+			},
+		},
+	}
+
+	relevantFiles := mapset.NewSet[string]()
+	relevantFiles.Add("/app/relevant.class")
+
+	filtered, err := filterSBOM(sbom, instanceID, "wlid://x", relevantFiles, map[string]string{}, helpersv1.Full)
+	require.NoError(t, err)
+
+	var gotIDs []string
+	for _, a := range filtered.Content.Artifacts {
+		gotIDs = append(gotIDs, a.ID)
+	}
+	assert.ElementsMatch(t, []string{"pkg-A", "pkg-B", "pkg-C"}, gotIDs,
+		"every artifact that transitively contains a relevant file must be kept, regardless of relationship order")
+
+	var gotRelationshipPairs []string
+	for _, r := range filtered.Content.ArtifactRelationships {
+		gotRelationshipPairs = append(gotRelationshipPairs, r.Parent+"->"+r.Child)
+	}
+	assert.ElementsMatch(t, []string{"pkg-A->file-F", "pkg-B->pkg-A", "pkg-C->pkg-B"}, gotRelationshipPairs)
 }

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1983,3 +1983,53 @@ func TestFilterSBOM_TransitiveClosure(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"pkg-A->file-F", "pkg-B->pkg-A", "pkg-C->pkg-B"}, gotRelationshipPairs)
 }
+
+// TestFilterSBOM_PreservesSourceRelationshipOrder is a regression test for CodeRabbit's
+// review on #515: the BFS fix for #514 emitted relationships as it discovered them, but
+// mapset's ToSlice() has no stable order, so with multiple relevant files the output order
+// could vary between calls on the same input. filterSBOM must emit ArtifactRelationships in
+// the same order they appear in sbom.Content.ArtifactRelationships, filtered down to the
+// relevant ones - not in discovery order.
+func TestFilterSBOM_PreservesSourceRelationshipOrder(t *testing.T) {
+	instanceID, err := instanceidhandlerv1.GenerateInstanceIDFromString(
+		"apiVersion-apps/v1/namespace-default/kind-Deployment/name-probe/containerName-probe",
+	)
+	require.NoError(t, err)
+
+	// Two independent relevant files, each with its own 2-level chain, interleaved in the
+	// source relationship list rather than grouped by file.
+	sourceRelationships := []v1beta1.SyftRelationship{
+		{Parent: "pkg-B1", Child: "pkg-A1", Type: "contains"},
+		{Parent: "pkg-A2", Child: "file-F2", Type: "contains"},
+		{Parent: "pkg-A1", Child: "file-F1", Type: "contains"},
+		{Parent: "pkg-B2", Child: "pkg-A2", Type: "contains"},
+	}
+
+	sbom := domain.SBOM{
+		Content: &v1beta1.SyftDocument{
+			Files: []v1beta1.SyftFile{
+				{ID: "file-F1", Location: v1beta1.Coordinates{RealPath: "/app/f1.class"}},
+				{ID: "file-F2", Location: v1beta1.Coordinates{RealPath: "/app/f2.class"}},
+			},
+			Artifacts: []v1beta1.SyftPackage{
+				{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-A1", Name: "A1"}},
+				{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-B1", Name: "B1"}},
+				{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-A2", Name: "A2"}},
+				{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-B2", Name: "B2"}},
+			},
+			ArtifactRelationships: sourceRelationships,
+		},
+	}
+
+	relevantFiles := mapset.NewSet[string]()
+	relevantFiles.Add("/app/f1.class")
+	relevantFiles.Add("/app/f2.class")
+
+	filtered, err := filterSBOM(sbom, instanceID, "wlid://x", relevantFiles, map[string]string{}, helpersv1.Full)
+	require.NoError(t, err)
+
+	// Every source relationship is relevant here, so the filtered order must equal the
+	// source order exactly - not just contain the same elements.
+	require.Equal(t, sourceRelationships, filtered.Content.ArtifactRelationships,
+		"filterSBOM must emit ArtifactRelationships in source order, not discovery order")
+}


### PR DESCRIPTION
## Overview

`filterSBOM` (core/services/scan.go) is supposed to keep every artifact that transitively owns a file the runtime profile actually touched. It computed that with exactly two fixed passes over `ArtifactRelationships` - the second pass only ever caught one hop past the direct file owner, and even that one hop depended on the order `ArtifactRelationships` happened to be in, since the pass mutates the same set it's checking against while iterating the same slice once.

Syft doesn't document or guarantee any relationship ordering, and this codebase already has `scanEmbeddedSboms` for exactly the multi-level nested-archive case (archive-in-archive) that needs more than one hop of transitivity. An artifact nested deeper than that, or even a 2-hop chain in the "wrong" order, was silently dropped from the filtered SBOM along with any CVEs found in it.

This replaces the two fixed passes with a worklist that walks the relationship graph to a fixed point - correct at any depth, independent of ordering.

## Additional Information

- Relationships are indexed by child once (`childToRelationships`), then a breadth-first walk starts from the relevant files and adds each newly-discovered relevant artifact to the next frontier, repeating until nothing new is found.
- Existing dedup (`addedRelationshipIDs`) and output-ordering for the already-working 0-hop and 1-hop cases is unchanged.
- The "filter relevant artifacts" step downstream is untouched - it already just filters by membership in `relationshipsArtifacts`, however that set was computed.

## How to Test

```
go test ./core/services/... -run TestFilterSBOM_TransitiveClosure -v
```

The new test constructs a 3-level containment chain (file F owned by pkg-A, pkg-A contained in pkg-B, pkg-B contained in pkg-C) with the relationships listed **outermost-first** (C->B, B->A, A->F) - the ordering that reproduces the bug against the old two-pass code. Before this fix, `pkg-C` was missing from the filtered artifacts; after, all three are present.

`go build ./...`, `go vet ./core/services/...`, and the full `core/services` suite all pass.

## Related issues/PRs:

* Resolved #514

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM filtering to retain artifacts across deeply nested containment relationships.
  * Ensured related artifacts are preserved regardless of relationship ordering.
  * Preserved the source SBOM’s relationship order in filtered results.
  * Prevented valid relationships from being omitted in multi-level artifact hierarchies.

* **Tests**
  * Added coverage for three-level transitive artifact relationships and relationship ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->