### PR TITLE
fix(config): avoid mutating default HTTP client

### DIFF
--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -1012,7 +1012,7 @@ func TestConvertAffectedSuppression(t *testing.T) {
 				},
 			}
 
-			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+			policies, _ := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 
 			if tt.wantSuppressed {
 				require.Len(t, policies, 1)
@@ -1043,7 +1043,7 @@ func TestConvertResolvingStatusesUnchangedByAffected(t *testing.T) {
 				},
 			}
 
-			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+			policies, _ := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 
 			require.Len(t, policies, 1, "no actionStatement or response should be needed")
 		})
@@ -1067,7 +1067,7 @@ func TestConvertAffectedRecordsProvenance(t *testing.T) {
 		},
 	}
 
-	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+	policies, _ := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 
 	require.Len(t, policies, 1)
 	assert.Equal(t, "WAF mitigation in place, ticket SEC-1234", policies[0].Attributes["actionStatement"])

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,6 +19,24 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/spf13/viper"
 )
+
+type timeoutBoundServiceDiscoveryGetter struct {
+	schema.IServiceDiscoveryClient
+	httpClient *http.Client
+}
+
+func (g timeoutBoundServiceDiscoveryGetter) Get() (io.Reader, error) {
+	response, err := g.httpClient.Get(g.GetServiceDiscoveryUrl())
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("server (%s) responded: %v", g.GetHost(), response.StatusCode)
+	}
+	return response.Body, nil
+}
 
 // CVEMatchingMode controls how kubevuln configures Grype's CPE-based matching.
 type CVEMatchingMode string
@@ -224,9 +243,7 @@ func LoadBackendServicesConfig(configDir, apiURL string) (schema.IBackendService
 	if err != nil {
 		return nil, err
 	}
-	// http.DefaultClient has no timeout by default; cap the startup discovery call.
-	http.DefaultClient = &http.Client{Timeout: 30 * time.Second}
-	services, err := servicediscovery.GetServices(client)
+	services, err := loadBackendServicesFromAPI(client, &http.Client{Timeout: 30 * time.Second})
 	if err == nil {
 		return services, nil
 	}
@@ -238,4 +255,11 @@ func LoadBackendServicesConfig(configDir, apiURL string) (schema.IBackendService
 		return fallbackServices, nil
 	}
 	return nil, errors.Join(err, fallbackErr)
+}
+
+func loadBackendServicesFromAPI(client schema.IServiceDiscoveryClient, httpClient *http.Client) (schema.IBackendServices, error) {
+	return servicediscovery.GetServices(timeoutBoundServiceDiscoveryGetter{
+		IServiceDiscoveryClient: client,
+		httpClient:              httpClient,
+	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +11,9 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v3 "github.com/kubescape/backend/pkg/servicediscovery/v3"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -73,6 +77,34 @@ func TestLoadBackendServicesConfig_FallbackToClusterData(t *testing.T) {
 		assert.Equal(t, "https://report.armo.cloud", services.GetReportReceiverHttpUrl())
 	})
 
+	t.Run("does not mutate http.DefaultClient when API_URL discovery runs", func(t *testing.T) {
+		dir := t.TempDir()
+		clusterData := `{
+			"backendOpenAPI":"https://api.armosec.io/api",
+			"eventReceiverRestURL":"https://report.armo.cloud"
+		}`
+		err := os.WriteFile(filepath.Join(dir, "clusterData.json"), []byte(clusterData), 0o600)
+		require.NoError(t, err)
+
+		originalDefaultClient := http.DefaultClient
+		http.DefaultClient = &http.Client{}
+		t.Cleanup(func() {
+			http.DefaultClient = originalDefaultClient
+		})
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		defaultClient := http.DefaultClient
+		services, err := LoadBackendServicesConfig(dir, server.URL)
+		require.NoError(t, err)
+		assert.Same(t, defaultClient, http.DefaultClient)
+		assert.Zero(t, http.DefaultClient.Timeout)
+		assert.Equal(t, "https://api.armosec.io", services.GetApiServerUrl())
+	})
+
 	t.Run("returns joined error when discovery and fallback fail", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
@@ -84,6 +116,24 @@ func TestLoadBackendServicesConfig_FallbackToClusterData(t *testing.T) {
 		assert.Contains(t, err.Error(), "404")
 		assert.Contains(t, err.Error(), "clusterData.json")
 	})
+}
+
+func TestLoadBackendServicesFromAPI_UsesProvidedTimeoutBoundClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"version":"v3","response":{"api-server":"https://api.armosec.io","event-receiver-http":"https://report.armo.cloud"}}`))
+	}))
+	defer server.Close()
+
+	client, err := v3.NewServiceDiscoveryClientV3(server.URL)
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, err = loadBackendServicesFromAPI(client, &http.Client{Timeout: 20 * time.Millisecond})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
 }
 
 func TestNormalizeServiceURL(t *testing.T) {


### PR DESCRIPTION
## Overview
Startup backend service discovery now uses a private timeout-bound HTTP client instead of replacing `http.DefaultClient`, so the discovery timeout stays scoped to config loading.

## Summary
- Stop mutating `http.DefaultClient` in `LoadBackendServicesConfig`
- Route API discovery through a local wrapper that reuses the existing v3 parser but performs the request with a dedicated `http.Client{Timeout: 30 * time.Second}`
- Add regression coverage for both timeout enforcement and the absence of global default-client mutation
- Fix stale test call sites so the current base branch compiles cleanly in PR CI

## Linked Issue
Fixes #560

## What Changed
- Added `timeoutBoundServiceDiscoveryGetter` in `config/config.go`
- Switched `LoadBackendServicesConfig` to call `loadBackendServicesFromAPI(...)` with a private timeout-bound client
- Added tests covering fallback without `http.DefaultClient` mutation and a short-timeout discovery failure path
- Updated three `adapters/v1/securityexception_test.go` call sites to ignore the stats return from `ConvertToVulnerabilityExceptionPolicies`
- Rebasing onto current `main` removed already-merged unrelated changes from the PR diff

## Verification
- `go test ./adapters/v1 -run 'TestConvertAffectedStatusRequiresAcceptedResponse|TestConvertResolvingStatusesUnchangedByAffected|TestConvertAffectedRecordsProvenance' -count=1` — passed
- `go test ./... -run '^$' -count=1` — passed
- `go test ./config/...` — passed earlier before the CI follow-up fix
- `make build` — passed earlier before the CI follow-up fix

## Scope
- `config/config.go`
- `config/config_test.go`
- `adapters/v1/securityexception_test.go` for the CI-only signature fix
