### PR TITLE
fix(adapters): share one fix-state predicate across suppression paths

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/anchore/grype/grype/match"
 	"github.com/anchore/syft/syft/source"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/containerscan"
@@ -116,26 +115,11 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 		// iterate over all vulnerabilities
 		for _, m := range grypeDocument.Matches {
 			var isFixed int
-			var version string
 			description := m.Vulnerability.Description
 			link := linkToVuln(m.Vulnerability.ID)
-			if len(m.Vulnerability.Fix.Versions) != 0 {
+			fixed, version := hasKnownFix(m)
+			if fixed {
 				isFixed = 1
-				version = suggestedVersion(m.Artifact.Version, m.Vulnerability.Fix.Versions)
-			} else {
-				// also check CPE matches
-				for _, detail := range m.MatchDetails {
-					var found match.CPEResult
-					err := json.Unmarshal(detail.Found, &found)
-					if err == nil {
-						// we assume that if a higher version is mentioned in the CPE, then it is fixed somewhere
-						if strings.Contains(found.VersionConstraint, "<") {
-							isFixed = 1
-							version = "unknown"
-							break
-						}
-					}
-				}
 			}
 			if description == "" && len(m.RelatedVulnerabilities) > 0 {
 				description = m.RelatedVulnerabilities[0].Description

--- a/adapters/v1/fixstate.go
+++ b/adapters/v1/fixstate.go
@@ -37,8 +37,14 @@ func hasKnownFix(m v1beta1.Match) (bool, string) {
 	if m.Vulnerability.Fix.State == fixStateFixed {
 		return true, unknownFixVersion
 	}
-	// no concrete version: fall back to CPE matches
+	// no concrete version: fall back to CPE matches. Only cpe-match details are read,
+	// since match.CPEResult is the shape Grype emits for those alone; a distro detail
+	// would also unmarshal into it (unknown fields are dropped) and its constraint would
+	// then be read as if it came from a CPE.
 	for _, detail := range m.MatchDetails {
+		if detail.Type != string(match.CPEMatch) {
+			continue
+		}
 		var found match.CPEResult
 		if err := json.Unmarshal(detail.Found, &found); err != nil {
 			continue

--- a/adapters/v1/fixstate.go
+++ b/adapters/v1/fixstate.go
@@ -1,0 +1,52 @@
+package v1
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+)
+
+const (
+	// fixStateFixed is the Grype fix state indicating a fix has been released.
+	fixStateFixed = "fixed"
+	// unknownFixVersion is reported when a fix is known to exist but no concrete
+	// version can be derived from the match.
+	unknownFixVersion = "unknown"
+)
+
+// hasKnownFix reports whether a fix exists for a Grype match, along with the version
+// to suggest for it. The version is "unknown" when a fix exists but no concrete
+// version is available, and empty when no fix is known.
+//
+// A fix is considered known when any of the following hold:
+//  1. The vulnerability carries concrete fixed versions.
+//  2. Grype reports the fix state as "fixed".
+//  3. A CPE match bounds the vulnerable range from above ("<"), which implies a fixed
+//     version exists somewhere above that range.
+//
+// Both the in-cluster manifest path (ApplySecurityExceptions) and the backend report
+// path (DomainToArmo) must decide "is this fixed?" the same way. When they disagree, an
+// ExpiredOnFix exception is honoured on one surface and expired on the other, so the
+// same CVE shows up as ignored in the VulnerabilityManifest but active in the report.
+func hasKnownFix(m v1beta1.Match) (bool, string) {
+	if len(m.Vulnerability.Fix.Versions) != 0 {
+		return true, suggestedVersion(m.Artifact.Version, m.Vulnerability.Fix.Versions)
+	}
+	if m.Vulnerability.Fix.State == fixStateFixed {
+		return true, unknownFixVersion
+	}
+	// no concrete version: fall back to CPE matches
+	for _, detail := range m.MatchDetails {
+		var found match.CPEResult
+		if err := json.Unmarshal(detail.Found, &found); err != nil {
+			continue
+		}
+		// we assume that if a higher version is mentioned in the CPE, then it is fixed somewhere
+		if strings.Contains(found.VersionConstraint, "<") {
+			return true, unknownFixVersion
+		}
+	}
+	return false, ""
+}

--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -12,14 +12,18 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // cpeMatchDetail builds a cpe-match detail carrying the given version constraint, the
 // shape Grype emits when a CVE is matched through a CPE rather than a distro advisory.
 func cpeMatchDetail(constraint string) v1beta1.MatchDetails {
+	return matchDetail("cpe-match", constraint)
+}
+
+func matchDetail(detailType, constraint string) v1beta1.MatchDetails {
 	return v1beta1.MatchDetails{
-		Type:  "cpe-match",
+		Type:  detailType,
 		Found: json.RawMessage(`{"vulnerabilityID":"CVE-2024-13176","versionConstraint":"` + constraint + `","cpes":["cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"]}`),
 	}
 }
@@ -134,7 +138,7 @@ func expiredOnFixException(cve string) domain.CVEExceptions {
 			PolicyType:            "vulnerabilityExceptionPolicy",
 			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
 			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: cve}},
-			ExpiredOnFix:          pointer.Bool(true),
+			ExpiredOnFix:          ptr.To(true),
 		},
 	}
 }
@@ -193,4 +197,25 @@ func TestExpiredOnFixAgreesAcrossPathsWhenUnfixed(t *testing.T) {
 	assert.Len(t, doc.IgnoredMatches, 1, "CVE without a fix should be ignored in the manifest")
 	assert.NotEmpty(t, results[0].ExceptionApplied, "CVE without a fix should carry an applied exception")
 	assert.Equal(t, 0, results[0].IsFixed)
+}
+
+// A distro detail unmarshals into match.CPEResult just as cleanly as a CPE one, so the
+// constraint is only read when the detail actually came from a CPE match.
+func TestHasKnownFixOnlyReadsCPEDetails(t *testing.T) {
+	for _, detailType := range []string{"exact-direct-match", "exact-indirect-match"} {
+		t.Run(detailType, func(t *testing.T) {
+			m := v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2024-13176"},
+					Fix:                   v1beta1.Fix{State: "unknown"},
+				},
+				MatchDetails: []v1beta1.MatchDetails{matchDetail(detailType, ">= 1.0.2, < 1.0.2zl")},
+			}
+
+			fixed, version := hasKnownFix(m)
+
+			assert.False(t, fixed, "an upper-bounded constraint outside a cpe-match is not a fix signal")
+			assert.Empty(t, version)
+		})
+	}
 }

