### PR TITLE
Add a local verify workflow for contributors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,28 @@ BINARY_NAME=kubevuln
 IMAGE?=quay.io/kubescape/$(BINARY_NAME)
 TAG=v0.0.0
 
+.PHONY: build test vet lint verify verify-image
+
 build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME) cmd/http/main.go
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
+
+lint:
+	@base=$$(git merge-base HEAD upstream/main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || true); \
+	if [ -n "$$base" ]; then \
+		golangci-lint run --new-from-rev "$$base"; \
+	else \
+		golangci-lint run; \
+	fi
+
+verify: build test vet lint
+
+verify-image: docker-build
 
 docker-build:
 	docker buildx build --platform linux/amd64 -t $(IMAGE):${TAG} -f $(DOCKERFILE_PATH) .

--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -158,7 +158,7 @@ func TestExpiredOnFixAgreesAcrossPaths(t *testing.T) {
 
 	// storage path
 	doc := &v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}
-	ApplySecurityExceptions(doc, exceptions)
+	ApplySecurityExceptions(doc, exceptions, nil)
 	storageSuppressed := len(doc.IgnoredMatches) == 1
 
 	// report path
@@ -188,7 +188,7 @@ func TestExpiredOnFixAgreesAcrossPathsWhenUnfixed(t *testing.T) {
 	ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
 
 	doc := &v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}
-	ApplySecurityExceptions(doc, exceptions)
+	ApplySecurityExceptions(doc, exceptions, nil)
 
 	results, err := DomainToArmo(ctx, v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}, exceptions)
 	require.NoError(t, err)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -167,6 +167,9 @@ ldd kubevuln
 ### Running Tests
 
 ```bash
+# Run the default local verification workflow
+make verify
+
 # Run all tests
 go test ./...
 
@@ -418,22 +421,52 @@ kubevuln/
 │  2. Make changes                                                 │
 │     └── Edit files, add tests                                    │
 │                                                                  │
-│  3. Run tests                                                    │
-│     └── go test ./...                                           │
+│  3. Run the fast local verification workflow                     │
+│     └── make verify                                             │
 │                                                                  │
-│  4. Run linter                                                   │
-│     └── golangci-lint run                                        │
+│  4. Run slower checks as needed                                  │
+│     └── make verify-image                                        │
+│     └── CONFIG_DIR=.dev/config ./kubevuln                       │
 │                                                                  │
-│  5. Build and verify                                             │
-│     └── make && CONFIG_DIR=.dev/config ./kubevuln               │
-│                                                                  │
-│  6. Commit changes                                               │
+│  5. Commit changes                                               │
 │     └── git commit -m "Add feature X"                           │
 │                                                                  │
-│  7. Push and create PR                                           │
+│  6. Push and create PR                                           │
 │     └── git push origin feature/my-feature                       │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
+```
+
+### Local Validation Workflow
+
+Use `make verify` as the default contributor check before opening a pull request. It keeps the fast path local and deterministic:
+
+```bash
+# Build the Linux amd64 binary, run all tests, run go vet, and lint against
+# changes since the branch point on upstream/main or origin/main
+make verify
+```
+
+`make verify` expands to these targets:
+
+```bash
+make build   # CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubevuln cmd/http/main.go
+make test    # go test ./...
+make vet     # go vet ./...
+make lint    # golangci-lint run --new-from-rev "$(git merge-base HEAD upstream/main || git merge-base HEAD origin/main)"
+```
+
+Keep slower or network-backed checks separate from the fast path:
+
+```bash
+# Slower container image build that can require Docker/buildx and network pulls
+make verify-image
+
+# Optional runtime smoke check; readiness may wait on vulnerability DB download
+CONFIG_DIR=.dev/config ./kubevuln
+
+# Optional integration suite when external dependencies are available
+go test -tags=integration ./...
 ```
 
 ### Code Style

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -460,6 +460,7 @@ func TestCreateSBOM_ImageTooLarge_LocalRegistry(t *testing.T) {
 	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
 		ImageId:         u.Host + "/test-image",
 		ImageTag:        u.Host + "/test-image:latest",
+		Platform:        "linux/amd64",
 		MaxImageSize:    1, // Exceeded by layer size
 		InsecureUseHttp: true,
 	})


### PR DESCRIPTION
## Overview
Add a contributor-facing local verification workflow around `make verify`, keep slower checks separate, and make the lint target resolve cleanly in both upstream and fork-style clones.

## How to Test
- `make build` - passed
- `go vet ./...` - passed
- `PATH="$(go env GOPATH)/bin:$PATH" make lint` - passed
- `go test ./... -count=1` - failed on existing `adapters/v1` Syft fixture expectations on this `darwin/arm64` machine
- `PATH="$(go env GOPATH)/bin:$PATH" make verify` - fails at the same existing `go test ./...` arm64 fixture issue

## Related issues/PRs:
- Fixes #534

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] New and existing unit tests pass locally with my changes
