### PR TITLE
fix(repositories): guard nil CVEManifest.Content in parseSeverities

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -488,23 +488,25 @@ func parseSeverities(cve domain.CVEManifest, cvep domain.CVEManifest, withReleva
 	var unknown int64
 	var unknownRelevant int64
 
-	for i := range cve.Content.Matches {
-		switch cve.Content.Matches[i].Vulnerability.Severity {
-		case domain.CriticalSeverity:
-			critical += 1
-		case domain.HighSeverity:
-			high += 1
-		case domain.MediumSeverity:
-			medium += 1
-		case domain.LowSeverity:
-			low += 1
-		case domain.NegligibleSeverity:
-			negligible += 1
-		case domain.UnknownSeverity:
-			unknown += 1
+	if cve.Content != nil {
+		for i := range cve.Content.Matches {
+			switch cve.Content.Matches[i].Vulnerability.Severity {
+			case domain.CriticalSeverity:
+				critical += 1
+			case domain.HighSeverity:
+				high += 1
+			case domain.MediumSeverity:
+				medium += 1
+			case domain.LowSeverity:
+				low += 1
+			case domain.NegligibleSeverity:
+				negligible += 1
+			case domain.UnknownSeverity:
+				unknown += 1
+			}
 		}
 	}
-	if withRelevancy {
+	if withRelevancy && cvep.Content != nil {
 		for i := range cvep.Content.Matches {
 			switch cvep.Content.Matches[i].Vulnerability.Severity {
 			case domain.CriticalSeverity:

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2484,3 +2484,39 @@ func TestAPIServerStore_StoreVEX_NilContentDoesNotPanic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, vexContainerUpdated.Spec.Statements, "updateVEX must not fabricate statements out of a nil CVEManifest.Content")
 }
+
+// TestAPIServerStore_StoreCVESummary_NilContentDoesNotPanic is a regression test for #524:
+// parseSeverities dereferenced cve.Content.Matches unguarded, and cvep.Content.Matches guarded
+// only by the caller-supplied withRelevancy bool rather than an actual nil check on
+// cvep.Content. StoreCVESummary is part of the public ports.CVERepository interface, so
+// nothing enforced that precondition on it. This calls StoreCVESummary directly (not just
+// indirectly through scan.go) with a CVEManifest{} - Content is nil - for both cve and cvep,
+// in both withRelevancy states, and asserts none of the four combinations panic or error.
+func TestAPIServerStore_StoreCVESummary_NilContentDoesNotPanic(t *testing.T) {
+	for _, withRelevancy := range []bool{false, true} {
+		t.Run(fmt.Sprintf("withRelevancy=%v", withRelevancy), func(t *testing.T) {
+			a := NewFakeAPIServerStorage("kubescape")
+			ctx := context.TODO()
+			workload := domain.ScanCommand{
+				Wlid:          "wlid://cluster-x/namespace-y/deployment-z",
+				ContainerName: "container",
+			}
+			ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+			ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(123456))
+
+			empty := domain.CVEManifest{Name: name}
+
+			require.NotPanics(t, func() {
+				err := a.StoreCVESummary(ctx, empty, empty, withRelevancy)
+				assert.NoError(t, err, "StoreCVESummary must handle a nil CVEManifest.Content without erroring")
+			})
+
+			// Second call with the same (still nil-Content) manifests exercises the
+			// RetryOnConflict update path, not just the initial Create.
+			require.NotPanics(t, func() {
+				err := a.StoreCVESummary(ctx, empty, empty, withRelevancy)
+				assert.NoError(t, err, "the update path must also handle a nil CVEManifest.Content without erroring")
+			})
+		})
+	}
+}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2520,3 +2520,52 @@ func TestAPIServerStore_StoreCVESummary_NilContentDoesNotPanic(t *testing.T) {
 		})
 	}
 }
+
+// TestAPIServerStore_StoreCVESummary_MixedNilContentDoesNotPanic is a regression test for
+// CodeRabbit's review on #525: the "both nil" cases above never actually reach the second
+// (cvep) loop in parseSeverities when withRelevancy is true and cve.Content is non-nil, which
+// is the exact combination that used to panic. This gives cve real match data and leaves
+// cvep.Content nil with withRelevancy=true, then reads the stored summary back and asserts
+// the real manifest's counts are recorded while the relevant counts stay zero.
+func TestAPIServerStore_StoreCVESummary_MixedNilContentDoesNotPanic(t *testing.T) {
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		Wlid:          "wlid://cluster-x/namespace-y/deployment-z",
+		ContainerName: "container",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(123456))
+
+	cve := domain.CVEManifest{
+		Name: name,
+		Content: &v1beta1.GrypeDocument{
+			Matches: []v1beta1.Match{
+				{
+					Vulnerability: v1beta1.Vulnerability{
+						VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+							ID:       "CVE-MIXED-TEST",
+							Severity: domain.CriticalSeverity,
+						},
+					},
+				},
+			},
+		},
+	}
+	cvep := domain.CVEManifest{Name: name} // Content is nil
+
+	require.NotPanics(t, func() {
+		err := a.StoreCVESummary(ctx, cve, cvep, true)
+		assert.NoError(t, err, "StoreCVESummary must handle a non-nil cve.Content with a nil cvep.Content under withRelevancy=true")
+	})
+
+	resourceName, err := GetCVESummaryK8sResourceNameWithCVEName(ctx, cve.Name)
+	require.NoError(t, err)
+	namespace, err := GetCVESummaryK8sResourceNamespace(ctx)
+	require.NoError(t, err)
+
+	summary, err := a.StorageClient.VulnerabilityManifestSummaries(namespace).Get(ctx, resourceName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), summary.Spec.Severities.Critical.All, "the real cve manifest's match must still be counted")
+	assert.Equal(t, int64(0), summary.Spec.Severities.Critical.Relevant, "cvep.Content is nil, so no relevant count should be recorded")
+}


