### PR TITLE
fix(services): generate VEX on every CVE-scan path, not two of five

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -667,9 +667,19 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 							helpers.String("imageSlug", workload.ImageSlug))
 					}
 					// The stored manifest just changed, so the VEX document describing it is
-					// now stale. Kept in sync under the same condition, so a cache hit that
-					// re-evaluates exceptions updates both or neither.
-					s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
+					// now stale. Republish it, but only from a known-complete exception set,
+					// the same rule the cache-miss path follows.
+					//
+					// The manifest is persisted on the looser `exceptionsComplete ||
+					// !hasRemovals` condition because a partial set can only under-suppress,
+					// never wrongly un-suppress, so additions are safe to keep. A VEX document
+					// is a published assertion about which CVEs are suppressed, and one built
+					// from a partial set understates that. Leaving the previous document in
+					// place, written when the set was complete, beats replacing it with a
+					// weaker claim, so the two can briefly disagree until a complete scan.
+					if exceptionsComplete {
+						s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
+					}
 				}
 			}
 		}
@@ -845,9 +855,19 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 							helpers.String("imageSlug", workload.ImageSlug))
 					}
 					// The stored manifest just changed, so the VEX document describing it is
-					// now stale. Kept in sync under the same condition, so a cache hit that
-					// re-evaluates exceptions updates both or neither.
-					s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
+					// now stale. Republish it, but only from a known-complete exception set,
+					// the same rule the cache-miss path follows.
+					//
+					// The manifest is persisted on the looser `exceptionsComplete ||
+					// !hasRemovals` condition because a partial set can only under-suppress,
+					// never wrongly un-suppress, so additions are safe to keep. A VEX document
+					// is a published assertion about which CVEs are suppressed, and one built
+					// from a partial set understates that. Leaving the previous document in
+					// place, written when the set was complete, beats replacing it with a
+					// weaker claim, so the two can briefly disagree until a complete scan.
+					if exceptionsComplete {
+						s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
+					}
 				}
 			}
 		}

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -788,7 +788,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		}
 
 		// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-		filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
+		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
 
 		// store filtered CVE
 		if s.storage {
@@ -802,7 +802,12 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 				logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
 					helpers.String("imageSlug", workload.ImageSlug))
 			}
-			s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
+			// Only publish VEX built from a known-complete exception set, matching how
+			// ScanCVE and ScanCP gate their own calls: a degraded fetch would otherwise
+			// emit a document asserting fewer suppressions than the user configured.
+			if exceptionsComplete {
+				s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
+			}
 		}
 	} else {
 		// A cached manifest was filtered against the exception set at store time.

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -483,13 +483,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 						helpers.String("imageSlug", slug))
 					// no continue, storing the CVE summary is not critical
 				}
-				if s.vexGeneration && cveExceptionsComplete && cvepExceptionsComplete {
-					err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCvep, true)
-					if err != nil {
-						logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
-							helpers.String("imageSlug", slug))
-						// no continue, storing the VEX is not critical
-					}
+				if cveExceptionsComplete && cvepExceptionsComplete {
+					s.storeVEX(ctx, filteredCve, filteredCvep, true, slug)
 				}
 			}
 		}
@@ -615,7 +610,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 		}
 
 		// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-		filteredCve, _ := s.applyExceptionsToManifest(ctx, cve)
+		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
 
 		// store filtered CVE
 		if s.storage {
@@ -629,13 +624,19 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 				logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
 					helpers.String("imageSlug", workload.ImageSlug))
 			}
+			// Only publish VEX built from a known-complete exception set, matching how
+			// ScanCP gates its own call: a degraded fetch would otherwise emit a document
+			// asserting fewer suppressions than the user actually configured.
+			if exceptionsComplete {
+				s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
+			}
 		}
 	} else {
 		// A cached manifest was filtered against the exception set at store time.
 		// Reconstruct the unfiltered manifest so the CURRENT exception set is
 		// re-evaluated (deleted exceptions and ExpiredOnFix transitions
-		// un-suppress findings) and SubmitCVE receives the same unfiltered data a
-		// cache miss would produce.
+		// un-suppress findings) and SubmitCVE/StoreVEX receive the same unfiltered
+		// data a cache miss would produce.
 		prevIgnored := v1.IgnoredMatchKeys(cve.Content)
 		cve.Content = v1.RestoreSuppressedMatches(cve.Content)
 		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
@@ -665,6 +666,10 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 						logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
 							helpers.String("imageSlug", workload.ImageSlug))
 					}
