### PR TITLE
feat(securityexception): add affected status with actionStatement and typed response

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -111,16 +111,57 @@ func effectiveExpiresAt(spec sev1beta1.SecurityExceptionSpec, vuln sev1beta1.Vul
 // converted into an ignore policy.
 //
 // The allowlist approach (fail-closed): only the two VEX statuses that
-// definitively resolve a CVE – not_affected and fixed – produce a
-// suppression policy. Every other value, including the empty string,
-// under_investigation, and any future status that is not yet in the
-// enum, leaves the finding visible in the scan results.
+// definitively resolve a CVE, not_affected and fixed, suppress on the status
+// alone. An affected entry suppresses only when it also states that no
+// remediation is coming (see affectedSuppresses). Every other value, including
+// the empty string, under_investigation, and any future status that is not yet
+// in the enum, leaves the finding visible in the scan results.
 func shouldSuppress(vuln sev1beta1.VulnerabilityException) bool {
 	if strings.TrimSpace(vuln.Vulnerability.ID) == "" {
 		return false
 	}
 	switch vuln.Status {
 	case sev1beta1.VulnerabilityStatusNotAffected, sev1beta1.VulnerabilityStatusFixed:
+		return true
+	case sev1beta1.VulnerabilityStatusAffected:
+		return affectedSuppresses(vuln)
+	default:
+		return false
+	}
+}
+
+// affectedSuppresses reports whether an affected entry hides its finding.
+//
+// The status alone never does. affected asserts that the vulnerability is real and applies,
+// which is the opposite of an assertion an author would expect to hide a finding, so two
+// further things are required.
+//
+// First an actionStatement. OpenVEX requires one for every affected statement ("a VEX
+// statement MUST include a statement that SHOULD describe actions to remediate or mitigate
+// the vulnerability"), so an entry without one is not a valid affected statement and does not
+// get to suppress.
+//
+// Then a response saying the finding will not be remediated. can_not_fix and will_not_fix
+// both mean no fix is coming, so the risk has been accepted rather than scheduled. update,
+// rollback and workaround_available mean a remediation is planned or already in place, and
+// the finding stays visible until it is confirmed. Every stated response has to be a
+// non-remediating one: an entry pairing will_not_fix with update is still tracking work, and
+// keeping the finding visible is the fail-closed reading of that combination.
+func affectedSuppresses(vuln sev1beta1.VulnerabilityException) bool {
+	if strings.TrimSpace(vuln.ActionStatement) == "" || len(vuln.Response) == 0 {
+		return false
+	}
+	for _, response := range vuln.Response {
+		if !isNonRemediatingResponse(response) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNonRemediatingResponse(response sev1beta1.VulnerabilityResponse) bool {
+	switch response {
+	case sev1beta1.VulnerabilityResponseCanNotFix, sev1beta1.VulnerabilityResponseWillNotFix:
 		return true
 	default:
 		return false
@@ -185,6 +226,16 @@ func buildSuppressionAttributes(spec sev1beta1.SecurityExceptionSpec, vuln sev1b
 	}
 	if s := strings.TrimSpace(vuln.ImpactStatement); s != "" {
 		attrs["impactStatement"] = s
+	}
+	if s := strings.TrimSpace(vuln.ActionStatement); s != "" {
+		attrs["actionStatement"] = s
+	}
+	if len(vuln.Response) > 0 {
+		responses := make([]string, 0, len(vuln.Response))
+		for _, response := range vuln.Response {
+			responses = append(responses, string(response))
+		}
+		attrs["response"] = responses
 	}
 	if t := normalizedTarget(spec.Match.Resources, namespace); t != "" {
 		attrs["normalizedTarget"] = t

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -878,3 +878,161 @@ func TestConvertPerEntryExpiresAtSetsExpirationDate(t *testing.T) {
 	require.NotNil(t, policies[1].ExpirationDate)
 	assert.Equal(t, entryLevel.Time, *policies[1].ExpirationDate)
 }
+
+// affected is the one status whose suppression depends on more than the status itself, so
+// the matrix below is the contract: an actionStatement plus a response that says no
+// remediation is coming, and nothing less.
+func TestConvertAffectedSuppression(t *testing.T) {
+	tests := []struct {
+		name            string
+		actionStatement string
+		response        []sev1beta1.VulnerabilityResponse
+		wantSuppressed  bool
+	}{
+		{
+			name:            "will_not_fix with an action statement is an accepted risk",
+			actionStatement: "WAF blocks the exploit vector, reviewed by security lead",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseWillNotFix},
+			wantSuppressed:  true,
+		},
+		{
+			name:            "can_not_fix with an action statement is an accepted risk",
+			actionStatement: "no upstream fix available",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseCanNotFix},
+			wantSuppressed:  true,
+		},
+		{
+			name:            "both non-remediating responses together",
+			actionStatement: "no upstream fix and none planned",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseCanNotFix, sev1beta1.VulnerabilityResponseWillNotFix},
+			wantSuppressed:  true,
+		},
+		{
+			name:            "update keeps the finding visible until the fix lands",
+			actionStatement: "upgrade scheduled for the Q4 release",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseUpdate},
+			wantSuppressed:  false,
+		},
+		{
+			name:            "rollback keeps the finding visible",
+			actionStatement: "rolling back to 1.2.3",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseRollback},
+			wantSuppressed:  false,
+		},
+		{
+			name:            "workaround_available keeps the finding visible",
+			actionStatement: "config workaround applied",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseWorkaroundAvailable},
+			wantSuppressed:  false,
+		},
+		{
+			name:            "a remediating response alongside will_not_fix still tracks work",
+			actionStatement: "not fixing now, upgrade planned later",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseWillNotFix, sev1beta1.VulnerabilityResponseUpdate},
+			wantSuppressed:  false,
+		},
+		{
+			name:            "no response is no suppression signal",
+			actionStatement: "under discussion with the vendor",
+			response:        nil,
+			wantSuppressed:  false,
+		},
+		{
+			name:            "will_not_fix without an action statement is not a valid affected statement",
+			actionStatement: "",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseWillNotFix},
+			wantSuppressed:  false,
+		},
+		{
+			name:            "a blank action statement does not count",
+			actionStatement: "   ",
+			response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseWillNotFix},
+			wantSuppressed:  false,
+		},
+		{
+			name:            "an unrecognised response value suppresses nothing",
+			actionStatement: "accepted",
+			response:        []sev1beta1.VulnerabilityResponse{"risk_accepted"},
+			wantSuppressed:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exceptions := []sev1beta1.SecurityException{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+					Spec: sev1beta1.SecurityExceptionSpec{
+						Vulnerabilities: []sev1beta1.VulnerabilityException{
+							{
+								Vulnerability:   sev1beta1.VulnerabilityRef{ID: "CVE-2021-44228"},
+								Status:          sev1beta1.VulnerabilityStatusAffected,
+								ActionStatement: tt.actionStatement,
+								Response:        tt.response,
+							},
+						},
+					},
+				},
+			}
+
+			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+
+			if tt.wantSuppressed {
+				require.Len(t, policies, 1)
+				assert.Equal(t, "CVE-2021-44228", policies[0].VulnerabilityPolicies[0].Name)
+			} else {
+				assert.Empty(t, policies)
+			}
+		})
+	}
+}
+
+// The statuses that resolve a CVE keep suppressing on the status alone, so documents written
+// before affected existed are unaffected by the new rules.
+func TestConvertResolvingStatusesUnchangedByAffected(t *testing.T) {
+	for _, status := range []sev1beta1.VulnerabilityStatus{
+		sev1beta1.VulnerabilityStatusNotAffected,
+		sev1beta1.VulnerabilityStatusFixed,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			exceptions := []sev1beta1.SecurityException{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+					Spec: sev1beta1.SecurityExceptionSpec{
+						Vulnerabilities: []sev1beta1.VulnerabilityException{
+							{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2021-44228"}, Status: status},
+						},
+					},
+				},
+			}
+
+			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+
+			require.Len(t, policies, 1, "no actionStatement or response should be needed")
+		})
+	}
+}
+
+func TestConvertAffectedRecordsProvenance(t *testing.T) {
+	exceptions := []sev1beta1.SecurityException{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "risk-accepted-log4j", Namespace: "ns"},
+			Spec: sev1beta1.SecurityExceptionSpec{
+				Vulnerabilities: []sev1beta1.VulnerabilityException{
+					{
+						Vulnerability:   sev1beta1.VulnerabilityRef{ID: "CVE-2021-44228"},
+						Status:          sev1beta1.VulnerabilityStatusAffected,
+						ActionStatement: "WAF mitigation in place, ticket SEC-1234",
+						Response:        []sev1beta1.VulnerabilityResponse{sev1beta1.VulnerabilityResponseWillNotFix},
+					},
+				},
+			},
+		},
+	}
+
+	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+
+	require.Len(t, policies, 1)
+	assert.Equal(t, "WAF mitigation in place, ticket SEC-1234", policies[0].Attributes["actionStatement"])
+	assert.Equal(t, []string{"will_not_fix"}, policies[0].Attributes["response"])
+}