--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -1,0 +1,196 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/google/uuid"
+	"github.com/kubescape/kubevuln/core/domain"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+)
+
+// cpeMatchDetail builds a cpe-match detail carrying the given version constraint, the
+// shape Grype emits when a CVE is matched through a CPE rather than a distro advisory.
+func cpeMatchDetail(constraint string) v1beta1.MatchDetails {
+	return v1beta1.MatchDetails{
+		Type:  "cpe-match",
+		Found: json.RawMessage(`{"vulnerabilityID":"CVE-2024-13176","versionConstraint":"` + constraint + `","cpes":["cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"]}`),
+	}
+}
+
+func TestHasKnownFix(t *testing.T) {
+	tests := []struct {
+		name        string
+		match       v1beta1.Match
+		wantFixed   bool
+		wantVersion string
+	}{
+		{
+			name:      "no fix signals at all",
+			match:     v1beta1.Match{},
+			wantFixed: false,
+		},
+		{
+			name: "concrete fix versions win and suggest a version",
+			match: v1beta1.Match{
+				Artifact:      v1beta1.GrypePackage{Version: "1.0.0"},
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed, Versions: []string{"2.17.0"}}},
+			},
+			wantFixed:   true,
+			wantVersion: "2.17.0",
+		},
+		{
+			name: "fix state fixed without versions",
+			match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed}},
+			},
+			wantFixed:   true,
+			wantVersion: unknownFixVersion,
+		},
+		{
+			// The #449 shape: Grype reports no fix, but the CPE range is bounded above.
+			name: "upper-bounded CPE constraint implies a fix",
+			match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: "unknown"}},
+				MatchDetails:  []v1beta1.MatchDetails{cpeMatchDetail(">= 3.0.0, < 3.0.16")},
+			},
+			wantFixed:   true,
+			wantVersion: unknownFixVersion,
+		},
+		{
+			name: "unbounded CPE constraint implies no fix",
+			match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: "not-fixed"}},
+				MatchDetails:  []v1beta1.MatchDetails{cpeMatchDetail(">= 3.0.0")},
+			},
+			wantFixed: false,
+		},
+		{
+			name: "malformed match detail is skipped, later detail still counts",
+			match: v1beta1.Match{
+				MatchDetails: []v1beta1.MatchDetails{
+					{Type: "cpe-match", Found: json.RawMessage(`not json`)},
+					cpeMatchDetail(">= 1.0.2, < 1.0.2zl"),
+				},
+			},
+			wantFixed:   true,
+			wantVersion: unknownFixVersion,
+		},
+		{
+			name: "malformed match detail alone implies no fix",
+			match: v1beta1.Match{
+				MatchDetails: []v1beta1.MatchDetails{{Type: "cpe-match", Found: json.RawMessage(`not json`)}},
+			},
+			wantFixed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixed, version := hasKnownFix(tt.match)
+			assert.Equal(t, tt.wantFixed, fixed)
+			assert.Equal(t, tt.wantVersion, version)
+		})
+	}
+}
+
+// singleLayerSource is the minimal image source the domainToArmo tests use, so these
+// tests exercise the exception logic rather than layer/config parsing.
+var singleLayerSource = &v1beta1.Source{
+	Target: json.RawMessage(`{"userInput":"","imageID":"","manifestDigest":"","mediaType":"","tags":null,"imageSize":0,"layers":[{"mediaType":"","digest":"dummyLayer","size":0}],"manifest":null,"config":null,"repoDigests":null,"architecture":"","os":""}`),
+}
+
+// alpineMatch returns the CVE-2024-13176 match from the repo's real Grype output. That
+// match is the exact divergence shape from #449: fix state "unknown" with no fix
+// versions, but a CPE constraint bounded above.
+func alpineMatch(t *testing.T) v1beta1.Match {
+	t.Helper()
+
+	var doc v1beta1.GrypeDocument
+	require.NoError(t, json.Unmarshal(fileContent("testdata/alpine-cve.format.json"), &doc))
+
+	for _, m := range doc.Matches {
+		if m.Vulnerability.ID != "CVE-2024-13176" {
+			continue
+		}
+		require.Empty(t, m.Vulnerability.Fix.Versions, "fixture no longer has the CPE-only shape")
+		require.NotEqual(t, fixStateFixed, m.Vulnerability.Fix.State, "fixture no longer has the CPE-only shape")
+		return m
+	}
+
+	t.Fatal("CVE-2024-13176 not found in testdata/alpine-cve.format.json")
+	return v1beta1.Match{}
+}
+
+func expiredOnFixException(cve string) domain.CVEExceptions {
+	return domain.CVEExceptions{
+		{
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: cve}},
+			ExpiredOnFix:          pointer.Bool(true),
+		},
+	}
+}
+
+// TestExpiredOnFixAgreesAcrossPaths is the regression test for #449. The in-cluster
+// manifest path (ApplySecurityExceptions) and the backend report path (DomainToArmo)
+// used to compute "is this fixed?" differently, so a CPE-matched CVE was hidden in the
+// VulnerabilityManifest while being reported as active to the backend. Both paths now
+// share hasKnownFix, so they must reach the same verdict.
+func TestExpiredOnFixAgreesAcrossPaths(t *testing.T) {
+	match := alpineMatch(t)
+	exceptions := expiredOnFixException(match.Vulnerability.ID)
+
+	ctx := context.WithValue(context.Background(), domain.TimestampKey{}, time.Now().Unix())
+	ctx = context.WithValue(ctx, domain.ScanIDKey{}, uuid.New().String())
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
+
+	// storage path
+	doc := &v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}
+	ApplySecurityExceptions(doc, exceptions)
+	storageSuppressed := len(doc.IgnoredMatches) == 1
+
+	// report path
+	results, err := DomainToArmo(ctx, v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}, exceptions)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	reportSuppressed := len(results[0].ExceptionApplied) > 0
+
+	assert.Equal(t, reportSuppressed, storageSuppressed,
+		"storage and report paths disagree on whether the ExpiredOnFix exception applies")
+
+	// A fix exists for this CVE, so expiredOnFix expires the exception on both surfaces.
+	assert.False(t, storageSuppressed, "CVE with a known fix should not be ignored in the manifest")
+	assert.False(t, reportSuppressed, "CVE with a known fix should not carry an applied exception")
+	assert.Equal(t, 1, results[0].IsFixed)
+}
+
+// TestExpiredOnFixAgreesAcrossPathsWhenUnfixed is the counterpart: with no fix signal at
+// all the exception has not expired, so both paths must suppress the CVE.
+func TestExpiredOnFixAgreesAcrossPathsWhenUnfixed(t *testing.T) {
+	match := alpineMatch(t)
+	match.MatchDetails = nil // strip the CPE constraint, leaving no fix signal
+	exceptions := expiredOnFixException(match.Vulnerability.ID)
+
+	ctx := context.WithValue(context.Background(), domain.TimestampKey{}, time.Now().Unix())
+	ctx = context.WithValue(ctx, domain.ScanIDKey{}, uuid.New().String())
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
+
+	doc := &v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}
+	ApplySecurityExceptions(doc, exceptions)
+
+	results, err := DomainToArmo(ctx, v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}, exceptions)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Len(t, doc.IgnoredMatches, 1, "CVE without a fix should be ignored in the manifest")
+	assert.NotEmpty(t, results[0].ExceptionApplied, "CVE without a fix should carry an applied exception")
+	assert.Equal(t, 0, results[0].IsFixed)
+}

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -220,7 +220,7 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 
 	var remaining []v1beta1.Match
 	for _, m := range doc.Matches {
-		isFixed := m.Vulnerability.Fix.State == "fixed"
+		isFixed, _ := hasKnownFix(m)
 		matched := getCVEExceptionMatchCVENameFromList(exceptions, m.Vulnerability.ID, isFixed)
 		if len(matched) > 0 && hasIgnoreAction(matched) {
 			doc.IgnoredMatches = append(doc.IgnoredMatches, v1beta1.IgnoredMatch{
@@ -335,8 +335,8 @@ func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 
 // IgnoredMatchKeys returns the set of match-identity keys for a manifest's ignored matches.
 // Keyed by vulnerability ID + artifact name + version (via \x00 separators) rather than CVE ID
-// alone, because an ExpiredOnFix policy suppresses only the matches of a CVE whose
-// Fix.State != "fixed" (getCVEExceptionMatchCVENameFromList), so two matches of the same CVE can
+// alone, because an ExpiredOnFix policy suppresses only the matches of a CVE that have no known
+// fix (hasKnownFix, via getCVEExceptionMatchCVENameFromList), so two matches of the same CVE can
 // have different suppression states. The manifest content is fixed across a cache hit, so these
 // keys are stable and detect both ID- and fix-state-driven changes to the ignored set.
 func IgnoredMatchKeys(doc *v1beta1.GrypeDocument) map[string]struct{} {


### PR DESCRIPTION
## Overview

`ApplySecurityExceptions` and `DomainToArmo` computed "is this CVE fixed?" with different predicates: the first used `Fix.State == "fixed"`, the second used `len(Fix.Versions) != 0` or a CPE match whose `versionConstraint` contains `"<"`. Both feed `getCVEExceptionMatchCVENameFromList`, which skips an `ExpiredOnFix` policy when the CVE is considered fixed. For CPE-matched CVEs carrying no concrete fix version, the two disagreed, so the same exception was applied in the stored `VulnerabilityManifest` but expired in the report sent to the backend.

Both paths now share a single `hasKnownFix` predicate. A fix is known when the vulnerability carries concrete fix versions, when Grype reports the state as `fixed`, or when a CPE match bounds the vulnerable range from above. This is the union of the two previous predicates, so no CVE that either path already treated as fixed becomes unfixed.

## How to Test

```
go test ./adapters/v1/ -run 'TestHasKnownFix|TestExpiredOnFix'
```

`TestExpiredOnFixAgreesAcrossPaths` uses the `CVE-2024-13176` match from `adapters/v1/testdata/alpine-cve.format.json`, which has the reported shape: fix state `unknown`, no fix versions, and an upper-bounded CPE constraint. It fails on `main` with `storage and report paths disagree on whether the ExpiredOnFix exception applies` and passes with this change.

## Related issues/PRs:

* Resolved #449

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability fix detection across security reports and exception handling.
  * Recognizes fixes identified by explicit versions, fixed status, or bounded version constraints.
  * Keeps fix recommendations and expiration behavior consistent across reporting paths.
  * Handles malformed vulnerability details without disrupting processing.

* **Tests**
  * Added coverage for fixed, unfixed, unknown, and malformed vulnerability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->