+					// The stored manifest just changed, so the VEX document describing it is
+					// now stale. Kept in sync under the same condition, so a cache hit that
+					// re-evaluates exceptions updates both or neither.
+					s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
 				}
 			}
 		}
@@ -797,13 +802,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 				logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
 					helpers.String("imageSlug", workload.ImageSlug))
 			}
-			if s.vexGeneration {
-				err = s.cveRepository.StoreVEX(ctx, filteredCve, filteredCve, false)
-				if err != nil {
-					logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
-						helpers.String("imageSlug", workload.ImageSlug))
-				}
-			}
+			s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
 		}
 	} else {
 		// A cached manifest was filtered against the exception set at store time.
@@ -840,6 +839,10 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 						logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
 							helpers.String("imageSlug", workload.ImageSlug))
 					}
+					// The stored manifest just changed, so the VEX document describing it is
+					// now stale. Kept in sync under the same condition, so a cache hit that
+					// re-evaluates exceptions updates both or neither.
+					s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
 				}
 			}
 		}
@@ -869,6 +872,23 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		helpers.String("imageSlug", workload.ImageSlug),
 		helpers.String("jobID", workload.JobID))
 	return nil
+}
+
+// storeVEX writes the VEX document for a scanned image when VEX generation is enabled,
+// and is a no-op otherwise. Every CVE-scan flow stores VEX the same way, so they share
+// this rather than each carrying its own copy: the reason ScanCVE ended up with none at
+// all was that the call had to be ported to each flow by hand.
+//
+// A failure is logged rather than returned. The CVE manifest is already stored at every
+// call site, so the scan result stands without the VEX document.
+func (s *ScanService) storeVEX(ctx context.Context, cve, cvep domain.CVEManifest, withRelevancy bool, imageSlug string) {
+	if !s.vexGeneration {
+		return
+	}
+	if err := s.cveRepository.StoreVEX(ctx, cve, cvep, withRelevancy); err != nil {
+		logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
+			helpers.String("imageSlug", imageSlug))
+	}
 }
 
 // applyExceptionsToManifest returns a filtered copy of the CVE manifest with

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1692,11 +1692,15 @@ func exceptionPolicyForTest(id string) domain.CVEExceptions {
 // and CVE repository/scanner, returning the service, the version strings needed to seed/read a
 // CVE manifest, and a validated context.
 func newScanCVETestService(t *testing.T, platform ports.Platform, cveRepo ports.CVERepository, cveScanner ports.CVEScanner) (*ScanService, string, string, string, context.Context) {
+	return newScanCVETestServiceVEX(t, platform, cveRepo, cveScanner, false)
+}
+
+func newScanCVETestServiceVEX(t *testing.T, platform ports.Platform, cveRepo ports.CVERepository, cveScanner ports.CVEScanner, vexGeneration bool) (*ScanService, string, string, string, context.Context) {
 	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
 	if cveScanner == nil {
 		cveScanner = adapters.NewMockCVEAdapter()
 	}
-	s := NewScanService(sbomAdapter, repositories.NewMemoryStorage(false, false), cveScanner, cveRepo, platform, adapters.NewMockRelevancyAdapter(), true, false, true, false, false)
+	s := NewScanService(sbomAdapter, repositories.NewMemoryStorage(false, false), cveScanner, cveRepo, platform, adapters.NewMockRelevancyAdapter(), true, vexGeneration, true, false, false)
 	ctx := context.TODO()
 	s.Ready(ctx)
 	workload := domain.ScanCommand{
@@ -2258,4 +2262,121 @@ func TestScanCVE_NoSBOMRegeneration_OnCacheHit(t *testing.T) {
 	require.NoError(t, err, "MemoryStorage returns a nil error on a cache miss")
 	require.Nil(t, generatedSBOM.Content, "The generated SBOM should be nil since we avoided regenerating it wastefully")
 
+}
+
+// vexRecordingCVERepository records StoreVEX calls so a test can assert whether a VEX
+// document was written, which the in-memory repository cannot show on its own: its StoreVEX
+// is a no-op that keeps nothing.
+type vexRecordingCVERepository struct {
+	ports.CVERepository
+	vexCalls []domain.CVEManifest
+}
+
+func (v *vexRecordingCVERepository) StoreVEX(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, withRelevancy bool) error {
+	v.vexCalls = append(v.vexCalls, cve)
+	return v.CVERepository.StoreVEX(ctx, cve, cvep, withRelevancy)
+}
+
+// TestScanService_ScanCVE_CacheMiss_GeneratesVEX is the core regression test for #557: ScanCVE
+// had no StoreVEX call anywhere in its body, so an operator running with vexGeneration enabled
+// got no VEX document from the plain per-container scan route at all.
+func TestScanService_ScanCVE_CacheMiss_GeneratesVEX(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	s, _, _, _, ctx := newScanCVETestServiceVEX(t, platform, repo, fakeCVEScanner{}, true)
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	require.Len(t, repo.vexCalls, 1, "a fresh ScanCVE must generate a VEX document")
+	require.NotNil(t, repo.vexCalls[0].Content)
+	assert.Len(t, repo.vexCalls[0].Content.IgnoredMatches, 1,
+		"the VEX document must be built from the exception-filtered manifest")
+}
+
+func TestScanService_ScanCVE_CacheMiss_NoVEXWhenDisabled(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	s, _, _, _, ctx := newScanCVETestServiceVEX(t, platform, repo, fakeCVEScanner{}, false)
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	assert.Empty(t, repo.vexCalls, "vexGeneration is off, so nothing should be written")
+}
+
+// A degraded exception fetch means the set is incomplete, so the document would assert fewer
+// suppressions than the user configured. ScanCP already declines to publish in that case.
+func TestScanService_ScanCVE_CacheMiss_DegradedFetchSkipsVEX(t *testing.T) {
+	platform := &recordingPlatform{
+		exceptions:       exceptionPolicyForTest("CVE-A"),
+		getExceptionsErr: domain.ErrExceptionsDegraded,
+	}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	s, _, _, _, ctx := newScanCVETestServiceVEX(t, platform, repo, fakeCVEScanner{}, true)
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	assert.Empty(t, repo.vexCalls, "an incomplete exception set must not produce a VEX document")
+}
+
+// On a cache hit that re-evaluates exceptions, the stored manifest changes, so the VEX document
+// describing it has to change with it or the two disagree until the next cache miss.
+func TestScanService_ScanCVE_CacheHit_ExceptionChangeUpdatesVEX(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestServiceVEX(t, platform, repo, nil, true)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{matchForTest("CVE-A"), matchForTest("CVE-B")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	require.Len(t, repo.vexCalls, 1, "a changed ignored-match set must update the VEX document")
+	require.NotNil(t, repo.vexCalls[0].Content)
+	assert.Len(t, repo.vexCalls[0].Content.IgnoredMatches, 1)
+}
+
+func TestScanService_ScanCVE_CacheHit_UnchangedExceptionSkipsVEX(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestServiceVEX(t, platform, repo, nil, true)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches:        []v1beta1.Match{matchForTest("CVE-B")},
+		IgnoredMatches: []v1beta1.IgnoredMatch{ignoredMatchForTest("CVE-A")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	assert.Empty(t, repo.vexCalls, "nothing changed, so the stored VEX document is still accurate")
+}
+
+// TestScanService_ScanRegistry_CacheHit_ExceptionChangeUpdatesVEX covers the second half of
+// #557: ScanRegistry's cache-miss branch stored VEX but its cache-hit branch did not, even
+// though the comment directly above that branch says StoreVEX runs there.
+func TestScanService_ScanRegistry_CacheHit_ExceptionChangeUpdatesVEX(t *testing.T) {
+	platform := &recordingPlatform{exceptions: exceptionPolicyForTest("CVE-A")}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
+	cveAdapter := adapters.NewMockCVEAdapter()
+	s := NewScanService(sbomAdapter, repositories.NewMemoryStorage(false, false), cveAdapter, repo,
+		platform, adapters.NewMockRelevancyAdapter(), true, true, true, false, false)
+	ctx := context.TODO()
+	s.Ready(ctx)
+
+	workload := domain.ScanCommand{
+		ImageSlug:          "imageSlug",
+		ImageTagNormalized: "docker.io/library/test-registry-image:latest",
+		JobID:              "job-123",
+	}
+	ctx, err := s.ValidateScanRegistry(ctx, workload)
+	require.NoError(t, err)
+
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx), ctx, &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{matchForTest("CVE-A"), matchForTest("CVE-B")},
+	})
+
+	require.NoError(t, s.ScanRegistry(ctx))
+
+	require.Len(t, repo.vexCalls, 1, "a ScanRegistry cache hit that changes the ignored set must update the VEX document")
+	require.NotNil(t, repo.vexCalls[0].Content)
+	assert.Len(t, repo.vexCalls[0].Content.IgnoredMatches, 1)
 }

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2407,3 +2407,27 @@ func TestScanService_ScanRegistry_CacheMiss_DegradedFetchSkipsVEX(t *testing.T) 
 
 	assert.Empty(t, repo.vexCalls, "an incomplete exception set must not produce a VEX document")
 }
+
+// A degraded exception fetch must not republish VEX on a cache hit either, even when the
+// change is purely additive and the manifest itself is persisted. The manifest can safely
+// take additions from a partial set; a published VEX document built from one understates
+// which CVEs are suppressed.
+func TestScanService_ScanCVE_CacheHit_DegradedAdditiveSkipsVEX(t *testing.T) {
+	platform := &recordingPlatform{
+		exceptions:       exceptionPolicyForTest("CVE-A"),
+		getExceptionsErr: domain.ErrExceptionsDegraded,
+	}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	s, sbomVer, cveVer, cveDBVer, ctx := newScanCVETestServiceVEX(t, platform, repo, nil, true)
+	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{matchForTest("CVE-A"), matchForTest("CVE-B")},
+	})
+
+	require.NoError(t, s.ScanCVE(ctx))
+
+	stored, err := s.cveRepository.GetCVE(ctx, "imageSlug", s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
+	require.NoError(t, err)
+	require.Len(t, stored.Content.IgnoredMatches, 1, "the additive change is still persisted to the manifest")
+
+	assert.Empty(t, repo.vexCalls, "but no VEX document is published from a partial exception set")
+}

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2380,3 +2380,30 @@ func TestScanService_ScanRegistry_CacheHit_ExceptionChangeUpdatesVEX(t *testing.
 	require.NotNil(t, repo.vexCalls[0].Content)
 	assert.Len(t, repo.vexCalls[0].Content.IgnoredMatches, 1)
 }
