### PR TITLE
fix(services): report GenerateSBOM SBOM-status failures and add reason label to scan metrics

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	wssc "github.com/armosec/armoapi-go/apis"
+	"github.com/armosec/armoapi-go/scanfailure"
 	"github.com/gammazero/workerpool"
 	"github.com/gin-gonic/gin"
 	"github.com/kubescape/go-logger"
@@ -62,16 +63,36 @@ func (h *HTTPController) WithMetrics(m *metrics.Metrics) (*HTTPController, error
 // recordScan records the outcome and duration of a background scan job for the given endpoint.
 // outcome is one of "success", "partial", or "error" -- see the ScanCP call site, where a
 // domain.ErrPartialContainerProfile result is a warning-level expected outcome, not a failure.
-func (h HTTPController) recordScan(ctx context.Context, endpoint string, start time.Time, outcome string) {
+// err is the error returned by the scan (nil for success/partial) and is only consulted to
+// resolve the bounded reason label on a failed outcome; see scanFailureReason.
+func (h HTTPController) recordScan(ctx context.Context, endpoint string, start time.Time, outcome string, err error) {
 	if h.metrics == nil {
 		return
 	}
 	attrs := metric.WithAttributes(
 		attribute.String("endpoint", endpoint),
 		attribute.String("outcome", outcome),
+		attribute.String("reason", scanFailureReason(outcome, err)),
 	)
 	h.metrics.ScanCounter.Add(ctx, 1, attrs)
 	h.metrics.ScanDuration.Record(ctx, time.Since(start).Seconds(), attrs)
+}
+
+// scanFailureReason resolves the bounded scanfailure.Reason* label for a scan-outcome metric.
+// Successful/partial outcomes carry no specific failure reason ("none"). A failed outcome whose
+// error was classified via *domain.ScanError (set at the point of failure in
+// core/services/scan.go, alongside the equivalent ReportScanFailure call to the platform)
+// surfaces that reason; any other error defaults to scanfailure.ReasonUnexpected, keeping the
+// label's cardinality fixed regardless of what an unclassified error's message happens to say.
+func scanFailureReason(outcome string, err error) string {
+	if outcome != "error" {
+		return "none"
+	}
+	var scanErr *domain.ScanError
+	if errors.As(err, &scanErr) && scanErr.Reason != "" {
+		return scanErr.Reason
+	}
+	return scanfailure.ReasonUnexpected
 }
 
 // recordRejection records a validation-time rejection for the given endpoint. reason is
@@ -129,7 +150,7 @@ func (h HTTPController) GenerateSBOM(c *gin.Context) {
 		if err != nil {
 			outcome = "error"
 		}
-		h.recordScan(bgCtx, "generateSBOM", start, outcome)
+		h.recordScan(bgCtx, "generateSBOM", start, outcome, err)
 		if err != nil {
 			logger.L().Ctx(bgCtx).Error("service error - GenerateSBOM", helpers.Error(err),
 				helpers.String("imageSlug", newScan.ImageSlug),
@@ -191,20 +212,20 @@ func (h HTTPController) ScanCP(c *gin.Context) {
 		err = h.scanService.ScanCP(bgCtx)
 		if err != nil {
 			if errors.Is(err, domain.ErrPartialContainerProfile) {
-				h.recordScan(bgCtx, "scanCP", start, "partial")
+				h.recordScan(bgCtx, "scanCP", start, "partial", err)
 				logger.L().Ctx(bgCtx).Warning("service warning - ScanCP", helpers.Error(err),
 					helpers.String("wlid", newScan.Wlid),
 					helpers.String("name", name),
 					helpers.String("namespace", namespace))
 			} else {
-				h.recordScan(bgCtx, "scanCP", start, "error")
+				h.recordScan(bgCtx, "scanCP", start, "error", err)
 				logger.L().Ctx(bgCtx).Error("service error - ScanCP", helpers.Error(err),
 					helpers.String("wlid", newScan.Wlid),
 					helpers.String("name", name),
 					helpers.String("namespace", namespace))
 			}
 		} else {
-			h.recordScan(bgCtx, "scanCP", start, "success")
+			h.recordScan(bgCtx, "scanCP", start, "success", nil)
 		}
 	})
 }
@@ -246,7 +267,7 @@ func (h HTTPController) ScanCVE(c *gin.Context) {
 		if err != nil {
 			outcome = "error"
 		}
-		h.recordScan(bgCtx, "scanCVE", start, outcome)
+		h.recordScan(bgCtx, "scanCVE", start, outcome, err)
 		if err != nil {
 			logger.L().Ctx(bgCtx).Error("service error - ScanCVE", helpers.Error(err),
 				helpers.String("wlid", newScan.Wlid),
@@ -333,7 +354,7 @@ func (h HTTPController) ScanRegistry(c *gin.Context) {
 		if err != nil {
 			outcome = "error"
 		}
-		h.recordScan(bgCtx, "scanRegistry", start, outcome)
+		h.recordScan(bgCtx, "scanRegistry", start, outcome, err)
 		if err != nil {
 			logger.L().Ctx(bgCtx).Error("service error - ScanRegistry", helpers.Error(err),
 				helpers.String("imageSlug", newScan.ImageSlug),

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -721,6 +721,8 @@ func TestHTTPController_MetricsEndpoint_RecordsScanFailureReason(t *testing.T) {
 			body := w.Body.String()
 			wantSeries := `kubevuln_scans_completed_total{endpoint="` + tt.endpoint + `",outcome="error",reason="` + tt.wantReason + `"} 1`
 			assert.True(t, strings.Contains(body, wantSeries), body)
+			wantDurationSeries := `kubevuln_scan_duration_seconds_count{endpoint="` + tt.endpoint + `",outcome="error",reason="` + tt.wantReason + `"} 1`
+			assert.True(t, strings.Contains(body, wantDurationSeries), body)
 		})
 	}
 }

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	wssc "github.com/armosec/armoapi-go/apis"
+	"github.com/armosec/armoapi-go/scanfailure"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/gammazero/workerpool"
 	"github.com/gin-gonic/gin"
@@ -610,4 +612,115 @@ func TestHTTPController_MetricsEndpoint_InvalidRequestDoesNotCountAsRejection(t 
 	body := w.Body.String()
 	assert.True(t, strings.Contains(body, `kubevuln_scan_rejections_total{endpoint="generateSBOM",reason="invalid_request"} 1`), body)
 	assert.False(t, strings.Contains(body, `reason="too_many_requests"`), body)
+}
+
+// scanErrorService validates every request successfully, then returns a fixed error from
+// whichever scan flow the test exercises -- used to prove HTTPController.recordScan resolves
+// a specific reason label (see scanFailureReason) all the way from the scan service's error,
+// through the worker pool, onto the kubevuln_scans_completed_total/kubevuln_scan_duration_seconds
+// metrics (see #540).
+type scanErrorService struct {
+	*services.MockScanService
+	err error
+}
+
+func (s scanErrorService) GenerateSBOM(context.Context) error { return s.err }
+func (s scanErrorService) ScanCVE(context.Context) error      { return s.err }
+func (s scanErrorService) ScanRegistry(context.Context) error { return s.err }
+
+func (s scanErrorService) ValidateGenerateSBOM(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+func (s scanErrorService) ValidateScanCVE(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+func (s scanErrorService) ValidateScanRegistry(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+// TestHTTPController_MetricsEndpoint_RecordsScanFailureReason is a regression test for #540:
+// every scan flow used to collapse its failure into a bare outcome="error" label, discarding
+// the scanfailure.Reason* classification already computed in core/services/scan.go. It now
+// rides along on a *domain.ScanError and lands on the "reason" attribute of both
+// kubevuln_scans_completed_total and kubevuln_scan_duration_seconds, one specific value per
+// endpoint instead of a single opaque bucket.
+func TestHTTPController_MetricsEndpoint_RecordsScanFailureReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		endpoint     string
+		register     func(router *gin.Engine, c *HTTPController)
+		wantReason   string
+		unclassified bool // when true, err is a bare error instead of *domain.ScanError
+	}{
+		{
+			name:       "generateSBOM, classified reason",
+			path:       "/v1/generateSBOM",
+			endpoint:   "generateSBOM",
+			register:   func(router *gin.Engine, c *HTTPController) { router.POST("/v1/generateSBOM", c.GenerateSBOM) },
+			wantReason: scanfailure.ReasonSBOMIncomplete,
+		},
+		{
+			name:       "scanCVE, classified reason",
+			path:       "/v1/scanImage",
+			endpoint:   "scanCVE",
+			register:   func(router *gin.Engine, c *HTTPController) { router.POST("/v1/scanImage", c.ScanCVE) },
+			wantReason: scanfailure.ReasonCVEMatchingFailed,
+		},
+		{
+			name:       "scanRegistryImage, classified reason",
+			path:       "/v1/scanRegistryImage",
+			endpoint:   "scanRegistry",
+			register:   func(router *gin.Engine, c *HTTPController) { router.POST("/v1/scanRegistryImage", c.ScanRegistry) },
+			wantReason: scanfailure.ReasonImageAuthFailed,
+		},
+		{
+			name:         "generateSBOM, unclassified error defaults to unexpected",
+			path:         "/v1/generateSBOM",
+			endpoint:     "generateSBOM",
+			register:     func(router *gin.Engine, c *HTTPController) { router.POST("/v1/generateSBOM", c.GenerateSBOM) },
+			wantReason:   scanfailure.ReasonUnexpected,
+			unclassified: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var scanErr error = &domain.ScanError{Reason: tt.wantReason, Err: errors.New("boom")}
+			if tt.unclassified {
+				scanErr = errors.New("boom")
+			}
+			c := &HTTPController{
+				scanService: scanErrorService{MockScanService: services.NewMockScanService(true), err: scanErr},
+				workerPool:  workerpool.New(1),
+			}
+			m, err := metrics.New()
+			require.NoError(t, err)
+			c, err = c.WithMetrics(m)
+			require.NoError(t, err)
+
+			router := gin.Default()
+			tt.register(router, c)
+			router.GET("/metrics", gin.WrapH(m.Handler()))
+
+			file, err := os.Open("../api/v1/testdata/scan.yaml")
+			require.NoError(t, err)
+			req, _ := http.NewRequest("POST", tt.path, file)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			c.Shutdown(5 * time.Second)
+
+			req, _ = http.NewRequest("GET", "/metrics", nil)
+			w = httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			body := w.Body.String()
+			wantSeries := `kubevuln_scans_completed_total{endpoint="` + tt.endpoint + `",outcome="error",reason="` + tt.wantReason + `"} 1`
+			assert.True(t, strings.Contains(body, wantSeries), body)
+		})
+	}
 }

--- a/core/domain/scan.go
+++ b/core/domain/scan.go
@@ -36,6 +36,20 @@ var (
 	ErrExceptionsDegraded = errors.New("exception set is incomplete")
 )
 
+// ScanError wraps a scan-flow error together with the scanfailure.Reason* classification
+// (github.com/armosec/armoapi-go/scanfailure) already computed at the point of failure, so
+// callers up the stack — namely the HTTP controller's Prometheus metrics — can recover the
+// specific reason via errors.As without re-deriving it from the error string. Unwrap exposes
+// the original error unchanged, so existing errors.Is-based checks (e.g. against
+// ErrTooManyRequests or ErrPartialContainerProfile) keep working exactly as before.
+type ScanError struct {
+	Reason string
+	Err    error
+}
+
+func (e *ScanError) Error() string { return e.Err.Error() }
+func (e *ScanError) Unwrap() error { return e.Err }
+
 type ScanIDKey struct{}
 type TimestampKey struct{}
 type WorkloadKey struct{}

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -162,16 +162,25 @@ func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 				helpers.String("imageSlug", workload.ImageSlug))
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
 				scanfailure.ReasonSBOMGenerationFailed, domain.ErrTooManyRequests)
-			return domain.ErrTooManyRequests
+			return &domain.ScanError{Reason: scanfailure.ReasonSBOMGenerationFailed, Err: domain.ErrTooManyRequests}
 		}
 		// create SBOM
 		sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
 		s.checkCreateSBOM(err, rateLimitCacheKey(workload))
 		if err != nil {
+			reason := classifySBOMError(err)
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-				classifySBOMError(err), err)
-			return err
+				reason, err)
+			return &domain.ScanError{Reason: reason, Err: err}
 		}
+	}
+
+	// do not treat a timed out or too-large SBOM as a successful scan — mirrors the same
+	// check in ScanCP/ScanCVE/ScanRegistry, which this flow had lost track of (see #540)
+	if sbom.Status == helpersv1.Incomplete || sbom.Status == helpersv1.TooLarge {
+		reason := classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations)
+		_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration, reason, nil)
+		return &domain.ScanError{Reason: reason, Err: domain.ErrIncompleteSBOM}
 	}
 
 	// store SBOM