--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -138,6 +138,26 @@ spec:
       action: "alert_only"
 ```
 
+#### Namespaced: risk-accepted finding (`affected`)
+
+```yaml
+apiVersion: kubescape.io/v1
+kind: SecurityException
+metadata:
+  name: risk-accepted-log4j
+  namespace: production
+spec:
+  reason: "Accepted risks for Q3 2026 release"
+
+  vulnerabilities:
+    - vulnerability:
+        id: "CVE-2021-44228"
+      status: "affected"
+      actionStatement: "Risk accepted: WAF blocks the exploit vector. Reviewed 2026-07-30 by security lead. Ticket SEC-1234."
+      response:
+        - will_not_fix
+```
+
 #### Namespaced — apply to all workloads in namespace (no match selector)
 
 ```yaml
@@ -344,11 +364,15 @@ Organizations should create dedicated `ClusterRole`/`Role` resources for Securit
 
 The CRD schema should include CEL validation rules to enforce invariants at admission time, without requiring a separate webhook:
 
-- `justification` is required when `status` is `not_affected`
+- `justification` or `impactStatement` is required when `status` is `not_affected`, mirroring the OpenVEX rule that a `not_affected` statement MUST carry one or the other
+- `actionStatement` is required when `status` is `affected`, mirroring the OpenVEX rule that an `affected` statement MUST describe the action taken
 - `expiresAt`, if set, must be a valid RFC3339 timestamp in the future (at creation time)
 - At least one entry must exist in either `vulnerabilities` or `posture`
 - `posture[].action` must be one of `ignore`, `alert_only`
