### PR TITLE
feat: add SafeFetch, an SSRF-guarded HTTP fetcher 

### DIFF
--- a/internal/safefetch/safefetch.go
+++ b/internal/safefetch/safefetch.go
@@ -17,6 +17,28 @@ import (
 	"time"
 )
 
+// carrierGradeNAT is RFC 6598's shared address space (100.64.0.0/10),
+// used inside cloud provider and Kubernetes internal networks (AWS CNI,
+// GCP, Tailscale, pod CIDRs). net.IP.IsPrivate() does not cover this
+// range, so it must be checked explicitly.
+var carrierGradeNAT = mustParseCIDR("100.64.0.0/10")
+
+// thisHostOnThisNetwork is RFC 1122's 0.0.0.0/8. Every address in this
+// range other than 0.0.0.0 itself is non-zero, so it passes
+// IsUnspecified(), and none of it is covered by IsLoopback() or
+// IsPrivate() - but on Linux, dialing any address in this range
+// (e.g. 0.0.0.1) actually connects to 127.0.0.1 (localhost), making it a
+// working bypass of the loopback check if left unhandled.
+var thisHostOnThisNetwork = mustParseCIDR("0.0.0.0/8")
+
+func mustParseCIDR(s string) *net.IPNet {
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return ipnet
+}
+
 var (
 	// ErrScheme is returned when a URL is not https.
 	ErrScheme = errors.New("only https URLs are allowed")
@@ -117,7 +139,9 @@ func checkIPAllowed(ip net.IP) error {
 		ip.IsLinkLocalMulticast() ||
 		ip.IsPrivate() ||
 		ip.IsUnspecified() ||
-		ip.IsMulticast() {
+		ip.IsMulticast() ||
+		carrierGradeNAT.Contains(ip) ||
+		thisHostOnThisNetwork.Contains(ip) {
 		return fmt.Errorf("%w: %s", ErrBlockedIP, ip)
 	}
 	return nil

--- a/internal/safefetch/safefetch.go
+++ b/internal/safefetch/safefetch.go
@@ -1,0 +1,173 @@
+// Package safefetch provides an HTTP client for fetching arbitrary,
+// user-controlled URLs safely, guarding against SSRF (Server-Side Request
+// Forgery). It is not wired into any specific feature; it exists as a
+// reusable primitive for any future code path (such as VEXSource
+// ingestion, kubevuln#387) that needs to fetch a URL a user supplied,
+// rather than a fixed, trusted endpoint.
+package safefetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var (
+	// ErrScheme is returned when a URL is not https.
+	ErrScheme = errors.New("only https URLs are allowed")
+	// ErrBlockedIP is returned when a URL resolves to a private, loopback,
+	// link-local, or otherwise non-routable IP address.
+	ErrBlockedIP = errors.New("target address is not allowed")
+	// ErrTooManyRedirects is returned when a fetch follows more redirects
+	// than allowed.
+	ErrTooManyRedirects = errors.New("too many redirects")
+	// ErrTooLarge is returned when a response body exceeds MaxBytes.
+	ErrTooLarge = errors.New("response body exceeds maximum size")
+	// ErrStatus is returned when the server responds with a non-2xx status.
+	ErrStatus = errors.New("unexpected response status")
+	// ErrNoClient is returned when a Fetcher is used without being built
+	// via New, so it has no underlying HTTP client.
+	ErrNoClient = errors.New("fetcher has no http client")
+)
+
+const (
+	defaultTimeout      = 10 * time.Second
+	defaultDialTimeout  = 5 * time.Second
+	defaultMaxBytes     = 10 << 20 // 10 MiB
+	defaultMaxRedirects = 5
+)
+
+// Fetcher retrieves a URL over HTTPS, rejecting private, loopback, and
+// link-local destinations (including cloud metadata endpoints such as
+// 169.254.169.254) both for the initial request and for every redirect
+// hop. IP validation happens at actual connection time via a custom
+// DialContext, not just when the URL is first parsed, so a DNS record
+// that changes between the check and the connection (DNS rebinding)
+// cannot bypass it.
+type Fetcher struct {
+	Client   *http.Client
+	MaxBytes int64
+}
+
+// New builds a Fetcher with SSRF protections wired into its transport.
+func New() *Fetcher {
+	dialer := &net.Dialer{Timeout: defaultDialTimeout}
+
+	safeDialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("splitting host/port for %q: %w", addr, err)
+		}
+
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("resolving %s: %w", host, err)
+		}
+
+		var lastErr error
+		for _, ip := range ips {
+			if err := checkIPAllowed(ip); err != nil {
+				lastErr = err
+				continue
+			}
+			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if dialErr == nil {
+				return conn, nil
+			}
+			lastErr = dialErr
+		}
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no addresses found for %s", host)
+		}
+		return nil, lastErr
+	}
+
+	return &Fetcher{
+		MaxBytes: defaultMaxBytes,
+		Client: &http.Client{
+			Timeout: defaultTimeout,
+			Transport: &http.Transport{
+				DialContext: safeDialContext,
+			},
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= defaultMaxRedirects {
+					return ErrTooManyRedirects
+				}
+				if req.URL.Scheme != "https" {
+					return fmt.Errorf("redirect target: %w", ErrScheme)
+				}
+				return nil
+			},
+		},
+	}
+}
+
+// checkIPAllowed reports an error if ip is loopback, link-local (unicast
+// or multicast; this range includes cloud metadata endpoints such as
+// 169.254.169.254), private (RFC 1918 for IPv4, the IPv6 unique local
+// range), unspecified, or multicast.
+func checkIPAllowed(ip net.IP) error {
+	if ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsPrivate() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast() {
+		return fmt.Errorf("%w: %s", ErrBlockedIP, ip)
+	}
+	return nil
+}
+
+// Fetch retrieves rawURL and returns its body. rawURL must use the https
+// scheme; the destination (and every redirect target) must not resolve to
+// a blocked IP range.
+func (f *Fetcher) Fetch(ctx context.Context, rawURL string) ([]byte, error) {
+	if f.Client == nil {
+		return nil, ErrNoClient
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing url: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return nil, ErrScheme
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+
+	resp, err := f.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("%w: %s returned %s", ErrStatus, rawURL, resp.Status)
+	}
+
+	maxBytes := f.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBytes
+	}
+
+	// Read one byte past the limit so an oversized body is detected
+	// rather than silently truncated into whatever the caller does next.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("%w: %s exceeds %d bytes", ErrTooLarge, rawURL, maxBytes)
+	}
+
+	return body, nil
+}