@@ -180,7 +189,7 @@ func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 		if err != nil {
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost,
 				scanfailure.ReasonSBOMStorageFailed, err)
-			return err
+			return &domain.ScanError{Reason: scanfailure.ReasonSBOMStorageFailed, Err: err}
 		}
 	}
 
@@ -525,7 +534,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 						helpers.String("imageSlug", workload.ImageSlug))
 					_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
 						scanfailure.ReasonSBOMGenerationFailed, domain.ErrTooManyRequests)
-					return domain.ErrTooManyRequests
+					return &domain.ScanError{Reason: scanfailure.ReasonSBOMGenerationFailed, Err: domain.ErrTooManyRequests}
 				}
 				// create SBOM
 				sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
@@ -546,7 +555,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 								helpers.String("imageSlug", workload.ImageSlug))
 						}
 					}
-					return fmt.Errorf("creating SBOM: %w", err)
+					return &domain.ScanError{Reason: reason, Err: fmt.Errorf("creating SBOM: %w", err)}
 				}
 				// store SBOM
 				if s.storage {
@@ -565,9 +574,9 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 
 		// do not process timed out SBOM
 		if sbom.Status == helpersv1.Incomplete || sbom.Status == helpersv1.TooLarge {
-			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-				classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations), nil)
-			return domain.ErrIncompleteSBOM
+			reason := classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations)
+			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration, reason, nil)
+			return &domain.ScanError{Reason: reason, Err: domain.ErrIncompleteSBOM}
 		}
 	}
 
