### PR TITLE
docs+fix: document per-pod cache tradeoff and tighten exceptionsCache TTL

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -54,9 +54,16 @@ var _ ports.Platform = (*BackendAdapter)(nil)
 // exceptionsCacheTTL bounds how stale a cached exceptions/CRD merge can be before the next scan
 // re-fetches from the backend and cluster; exceptions rarely change within a scan burst, so this
 // avoids a network + CRD round trip on every single container scan.
+//
+// exceptionsCache is process-local (see #528): each Kubevuln replica keeps its own copy, so a
+// SecurityException change observed by one pod is not visible to the others until their own
+// cache entries expire. 1m (rather than the 5m this used to be) bounds that cross-pod worst case
+// to something closer to the underlying CRD-list cache's own 30s TTL
+// (repositories/apiserver.go's securityExceptionListCacheTTL), while still avoiding a
+// network+CRD round trip on every single container scan within a burst.
 const (
 	exceptionsCacheCleaningInterval = 1 * time.Minute
-	exceptionsCacheTTL              = 5 * time.Minute
+	exceptionsCacheTTL              = 1 * time.Minute
 )
 
 func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, accessKey string, seRepo ports.SecurityExceptionRepository) *BackendAdapter {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -513,6 +513,27 @@ The central business logic component implementing the `ScanService` port.
 
 ---
 
+## In-Process Caching
+
+Kubevuln keeps three TTL caches in memory, all backed by `github.com/akyoto/cache`:
+
+| Cache | Location | TTL | Purpose |
+|-------|----------|-----|---------|
+| `tooManyRequests` | `core/services/scan.go` | 10m | Registry rate-limit (429) backoff, keyed by image reference |
+| `exceptionsCache` | `adapters/v1/backend.go` | 1m | Merged CVE-exceptions/VEX policy, keyed per workload |
+| `securityExceptionListCache` | `repositories/apiserver.go` | 30s | Raw `SecurityException`/`ClusterSecurityException` `List()` results, keyed per namespace/cluster |
+
+**These caches are process-local by design, not shared across replicas.** In a multi-replica Kubevuln deployment (see #438 for the equivalent discussion about the Grype vulnerability DB), each pod keeps an independent copy of each cache with no cross-pod coordination:
+
+- A 429 recorded by one pod's `tooManyRequests` cache is invisible to the others - they can each independently discover and cache the same backoff, so the mitigation this cache exists to provide only fully applies within a single pod.
+- A `SecurityException` change (create/update/delete) observed by one pod is not reflected on the others until their own cache entries naturally expire - the same workload can show a CVE as suppressed or not depending on which pod happens to handle a given scan request, for up to the relevant cache's TTL.
+
+This is an accepted tradeoff, not an oversight: introducing a shared backing store (e.g. an external KV store) is a real architectural change with its own operational cost, and the deployment-side wiring for anything like that lives outside this repo (see kubescape-operator/helm-charts), matching how #438 scoped the equivalent Grype-DB-cache decision. Given that, the TTLs above are chosen deliberately per cache's actual stakes: `securityExceptionListCache` and `exceptionsCache` are kept short (30s / 1m) because a stale read there is a suppression-correctness question, not just a performance one, while `tooManyRequests` can tolerate a longer window (10m) since its only cost is a redundant registry pull attempt.
+
+If this tradeoff ever needs to change (e.g. Kubevuln starts running at a replica count where the redundant-429 or suppression-disagreement window becomes a real operational problem), the right first step is `exceptionsCache`, since it's the one with actual correctness/security stakes rather than a pure performance cost.
+
+---
+
 ## Integration Points
 
 ### External System Integration


### PR DESCRIPTION
## Overview

`tooManyRequests`, `exceptionsCache`, and `securityExceptionListCache` are all process-local in-memory caches with no state shared across Kubevuln replicas - a gap #438 explicitly flagged as an intended follow-up ("see #TBD" in its own text) that never actually got filed until #528.

This documents that as a deliberate, bounded tradeoff rather than a silent gap, and tightens `exceptionsCacheTTL` from 5m to 1m - the one cache with actual correctness/security stakes, since a `SecurityException` change is invisible across pods until the TTL expires, meaning the same workload can show a CVE as suppressed or not depending purely on which pod handles a given scan request.

## Additional Information

- Added an "In-Process Caching" section to `docs/ARCHITECTURE.md` covering all three caches, their TTLs, and why this is an accepted tradeoff rather than an oversight - introducing a shared backing store is a real architectural change whose deployment-side wiring lives outside this repo, matching how #438 scoped the equivalent Grype-DB-cache decision.
- 1m brings `exceptionsCache`'s worst-case cross-pod disagreement window much closer to the underlying raw-List() cache's own 30s TTL (`repositories/apiserver.go`'s `securityExceptionListCache`), while still avoiding a network+CRD round trip on every container scan within a burst.
- `tooManyRequests` and `securityExceptionListCache` are intentionally left as-is in this PR, per #528's own proposed rollout: validate the approach on `exceptionsCache` first since it's the one with real correctness stakes, not just a performance cost.
- No test asserted the specific TTL value, so no test changes were needed; confirmed by grepping for `exceptionsCacheTTL` usage before making the change.

## How to Test

```
go build ./adapters/v1/...
go vet ./adapters/v1/...
go test ./adapters/v1/... -count=1
```

All pass. This is a config-value and documentation change, not new logic, so no new test was added - existing `adapters/v1` coverage (including the exceptions-cache tests) continues to pass unchanged with the new TTL.

## Related issues/PRs:

* Resolved #528

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced the exception cache refresh interval from five minutes to one minute, helping updates appear sooner across application instances.

- **Documentation**
  - Added documentation describing in-process caches, their refresh behavior, replication considerations, and tradeoffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->