--- a/internal/safefetch/safefetch_test.go
+++ b/internal/safefetch/safefetch_test.go
@@ -33,6 +33,8 @@ func TestCheckIPAllowed(t *testing.T) {
 		{"multicast", "224.0.0.1", true},
 		{"real public IPv4 (Google DNS)", "8.8.8.8", false},
 		{"real public IPv4 (Cloudflare DNS)", "1.1.1.1", false},
+		{"carrier-grade NAT / cloud internal (100.64.0.0/10)", "100.64.0.1", true},
+		{"0.0.0.0/8 (routes to localhost on Linux)", "0.0.0.1", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -99,21 +101,24 @@ func TestFetch_BlocksRealLoopbackServer(t *testing.T) {
 }
 
 func TestFetch_RejectsOversizedBody(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, strings.Repeat("x", 100))
 	}))
 	defer server.Close()
 
-	// Use the Fetcher's http.Client directly against the plain-http test
-	// server to isolate the size-limiting logic from the SSRF dial guard,
-	// which would otherwise also (correctly) reject this loopback target.
+	// Use the TLS test server's own client (which trusts its self-signed
+	// cert) instead of New()'s SSRF-guarded client, since the server
+	// necessarily listens on loopback, which SafeFetch correctly refuses
+	// to dial (covered separately by TestFetch_BlocksRealLoopbackServer).
+	// This still exercises Fetch's real logic end-to-end: scheme
+	// validation, request execution, and MaxBytes/ErrTooLarge
+	// enforcement, via an actual https:// call to Fetch itself.
 	f := &Fetcher{Client: server.Client(), MaxBytes: 10}
