### PR TITLE
fix(adapters): guard nil error and check context cancellation in ReportError/SendStatus (#538)

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -244,6 +244,14 @@ func (a *BackendAdapter) ReportError(ctx context.Context, err error) error {
 	ctx, span := otel.Tracer("").Start(ctx, "BackendAdapter.ReportError")
 	defer span.End()
 
+	if err == nil {
+		return nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	report, err2 := a.reportFromContext(ctx)
 	if err2 != nil {
 		return err2
@@ -331,6 +339,10 @@ func (a *BackendAdapter) ReportScanFailure(ctx context.Context, failureCase scan
 func (a *BackendAdapter) SendStatus(ctx context.Context, step int) error {
 	ctx, span := otel.Tracer("").Start(ctx, "BackendAdapter.SendStatus")
 	defer span.End()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	report, err := a.reportFromContext(ctx)
 	if err != nil {

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -1239,7 +1239,7 @@ func TestShouldRetryReport(t *testing.T) {
 
 func TestSubmitCVE_NoPanicOnNonStringArgs(t *testing.T) {
 	backend := &BackendAdapter{
-		clusterConfig: armometadata.ClusterConfig{},
+		clusterConfig:         armometadata.ClusterConfig{},
 		securityExceptionRepo: &testSecurityExceptionRepo{},
 		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
@@ -1251,7 +1251,7 @@ func TestSubmitCVE_NoPanicOnNonStringArgs(t *testing.T) {
 	}
 	ctx := context.WithValue(context.Background(), domain.TimestampKey{}, int64(123456))
 	ctx = context.WithValue(ctx, domain.ScanIDKey{}, "56275825-4c07-4e3f-9a4c-53f05b0d0c2e")
-	
+
 	// Create a scan command with non-string args
 	workload := domain.ScanCommand{
 		Wlid: "wlid://cluster-x/namespace-y/deployment-z",
@@ -1260,14 +1260,36 @@ func TestSubmitCVE_NoPanicOnNonStringArgs(t *testing.T) {
 		},
 	}
 	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
-	
+
 	cve := domain.CVEManifest{
 		Content: &v1beta1.GrypeDocument{},
 	}
 	cvep := domain.CVEManifest{}
-	
+
 	// Ensure it does NOT panic
 	assert.NotPanics(t, func() {
 		_ = backend.SubmitCVE(ctx, cve, cvep)
 	})
+}
+
+func TestBackendAdapter_ReportError_NilError(t *testing.T) {
+	backend := &BackendAdapter{}
+	err := backend.ReportError(context.Background(), nil)
+	assert.NoError(t, err)
+}
+
+func TestBackendAdapter_ReportErrorAbortsPromptlyOnCtxCancellation(t *testing.T) {
+	backend := &BackendAdapter{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := backend.ReportError(ctx, errors.New("boom"))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBackendAdapter_SendStatusAbortsPromptlyOnCtxCancellation(t *testing.T) {
+	backend := &BackendAdapter{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := backend.SendStatus(ctx, 0)
+	assert.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION


## Overview
This PR resolves issue #538 in `BackendAdapter` (`adapters/v1/backend.go`).

**Current behavior**: 
1. `BackendAdapter.ReportError` dereferences `err.Error()` directly without checking if `err` is `nil`. Calling `ReportError(ctx, nil)` results in a runtime nil-pointer dereference panic.
2. `ReportError` and `SendStatus` do not check for context cancellation, attempting network operations even when the caller's context `ctx` has already timed out or been canceled.

**Future behavior**: 
1. `ReportError` includes an `if err == nil { return nil }` guard, preventing nil-pointer panics when invoked with a nil error.
2. Both `ReportError` and `SendStatus` check `if err := ctx.Err(); err != nil { return err }` before performing network I/O, ensuring prompt abort on context cancellation.
3. Added unit tests in `adapters/v1/backend_test.go` covering nil error safety and prompt return on context cancellation.

## Additional Information
Completes context cancellation propagation work in backend reporting adapters and ensures nil safety across error reporting endpoints.

## How to Test
Run unit tests in `adapters/v1`:
```bash
go test -v -run TestBackendAdapter ./adapters/v1/...
```

## Related issues/PRs:
* Resolved #538

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary error reports when no error is present.
  * Improved cancellation handling so status updates and error reports stop immediately when the operation is canceled.

* **Tests**
  * Added coverage for nil-error handling and prompt cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->