### PR TITLE
feat(adapters): emit K8s Events for suppressed CVEs on SecurityExceptions

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -11,8 +11,15 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 )
+
+// securityExceptionAPIVersion is the apiVersion recorded on the ObjectReference used
+// when emitting suppression Events, matching pkg/securityexception/v1beta1's group/version.
+const securityExceptionAPIVersion = "kubescape.io/v1beta1"
 
 // suppressionSource identifies the CRD object a suppression provenance record originated
 // from, so a suppressed CVE can be traced back to the exception (and its scope) that
@@ -21,6 +28,7 @@ type suppressionSource struct {
 	kind      string // "SecurityException" or "ClusterSecurityException"
 	name      string
 	namespace string
+	uid       types.UID
 }
 
 // ConvertToVulnerabilityExceptionPolicies converts SecurityException and
@@ -52,6 +60,7 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 				kind:      "SecurityException",
 				name:      se.Name,
 				namespace: se.Namespace,
+				uid:       se.UID,
 			})
 			policies = append(policies, p)
 		}
@@ -72,6 +81,7 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 			p := buildPolicy(cse.Spec, vuln, "", suppressionSource{
 				kind: "ClusterSecurityException",
 				name: cse.Name,
+				uid:  cse.UID,
 			})
 			policies = append(policies, p)
 		}
@@ -154,6 +164,9 @@ func buildSuppressionAttributes(spec sev1beta1.SecurityExceptionSpec, vuln sev1b
 	if src.namespace != "" {
 		attrs["sourceNamespace"] = src.namespace
 	}
+	if src.uid != "" {
+		attrs["sourceUID"] = string(src.uid)
+	}
 	if j := strings.TrimSpace(vuln.Justification); j != "" {
 		attrs["justification"] = j
 	}
@@ -213,7 +226,11 @@ func hasIgnoreAction(policies []armotypes.VulnerabilityExceptionPolicy) bool {
 
 // ApplySecurityExceptions moves CVEs covered by exception policies from
 // doc.Matches to doc.IgnoredMatches with applied ignore rules.
-func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEExceptions) {
+//
+// recorder is optional: when nil, suppression is still logged via logSuppression but no
+// K8s Event is emitted, so callers with no EventRecorder configured (e.g. tests, or
+// deployments without SecurityException CRD integration enabled) are unaffected.
+func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEExceptions, recorder record.EventRecorder) {
 	if doc == nil || len(exceptions) == 0 {
 		return
 	}
@@ -229,7 +246,7 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 					{Vulnerability: m.Vulnerability.ID},
 				},
 			})
-			logSuppression(m, matched)
+			logSuppression(m, matched, recorder)
 		} else {
 			remaining = append(remaining, m)
 		}
@@ -255,7 +272,11 @@ func suppressingPolicies(matched []armotypes.VulnerabilityExceptionPolicy) []arm
 // matched, its scope, and the stated reason/justification. This is logged rather than stored on
 // the manifest because the filtered manifest's IgnoreRule (github.com/kubescape/storage) has no
 // fields for this provenance; see buildSuppressionAttributes for where it is captured.