### PR DESCRIPTION
## Overview

`parseSeverities` (repositories/apiserver.go) dereferenced `cve.Content.Matches` unconditionally, and `cvep.Content.Matches` guarded only by the caller-supplied `withRelevancy` bool - not by an actual nil check on `cvep.Content`. `StoreCVESummary`, which calls it, is part of the public `ports.CVERepository` interface, so this precondition was never documented or enforced anywhere; it only held because of how `core/services/scan.go` happens to construct its arguments today.

Unlike VEX generation (gated behind the `vexGeneration` config flag), `StoreCVESummary` runs on every successful scan with storage enabled - the default production configuration - across all four scan flows, and produces the severity counts shown to users. This guards both loops with an explicit nil check, the same pattern already applied to VEX generation in #519.

## Additional Information

- `parseVulnerabilitiesComponents` (the sibling function `StoreCVESummary` also calls) only reads `.Name` off `cve`/`cvep`, never `.Content` - confirmed it has no equivalent gap, so it's untouched.
- Checked `MemoryStore.StoreCVESummary` (the test-double implementation of the same interface) - it never touches `.Content` either, so it was naturally nil-safe by accident. That's part of why this had gone unnoticed: tests written against the mock can't exercise this, only the real `APIServerStore` implementation has the dereference.
- No behavior change for the existing non-nil-`Content` path - severity counts are computed identically when both are non-nil.

## How to Test

```
go test ./repositories/... -run TestAPIServerStore_StoreCVESummary_NilContentDoesNotPanic -v
```

The new test calls `StoreCVESummary` directly (not just indirectly through `scan.go`) with a `CVEManifest{}` (nil `Content`) for both `cve` and `cvep`, in both `withRelevancy` states, and calls it twice per state to exercise both the initial `Create` and the `RetryOnConflict` update path - asserts none of it panics or errors.

`go build ./repositories/...`, `go vet ./repositories/...`, and the full `repositories` suite all pass.

## Related issues/PRs:

* Resolved #524

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause CVE summary processing to fail when vulnerability content is missing.
  * CVE manifests with empty content are now handled safely during both creation and updates.

* **Tests**
  * Added coverage for empty-content CVE manifests across supported relevancy settings and processing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->