@@ -578,7 +587,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 		if err != nil {
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureCVE,
 				scanfailure.ReasonCVEMatchingFailed, err)
-			return fmt.Errorf("scanning SBOM: %w", err)
+			return &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: fmt.Errorf("scanning SBOM: %w", err)}
 		}
 
 		// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
@@ -643,7 +652,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 		if err != nil {
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost,
 				scanfailure.ReasonResultUploadFailed, err)
-			return fmt.Errorf("submitting CVEs: %w", err)
+			return &domain.ScanError{Reason: scanfailure.ReasonResultUploadFailed, Err: fmt.Errorf("submitting CVEs: %w", err)}
 		}
 	}
 
@@ -703,7 +712,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 					helpers.String("imageSlug", workload.ImageSlug))
 				_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
 					scanfailure.ReasonSBOMGenerationFailed, domain.ErrTooManyRequests)
-				return domain.ErrTooManyRequests
+				return &domain.ScanError{Reason: scanfailure.ReasonSBOMGenerationFailed, Err: domain.ErrTooManyRequests}
 			}
 			// create SBOM
 			sbom, err = s.sbomCreator.CreateSBOM(ctx, workload.ImageSlug, workload.ImageHash, workload.ImageTagNormalized, optionsFromWorkload(ctx, workload))
