### PR TITLE
fix(repositories): guard nil CVEManifest.Content in the VEX path

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -903,6 +903,9 @@ func buildActionStatement(v v1beta1.Match) string {
 }
 
 func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domain.CVEManifest) error {
+	if cvep == nil || cvep.Content == nil {
+		return nil
+	}
 	// Now change the status of the filtered vulnerabilities to "Affected"
 	for _, v := range cvep.Content.Matches {
 		for i, s := range vexDoc.Statements {
@@ -934,6 +937,11 @@ func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domai
 func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest) error {
 	_, span := otel.Tracer("").Start(ctx, "APIServerStore.createVEX")
 	defer span.End()
+
+	if cve.Content == nil {
+		logger.L().Debug("no CVE content, skipping VEX creation")
+		return nil
+	}
 
 	imagePullable := cve.Annotations[helpersv1.ImageIDMetadataKey]
 
@@ -1186,51 +1194,6 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 					ImpactStatement: "Vulnerability was ignored by a SecurityException",
 				})
 			}
-		}
-	}
-
-	for _, v := range cve.Content.IgnoredMatches {
-		found := false
-		for _, s := range vexDoc.Statements {
-			if s.Vulnerability.Name != v.Vulnerability.ID {
-				continue
-			}
-			if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
-				continue
-			}
-			if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			// Add the vulnerability to the VEX document
-			var aliases []string
-			for _, alias := range v.RelatedVulnerabilities {
-				aliases = append(aliases, alias.ID)
-			}
-
-			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
-			if err != nil {
-				return err
-			}
-
-			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
-				Vulnerability: v1beta1.VexVulnerability{
-					ID:          v.Vulnerability.DataSource,
-					Name:        v.Vulnerability.ID,
-					Description: v.Vulnerability.Description,
-					Aliases:     aliases,
-				},
-
-				Products: []v1beta1.Product{
-					*product,
-				},
-
-				Status:          v1beta1.Status(vex.StatusNotAffected),
-				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-				ImpactStatement: "Vulnerability was ignored by a SecurityException",
-			})
 		}
 	}
 

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2450,3 +2450,66 @@ func TestAPIServerStore_storeVEX_ignoredMatches(t *testing.T) {
 	}
 	assert.True(t, foundTransitioned, "Transitioned match should be updated to not_affected with SecurityException impact statement")
 }
+
+// A nil Content used to reach an unguarded range and panic. StoreVEX should
+// treat it as nothing to do.
+func TestAPIServerStore_storeVEX_nilContent(t *testing.T) {
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		Wlid:          "wlid://cluster-aaa/namespace-any/job-any",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "any",
+	})
+
+	filtered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	assert.NotPanics(t, func() {
+		err := a.StoreVEX(ctx, domain.CVEManifest{Name: "nil-content"}, filtered, false)
+		assert.NoError(t, err)
+	})
+
+	assert.NotPanics(t, func() {
+		full := tools.FileToCVEManifest("testdata/nginx-cve.json")
+		err := a.StoreVEX(ctx, full, domain.CVEManifest{Name: full.Name}, false)
+		assert.NoError(t, err)
+	})
+}
+
+// The IgnoredMatches loop that ran outside the cve.Content guard rebuilt
+// statements the guarded loop above had already appended, and its own dedupe
+// meant it could never add anything. Removing it must leave the document
+// identical, including on the update path.
+func TestAPIServerStore_storeVEX_ignoredMatchesNotDuplicated(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		Wlid:          "wlid://cluster-aaa/namespace-any/job-any",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "any",
+	})
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false))
+	// second store takes the update path, which is where the duplicate loop lived
+	require.NoError(t, a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false))
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).
+		Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	seen := map[string]int{}
+	for _, s := range vexContainer.Spec.Statements {
+		key := s.Vulnerability.Name
+		if len(s.Products) > 0 && len(s.Products[0].Subcomponents) > 0 {
+			key += "|" + string(s.Products[0].Subcomponents[0].ID)
+		}
+		seen[key]++
+	}
+	for key, n := range seen {
+		assert.Equal(t, 1, n, "statement %q appears %d times", key, n)
+	}
+}


### PR DESCRIPTION
## Overview

`createVEX` and `markRelevantVulnerabilitiesAsAffectedInVex` dereference `cve.Content` / `cvep.Content` without checking, while other loops in the same functions do check. No current caller passes a nil `Content`, so nothing panics today — but the functions carry no defence of their own, which is what #518 describes.

Two changes:

**Guard `Content` once at the top** of `createVEX` and `markRelevantVulnerabilitiesAsAffectedInVex`, rather than adding more inline checks alongside the existing ones.

**Drop the second `cve.Content.IgnoredMatches` loop in `updateVEX`.** It sat outside the surrounding `if cve.Content != nil` block and rebuilt the same statements the guarded loop above had already appended — same status, same justification, same `"Vulnerability was ignored by a SecurityException"` impact statement. Its own `found` check searches `vexDoc.Statements` for the same vulnerability/PURL pair, so it could only ever re-find what the first loop added. Dead code, and an unguarded dereference of the variable the function had just finished being careful about.

The inner `if cve.Content != nil` blocks are left alone. They are trivially true now that the top-level guard exists, but removing them means dedenting large blocks for no behavioural change, which makes the diff harder to review than it needs to be.

## How to Test

```
go test ./repositories/ -run storeVEX
```

Two tests added:

* `TestAPIServerStore_storeVEX_nilContent` — passes a zero-value `CVEManifest` as each of `cve` and `cvep`. **Fails on main** (panic), passes here.
* `TestAPIServerStore_storeVEX_ignoredMatchesNotDuplicated` — stores twice so the second call takes the update path where the removed loop lived, then asserts no statement appears more than once. Passes both before and after, which is the point: it demonstrates the removal changes nothing.

All six pre-existing `storeVEX` tests still pass.

## Related issues/PRs:

* Resolved #518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when vulnerability content is missing during VEX creation.
  * Improved handling of empty or unavailable filtered manifests.
  * Prevented ignored vulnerability entries from being duplicated during repeated VEX updates.
  * Ensured existing vulnerability statements retain accurate affected and not-affected statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->