-func logSuppression(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionPolicy) {
+//
+// When recorder is non-nil, the same suppression is also recorded as a K8s Event on the
+// SecurityException/ClusterSecurityException object that caused it, so it shows up in
+// `kubectl describe`. The log line is always written regardless of recorder.
+func logSuppression(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionPolicy, recorder record.EventRecorder) {
 	for _, p := range suppressingPolicies(matched) {
 		fields := []helpers.IDetails{
 			helpers.String("cve", m.Vulnerability.ID),
@@ -286,7 +307,36 @@ func logSuppression(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionP
 			fields = append(fields, helpers.String("normalizedTarget", target))
 		}
 		logger.L().Info("CVE suppressed by security exception", fields...)
+
+		emitSuppressionEvent(recorder, p, m)
 	}
+}
+
+// emitSuppressionEvent records a K8s Event on the CRD object that produced p, if recorder is
+// configured and p carries enough provenance (kind, name, UID) to build an ObjectReference.
+// A manually-built *corev1.ObjectReference bypasses live Get and scheme registration entirely
+// (client-go/tools/reference.GetReference short-circuits on it), so no K8s client access beyond
+// the recorder itself is needed here.
+func emitSuppressionEvent(recorder record.EventRecorder, p armotypes.VulnerabilityExceptionPolicy, m v1beta1.Match) {
+	if recorder == nil {
+		return
+	}
+	kind, _ := p.Attributes["sourceKind"].(string)
+	uid, _ := p.Attributes["sourceUID"].(string)
+	if kind == "" || p.Name == "" || uid == "" {
+		return
+	}
+	namespace, _ := p.Attributes["sourceNamespace"].(string)
+
+	ref := &corev1.ObjectReference{
+		Kind:       kind,
+		APIVersion: securityExceptionAPIVersion,
+		Name:       p.Name,
+		Namespace:  namespace,
+		UID:        types.UID(uid),
+	}
+	recorder.Eventf(ref, corev1.EventTypeNormal, "VulnerabilitySuppressed",
+		"Suppressed %s in package %s", m.Vulnerability.ID, m.Artifact.Name)
 }
 
 // RestoreSuppressedMatches is the inverse of ApplySecurityExceptions: it returns a copy of doc

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 )
 
 func TestConvertVulnerabilityExceptions(t *testing.T) {
@@ -263,7 +264,7 @@ func TestApplySecurityExceptions_MovesToIgnored(t *testing.T) {
 		},
 	}
 
-	ApplySecurityExceptions(doc, exceptions)
+	ApplySecurityExceptions(doc, exceptions, nil)
 
 	assert.Len(t, doc.Matches, 1, "one match should remain")
 	assert.Equal(t, "CVE-2023-9999", doc.Matches[0].Vulnerability.ID)
@@ -294,7 +295,7 @@ func TestApplySecurityExceptions_ExpiredOnFix(t *testing.T) {
 		},
 	}
 
-	ApplySecurityExceptions(doc, exceptions)
+	ApplySecurityExceptions(doc, exceptions, nil)
 
 	// Fix available + expiredOnFix = exception skipped, CVE stays in Matches
 	assert.Len(t, doc.Matches, 1, "CVE with fix should remain in Matches when expiredOnFix is set")
@@ -361,7 +362,7 @@ func TestApplySecurityExceptions_CaseInsensitive(t *testing.T) {
 		},
 	}
 
-	ApplySecurityExceptions(doc, exceptions)
+	ApplySecurityExceptions(doc, exceptions, nil)
 
 	assert.Len(t, doc.Matches, 1)
 	assert.Equal(t, "CVE-2023-9999", doc.Matches[0].Vulnerability.ID)
@@ -370,7 +371,7 @@ func TestApplySecurityExceptions_CaseInsensitive(t *testing.T) {
 }
 
 func TestApplySecurityExceptions_NilDoc(t *testing.T) {
-	ApplySecurityExceptions(nil, domain.CVEExceptions{})
+	ApplySecurityExceptions(nil, domain.CVEExceptions{}, nil)
 }
 
 func TestApplySecurityExceptions_NoExceptions(t *testing.T) {
@@ -380,7 +381,7 @@ func TestApplySecurityExceptions_NoExceptions(t *testing.T) {
 		},
 	}
 
-	ApplySecurityExceptions(doc, nil)
+	ApplySecurityExceptions(doc, nil, nil)
 
 	assert.Len(t, doc.Matches, 1, "no filtering when no exceptions")
 }
@@ -423,7 +424,7 @@ func TestConvertMixedStatusException(t *testing.T) {
 		},
 	}
 
-	ApplySecurityExceptions(doc, domain.CVEExceptions(policies))
+	ApplySecurityExceptions(doc, domain.CVEExceptions(policies), nil)
 
 	// under_investigation stays in Matches.
 	assert.Len(t, doc.Matches, 1)