@@ -714,9 +723,10 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 					logger.L().Ctx(ctx).Warning("telemetry error", helpers.Error(repErr),
 						helpers.String("imageSlug", workload.ImageSlug))
 				}
+				reason := classifySBOMError(err)
 				_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-					classifySBOMError(err), err)
-				return err
+					reason, err)
+				return &domain.ScanError{Reason: reason, Err: err}
 			}
 
 			if s.storage {
@@ -730,9 +740,9 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 
 		// do not process timed out SBOM
 		if sbom.Status == helpersv1.Incomplete || sbom.Status == helpersv1.TooLarge {
-			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-				classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations), nil)
-			return domain.ErrIncompleteSBOM
+			reason := classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations)
+			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration, reason, nil)
+			return &domain.ScanError{Reason: reason, Err: domain.ErrIncompleteSBOM}
 		}
 
 		// scan for CVE
@@ -745,7 +755,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 			}
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureCVE,
 				scanfailure.ReasonCVEMatchingFailed, err)
-			return err
+			return &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: err}
 		}
 
 		// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
@@ -822,7 +832,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	if err != nil {
 		_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost,
 			scanfailure.ReasonResultUploadFailed, err)
-		return err
+		return &domain.ScanError{Reason: scanfailure.ReasonResultUploadFailed, Err: err}
 	}
 	// report submit success to platform
 	err = s.platform.SendStatus(ctx, domain.Done)

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -44,6 +44,9 @@ func TestScanService_GenerateSBOM(t *testing.T) {
 		toomanyrequests bool
 		workload        bool
 		wantErr         bool
+		// wantReason, when non-empty, asserts the error GenerateSBOM returns is a
+		// *domain.ScanError carrying this scanfailure.Reason* value (see #540).
+		wantReason string
 	}{
 		{
 			name:     "phase 1, no workload",
@@ -60,18 +63,21 @@ func TestScanService_GenerateSBOM(t *testing.T) {
 			createSBOMError: true,
 			workload:        true,
 			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
-			name:     "phase 1, timeout",
-			timeout:  true,
-			workload: true,
-			wantErr:  true,
+			name:       "phase 1, timeout",
+			timeout:    true,
+			workload:   true,
+			wantErr:    true,
+			wantReason: scanfailure.ReasonSBOMIncomplete,
 		},
 		{
 			name:            "phase 1, too many requests",
 			toomanyrequests: true,
 			workload:        true,
 			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
 			name:     "phase 2, get SBOM failed",
@@ -86,6 +92,7 @@ func TestScanService_GenerateSBOM(t *testing.T) {
 			storeError: true,
 			workload:   true,
 			wantErr:    true,
+			wantReason: scanfailure.ReasonSBOMStorageFailed,
 		},
 		{
 			name:     "phase 2, create and store SBOM",
@@ -465,6 +472,9 @@ func TestScanService_ScanCVE(t *testing.T) {
 		workload        bool
 		wantEmptyReport bool
 		wantErr         bool
+		// wantReason, when non-empty, asserts the error ScanCVE returns is a
+		// *domain.ScanError carrying this scanfailure.Reason* value (see #540).
+		wantReason string
 	}{
 		{
 			name:     "no workload",
@@ -481,12 +491,14 @@ func TestScanService_ScanCVE(t *testing.T) {
 			createSBOMError: true,
 			workload:        true,
 			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
 			name:            "create SBOM too many requests",
 			toomanyrequests: true,
 			workload:        true,
 			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
 			name:      "empty wlid",
@@ -539,12 +551,13 @@ func TestScanService_ScanCVE(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name:     "timeout SBOM",
-			sbom:     true,
-			storage:  true,
-			timeout:  true,
-			workload: true,
-			wantErr:  true,
+			name:       "timeout SBOM",
+			sbom:       true,
+			storage:    true,
+			timeout:    true,
+			workload:   true,
+			wantErr:    true,
+			wantReason: scanfailure.ReasonSBOMIncomplete,
 		},
 	}
 	for _, tt := range tests {
@@ -584,12 +597,18 @@ func TestScanService_ScanCVE(t *testing.T) {
 					_ = storageCVE.StoreCVE(ctx, cve, false)
 				}
 			}
-			if err := s.ScanCVE(ctx); (err != nil) != tt.wantErr {
+			err := s.ScanCVE(ctx)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("ScanCVE() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.toomanyrequests {
-				_, err := s.ValidateScanCVE(ctx, workload)
-				assert.Equal(t, domain.ErrTooManyRequests, err)
+				_, verr := s.ValidateScanCVE(ctx, workload)
+				assert.Equal(t, domain.ErrTooManyRequests, verr)
+			}
+			if tt.wantReason != "" {
+				var scanErr *domain.ScanError
+				require.ErrorAsf(t, err, &scanErr, "expected a *domain.ScanError, got %T: %v", err, err)
+				assert.Equal(t, tt.wantReason, scanErr.Reason)
 			}
 		})
 	}
@@ -891,6 +910,9 @@ func TestScanService_ScanRegistry(t *testing.T) {
 		toomanyrequests bool
 		workload        bool
 		wantErr         bool
+		// wantReason, when non-empty, asserts the error ScanRegistry returns is a
+		// *domain.ScanError carrying this scanfailure.Reason* value (see #540).
+		wantReason string
 	}{
 		{
 			name:     "no workload",
@@ -902,18 +924,21 @@ func TestScanService_ScanRegistry(t *testing.T) {
 			createSBOMError: true,
 			workload:        true,
 			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
-			name:     "timeout SBOM",
-			timeout:  true,
-			workload: true,
-			wantErr:  true,
+			name:       "timeout SBOM",
+			timeout:    true,
+			workload:   true,
+			wantErr:    true,
+			wantReason: scanfailure.ReasonSBOMIncomplete,
 		},
 		{
 			name:            "toomanyrequests SBOM",
 			toomanyrequests: true,
 			workload:        true,
 			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
 			name:     "scan",
@@ -948,12 +973,18 @@ func TestScanService_ScanRegistry(t *testing.T) {
 				ctx, _ = s.ValidateScanRegistry(ctx, workload)
 				require.NoError(t, err)
 			}
-			if err := s.ScanRegistry(ctx); (err != nil) != tt.wantErr {
+			err := s.ScanRegistry(ctx)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("ScanRegistry() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.toomanyrequests {
-				_, err := s.ValidateScanRegistry(ctx, workload)
-				assert.Equal(t, domain.ErrTooManyRequests, err)
+				_, verr := s.ValidateScanRegistry(ctx, workload)
+				assert.Equal(t, domain.ErrTooManyRequests, verr)
+			}
+			if tt.wantReason != "" {
+				var scanErr *domain.ScanError
+				require.ErrorAsf(t, err, &scanErr, "expected a *domain.ScanError, got %T: %v", err, err)
+				assert.Equal(t, tt.wantReason, scanErr.Reason)
 			}
 		})
 	}

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -139,13 +139,15 @@ func TestScanService_GenerateSBOM(t *testing.T) {
 				_, err := s.ValidateGenerateSBOM(ctx, workload)
 				assert.Equal(t, domain.ErrTooManyRequests, err)
 			}
+			if tt.wantReason != "" {
+				var scanErr *domain.ScanError
+				require.ErrorAsf(t, err, &scanErr, "expected a *domain.ScanError, got %T: %v", err, err)
+				assert.Equal(t, tt.wantReason, scanErr.Reason)
+			}
 			if tt.timeout {
 				// a timed-out/too-large SBOM must be surfaced as a failure (see #540), not
 				// silently stored and reported as success like every other scan flow already does
 				assert.ErrorIs(t, err, domain.ErrIncompleteSBOM)
-				var scanErr *domain.ScanError
-				require.ErrorAs(t, err, &scanErr)
-				assert.Equal(t, scanfailure.ReasonSBOMIncomplete, scanErr.Reason)
 			}
 		})
 	}
@@ -610,6 +612,9 @@ func TestScanService_ScanCVE(t *testing.T) {
 				require.ErrorAsf(t, err, &scanErr, "expected a *domain.ScanError, got %T: %v", err, err)
 				assert.Equal(t, tt.wantReason, scanErr.Reason)
 			}
+			if tt.timeout {
+				assert.ErrorIs(t, err, domain.ErrIncompleteSBOM)
+			}
 		})
 	}
 }
@@ -985,6 +990,9 @@ func TestScanService_ScanRegistry(t *testing.T) {
 				var scanErr *domain.ScanError
 				require.ErrorAsf(t, err, &scanErr, "expected a *domain.ScanError, got %T: %v", err, err)
 				assert.Equal(t, tt.wantReason, scanErr.Reason)
+			}
+			if tt.timeout {
+				assert.ErrorIs(t, err, domain.ErrIncompleteSBOM)
 			}
 		})
 	}

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -65,7 +65,7 @@ func TestScanService_GenerateSBOM(t *testing.T) {
 			name:     "phase 1, timeout",
 			timeout:  true,
 			workload: true,
-			wantErr:  false, // we no longer check for timeout
+			wantErr:  true,
 		},
 		{
 			name:            "phase 1, too many requests",
@@ -124,12 +124,21 @@ func TestScanService_GenerateSBOM(t *testing.T) {
 			if tt.workload {
 				ctx, _ = s.ValidateGenerateSBOM(ctx, workload)
 			}
-			if err := s.GenerateSBOM(ctx); (err != nil) != tt.wantErr {
+			err := s.GenerateSBOM(ctx)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateSBOM() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.toomanyrequests {
 				_, err := s.ValidateGenerateSBOM(ctx, workload)
 				assert.Equal(t, domain.ErrTooManyRequests, err)
+			}
+			if tt.timeout {
+				// a timed-out/too-large SBOM must be surfaced as a failure (see #540), not
+				// silently stored and reported as success like every other scan flow already does
+				assert.ErrorIs(t, err, domain.ErrIncompleteSBOM)
+				var scanErr *domain.ScanError
+				require.ErrorAs(t, err, &scanErr)
+				assert.Equal(t, scanfailure.ReasonSBOMIncomplete, scanErr.Reason)
 			}
 		})
 	}

