### PR TITLE
fix(repositories): enforce nil CVEManifest.Content consistently in VEX generation

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -903,6 +903,9 @@ func buildActionStatement(v v1beta1.Match) string {
 }
 
 func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domain.CVEManifest) error {
+	if cvep == nil || cvep.Content == nil {
+		return nil
+	}
 	// Now change the status of the filtered vulnerabilities to "Affected"
 	for _, v := range cvep.Content.Matches {
 		for i, s := range vexDoc.Statements {
@@ -953,39 +956,40 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 		},
 	}
 
-	// Loop over the Vulnerability struct and add each vulnerability to the VEX document
-	for _, v := range cve.Content.Matches {
-		var aliases []string
-		for _, alias := range v.RelatedVulnerabilities {
-			aliases = append(aliases, alias.ID)
-		}
-
-		product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
-
-		if err != nil {
-			return err
-		}
-
-		vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
-			Vulnerability: v1beta1.VexVulnerability{
-				ID:          v.Vulnerability.DataSource,
-				Name:        v.Vulnerability.ID,
-				Description: v.Vulnerability.Description,
-				Aliases:     aliases,
-			},
-
-			Products: []v1beta1.Product{
-				*product,
-			},
-
-			Status:          v1beta1.Status(vex.StatusNotAffected),
-			Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-			ImpactStatement: "Vulnerable component is not loaded into the memory",
-		})
-	}
-
-	// Add ignored vulnerabilities as not_affected with SecurityException impact statement
+	// Loop over the Vulnerability struct and add each vulnerability to the VEX document, and
+	// add ignored vulnerabilities as not_affected with SecurityException impact statement.
+	// Both loops read cve.Content, so both are guarded by the same nil check.
 	if cve.Content != nil {
+		for _, v := range cve.Content.Matches {
+			var aliases []string
+			for _, alias := range v.RelatedVulnerabilities {
+				aliases = append(aliases, alias.ID)
+			}
+
+			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
+
+			if err != nil {
+				return err
+			}
+
+			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:          v.Vulnerability.DataSource,
+					Name:        v.Vulnerability.ID,
+					Description: v.Vulnerability.Description,
+					Aliases:     aliases,
+				},
+
+				Products: []v1beta1.Product{
+					*product,
+				},
+
+				Status:          v1beta1.Status(vex.StatusNotAffected),
+				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
+				ImpactStatement: "Vulnerable component is not loaded into the memory",
+			})
+		}
+
 		for _, v := range cve.Content.IgnoredMatches {
 			var aliases []string
 			for _, alias := range v.RelatedVulnerabilities {
@@ -1189,54 +1193,13 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		}
 	}
 
-	for _, v := range cve.Content.IgnoredMatches {
-		found := false
-		for _, s := range vexDoc.Statements {
-			if s.Vulnerability.Name != v.Vulnerability.ID {
-				continue
-			}
-			if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
-				continue
-			}
-			if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			// Add the vulnerability to the VEX document
-			var aliases []string
-			for _, alias := range v.RelatedVulnerabilities {
-				aliases = append(aliases, alias.ID)
-			}
-
-			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
-			if err != nil {
-				return err
-			}
-
-			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
-				Vulnerability: v1beta1.VexVulnerability{
-					ID:          v.Vulnerability.DataSource,
-					Name:        v.Vulnerability.ID,
-					Description: v.Vulnerability.Description,
-					Aliases:     aliases,
-				},
-
-				Products: []v1beta1.Product{
-					*product,
-				},
-
-				Status:          v1beta1.Status(vex.StatusNotAffected),
-				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-				ImpactStatement: "Vulnerability was ignored by a SecurityException",
-			})
-		}
-	}
-
+	// ignoredMap drives the "reset every statement" pass below; guarded the same way as the
+	// Matches/IgnoredMatches loops above, since it reads the same cve.Content.
 	ignoredMap := make(map[string]bool)
-	for _, v := range cve.Content.IgnoredMatches {
-		ignoredMap[v.Vulnerability.ID+v.Artifact.PURL] = true
+	if cve.Content != nil {
+		for _, v := range cve.Content.IgnoredMatches {
+			ignoredMap[v.Vulnerability.ID+v.Artifact.PURL] = true
+		}
 	}
 
 	// Reset every statement back to the baseline "not affected" status before

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2479,4 +2479,8 @@ func TestAPIServerStore_StoreVEX_NilContentDoesNotPanic(t *testing.T) {
 		err := a.StoreVEX(ctx, empty, empty, false)
 		assert.NoError(t, err, "updateVEX must handle a nil CVEManifest.Content without erroring")
 	})
