### PR TITLE
fix(metrics): export scan fallback counters

### DIFF
--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -158,7 +158,7 @@ func TestExpiredOnFixAgreesAcrossPaths(t *testing.T) {
 
 	// storage path
 	doc := &v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}
-	ApplySecurityExceptions(doc, exceptions)
+	ApplySecurityExceptions(doc, exceptions, nil)
 	storageSuppressed := len(doc.IgnoredMatches) == 1
 
 	// report path
@@ -188,7 +188,7 @@ func TestExpiredOnFixAgreesAcrossPathsWhenUnfixed(t *testing.T) {
 	ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
 
 	doc := &v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}
-	ApplySecurityExceptions(doc, exceptions)
+	ApplySecurityExceptions(doc, exceptions, nil)
 
 	results, err := DomainToArmo(ctx, v1beta1.GrypeDocument{Source: singleLayerSource, Matches: []v1beta1.Match{match}}, exceptions)
 	require.NoError(t, err)

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -25,6 +25,7 @@ import (
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
+	"github.com/kubescape/kubevuln/internal/metrics"
 	"github.com/kubescape/kubevuln/internal/tools"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/opencontainers/go-digest"
@@ -192,9 +193,11 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 
 	ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, s.maxImageSize)
 	pullRef := rewriteImageRef(imageID, s.proxyRegistryMap)
+	usedFallback := false
 	src, err := syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
 
 	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+		usedFallback = true
 		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
 			helpers.String("imageTag", imageTag),
 			helpers.String("imageID", imageID))
@@ -203,15 +206,22 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	}
 
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
+		usedFallback = true
 		unauthorizedErr := err
 		if isGCPRegistry(pullRef) {
 			if gcpCreds, gcpErr := gcpCredentials(ctx); gcpErr != nil {
+				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, metrics.FallbackOutcomeFailed)
 				logger.L().Debug("GCP ADC unavailable, falling back to anonymous",
 					helpers.Error(gcpErr),
 					helpers.String("imageID", imageID))
 			} else {
 				registryOptions.Credentials = []image.RegistryCredentials{*gcpCreds}
 				src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
+				outcome := metrics.FallbackOutcomeFailed
+				if err == nil {
+					outcome = metrics.FallbackOutcomeSucceeded
+				}
+				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, outcome)
 			}
 		}
 		// If GCP ADC was not attempted, succeeded in auth but still got 401, or the image is not a GCP registry,
@@ -221,14 +231,22 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 				helpers.String("imageID", imageID))
 			registryOptions.Credentials = nil
 			src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
+			outcome := metrics.FallbackOutcomeFailed
+			if err == nil {
+				outcome = metrics.FallbackOutcomeSucceeded
+			}
+			metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyAnonymous, outcome)
 			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
 				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
 			}
 		}
 	}
 
+	metrics.RecordSourceResolution(ctx, metrics.ComponentInProcess, usedFallback, err == nil)
+
 	switch {
 	case err != nil && (errors.Is(err, image.ErrImageTooLarge) || strings.Contains(err.Error(), image.ErrImageTooLarge.Error())):
+		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyImageTooLarge, metrics.FallbackOutcomeClassified)
 		logger.L().Ctx(ctx).Warning("Image exceeds size limit",
 			helpers.Int("maxImageSize", int(s.maxImageSize)),
 			helpers.String("imageID", imageID))
@@ -240,6 +258,10 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		domainSBOM.Status = helpersv1.Unauthorize
 		return domainSBOM, err
 	case err != nil:
+		var platformErr *image.ErrPlatformMismatch
+		if errors.As(err, &platformErr) {
+			metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryPlatform, metrics.FallbackStrategyPlatformMismatch, metrics.FallbackOutcomeFailed)
+		}
 		return domainSBOM, err
 	}
 
@@ -283,6 +305,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	})
 	switch {
 	case errors.Is(err, deadline.ErrTimedOut):
+		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		logger.L().Ctx(ctx).Warning("Syft timed out",
 			helpers.String("imageID", imageID))
 		domainSBOM.Status = helpersv1.Incomplete
@@ -290,6 +313,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	case err == nil:
 		// continue
 	default:
+		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		// also mark as incomplete if we failed to extract packages
 		domainSBOM.Status = helpersv1.Incomplete
 		return domainSBOM, err
@@ -305,6 +329,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	sz := size.Of(syftSBOM)
 	domainSBOM.Annotations[helpersv1.ResourceSizeMetadataKey] = fmt.Sprintf("%d", sz)
 	if sz > s.maxSBOMSize {
+		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategySBOMTooLarge, metrics.FallbackOutcomeClassified)
 		logger.L().Ctx(ctx).Warning("SBOM exceeds size limit",
 			helpers.Int("maxImageSize", s.maxSBOMSize),
 			helpers.Int("size", sz),

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -520,7 +520,7 @@ func TestHTTPController_MetricsEndpoint(t *testing.T) {
 	c := NewHTTPController(services.NewMockScanService(true), 1)
 	m, err := metrics.New()
 	require.NoError(t, err)
-	c, err = c.WithMetrics(m)
+	_, err = c.WithMetrics(m)
 	require.NoError(t, err)
 
 	router := gin.Default()
@@ -577,6 +577,33 @@ func TestHTTPController_MetricsEndpoint_RecordsRejection(t *testing.T) {
 	assert.True(t, strings.Contains(body, `reason="too_many_requests"`), body)
 	assert.True(t, strings.Contains(body, `kubevuln_scan_rejections_total{endpoint="generateSBOM",reason="too_many_requests"} 1`), body)
 	assert.False(t, strings.Contains(body, `reason="invalid_request"`), body)
+}
+
+func TestHTTPController_MetricsEndpoint_ExportsScanFallbackMetrics(t *testing.T) {
+	c := NewHTTPController(services.NewMockScanService(true), 1)
+	m, err := metrics.New()
+	require.NoError(t, err)
+	_, err = c.WithMetrics(m)
+	require.NoError(t, err)
+
+	router := gin.Default()
+	router.GET("/metrics", gin.WrapH(m.Handler()))
+
+	metrics.RecordScanFallback(context.Background(), metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, metrics.FallbackOutcomeFailed)
+	metrics.RecordScanFallback(context.Background(), metrics.ComponentSidecar, metrics.FallbackCategoryPlatform, metrics.FallbackStrategyPlatformMismatch, metrics.FallbackOutcomeFailed)
+	metrics.RecordScanFallback(context.Background(), metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategySBOMTooLarge, metrics.FallbackOutcomeClassified)
+	metrics.RecordSourceResolution(context.Background(), metrics.ComponentSidecar, true, false)
+
+	req, _ := http.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="registry_auth",component="sidecar",outcome="failed",strategy="gcp_adc"} 1`), body)
+	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="platform",component="sidecar",outcome="failed",strategy="platform_mismatch"} 1`), body)
+	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="size_classification",component="sidecar",outcome="classified",strategy="sbom_too_large"} 1`), body)
+	assert.True(t, strings.Contains(body, `kubevuln_scan_source_resolution_total{component="sidecar",outcome="fallback_failed"} 1`), body)
 }
 
 // TestHTTPController_MetricsEndpoint_InvalidRequestDoesNotCountAsRejection is a

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -3,9 +3,11 @@ package metrics
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -19,6 +21,35 @@ import (
 // a single bucket, which is most of the traffic on this instrument.
 var scanDurationBuckets = []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800}
 
+const (
+	ComponentInProcess = "in_process"
+	ComponentSidecar   = "sidecar"
+
+	FallbackCategoryRegistryAuth       = "registry_auth"
+	FallbackCategoryPlatform           = "platform"
+	FallbackCategorySizeClassification = "size_classification"
+
+	FallbackStrategyAnonymous        = "anonymous"
+	FallbackStrategyGCPADC           = "gcp_adc"
+	FallbackStrategyImageTooLarge    = "image_too_large"
+	FallbackStrategyIncomplete       = "incomplete"
+	FallbackStrategyPlatformMismatch = "platform_mismatch"
+	FallbackStrategySBOMTooLarge     = "sbom_too_large"
+
+	FallbackOutcomeClassified = "classified"
+	FallbackOutcomeFailed     = "failed"
+	FallbackOutcomeSucceeded  = "succeeded"
+
+	SourceResolutionFirstPassSuccess        = "first_pass_success"
+	SourceResolutionFallbackAssistedSuccess = "fallback_assisted_success"
+	SourceResolutionFallbackFailed          = "fallback_failed"
+	SourceResolutionFirstPassFailure        = "first_pass_failure"
+)
+
+var recorderMu sync.RWMutex
+var fallbackCounter metric.Int64Counter
+var sourceResolutionCounter metric.Int64Counter
+
 // Metrics wraps the OTel meter and Prometheus exporter used to expose kubevuln's
 // operational metrics (worker-pool backlog, scan outcomes, rejection counts) on
 // a GET /metrics HTTP route.
@@ -30,6 +61,8 @@ type Metrics struct {
 	ScanCounter               metric.Int64Counter
 	RejectCounter             metric.Int64Counter
 	ExceptionsDegradedCounter metric.Int64Counter
+	ScanFallbackCounter       metric.Int64Counter
+	SourceResolutionCounter   metric.Int64Counter
 }
 
 // New builds a Metrics instance backed by a Prometheus exporter registered
@@ -91,13 +124,36 @@ func New() (*Metrics, error) {
 		return nil, err
 	}
 
+	scanFallbackCounter, err := meter.Int64Counter(
+		"kubevuln_scan_fallbacks_total",
+		metric.WithDescription("Total number of scan fallback strategy changes, by component, category, strategy, and outcome"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceResolutionMetric, err := meter.Int64Counter(
+		"kubevuln_scan_source_resolution_total",
+		metric.WithDescription("Total number of source-resolution outcomes, distinguishing first-pass and fallback-assisted scans"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	recorderMu.Lock()
+	fallbackCounter = scanFallbackCounter
+	sourceResolutionCounter = sourceResolutionMetric
+	recorderMu.Unlock()
+
 	return &Metrics{
-		provider:      provider,
-		handler:       promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+		provider:                  provider,
+		handler:                   promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
 		ScanDuration:              scanDuration,
 		ScanCounter:               scanCounter,
 		RejectCounter:             rejectCounter,
 		ExceptionsDegradedCounter: exceptionsDegradedCounter,
+		ScanFallbackCounter:       scanFallbackCounter,
+		SourceResolutionCounter:   sourceResolutionMetric,
 	}, nil
 }
 
@@ -116,4 +172,41 @@ func (m *Metrics) Meter() metric.Meter {
 // Handler returns the http.Handler serving Prometheus exposition-format text.
 func (m *Metrics) Handler() http.Handler {
 	return m.handler
+}
+
+func RecordScanFallback(ctx context.Context, component, category, strategy, outcome string) {
+	recorderMu.RLock()
+	counter := fallbackCounter
+	recorderMu.RUnlock()
+	if counter == nil {
+		return
+	}
+	counter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("component", component),
+		attribute.String("category", category),
+		attribute.String("strategy", strategy),
+		attribute.String("outcome", outcome),
+	))
+}
+
+func RecordSourceResolution(ctx context.Context, component string, usedFallback, success bool) {
+	recorderMu.RLock()
+	counter := sourceResolutionCounter
+	recorderMu.RUnlock()
+	if counter == nil {
+		return
+	}
+	outcome := SourceResolutionFirstPassFailure
+	switch {
+	case usedFallback && success:
+		outcome = SourceResolutionFallbackAssistedSuccess
+	case usedFallback && !success:
+		outcome = SourceResolutionFallbackFailed
+	case !usedFallback && success:
+		outcome = SourceResolutionFirstPassSuccess
+	}
+	counter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("component", component),
+		attribute.String("outcome", outcome),
+	))
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -20,6 +20,8 @@ func TestNewAndHandler(t *testing.T) {
 	m.ScanDuration.Record(context.Background(), 0.5, metric.WithAttributes())
 	m.RejectCounter.Add(context.Background(), 1, metric.WithAttributes())
 	m.ExceptionsDegradedCounter.Add(context.Background(), 1, metric.WithAttributes())
+	RecordScanFallback(context.Background(), ComponentInProcess, FallbackCategoryRegistryAuth, FallbackStrategyAnonymous, FallbackOutcomeSucceeded)
+	RecordSourceResolution(context.Background(), ComponentInProcess, true, true)
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	w := httptest.NewRecorder()
@@ -31,6 +33,8 @@ func TestNewAndHandler(t *testing.T) {
 	assert.True(t, strings.Contains(body, "kubevuln_scan_duration_seconds"), body)
 	assert.True(t, strings.Contains(body, "kubevuln_scan_rejections_total"), body)
 	assert.True(t, strings.Contains(body, "kubevuln_exceptions_degraded_total"), body)
+	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="registry_auth",component="in_process",outcome="succeeded",strategy="anonymous"} 1`), body)
+	assert.True(t, strings.Contains(body, `kubevuln_scan_source_resolution_total{component="in_process",outcome="fallback_assisted_success"} 1`), body)
 }
 
 func TestMeterRegistersObservableGauge(t *testing.T) {

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
+	"github.com/kubescape/kubevuln/internal/metrics"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"golang.org/x/oauth2/google"
@@ -56,6 +57,11 @@ func isRegistryRateLimited(err error) bool {
 	errStr := err.Error()
 	return strings.Contains(errStr, "TOOMANYREQUESTS") ||
 		strings.Contains(errStr, "429 Too Many Requests")
+}
+
+func isPlatformMismatch(err error) bool {
+	var platformErr *image.ErrPlatformMismatch
+	return errors.As(err, &platformErr)
 }
 
 func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
@@ -108,8 +114,10 @@ type sourceGetter func(ctx context.Context, ref string, opts *image.RegistryOpti
 // adapters/v1/syft.go so the sidecar and in-process adapters behave the same.
 func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag string, opts image.RegistryOptions) (source.Source, error) {
 	pullRef := imageID
+	usedFallback := false
 	src, err := get(ctx, pullRef, &opts)
 	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+		usedFallback = true
 		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
 			helpers.String("imageTag", imageTag),
 			helpers.String("imageID", imageID))
@@ -117,18 +125,25 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 		src, err = get(ctx, pullRef, &opts)
 	}
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
+		usedFallback = true
 		unauthorizedErr := err
 		for _, provider := range registryAuthProviders {
 			if !provider.Matches(pullRef) {
 				continue
 			}
 			if creds, credErr := provider.Credentials(ctx); credErr != nil || creds == nil {
+				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, metrics.FallbackOutcomeFailed)
 				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
 					helpers.Error(credErr),
 					helpers.String("imageID", imageID))
 			} else {
 				opts.Credentials = []image.RegistryCredentials{*creds}
 				src, err = get(ctx, pullRef, &opts)
+				outcome := metrics.FallbackOutcomeFailed
+				if err == nil {
+					outcome = metrics.FallbackOutcomeSucceeded
+				}
+				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, outcome)
 			}
 			break
 		}
@@ -139,11 +154,17 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 				helpers.String("imageID", imageID))
 			opts.Credentials = nil
 			src, err = get(ctx, pullRef, &opts)
+			outcome := metrics.FallbackOutcomeFailed
+			if err == nil {
+				outcome = metrics.FallbackOutcomeSucceeded
+			}
+			metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyAnonymous, outcome)
 			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
 				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
 			}
 		}
 	}
+	metrics.RecordSourceResolution(ctx, metrics.ComponentSidecar, usedFallback, err == nil)
 	return src, err
 }
 
@@ -234,6 +255,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 
 	switch {
 	case err != nil && (errors.Is(err, image.ErrImageTooLarge) || strings.Contains(err.Error(), image.ErrImageTooLarge.Error())):
+		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyImageTooLarge, metrics.FallbackOutcomeClassified)
 		logger.L().Warning("Image exceeds size limit",
 			helpers.Int("maxImageSize", int(req.MaxImageSize)),
 			helpers.String("imageID", imageID))
@@ -256,6 +278,9 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 			StatusReason: domain.ReasonTooManyRequests,
 		}, nil
 	case err != nil:
+		if isPlatformMismatch(err) {
+			metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryPlatform, metrics.FallbackStrategyPlatformMismatch, metrics.FallbackOutcomeFailed)
+		}
 		return &pb.CreateSBOMResponse{
 			ErrorMessage: err.Error(),
 		}, nil