-- `vulnerabilities[].status` must be one of `not_affected`, `fixed`, `under_investigation`
+- `vulnerabilities[].status` must be one of `not_affected`, `affected`, `fixed`, `under_investigation`
+- `vulnerabilities[].response[]` values must be one of `can_not_fix`, `will_not_fix`, `update`, `rollback`, `workaround_available`
+
+The two cross-field rules are enforced at admission, where an invalid document is rejected outright. The scanner additionally treats an `affected` entry with no `actionStatement` as non-suppressing, so a document that predates the rule cannot hide a finding it was never valid to hide.
 
 ## Conflict Resolution & Precedence
 
@@ -400,8 +424,20 @@ The primary audit trail for SecurityException changes is **Git history** when us
 The vulnerability exception entries align with OpenVEX statements:
 
 - `vulnerability.id` → VEX vulnerability ID
-- `status` → VEX status
+- `status` → VEX status (all four values: `not_affected`, `affected`, `fixed`, `under_investigation`)
 - `justification` → VEX justification
 - `impactStatement` → VEX impact statement
+- `actionStatement` → VEX action statement
+
+`response[]` is the one field with no OpenVEX equivalent. It is a typed extension aligned with CycloneDX VEX `analysis.response[]`, and carries what is being done about a vulnerability, which is a separate question from the status of where it stands. When degrading to OpenVEX, its values can be serialized into the `action_statement` free text or dropped; nothing else is lost, since every other field maps one to one.
+
+### Suppression and `affected`
+
+`affected` is the only status whose suppression depends on more than the status. It asserts that the vulnerability is real and applies, so the finding stays visible unless the entry also carries an `actionStatement` and a `response[]` saying no remediation is coming:
+
+- `can_not_fix`, `will_not_fix`: no fix is coming and the risk has been accepted, so the finding may be filtered from default reports.
+- `update`, `rollback`, `workaround_available`: a remediation is planned or in place, so the finding stays visible until it is confirmed.
+
+Every value in `response[]` must be a non-remediating one for the finding to be suppressed. An entry pairing `will_not_fix` with `update` is still tracking work, so the finding stays visible.
 
 Note: OpenVEX `products` (purl-based product/subcomponent matching) is deferred to a future version. See "Identifier Bridging" above.

--- a/pkg/securityexception/v1beta1/types.go
+++ b/pkg/securityexception/v1beta1/types.go
@@ -41,8 +41,23 @@ type VulnerabilityStatus string
 
 const (
 	VulnerabilityStatusNotAffected        VulnerabilityStatus = "not_affected"
+	VulnerabilityStatusAffected           VulnerabilityStatus = "affected"
 	VulnerabilityStatusFixed              VulnerabilityStatus = "fixed"
 	VulnerabilityStatusUnderInvestigation VulnerabilityStatus = "under_investigation"
+)
+
+// VulnerabilityResponse is a typed action taken or planned in response to a vulnerability
+// that is real and applies. It answers "what are we doing about it", which is a separate
+// question from the status "where does it stand", and has no OpenVEX equivalent: the values
+// are aligned with CycloneDX VEX analysis.response[].
+type VulnerabilityResponse string
+
+const (
+	VulnerabilityResponseCanNotFix           VulnerabilityResponse = "can_not_fix"
+	VulnerabilityResponseWillNotFix          VulnerabilityResponse = "will_not_fix"
+	VulnerabilityResponseUpdate              VulnerabilityResponse = "update"
+	VulnerabilityResponseRollback            VulnerabilityResponse = "rollback"
+	VulnerabilityResponseWorkaroundAvailable VulnerabilityResponse = "workaround_available"
 )
 
 // PostureAction is the action to take for a posture exception.