--- a/docs/API.md
+++ b/docs/API.md
@@ -135,10 +135,18 @@ GET /metrics
 
 | Name | Type | Labels | Description |
 |------|------|--------|-------------|
-| `kubevuln_scans_completed_total` | counter | `endpoint`, `outcome` (`success`/`partial`/`error`) | Scans completed by the HTTP controller's worker pool |
-| `kubevuln_scan_duration_seconds` | histogram | `endpoint`, `outcome` | Duration of a scan job, measured from when it starts running (not from when it was queued) |
+| `kubevuln_scans_completed_total` | counter | `endpoint`, `outcome` (`success`/`partial`/`error`), `reason` | Scans completed by the HTTP controller's worker pool |
+| `kubevuln_scan_duration_seconds` | histogram | `endpoint`, `outcome`, `reason` | Duration of a scan job, measured from when it starts running (not from when it was queued) |
 | `kubevuln_scan_rejections_total` | counter | `endpoint`, `reason` (`too_many_requests`/`invalid_request`) | Requests rejected at validation time, before being queued |
 | `kubevuln_worker_pool_queue_depth` | gauge | - | Number of scan jobs currently waiting in the worker pool |
+
+`reason` is `"none"` for a `success`/`partial` outcome, and otherwise one of the bounded
+`scanfailure.Reason*` constants from [`armoapi-go/scanfailure`](https://github.com/armosec/armoapi-go)
+-- the same classification already sent to the backend via `ReportScanFailure` (see
+[scan-failure-reporting.md](scan-failure-reporting.md)) -- falling back to `"unexpected_error"`
+for an `error` outcome that carries no specific classification. This lets an operator watching
+only `/metrics` distinguish, for example, a registry auth failure from an oversized image
+without needing access to the backend's failure-report stream or pod logs.
 
 #### Example
 

--- a/docs/scan-failure-reporting.md
+++ b/docs/scan-failure-reporting.md
@@ -9,7 +9,10 @@ the failure being silent). Reporting is best-effort and never changes the scan's
 A report is sent from each scan entry point after the operation's existing retries are exhausted:
 
 - `GenerateSBOM()` — SBOM could not be created (unsupported image, image too large, auth/pull
-  failure, timeout).
+  failure, timeout), including a created SBOM whose status comes back `Incomplete`/`TooLarge`.
+  This last case used to be missed: `GenerateSBOM` stored the degraded SBOM and returned success
+  regardless of status, the one entry point that didn't check for it. It now checks and reports
+  the failure the same way the other three do.
 - `ScanCVE()` — an SBOM exists but CVE matching failed.
 - `ScanCP()` — continuous-protection scan failures (may cover several images per scan).
 - `ScanRegistry()` — registry image scan failures (reported at image level, no workload context).
