### PR TITLE
fix: prevent panic on non-string ScanCVE args in SubmitCVE

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -438,26 +438,26 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 	finalReport.Designators.Attributes[identifiers.AttributeSBOMToolVersion] = cve.SBOMCreatorVersion
 	finalReport.Designators.Attributes[identifiers.AttributeSBOMToolName] = cve.SBOMCreatorName
 
-	if val, ok := workload.Args[identifiers.AttributeRegistryName]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryName] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryName].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryName] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRepository]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRepository] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRepository].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRepository] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeTag]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeTag] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeTag].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeTag] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeSensor]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeSensor] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeSensor].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeSensor] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRegistryID]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryID] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryID].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryID] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRegistryScanID]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanID] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryScanID].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanID] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRegistryScanImagesCount]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanImagesCount] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryScanImagesCount].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanImagesCount] = val
 	}
 	if val, ok := finalReport.Designators.Attributes[identifiers.AttributeKind]; ok {
 		if s, err := k8sinterface.GetGroupVersionResource(val); err == nil {

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -1236,3 +1236,38 @@ func TestShouldRetryReport(t *testing.T) {
 		})
 	}
 }
+
+func TestSubmitCVE_NoPanicOnNonStringArgs(t *testing.T) {
+	backend := &BackendAdapter{
+		clusterConfig: armometadata.ClusterConfig{},
+		securityExceptionRepo: &testSecurityExceptionRepo{},
+		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
+		sendStatusFunc: func(*beClientV1.BaseReportSender, string, bool) {},
+		httpPostFunc: func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil
+		},
+	}
+	ctx := context.WithValue(context.Background(), domain.TimestampKey{}, int64(123456))
+	ctx = context.WithValue(ctx, domain.ScanIDKey{}, "56275825-4c07-4e3f-9a4c-53f05b0d0c2e")
+	
+	// Create a scan command with non-string args
+	workload := domain.ScanCommand{
+		Wlid: "wlid://cluster-x/namespace-y/deployment-z",
+		Args: map[string]interface{}{
+			identifiers.AttributeRegistryName: 12345, // Not a string!
+		},
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+	
+	cve := domain.CVEManifest{
+		Content: &v1beta1.GrypeDocument{},
+	}
+	cvep := domain.CVEManifest{}
+	
+	// Ensure it does NOT panic
+	assert.NotPanics(t, func() {
+		_ = backend.SubmitCVE(ctx, cve, cvep)
+	})
+}


### PR DESCRIPTION
## Overview

This PR fixes a bug in `adapters/v1/backend.go` where unchecked type assertions (e.g. `val.(string)`) on external JSON values from `workload.Args` could cause a fatal panic inside `SubmitCVE`.

If a client sent a non-string JSON value (such as an integer or boolean) for registry/image identifiers (e.g. `identifiers.AttributeRegistryName`), the goroutine executing `SubmitCVE` would crash.

Because it runs inside a worker pool outside the standard web request lifecycle, the unrecovered panic could kill the entire Go process and drop all in-flight scans.

This has been resolved by using safe, comma-ok type assertions.

## Additional Information

A very similar unchecked type assertion was previously fixed in `ScanCP` validation (Issue #415), but this particular path in `SubmitCVE` was missed.

## How to Test

 1. Start the `kubevuln` process locally.
 2. Submit a malformed `ScanCommand` payload to the `ScanCVE` endpoint where `workload.Args` contains an integer value for an expected string attribute (e.g. `"registryName": 12345`).
 3. Verify that the process safely handles or ignores the malformed input without panicking or crashing.
 4. Alternatively, run the newly added unit test:

    `go test -v -run TestSubmitCVE_NoPanicOnNonStringArgs ./adapters/v1`

## Examples/Screenshots

> Here are the logs for the new unit test confirming the fix works and no longer panics:

```text
=== RUN   TestSubmitCVE_NoPanicOnNonStringArgs
[warning] failed to parse image manifest from grype document. error: empty grype document
--- PASS: TestSubmitCVE_NoPanicOnNonStringArgs (0.00s)
PASS
ok  	github.com/kubescape/kubevuln/adapters/v1	1.327s
```

## Related issues/PRs

- Resolved #516

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes.