### PR TITLE
test(repositories): add unit tests for NoOpSecurityExceptionRepository

### DIFF
--- a/repositories/noop_security_exception_test.go
+++ b/repositories/noop_security_exception_test.go
@@ -1,0 +1,36 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoOpSecurityExceptionRepository_GetSecurityExceptions(t *testing.T) {
+	repo := &NoOpSecurityExceptionRepository{}
+
+	exceptions, clusterExceptions, err := repo.GetSecurityExceptions(context.Background(), "some-namespace")
+
+	assert.NoError(t, err)
+	assert.Nil(t, exceptions)
+	assert.Nil(t, clusterExceptions)
+}
+
+func TestNoOpSecurityExceptionRepository_GetWorkloadLabels(t *testing.T) {
+	repo := &NoOpSecurityExceptionRepository{}
+
+	labels, err := repo.GetWorkloadLabels(context.Background(), "namespace", "kind", "name")
+
+	assert.ErrorIs(t, err, errNoClusterConnection)
+	assert.Nil(t, labels)
+}
+
+func TestNoOpSecurityExceptionRepository_GetNamespaceLabels(t *testing.T) {
+	repo := &NoOpSecurityExceptionRepository{}
+
+	labels, err := repo.GetNamespaceLabels(context.Background(), "namespace")
+
+	assert.ErrorIs(t, err, errNoClusterConnection)
+	assert.Nil(t, labels)
+}


### PR DESCRIPTION
## Summary

Adds unit tests for `NoOpSecurityExceptionRepository` in `repositories/noop_security_exception.go`, the only file in `repositories/` without a matching test file.

## Changes

- Tests `GetSecurityExceptions` returns nil/nil/no error
- Tests `GetWorkloadLabels` returns the `errNoClusterConnection` sentinel error
- Tests `GetNamespaceLabels` returns the `errNoClusterConnection` sentinel error

## Testing

- Ran `go test ./repositories/... -run TestNoOpSecurityExceptionRepository -v`
- All 3 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for security exception retrieval behavior.
  * Verified workload and namespace label lookups return the expected connection error when unavailable.
  * Confirmed empty results are returned safely without unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->