### PR TITLE
fix: log expired security exceptions

### DIFF
--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
-	"k8s.io/client-go/tools/record"
+
 )
 
 // cpeMatchDetail builds a cpe-match detail carrying the given version constraint, the

--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	"k8s.io/client-go/tools/record"
 )
 
 // cpeMatchDetail builds a cpe-match detail carrying the given version constraint, the

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -57,10 +57,9 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 				continue
 			}
 			if isExpired(effectiveExpiresAt(se.Spec, vuln), now) {
-
 				stats.ExpiredBySource["SecurityException"]++
 
-				logger.L().Debug("security exception expired",
+				logger.L().Debug("security exception suppression expired",
 					helpers.String("name", se.Name),
 					helpers.String("namespace", se.Namespace))
 				continue
@@ -85,10 +84,9 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 				continue
 			}
 			if isExpired(effectiveExpiresAt(cse.Spec, vuln), now) {
-
 				stats.ExpiredBySource["ClusterSecurityException"]++
 
-				logger.L().Debug("cluster security exception expired",
+				logger.L().Debug("cluster security exception suppression expired",
 					helpers.String("name", cse.Name))
 				continue
 			}

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -57,7 +57,12 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 				continue
 			}
 			if isExpired(effectiveExpiresAt(se.Spec, vuln), now) {
+
 				stats.ExpiredBySource["SecurityException"]++
+
+				logger.L().Debug("security exception expired",
+					helpers.String("name", se.Name),
+					helpers.String("namespace", se.Namespace))
 				continue
 			}
 			p := buildPolicy(se.Spec, vuln, namespace, suppressionSource{
@@ -80,7 +85,11 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 				continue
 			}
 			if isExpired(effectiveExpiresAt(cse.Spec, vuln), now) {
+
 				stats.ExpiredBySource["ClusterSecurityException"]++
+
+				logger.L().Debug("cluster security exception expired",
+					helpers.String("name", cse.Name))
 				continue
 			}
 			p := buildPolicy(cse.Spec, vuln, "", suppressionSource{

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -1056,7 +1056,6 @@ func TestConvertAffectedSuppression(t *testing.T) {
 			}
 
 			policies, _ := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
-
 			if tt.wantSuppressed {
 				require.Len(t, policies, 1)
 				assert.Equal(t, "CVE-2021-44228", policies[0].VulnerabilityPolicies[0].Name)


### PR DESCRIPTION
## Summary

- add debug logging when a namespaced SecurityException expires
- include the exception name and namespace for easier troubleshooting
- keep the existing suppression behavior unchanged

## Testing
- `go test ./adapters/v1 -run TestConvertSkipsExpired -v` — unable to execute because the existing `fixstate_test.go` has calls to `ApplySecurityExceptions` using the old 2-argument signature while the current function requires 3 arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added debug logging when expired security exceptions are skipped.
  * Logs now include the exception name and, where applicable, its namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->