### PR TITLE
fix: skip SBOM regeneration on ScanCVE cache hit

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -438,26 +438,26 @@ func (a *BackendAdapter) SubmitCVE(ctx context.Context, cve domain.CVEManifest, 
 	finalReport.Designators.Attributes[identifiers.AttributeSBOMToolVersion] = cve.SBOMCreatorVersion
 	finalReport.Designators.Attributes[identifiers.AttributeSBOMToolName] = cve.SBOMCreatorName
 
-	if val, ok := workload.Args[identifiers.AttributeRegistryName]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryName] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryName].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryName] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRepository]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRepository] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRepository].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRepository] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeTag]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeTag] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeTag].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeTag] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeSensor]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeSensor] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeSensor].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeSensor] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRegistryID]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryID] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryID].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryID] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRegistryScanID]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanID] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryScanID].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanID] = val
 	}
-	if val, ok := workload.Args[identifiers.AttributeRegistryScanImagesCount]; ok {
-		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanImagesCount] = val.(string)
+	if val, ok := workload.Args[identifiers.AttributeRegistryScanImagesCount].(string); ok {
+		finalReport.Designators.Attributes[identifiers.AttributeRegistryScanImagesCount] = val
 	}
 	if val, ok := finalReport.Designators.Attributes[identifiers.AttributeKind]; ok {
 		if s, err := k8sinterface.GetGroupVersionResource(val); err == nil {

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -1236,3 +1236,38 @@ func TestShouldRetryReport(t *testing.T) {
 		})
 	}
 }
+
+func TestSubmitCVE_NoPanicOnNonStringArgs(t *testing.T) {
+	backend := &BackendAdapter{
+		clusterConfig: armometadata.ClusterConfig{},
+		securityExceptionRepo: &testSecurityExceptionRepo{},
+		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
+		sendStatusFunc: func(*beClientV1.BaseReportSender, string, bool) {},
+		httpPostFunc: func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil
+		},
+	}
+	ctx := context.WithValue(context.Background(), domain.TimestampKey{}, int64(123456))
+	ctx = context.WithValue(ctx, domain.ScanIDKey{}, "56275825-4c07-4e3f-9a4c-53f05b0d0c2e")
+	
+	// Create a scan command with non-string args
+	workload := domain.ScanCommand{
+		Wlid: "wlid://cluster-x/namespace-y/deployment-z",
+		Args: map[string]interface{}{
+			identifiers.AttributeRegistryName: 12345, // Not a string!
+		},
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+	
+	cve := domain.CVEManifest{
+		Content: &v1beta1.GrypeDocument{},
+	}
+	cvep := domain.CVEManifest{}
+	
+	// Ensure it does NOT panic
+	assert.NotPanics(t, func() {
+		_ = backend.SubmitCVE(ctx, cve, cvep)
+	})
+}

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -507,7 +507,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 
 	sbom := domain.SBOM{}
 	// check if we need SBOM