@@ -483,7 +484,7 @@ func TestUnderInvestigationDoesNotSuppress(t *testing.T) {
 				},
 			}
 
-			ApplySecurityExceptions(doc, domain.CVEExceptions(policies))
+			ApplySecurityExceptions(doc, domain.CVEExceptions(policies), nil)
 
 			assert.Len(t, doc.Matches, 1, "under_investigation CVE must remain in Matches")
 			assert.Empty(t, doc.IgnoredMatches, "under_investigation CVE must not appear in IgnoredMatches")
@@ -546,12 +547,74 @@ func TestApplySecurityExceptions_MatchesByAlias(t *testing.T) {
 	}
 
 	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
-	ApplySecurityExceptions(doc, domain.CVEExceptions(policies))
+	ApplySecurityExceptions(doc, domain.CVEExceptions(policies), nil)
 
 	assert.Len(t, doc.Matches, 1)
 	assert.Equal(t, "CVE-2023-9999", doc.Matches[0].Vulnerability.ID)
 	assert.Len(t, doc.IgnoredMatches, 1)
 	assert.Equal(t, "GHSA-jfh8-c2jp-5v3q", doc.IgnoredMatches[0].Vulnerability.ID)
+}
+
+func TestApplySecurityExceptions_EmitsEventWhenRecorderConfigured(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{
+				Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}},
+				Artifact:      v1beta1.GrypePackage{Name: "log4j-core"},
+			},
+		},
+	}
+
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "allow-log4shell", Namespace: "default", UID: "abc-123"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Reason: "accepted risk",
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{
+						Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2021-44228"},
+						Status:        sev1beta1.VulnerabilityStatusNotAffected,
+					},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+	require.Len(t, policies, 1)
+	assert.Equal(t, "abc-123", policies[0].Attributes["sourceUID"])
+
+	recorder := record.NewFakeRecorder(1)
+	ApplySecurityExceptions(doc, domain.CVEExceptions(policies), recorder)
+
+	require.Len(t, doc.IgnoredMatches, 1)
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, "CVE-2021-44228")
+		assert.Contains(t, event, "log4j-core")
+	default:
+		t.Fatal("expected a suppression event to be recorded")
+	}
+}
+
+func TestApplySecurityExceptions_NilRecorderIsNoOp(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}},
+		},
+	}
+	exceptions := domain.CVEExceptions{
+		{
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-44228"}},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		ApplySecurityExceptions(doc, exceptions, nil)
+	})
+	assert.Len(t, doc.IgnoredMatches, 1)
 }
 
 func TestRestoreSuppressedMatches(t *testing.T) {

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubescape/backend/pkg/utils"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubevuln/adapters"
 	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/config"
@@ -25,6 +26,11 @@ import (
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 	"github.com/kubescape/kubevuln/repositories"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 )
 
 func main() {
@@ -94,9 +100,25 @@ func main() {
 
 	// SecurityException CRD integration requires storage and riskAcceptance RBAC
 	var seRepo ports.SecurityExceptionRepository
+	var eventRecorder record.EventRecorder
 	if storage != nil && c.RiskAcceptance {
 		seRepo = storage
 		logger.L().Info("SecurityException CRD integration enabled")
+
+		// Event recording is best-effort: a confirmed suppression is always logged
+		// regardless, so a missing/broken k8s config here should not block startup.
+		if k8sConfig := k8sinterface.GetK8sConfig(); k8sConfig != nil {
+			if clientset, err := kubernetes.NewForConfig(k8sConfig); err != nil {
+				logger.L().Ctx(ctx).Warning("failed to build k8s clientset for SecurityException events", helpers.Error(err))
+			} else {
+				broadcaster := record.NewBroadcaster()
+				broadcaster.StartStructuredLogging(0)
+				broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
+				eventRecorder = broadcaster.NewRecorder(runtime.NewScheme(), corev1.EventSource{Component: "kubevuln"})
+			}
+		} else {
+			logger.L().Warning("failed to get k8s config for SecurityException events")
+		}
 	} else {
 		seRepo = &repositories.NoOpSecurityExceptionRepository{}
 	}
@@ -121,6 +143,9 @@ func main() {
 		relevancyProvider = adapters.NewMockRelevancyAdapter()
 	}
 	service := services.NewScanService(sbomAdapter, storage, cveAdapter, storage, platform, relevancyProvider, c.Storage, c.VexGeneration, !c.NodeSbomGeneration, c.StoreFilteredSbom, c.PartialRelevancy)
+	if eventRecorder != nil {
+		service.SetEventRecorder(eventRecorder)
+	}
 	controller := controllers.NewHTTPController(service, c.ScanConcurrency)
 
 	m, err := metrics.New()

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/client-go/tools/record"
 )
 
 const (
@@ -57,6 +58,7 @@ type ScanService struct {
 	vexGeneration     bool
 	tooManyRequests   *cache.Cache
 	metrics           *metrics.Metrics
+	eventRecorder     record.EventRecorder
 }
 
 // SetMetrics attaches an optional Metrics instance to the service. It is not
@@ -64,6 +66,14 @@ type ScanService struct {
 // sites) are unaffected; metric recording is a no-op until this is called.
 func (s *ScanService) SetMetrics(m *metrics.Metrics) {
 	s.metrics = m
+}
+
+// SetEventRecorder attaches an optional EventRecorder to the service. It is not a
+// constructor parameter so existing callers (including the many test call sites) are
+// unaffected; suppression events are a no-op (suppressions are still logged, just not
+// recorded as K8s Events) until this is called.
+func (s *ScanService) SetEventRecorder(r record.EventRecorder) {
+	s.eventRecorder = r
 }
 
 var _ ports.ScanService = (*ScanService)(nil)
@@ -869,7 +879,7 @@ func (s *ScanService) applyExceptionsToManifest(ctx context.Context, cve domain.
 		filtered.Annotations = maps.Clone(cve.Annotations)
 	}
 	docCopy := cve.Content.DeepCopy()
-	v1.ApplySecurityExceptions(docCopy, exceptions)
+	v1.ApplySecurityExceptions(docCopy, exceptions, s.eventRecorder)
 	filtered.Content = docCopy
 	return filtered, !degraded
 }

--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -375,10 +375,12 @@ SecurityException CRDs do not use the status subresource. Observability is provi
 
 When a scanner evaluates exceptions during a scan, it emits Events on the SecurityException/ClusterSecurityException resource that was matched:
 
-- **kubevuln**: Emits an Event when a vulnerability exception matches during a scan (e.g., "Matched CVE-2021-44228 on Deployment/nginx-frontend in namespace production")
+- **kubevuln**: Emits a `VulnerabilitySuppressed` Event when a vulnerability exception actually suppresses a finding during a scan (e.g., "Suppressed CVE-2021-44228 in package log4j-core"). The Event is built directly from the `SecurityException`/`ClusterSecurityException` object's name, namespace and UID captured while converting the CRD into an exception policy — no extra `Get` call is needed. Event emission is wired up only when SecurityException CRD integration itself is enabled (`storage` and `riskAcceptance` both configured, see RBAC below); a suppression is always logged regardless, so Event emission being unavailable (no recorder configured, or the scanner's k8s client could not be constructed at startup) never affects suppression behavior itself.
 - **kubescape**: Emits an Event when a posture exception matches during a scan (e.g., "Matched control C-0034 on Deployment/nginx-frontend")
 
 Users can inspect exception activity via `kubectl describe securityexception <name>` and see recent Events. Events are automatically garbage-collected by Kubernetes.
+
+Emitting Events requires the `create`/`patch` RBAC grant on the `events` resource noted above; that grant is deployment-manifest wiring owned by kubescape-operator/helm-charts, not this repo.
 
 ### Expiry
 

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
+	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
@@ -442,7 +443,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/gorm v1.30.2 // indirect
-	k8s.io/api v0.35.0 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/apiserver v0.35.0 // indirect
 	k8s.io/component-base v0.35.0 // indirect


### PR DESCRIPTION
## Overview

Suppression provenance - which `SecurityException`/`ClusterSecurityException` caused a CVE to be filtered out of scan results - has been tracked in memory since #495, but it only ever reached a log line. There was no `EventRecorder` anywhere in this codebase, so `kubectl describe securityexception` never showed suppression activity, even though `docs/security-exception-design.md` already documents that as the intended behavior.

This wires that up end to end: the CRD object's UID is now threaded through `suppressionSource` (needed to build a correct `ObjectReference`), `ApplySecurityExceptions`/`logSuppression` accept an optional `record.EventRecorder` and emit a `VulnerabilitySuppressed` Event alongside the existing log line when one is configured, and `cmd/http/main.go` constructs a real recorder from a typed K8s clientset, gated behind the same `storage && riskAcceptance` condition SecurityException CRD integration itself already requires.

## Additional Information

- `adapters/v1/securityexception.go`: added `uid types.UID` to `suppressionSource`, populated from `se.UID`/`cse.UID` in `ConvertToVulnerabilityExceptionPolicies`, surfaced as `attrs["sourceUID"]` in `buildSuppressionAttributes` alongside the existing `sourceKind`/`sourceNamespace`. `ApplySecurityExceptions`/`logSuppression` now take an optional `recorder record.EventRecorder`; a new `emitSuppressionEvent` builds a `*corev1.ObjectReference{Kind, APIVersion: "kubescape.io/v1beta1", Name, Namespace, UID}` from those attributes and calls `recorder.Eventf(ref, corev1.EventTypeNormal, "VulnerabilitySuppressed", ...)`. No live `Get` or scheme registration needed - `client-go/tools/reference.GetReference` short-circuits on a pre-built `*corev1.ObjectReference` anyway, and `kubescape.io/v1beta1` matches the GVR already used for these CRDs in `repositories/apiserver.go`.
- `core/services/scan.go`: added `ScanService.eventRecorder` + `SetEventRecorder`, following the exact same optional, nil-safe attachment pattern already used for `ScanService.metrics`/`SetMetrics` - existing callers and the many test call sites are unaffected, and event recording is a no-op until `SetEventRecorder` is called. `applyExceptionsToManifest` now passes `s.eventRecorder` through to `ApplySecurityExceptions`.
- `cmd/http/main.go`: builds a typed `kubernetes.Clientset` from the existing `k8sinterface.GetK8sConfig()`, then a `record.EventBroadcaster`/`EventRecorder` via `StartRecordingToSink(&typedcorev1.EventSinkImpl{...})`, gated behind the same `storage != nil && c.RiskAcceptance` condition SecurityException CRD integration itself already requires. Best-effort: a failed clientset build logs a warning and leaves the recorder nil rather than blocking startup, since suppression is always logged regardless of Event emission.
- `docs/security-exception-design.md`: updated the Events section to describe the implemented kubevuln behavior (`VulnerabilitySuppressed` events, built without an extra `Get`) and note that the `events` create/patch RBAC grant is deployment-manifest wiring owned by kubescape-operator/helm-charts, not this repo (consistent with how #438 scoped an equivalent concern).

## How to Test

```
go build ./...
go vet ./...
go test ./adapters/v1/... ./core/services/... -count=1
go build ./cmd/...
```

All pass. New/updated coverage:
- `adapters/v1/securityexception_test.go::TestApplySecurityExceptions_EmitsEventWhenRecorderConfigured` - a suppression with a `record.NewFakeRecorder` configured produces an event containing the CVE ID and package name, and the `sourceUID` attribute round-trips correctly from `ConvertToVulnerabilityExceptionPolicies` through to the emitted `ObjectReference`.
- `adapters/v1/securityexception_test.go::TestApplySecurityExceptions_NilRecorderIsNoOp` - nil recorder is a complete no-op, matching pre-existing behavior.
- Every existing `ApplySecurityExceptions(...)` call site (10 across `securityexception_test.go`) updated to pass `nil` for the new parameter; all continue to pass unchanged.

## Related issues/PRs:

* Resolved #536

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
