### PR TITLE
feat(securityexception): support per-vulnerability expiresAt override

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -37,15 +37,15 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 
 	for i := range exceptions {
 		se := &exceptions[i]
-		if isExpired(se.Spec.ExpiresAt, now) {
-			continue
-		}
 		if !matchExceptionTarget(se.Spec.Match, target, false) {
 			continue
 		}
 		namespace := se.Namespace
 		for _, vuln := range se.Spec.Vulnerabilities {
 			if !shouldSuppress(vuln) {
+				continue
+			}
+			if isExpired(effectiveExpiresAt(se.Spec, vuln), now) {
 				continue
 			}
 			p := buildPolicy(se.Spec, vuln, namespace, suppressionSource{
@@ -59,14 +59,14 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 
 	for i := range clusterExceptions {
 		cse := &clusterExceptions[i]
-		if isExpired(cse.Spec.ExpiresAt, now) {
-			continue
-		}
 		if !matchExceptionTarget(cse.Spec.Match, target, true) {
 			continue
 		}
 		for _, vuln := range cse.Spec.Vulnerabilities {
 			if !shouldSuppress(vuln) {
+				continue
+			}
+			if isExpired(effectiveExpiresAt(cse.Spec, vuln), now) {
 				continue
 			}
 			p := buildPolicy(cse.Spec, vuln, "", suppressionSource{
@@ -82,6 +82,19 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 
 func isExpired(expiresAt *metav1.Time, now time.Time) bool {
 	return expiresAt != nil && expiresAt.Time.Before(now)
+}
+
+// effectiveExpiresAt resolves the expiry governing a single vulnerability entry: the
+// per-entry expiresAt when set, otherwise the document-level default.
+//
+// Expiry is therefore decided per entry rather than per document. A document-level
+// expiresAt still expires every entry that does not override it, so documents written
+// before per-entry expiry existed behave exactly as they did before.
+func effectiveExpiresAt(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.VulnerabilityException) *metav1.Time {
+	if vuln.ExpiresAt != nil {
+		return vuln.ExpiresAt
+	}
+	return spec.ExpiresAt
 }
 
 // shouldSuppress reports whether a VulnerabilityException entry may be
@@ -125,8 +138,8 @@ func buildPolicy(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.Vulnerabil
 		Reason:                spec.Reason,
 	}
 
-	if spec.ExpiresAt != nil {
-		t := spec.ExpiresAt.Time
+	if exp := effectiveExpiresAt(spec, vuln); exp != nil {
+		t := exp.Time
 		p.ExpirationDate = &t
 	}
 

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -690,3 +690,128 @@ func TestSuppressingPolicies_FiltersNonIgnoreActions(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.Equal(t, "allow-log4shell", out[0].Name)
 }
+
+func TestConvertPerEntryExpiresAt(t *testing.T) {
+	past := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	future := metav1.NewTime(time.Now().Add(1 * time.Hour))
+
+	tests := []struct {
+		name       string
+		docLevel   *metav1.Time
+		entry      *metav1.Time
+		suppressed bool
+	}{
+		{name: "entry overrides an expired document", docLevel: &past, entry: &future, suppressed: true},
+		{name: "entry overrides a live document", docLevel: &future, entry: &past, suppressed: false},
+		{name: "entry inherits an expired document", docLevel: &past, entry: nil, suppressed: false},
+		{name: "entry inherits a live document", docLevel: &future, entry: nil, suppressed: true},
+		{name: "no expiry anywhere never expires", docLevel: nil, entry: nil, suppressed: true},
+		{name: "entry expiry without a document default", docLevel: nil, entry: &past, suppressed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exceptions := []sev1beta1.SecurityException{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+					Spec: sev1beta1.SecurityExceptionSpec{
+						ExpiresAt: tt.docLevel,
+						Vulnerabilities: []sev1beta1.VulnerabilityException{
+							{
+								Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2026-31808"},
+								Status:        sev1beta1.VulnerabilityStatusNotAffected,
+								ExpiresAt:     tt.entry,
+							},
+						},
+					},
+				},
+			}
+
+			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+
+			if tt.suppressed {
+				require.Len(t, policies, 1)
+				assert.Equal(t, "CVE-2026-31808", policies[0].VulnerabilityPolicies[0].Name)
+			} else {
+				assert.Empty(t, policies)
+			}
+		})
+	}
+}
+
+// A single document mixing per-entry expiries is the case that previously forced authors to
+// split one review into several CRDs: the document-level check expired every entry at once.
+func TestConvertPerEntryExpiresAtWithinOneDocument(t *testing.T) {
+	past := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	future := metav1.NewTime(time.Now().Add(1 * time.Hour))
+
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				ExpiresAt: &future,
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-INHERITS"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-EXPIRED-EARLY"}, Status: sev1beta1.VulnerabilityStatusNotAffected, ExpiresAt: &past},
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-EXTENDED"}, Status: sev1beta1.VulnerabilityStatusFixed, ExpiresAt: &future},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+
+	require.Len(t, policies, 2)
+	assert.Equal(t, "CVE-INHERITS", policies[0].VulnerabilityPolicies[0].Name)
+	assert.Equal(t, "CVE-EXTENDED", policies[1].VulnerabilityPolicies[0].Name)
+}
+
+func TestConvertPerEntryExpiresAtClusterScoped(t *testing.T) {
+	past := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	future := metav1.NewTime(time.Now().Add(1 * time.Hour))
+
+	clusterExceptions := []sev1beta1.ClusterSecurityException{
+		{
+			Spec: sev1beta1.SecurityExceptionSpec{
+				ExpiresAt: &past,
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-CLUSTER-EXPIRED"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-CLUSTER-EXTENDED"}, Status: sev1beta1.VulnerabilityStatusNotAffected, ExpiresAt: &future},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(nil, clusterExceptions, ExceptionTarget{})
+
+	require.Len(t, policies, 1)
+	assert.Equal(t, "CVE-CLUSTER-EXTENDED", policies[0].VulnerabilityPolicies[0].Name)
+}
+
+// The policy handed downstream must carry the same expiry the suppression decision used,
+// otherwise a per-entry override would be dropped on the way to the backend.
+func TestConvertPerEntryExpiresAtSetsExpirationDate(t *testing.T) {
+	docLevel := metav1.NewTime(time.Now().Add(1 * time.Hour))
+	entryLevel := metav1.NewTime(time.Now().Add(48 * time.Hour))
+
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				ExpiresAt: &docLevel,
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-INHERITS"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
+					{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-OVERRIDES"}, Status: sev1beta1.VulnerabilityStatusNotAffected, ExpiresAt: &entryLevel},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+
+	require.Len(t, policies, 2)
+	require.NotNil(t, policies[0].ExpirationDate)
+	assert.Equal(t, docLevel.Time, *policies[0].ExpirationDate)
+	require.NotNil(t, policies[1].ExpirationDate)
+	assert.Equal(t, entryLevel.Time, *policies[1].ExpirationDate)
+}

--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -130,6 +130,7 @@ spec:
       status: "not_affected"
       justification: "inline_mitigations_already_exist"
       impactStatement: "WAF mitigates HTTP/2 rapid reset"
+      expiresAt: "2026-09-15T00:00:00Z"  # overrides spec.expiresAt for this entry
 
   posture:
     - controlID: "C-0034"
@@ -382,7 +383,7 @@ Users can inspect exception activity via `kubectl describe securityexception <na
 
 ### Expiry
 
-Expiry (`expiresAt`) is evaluated at scan time by the scanners — no controller or status update is needed. When a scanner reads a SecurityException and `expiresAt` is in the past, the exception is simply skipped. This means:
+Expiry (`expiresAt`) is evaluated at scan time by the scanners — no controller or status update is needed. It may be set at the document level (`spec.expiresAt`) and overridden per entry (`vulnerabilities[].expiresAt`); an entry without its own value inherits the document-level one. When a scanner reads a SecurityException and an entry's effective `expiresAt` is in the past, that entry is simply skipped. This means:
 
 - No component writes to the SecurityException status subresource
 - Expired exceptions remain in the cluster until explicitly deleted by the user

--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -106,7 +106,7 @@ metadata:
 spec:
   author: "team-platform@example.com"
   reason: "Accepted risks for Q2 2026 release"
-  expiresAt: "2026-07-01T00:00:00Z"
+  expiresAt: "2026-12-31T00:00:00Z"
 
   match:
     objectSelector:
@@ -130,7 +130,7 @@ spec:
       status: "not_affected"
       justification: "inline_mitigations_already_exist"
       impactStatement: "WAF mitigates HTTP/2 rapid reset"
-      expiresAt: "2026-09-15T00:00:00Z"  # overrides spec.expiresAt for this entry
+      expiresAt: "2026-09-15T00:00:00Z"  # expires earlier than spec.expiresAt
 
   posture:
     - controlID: "C-0034"

--- a/pkg/securityexception/v1beta1/types.go
+++ b/pkg/securityexception/v1beta1/types.go
@@ -85,6 +85,9 @@ type VulnerabilityException struct {
 	Justification   string              `json:"justification,omitempty"`
 	ImpactStatement string              `json:"impactStatement,omitempty"`
 	ExpiredOnFix    bool                `json:"expiredOnFix,omitempty"`
+	// ExpiresAt overrides the document-level spec.expiresAt for this entry only.
+	// When unset, the entry inherits the document-level value.
+	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
 }
 
 // VulnerabilityRef identifies a vulnerability by CVE ID.


### PR DESCRIPTION
## Overview

`expiresAt` could only be set for a whole SecurityException document. A set of CVEs accepted in the same review but with different deadlines had to be split across several CRDs, or collapsed onto the earliest deadline and cut short.

This adds an optional `expiresAt` to each vulnerability entry. An entry uses its own value when set and inherits `spec.expiresAt` otherwise, so expiry is decided per entry rather than per document:

```yaml
spec:
  expiresAt: "2026-12-31T00:00:00Z"   # document-level default
  vulnerabilities:
    - vulnerability:
        id: "CVE-2025-14505"
      status: "not_affected"           # inherits 2026-12-31

    - vulnerability:
        id: "CVE-2026-31808"
      status: "not_affected"
      expiresAt: "2026-09-15T00:00:00Z"  # overrides for this entry
```

Documents that only set `spec.expiresAt` are unaffected — every entry inherits it and expires exactly as before. The resolved expiry is also what lands on the policy's `ExpirationDate`, so a per-entry override is not dropped on the way to the backend.

## How to Test

```
go test ./adapters/v1/ -run 'TestConvertPerEntry|TestConvertSkipsExpired'
```

`TestConvertPerEntryExpiresAt` covers the inheritance matrix (entry overriding an expired or live document, entry inheriting either, and no expiry set anywhere). `TestConvertPerEntryExpiresAtWithinOneDocument` covers the case this enables: one document whose entries expire on different dates. The pre-existing `TestConvertSkipsExpired` is unchanged and still passes, pinning the document-level behavior.

## Related issues/PRs:

* Resolved #454

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional expiration dates for individual vulnerability exceptions.
  * Individual dates override the overall exception expiration; entries without one inherit it.
  * Expired entries are excluded independently, including within mixed and cluster-scoped exceptions.
  * Generated policies now reflect each entry’s effective expiration date.

* **Documentation**
  * Updated configuration examples and expiration guidance for per-entry overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->