+
+	vexContainerUpdated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, vexContainerUpdated.Spec.Statements, "updateVEX must not fabricate statements out of a nil CVEManifest.Content")
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2450,3 +2450,33 @@ func TestAPIServerStore_storeVEX_ignoredMatches(t *testing.T) {
 	}
 	assert.True(t, foundTransitioned, "Transitioned match should be updated to not_affected with SecurityException impact statement")
 }
+
+// TestAPIServerStore_StoreVEX_NilContentDoesNotPanic is a regression test for #518:
+// createVEX, updateVEX, and markRelevantVulnerabilitiesAsAffectedInVex used to guard
+// CVEManifest.Content inconsistently - some reads were nil-checked, others weren't, within
+// the very same function. None of the current callers ever pass a nil Content, but the
+// functions themselves had no defense of their own. This exercises both the create path
+// (first call, container doesn't exist yet) and the update path (second call, container
+// already exists) with a completely empty CVEManifest{} - Content is nil - for both cve and
+// cvep, and asserts neither call panics or errors.
+func TestAPIServerStore_StoreVEX_NilContentDoesNotPanic(t *testing.T) {
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.TODO()
+
+	empty := domain.CVEManifest{Name: name}
+
+	require.NotPanics(t, func() {
+		err := a.StoreVEX(ctx, empty, empty, false)
+		assert.NoError(t, err, "createVEX must handle a nil CVEManifest.Content without erroring")
+	})
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, vexContainer.Spec.Statements, "no matches were ever provided, so no statements should be generated")
+
+	// Second call with the same (still nil-Content) manifests exercises updateVEX.
+	require.NotPanics(t, func() {
+		err := a.StoreVEX(ctx, empty, empty, false)
+		assert.NoError(t, err, "updateVEX must handle a nil CVEManifest.Content without erroring")
+	})
+}


### PR DESCRIPTION
## Overview

`createVEX`, `updateVEX`, and `markRelevantVulnerabilitiesAsAffectedInVex` (repositories/apiserver.go) each read `CVEManifest.Content`, but the nil-guarding around that was inconsistent - sometimes checked, sometimes not, within the same function. None of the current `StoreVEX` callers ever pass a nil `Content`, so nothing panics today, but the functions themselves had no defense of their own against it.

This enforces the guard consistently in all three places, and removes a dead unguarded duplicate loop in `updateVEX` along the way.

## Additional Information

- `markRelevantVulnerabilitiesAsAffectedInVex` now nil-checks `cvep` the same way its sibling `markIgnoredVulnerabilitiesInVex` already did - that sibling was the reference pattern.
- `createVEX`'s `Matches` loop is now under the same `cve.Content != nil` guard that already covered the `IgnoredMatches` loop right next to it, instead of being unguarded while its neighbor was guarded.
- `updateVEX` had a second, unguarded `IgnoredMatches` loop after the guarded block - dead code today since the guarded copy already adds everything it would, but still an unguarded dereference. Removed it, and guarded the `ignoredMap` build that follows (it reads the same `cve.Content`).
- No behavior change for the existing non-nil-`Content` path.

## How to Test

```
go test ./repositories/... -run TestAPIServerStore_StoreVEX_NilContentDoesNotPanic -v
```

The new test calls `StoreVEX` with a `CVEManifest{}` (nil `Content`) for both `cve` and `cvep`, twice - once to exercise the `createVEX` path (container doesn't exist yet) and once to exercise `updateVEX` (container already exists) - and asserts neither panics or errors.

`go build ./repositories/...`, `go vet ./repositories/...`, and the full `repositories` suite all pass.

## Related issues/PRs:

* Resolved #518

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing vulnerability records with missing content.
  * Prevented errors or crashes during initial creation and updates of incomplete vulnerability data.
  * Ensured no invalid VEX statements are generated when vulnerability content is unavailable.

* **Tests**
  * Added coverage for handling incomplete vulnerability records across creation and update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->