@@ -27,6 +30,15 @@ and `TooLarge` / `Incomplete` SBOM statuses. The raw error is preserved in a sep
 field for backend debugging; the reason code drives the user-facing text (mapped downstream).
 
 Failure cases: CVE scan failure, SBOM generation failure, OOM kill, backend post failure.
+
+The same reason code also lands on the HTTP controller's Prometheus metrics: `recordScan`
+(`controllers/http.go`) wraps a scan flow's error in `*domain.ScanError` at the point of
+failure — the same call site that already computes the reason for `ReportScanFailure` above —
+and attaches it as a `reason` attribute on `kubevuln_scans_completed_total` and
+`kubevuln_scan_duration_seconds` (see [API.md](API.md#metrics)). This gives an operator with
+only `/metrics` access (no backend `ReportScanFailure` stream, no pod logs) the same
+distinction between failure causes that this document describes, instead of a single opaque
+`outcome="error"` bucket.
 
 ## Report shape
 

--- a/docs/scan-failure-reporting.md
+++ b/docs/scan-failure-reporting.md
@@ -31,10 +31,11 @@ field for backend debugging; the reason code drives the user-facing text (mapped
 
 Failure cases: CVE scan failure, SBOM generation failure, OOM kill, backend post failure.
 
-The same reason code also lands on the HTTP controller's Prometheus metrics: `recordScan`
-(`controllers/http.go`) wraps a scan flow's error in `*domain.ScanError` at the point of
-failure — the same call site that already computes the reason for `ReportScanFailure` above —
-and attaches it as a `reason` attribute on `kubevuln_scans_completed_total` and
+The same reason code also lands on the HTTP controller's Prometheus metrics: the scan services
+create the `*domain.ScanError` at the point of failure — the same call site that already
+computes the reason for `ReportScanFailure` above — and `recordScan` (`controllers/http.go`)
+reads it back off the error the controller receives, attaching it as a `reason` attribute on
+`kubevuln_scans_completed_total` and
 `kubevuln_scan_duration_seconds` (see [API.md](API.md#metrics)). This gives an operator with
 only `/metrics` access (no backend `ReportScanFailure` stream, no pod logs) the same
 distinction between failure causes that this document describes, instead of a single opaque


### PR DESCRIPTION
## Overview

Two related gaps in scan-failure detection/observability, both in the same code path (`core/services/scan.go`'s scan flows → `controllers/http.go`'s outcome recording → `internal/metrics`):

1. `GenerateSBOM` never checked for an `Incomplete`/`TooLarge` SBOM status, unlike `ScanCP`, `ScanCVE`, and `ScanRegistry`, which all check `sbom.Status == helpersv1.Incomplete || sbom.Status == helpersv1.TooLarge` right after SBOM creation/retrieval and abort with a `ReportScanFailure` call. A timed-out or oversized SBOM going through `GenerateSBOM` was silently stored via `StoreSBOM` and the scan reported as a success. `GenerateSBOM` now performs the same check, reports the failure with the classified reason, and returns `domain.ErrIncompleteSBOM` instead.
2. Every scan flow collapsed all failure reasons into a single opaque `outcome="error"` metric label, even though a bounded, 13-value failure-reason taxonomy (`scanfailure.Reason*`) was already computed at each failure site and handed to `ReportScanFailure`, then discarded before it reached Prometheus. An operator watching only `/metrics` could not distinguish "registry auth is broken fleet-wide" from "images are hitting `maxImageSize`" from "the CVE DB match is failing" — all three incremented the identical `kubevuln_scans_completed_total{outcome="error"}` series.

`ScanCP` is deliberately left unchanged: it loops over multiple images per call and `continue`s past a per-image failure instead of returning it, so there's no single dominant reason to attach to its own return value the way the other three flows have.

### Changes

- `core/domain/scan.go`: new `ScanError{Reason, Err}` type (implements `Unwrap`) that lets a scan-flow call site hand its already-computed `scanfailure.Reason*` classification to callers without changing every method's return signature. Existing `errors.Is`-based checks (e.g. `ErrPartialContainerProfile`, `ErrTooManyRequests`) keep working unchanged through `Unwrap`.
- `core/services/scan.go`:
  - `GenerateSBOM` now checks the SBOM status the same way `ScanCP`/`ScanCVE`/`ScanRegistry` do, and reports/returns a failure instead of silently storing a degraded SBOM as a success.
  - Every `return err` at a `ReportScanFailure` call site across `GenerateSBOM`, `ScanCVE`, and `ScanRegistry` now wraps the error in `&domain.ScanError{Reason: ..., Err: ...}`, using the reason already computed at that call site.
- `controllers/http.go`: `recordScan` now takes the scan's `error` and resolves a bounded `reason` attribute via `errors.As(err, *domain.ScanError)`, defaulting to `scanfailure.ReasonUnexpected` for an unclassified error and `"none"` for success/partial outcomes. The `reason` attribute is added to both the `ScanCounter` and `ScanDuration` instruments.
- `core/services/scan_test.go`: corrected the stale "phase 1, timeout" case (previously `wantErr: false, // we no longer check for timeout`, which documented this exact regression) to assert the failure is now surfaced, and added `wantReason` coverage to the `GenerateSBOM`, `ScanCVE`, and `ScanRegistry` table tests, asserting the exact `scanfailure.Reason*` value each failure case's `domain.ScanError` should carry.
- `controllers/http_test.go`: added `TestHTTPController_MetricsEndpoint_RecordsScanFailureReason`, which drives `generateSBOM`, `scanCVE`, and `scanRegistry` through a failing scan service and scrapes `/metrics` to assert the exact `kubevuln_scans_completed_total{endpoint,outcome="error",reason}` series is produced, including the unclassified-error fallback to `scanfailure.ReasonUnexpected`.
- `docs/API.md`: documented the new `reason` label on `kubevuln_scans_completed_total`/`kubevuln_scan_duration_seconds`.
- `docs/scan-failure-reporting.md`: noted the `GenerateSBOM` fix and cross-linked the new metric label to the existing failure-classification explanation.

No behavior change for successful scans or for scans that were already correctly failing before this change — their HTTP response, `ReportScanFailure` payload, and non-reason metric labels are unaffected.

## How to Test

- `go build ./...`
- `go test ./core/services/... ./controllers/... ./core/domain/... ./internal/metrics/...`
- `TestScanService_GenerateSBOM`/`TestScanService_ScanCVE`/`TestScanService_ScanRegistry` (`core/services/scan_test.go`) assert `domain.ScanError.Reason` for every classified failure case.
- `TestHTTPController_MetricsEndpoint_RecordsScanFailureReason` (`controllers/http_test.go`) proves the `reason` label reaches `/metrics` end to end for `generateSBOM`, `scanCVE`, and `scanRegistry`.
- To see it live: trigger any scan failure and check `/metrics` — `kubevuln_scans_completed_total` and `kubevuln_scan_duration_seconds` now carry a `reason` attribute (e.g. `reason="sbom_incomplete"`) alongside `endpoint`/`outcome`, instead of only the coarse `outcome="error"`.

## Related issues/PRs

Resolved #540

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scan failures now include classified reasons, such as rate limiting, incomplete SBOMs, and storage or scanning errors.
  * Incomplete or oversized SBOMs are reported as scan failures.
  * Scan metrics now include a bounded failure-reason label, including an `unexpected` fallback.

* **Documentation**
  * Updated metrics and scan-failure documentation to describe available reason codes and reporting behavior.

* **Tests**
  * Added coverage for classified, unclassified, timeout, and rate-limit failures across scan workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->