+
+// A degraded exception fetch must not publish a VEX document from a partial set on the
+// registry cache-miss path either, matching how ScanCVE and ScanCP gate their own calls.
+func TestScanService_ScanRegistry_CacheMiss_DegradedFetchSkipsVEX(t *testing.T) {
+	platform := &recordingPlatform{
+		exceptions:       exceptionPolicyForTest("CVE-A"),
+		getExceptionsErr: domain.ErrExceptionsDegraded,
+	}
+	repo := &vexRecordingCVERepository{CVERepository: repositories.NewMemoryStorage(false, false)}
+	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
+	cveAdapter := adapters.NewMockCVEAdapter()
+	s := NewScanService(sbomAdapter, repositories.NewMemoryStorage(false, false), cveAdapter, repo,
+		platform, adapters.NewMockRelevancyAdapter(), true, true, true, false, false)
+	ctx := context.TODO()
+	s.Ready(ctx)
+
+	ctx, err := s.ValidateScanRegistry(ctx, domain.ScanCommand{
+		ImageSlug:          "imageSlug",
+		ImageTagNormalized: "docker.io/library/test-registry-image:latest",
+		JobID:              "job-123",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, s.ScanRegistry(ctx))
+
+	assert.Empty(t, repo.vexCalls, "an incomplete exception set must not produce a VEX document")
+}


### PR DESCRIPTION
## Overview

`ScanCVE`, the handler behind `POST /v1/scanImage`, had no `StoreVEX` call anywhere in its body, so an operator running with `vexGeneration: true` got no VEX document from that route at all and nothing logged or reported why. `ScanRegistry`'s cache-hit branch was missing one too, directly underneath a comment stating that `StoreVEX` runs there.

Before and after, by call site:

| Flow | Path | Before | After |
|---|---|---|---|
| `ScanCP` | both | stores VEX | unchanged |
| `ScanCVE` | cache miss | nothing | stores VEX when the exception set is complete |
| `ScanCVE` | cache hit | nothing | stores VEX when the ignored-match set changed |
| `ScanRegistry` | cache miss | stores VEX | unchanged |
| `ScanRegistry` | cache hit | nothing | stores VEX when the ignored-match set changed |

Each new call is gated the way its siblings gate theirs. On a cache miss `ScanCVE` requires a complete exception set, matching `ScanCP`, because a degraded fetch would otherwise publish a document asserting fewer suppressions than the user actually configured. On a cache hit both flows store VEX under the same condition that already gates `StoreCVE`, so a re-evaluated exception set updates the manifest and the document describing it together or not at all.

Nothing changes when `vexGeneration` is false, or for the two paths that were already correct.

## Additional Information

The call moves into a shared `storeVEX` helper. All five sites were the same six lines, and having to port them by hand is why `ScanCVE` ended up without one. This is the third VEX-consistency bug of this shape after #484 and #501, so the helper is the smallest change that stops the next feature landing in two flows out of three. The larger refactor the issue floats, factoring the whole store-and-submit tail into one helper, is deliberately not attempted here: it would touch all three flows at once and is much harder to review than the bug fix.

`docs/ARCHITECTURE.md` needs no change. Its CVE pipeline diagram already shows `Generate VEX` as a generic phase of CVE scanning, which was the inaccuracy the issue flagged; with this fix the diagram becomes true rather than aspirational.

All four call sites publish only from a known-complete exception set. Two of them changed to get there, both raised in review:

`ScanRegistry`'s cache-miss branch previously stored VEX unconditionally. It now checks `exceptionsComplete` like `ScanCVE` and `ScanCP`, so a degraded fetch no longer publishes a document with partial suppressions. This is a behaviour change on a path that already generated VEX.

The two cache-hit branches originally attached the call to the manifest's persist condition, `exceptionsComplete || !hasRemovals`, which meant a degraded fetch skipped VEX on a cache miss but published it on a cache hit whose change was purely additive. The manifest uses that looser rule because a partial set can only under-suppress, never wrongly un-suppress, so additions are safe to keep. A VEX document is a published assertion about which CVEs are suppressed, and one built from a partial set understates it, so keeping the previous document beats replacing it with a weaker claim. The manifest and the document can therefore disagree briefly until a complete scan, which is the deliberate trade.

## How to Test

```
go test ./core/services/ -run VEX
```

Six tests, of which three fail on `main` (verified by reverting the fix and re-running):

- `ScanCVE_CacheMiss_GeneratesVEX` and `ScanCVE_CacheHit_ExceptionChangeUpdatesVEX` cover the flow that had no VEX generation at all.
- `ScanRegistry_CacheHit_ExceptionChangeUpdatesVEX` covers the branch whose comment already claimed this behaviour.
- `ScanCVE_CacheMiss_NoVEXWhenDisabled`, `ScanCVE_CacheMiss_DegradedFetchSkipsVEX` and `ScanCVE_CacheHit_UnchangedExceptionSkipsVEX` pin the negative cases, so the fix cannot start writing documents when it should not.

The in-memory repository's `StoreVEX` is a no-op that keeps nothing, so the tests wrap it in a small recording repository to observe the calls.

## Related issues/PRs:

* Resolved #557

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of VEX data across vulnerability and registry scans.
  * VEX updates now reflect changes to filtered vulnerability results, including cached scans.
  * Prevented VEX generation when security-exception data is incomplete.
  * Disabled VEX configurations no longer create or store VEX records.
  * Improved handling of VEX persistence failures without interrupting scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