-	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
-	require.NoError(t, err)
-	resp, err := f.Client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := f.Fetch(context.Background(), server.URL)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooLarge)
+	assert.Nil(t, body)
 }
 
 func TestErrorsAreDistinguishable(t *testing.T) {

--- a/internal/safefetch/safefetch_test.go
+++ b/internal/safefetch/safefetch_test.go
@@ -1,0 +1,131 @@
+package safefetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckIPAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		wantErr bool
+	}{
+		{"loopback IPv4", "127.0.0.1", true},
+		{"loopback IPv6", "::1", true},
+		{"link-local IPv4 (cloud metadata range)", "169.254.169.254", true},
+		{"link-local IPv6", "fe80::1", true},
+		{"private RFC1918 class A", "10.0.0.1", true},
+		{"private RFC1918 class B", "172.16.0.1", true},
+		{"private RFC1918 class C", "192.168.1.1", true},
+		{"IPv6 unique local", "fc00::1", true},
+		{"unspecified IPv4", "0.0.0.0", true},
+		{"unspecified IPv6", "::", true},
+		{"multicast", "224.0.0.1", true},
+		{"real public IPv4 (Google DNS)", "8.8.8.8", false},
+		{"real public IPv4 (Cloudflare DNS)", "1.1.1.1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip, "test IP %q failed to parse", tt.ip)
+			err := checkIPAllowed(ip)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, ErrBlockedIP)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFetch_RejectsNonHTTPS(t *testing.T) {
+	f := New()
+	tests := []string{
+		"http://example.com/feed.json",
+		"ftp://example.com/feed.json",
+		"file:///etc/passwd",
+	}
+	for _, u := range tests {
+		t.Run(u, func(t *testing.T) {
+			_, err := f.Fetch(context.Background(), u)
+			assert.ErrorIs(t, err, ErrScheme)
+		})
+	}
+}
+
+func TestFetch_MalformedURL(t *testing.T) {
+	f := New()
+	_, err := f.Fetch(context.Background(), "://not-a-url")
+	assert.Error(t, err)
+}
+
+func TestFetch_WithoutClient(t *testing.T) {
+	f := Fetcher{}
+	_, err := f.Fetch(context.Background(), "https://example.com")
+	assert.ErrorIs(t, err, ErrNoClient)
+}
+
+// TestFetch_BlocksRealLoopbackServer is the key end-to-end proof: it spins
+// up a real, working HTTPS server (so this is not a theoretical IP check,
+// it is a genuinely reachable server that would happily respond), and
+// confirms our own Fetch refuses to talk to it, because the server listens
+// on loopback - simulating exactly the SSRF scenario where an attacker
+// points a VEXSource.url at an internal address.
+func TestFetch_BlocksRealLoopbackServer(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"secret": "you should never see this"}`)
+	}))
+	defer server.Close()
+
+	f := New()
+	// The test server's own TLS cert isn't trusted by the default client,
+	// but that's irrelevant here: our dial-time IP check must reject the
+	// connection before TLS verification is ever reached.
+	body, err := f.Fetch(context.Background(), server.URL)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBlockedIP)
+	assert.Nil(t, body)
+}
+
+func TestFetch_RejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, strings.Repeat("x", 100))
+	}))
+	defer server.Close()
+
+	// Use the Fetcher's http.Client directly against the plain-http test
+	// server to isolate the size-limiting logic from the SSRF dial guard,
+	// which would otherwise also (correctly) reject this loopback target.
+	f := &Fetcher{Client: server.Client(), MaxBytes: 10}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := f.Client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestErrorsAreDistinguishable(t *testing.T) {
+	// Sanity check that each sentinel error is genuinely distinct, so
+	// callers relying on errors.Is get meaningful results.
+	all := []error{ErrScheme, ErrBlockedIP, ErrTooManyRedirects, ErrTooLarge, ErrStatus, ErrNoClient}
+	for i, a := range all {
+		for j, b := range all {
+			if i == j {
+				continue
+			}
+			assert.False(t, errors.Is(a, b), "%v should not match %v", a, b)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

`kubevuln` has no safe way to fetch an arbitrary, user-controlled URL.
`adapters/v1/backend.go`'s HTTP client only ever calls Armo's own fixed,
trusted backend. The External VEX Ingestion project (kubevuln#387) will
introduce a genuinely new attack surface: `VEXSource.spec.url` is a
user-writable field a future fetcher will trust and call, without any
protection today.

## Changes

Add `internal/safefetch`, a standalone, reusable `Fetcher` providing:

- HTTPS-only enforcement
- Rejection of loopback, link-local (including cloud metadata endpoints
  like `169.254.169.254`), private (RFC 1918 / IPv6 ULA), unspecified,
  and multicast destinations, for both IPv4 and IPv6
- DNS-rebinding protection: IP validation happens in a custom
  `DialContext` at actual connection time, per resolved address, not
  just once when the URL is first parsed
- Redirect target re-validation (same checks apply to every hop, with a
  redirect limit)
- Configurable response size limit

Not wired into any specific feature - deliberately a reusable primitive
any future URL-fetching code path can build on.

## Before / After

**Before (a plain, unprotected client):**
```
Get "https://169.254.169.254/": context deadline exceeded
```
The request is attempted regardless - this only "fails" because nothing
is listening at that address in a test environment. On a real cloud VM,
this exact request would succeed and return real credentials.

**After (`SafeFetch`):**
```
target address is not allowed: 169.254.169.254
```
Refused immediately, on principle, before any connection is attempted.

A legitimate real HTTPS request (`https://api.github.com/zen`) still
succeeds normally, confirming this isn't blocking everything
indiscriminately.

## Testing

8 scenarios in `safefetch_test.go`, including
`TestFetch_BlocksRealLoopbackServer`, which proves the guard against a
genuinely reachable, real running server - not just a synthetic IP
check.

Full repo build and `go test ./...` pass with no failures.

## Related issues/PRs:

* Resolved #547

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure HTTPS-only fetching with SSRF protection.
  * Blocks requests to private, loopback, link-local, multicast, carrier-grade NAT, and unspecified addresses.
  * Enforces request timeouts, redirect limits, and response-size limits.
  * Provides clear, distinguishable errors for invalid URLs, blocked destinations, oversized responses, excessive redirects, and failed HTTP statuses.

* **Tests**
  * Added comprehensive coverage for URL validation, SSRF prevention, size and redirect limits, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->