@@ -298,6 +323,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 
 	switch {
 	case errors.Is(err, deadline.ErrTimedOut):
+		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		logger.L().Warning("Syft timed out", helpers.String("imageID", imageID))
 		return &pb.CreateSBOMResponse{
 			Status: helpersv1.Incomplete,
@@ -305,6 +331,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	case err == nil:
 		// continue
 	default:
+		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		return &pb.CreateSBOMResponse{
 			Status:       helpersv1.Incomplete,
 			ErrorMessage: err.Error(),
@@ -321,6 +348,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// by the scanner container's memory limit, not by MaxSbomSize.
 	sz := size.Of(syftSBOM)
 	if sz > int(req.MaxSbomSize) {
+		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategySBOMTooLarge, metrics.FallbackOutcomeClassified)
 		logger.L().Warning("SBOM exceeds size limit",
 			helpers.Int("maxSBOMSize", int(req.MaxSbomSize)),
 			helpers.Int("size", sz),

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/kubevuln/internal/metrics"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -255,6 +256,37 @@ func TestResolveSource(t *testing.T) {
 	}
 }
 
+func TestResolveSource_RecordsFallbackMetrics(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	orig := gcpCredsFn
+	defer func() { gcpCredsFn = orig }()
+	gcpCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
+		return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "token"}, nil
+	}
+
+	callCount := 0
+	get := func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		callCount++
+		if callCount == 1 {
+			return nil, errors.New("401 Unauthorized")
+		}
+		return nil, nil
+	}
+
+	_, err = resolveSource(context.Background(), get, "gcr.io/project/image", "", image.RegistryOptions{})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	m.Handler().ServeHTTP(w, req)
+	body := w.Body.String()
+
+	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="registry_auth",component="sidecar",outcome="succeeded",strategy="gcp_adc"} 1`), body)
+	assert.True(t, strings.Contains(body, `kubevuln_scan_source_resolution_total{component="sidecar",outcome="fallback_assisted_success"} 1`), body)
+}
+
 // fakeAuthProvider is a scripted registryAuthProvider used to prove
 // resolveSource consults registryAuthProviders generically, not just GCP.
 type fakeAuthProvider struct {
@@ -460,6 +492,7 @@ func TestCreateSBOM_ImageTooLarge_LocalRegistry(t *testing.T) {
 	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
 		ImageId:         u.Host + "/test-image",
 		ImageTag:        u.Host + "/test-image:latest",
+		Platform:        "linux/amd64",
 		MaxImageSize:    1, // Exceeded by layer size
 		InsecureUseHttp: true,
 	})


### PR DESCRIPTION
## Overview
Add low-cardinality Prometheus counters for scan fallback strategies and source-resolution outcomes in the in-process and sidecar scan paths, and extend the metrics coverage around `/metrics` export.

## How to Test
- `go test ./internal/metrics ./controllers ./pkg/sbomscanner/v1 -count=1` - passed
- `go vet ./...` - passed
- `go test ./... -count=1` - failed on existing `adapters/v1` Syft fixture expectations on this `darwin/arm64` machine

## Related issues/PRs:
- Fixes #545

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed scan metrics covering fallback usage, source resolution, platform mismatches, image and SBOM size limits, timeouts, and incomplete scans.
  * Added visibility into registry authentication and anonymous access fallback outcomes.
* **Bug Fixes**
  * Improved detection and classification of platform mismatches during image scanning.
* **Tests**
  * Expanded coverage for fallback behavior, source resolution, scan classifications, and platform-specific image requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->