@@ -88,6 +103,13 @@ type VulnerabilityException struct {
 	// ExpiresAt overrides the document-level spec.expiresAt for this entry only.
 	// When unset, the entry inherits the document-level value.
 	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
+	// ActionStatement describes what is being done about a vulnerability that is real and
+	// applies. It maps to OpenVEX action_statement, which the spec requires for every
+	// affected statement, and is the counterpart to ImpactStatement on the not_affected path.
+	ActionStatement string `json:"actionStatement,omitempty"`
+	// Response carries the typed actions taken or planned for an affected vulnerability.
+	// It is always optional and layers on top of ActionStatement rather than replacing it.
+	Response []VulnerabilityResponse `json:"response,omitempty"`
 }
 
 // VulnerabilityRef identifies a vulnerability by CVE ID.


### PR DESCRIPTION
## Overview

SecurityException implemented three of OpenVEX's four statuses, so there was no way to say a finding is real and the risk has been accepted. Authors had to reach for `not_affected` with a stretched justification, which suppresses the finding but publishes a claim that does not survive audit: the vulnerability is present and the code path is reachable.

This adds the three pieces the RFC asks for:

1. `affected` as the fourth `status` value, completing the OpenVEX vocabulary.
2. An optional `actionStatement` free-text field, mapping to OpenVEX `action_statement` and parallel to the existing `impactStatement`.
3. An optional typed `response[]` list, aligned with CycloneDX VEX `analysis.response[]`.

```yaml
vulnerabilities:
  - vulnerability:
      id: "CVE-2021-44228"
    status: "affected"
    actionStatement: "Risk accepted: WAF blocks the exploit vector. Reviewed 2026-07-30 by security lead. Ticket SEC-1234."
    response:
      - will_not_fix
```

### Suppression semantics

Suppression is driven by `response[]` rather than by the status. `affected` asserts the vulnerability applies, which is the opposite of an assertion an author would expect to hide a finding, so the finding stays visible unless the entry also carries an `actionStatement` and every stated response says no remediation is coming:

| `response[]` | Finding |
|---|---|
| `can_not_fix`, `will_not_fix` | Suppressed. No fix is coming, the risk is accepted. |
| `update`, `rollback`, `workaround_available` | Visible. A remediation is planned or in place, so it stays trackable until confirmed. |
| A mix, such as `will_not_fix` plus `update` | Visible. The entry is still tracking work, which is the fail-closed reading. |
| Empty, or no `actionStatement` | Visible. |

Documents using the existing three statuses are unaffected: `not_affected` and `fixed` still suppress on the status alone, with no `actionStatement` or `response[]` needed.

## Additional Information

**On requiring `actionStatement`.** The issue body proposes "at least one of `actionStatement` or `response[]`" and lists strict OpenVEX conformance under Alternatives. The discussion settled the other way: @slashben argued for requiring `actionStatement` unconditionally so every `affected` entry is a valid OpenVEX statement by construction rather than needing `response[]` serialized into free text on degradation, and @pjungermann agreed. This PR implements that, so `response[]` stays a purely additive typed extension layered on top.

**On the `not_affected` rule.** The same discussion agreed to enforce the symmetric rule that `not_affected` must carry `justification` or `impactStatement`. That one is documented here as a CEL rule but deliberately not enforced in the scanner: unlike `affected`, which is new, applying it at scan time would silently stop suppressing for documents that are valid under today's schema and are already deployed. It belongs at admission, where an invalid document is rejected outright. Both cross-field rules are listed in the design document's CEL section.

`action_statement_timestamp` is out of scope, as agreed in the discussion.

## How to Test

```
go test ./adapters/v1/ -run 'TestConvertAffected|TestConvertResolvingStatuses|TestConvertShouldSuppressAllowlist'
```

`TestConvertAffectedSuppression` is the contract for the new status, covering each response value, mixed remediating and non-remediating combinations, a missing or blank `actionStatement`, an empty response list, and an unrecognised response value. `TestConvertResolvingStatusesUnchangedByAffected` pins that `not_affected` and `fixed` still suppress on the status alone. Eight of those subtests fail if `affected` is made to suppress unconditionally.

## Related issues/PRs:

* Resolved #453

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