-	if cve.Content == nil || (s.storage && workload.InstanceID != "") {
+	if cve.Content == nil {
 		// check if SBOM is already available
 		if s.storage {
 			sbom, err = s.getSBOM(ctx, workload.ImageSlug, s.sbomCreator.Version())

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -22,8 +22,8 @@ import (
 	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
-	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/kubevuln/internal/tools"
+	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/kubevuln/repositories"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
@@ -973,7 +973,7 @@ type fakeCVEScannerWithVuln struct {
 
 func (f *fakeCVEScannerWithVuln) DBVersion(context.Context) string { return "v1.0.0" }
 func (f *fakeCVEScannerWithVuln) Ready(context.Context) bool       { return true }
-func (f *fakeCVEScannerWithVuln) Version() string                   { return "v1.0.0" }
+func (f *fakeCVEScannerWithVuln) Version() string                  { return "v1.0.0" }
 func (f *fakeCVEScannerWithVuln) ScanSBOM(ctx context.Context, sbom domain.SBOM) (domain.CVEManifest, error) {
 	return domain.CVEManifest{
 		Name:               sbom.Name,
@@ -2025,4 +2025,59 @@ func TestScanService_CrossFlowRateLimitBackoff(t *testing.T) {
 	assert.ErrorIs(t, s.ScanCVE(ctx), domain.ErrTooManyRequests)
 	assert.ErrorIs(t, s.ScanRegistry(registryCtx), domain.ErrTooManyRequests)
 	assert.Equal(t, 0, countingSBOM.calls, "No execution path should attempt CreateSBOM when rate limited")
+}
+
+func TestScanCVE_NoSBOMRegeneration_OnCacheHit(t *testing.T) {
+	// Setup
+	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
+	storageSBOM := repositories.NewMemoryStorage(false, false)
+	cveAdapter := adapters.NewMockCVEAdapter()
+	storageCVE := repositories.NewMemoryStorage(false, false)
+	platform := &recordingPlatform{}
+	relevancy := adapters.NewMockRelevancyAdapter()
+	service := NewScanService(sbomAdapter, storageSBOM, cveAdapter, storageCVE, platform, relevancy, true, true, true, false, false)
+
+	slug := "wasteful-sbom-test"
+
+	// Create a cached CVE
+	cveAdapterDBVersion := cveAdapter.DBVersion(context.TODO())
+	cacheCVE := domain.CVEManifest{
+		Name:               slug,
+		SBOMCreatorVersion: sbomAdapter.Version(),
+		CVEScannerVersion:  cveAdapter.Version(),
+		CVEDBVersion:       cveAdapterDBVersion,
+		Content:            &v1beta1.GrypeDocument{},
+		Labels: map[string]string{
+			"kubevuln.kubescape.io/image-slug":         slug,
+			"kubevuln.kubescape.io/sbom-creator":       sbomAdapter.Version(),
+			"kubevuln.kubescape.io/cve-scanner":        cveAdapter.Version(),
+			"kubevuln.kubescape.io/cve-scanner-db":     cveAdapterDBVersion,
+			"kubevuln.kubescape.io/workload-name":      "my-workload",
+			"kubevuln.kubescape.io/workload-namespace": "default",
+			"kubevuln.kubescape.io/workload-kind":      "Deployment",
+		},
+	}
+	require.NoError(t, storageCVE.StoreCVE(context.TODO(), cacheCVE, false))
+
+	// No SBOM in storage! (cache miss for SBOM)
+
+	// Context with Workload containing an InstanceID
+	workload := domain.ScanCommand{
+		ImageSlug:  slug,
+		InstanceID: "some-instance-id", // triggers `workload.InstanceID != ""`
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+
+	// Run ScanCVE
+	err := service.ScanCVE(ctx)
+	require.NoError(t, err)
+
+	// Verify that CreateSBOM was NOT called.
+	// We check if the storage now has the SBOM (which indicates it was generated).
+	generatedSBOM, err := storageSBOM.GetSBOM(context.TODO(), slug, sbomAdapter.Version())
+
+	// Since we no longer generate the SBOM wastefully, the storage should return an empty content
+	require.NoError(t, err, "MemoryStorage returns a nil error on a cache miss")
+	require.Nil(t, generatedSBOM.Content, "The generated SBOM should be nil since we avoided regenerating it wastefully")
+
 }


### PR DESCRIPTION
## Overview

This PR fixes a performance issue in `core/services/scan.go` where `ScanCVE` would wastefully regenerate an SBOM on a CVE cache hit (`cve.Content != nil`) if the incoming workload had a non-empty `InstanceID`.

Unlike `ScanCP`, `ScanCVE` does not generate a filtered relevancy manifest (`cvep`) and never reads the SBOM variable unless it's explicitly computing a cache miss. Dropping the unnecessary `(s.storage && workload.InstanceID != "")` condition prevents wasted CPU cycles and image pulls on busy clusters.

## How to Test

A unit test `TestScanCVE_NoSBOMRegeneration_OnCacheHit` has been updated to simulate a CVE cache hit and strictly assert that `CreateSBOM` is bypassed.

You can run it locally to verify:

```bash
go test -v ./core/services/... -run TestScanCVE_NoSBOMRegeneration_OnCacheHit
```

## Examples/Screenshots

Here are the local test execution logs confirming that `CreateSBOM` is successfully bypassed and the test passes:

```text
=== RUN   TestScanCVE_NoSBOMRegeneration_OnCacheHit
[info] NewMockSBOMAdapter
[info] NewMockCVEAdapter
[info] MockCVEAdapter.DBVersion
[info] MockSBOMAdapter.Version
[info] MockCVEAdapter.Version
[info] MockSBOMAdapter.Version
[info] MockCVEAdapter.Version
[info] scan started. imageSlug: wasteful-sbom-test; jobID: 
[info] MockSBOMAdapter.Version
[info] MockCVEAdapter.Version
[info] MockCVEAdapter.DBVersion
[info] scan complete. imageSlug: wasteful-sbom-test; instanceID: some-instance-id; jobID: 
[info] MockSBOMAdapter.Version
--- PASS: TestScanCVE_NoSBOMRegeneration_OnCacheHit (0.00s)

PASS

ok  	github.com/kubescape/kubevuln/core/services	1.431s
```

## Related issues/PRs

- Resolved #521

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scan submissions from failing when registry metadata contains unexpected value types.
  * Improved cached CVE scan handling by avoiding unnecessary SBOM generation and storage when results are already available.

* **Tests**
  * Added regression coverage for malformed registry metadata.
  * Added coverage confirming cached scans do not regenerate SBOM data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->