### PR TITLE
feat(registryauth): resolve ECR credentials from the ambient AWS identity

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -26,11 +26,11 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/internal/metrics"
+	"github.com/kubescape/kubevuln/internal/registryauth"
 	"github.com/kubescape/kubevuln/internal/tools"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/oauth2/google"
 )
 
 // formatResolvedPlatform builds an OCI-style "os/arch[/variant]" string from the platform
@@ -45,23 +45,6 @@ func formatResolvedPlatform(os, arch, variant string) string {
 		parts = append(parts, variant)
 	}
 	return strings.Join(parts, "/")
-}
-
-func isGCPRegistry(imageID string) bool {
-	host, _, _ := strings.Cut(imageID, "/")
-	return host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") || strings.HasSuffix(host, "-docker.pkg.dev")
-}
-
-func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
-	if err != nil {
-		return nil, err
-	}
-	token, err := creds.TokenSource.Token()
-	if err != nil {
-		return nil, err
-	}
-	return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: token.AccessToken}, nil
 }
 
 // SyftAdapter implements SBOMCreator from ports using Syft's API
@@ -222,24 +205,24 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
 		usedFallback = true
 		unauthorizedErr := err
-		if isGCPRegistry(pullRef) {
-			if gcpCreds, gcpErr := gcpCredentials(ctx); gcpErr != nil {
-				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, metrics.FallbackOutcomeFailed)
-				logger.L().Debug("GCP ADC unavailable, falling back to anonymous",
-					helpers.Error(gcpErr),
+		if provider, ok := registryauth.For(pullRef); ok {
+			if creds, credErr := provider.Credentials(ctx, pullRef); credErr != nil || creds == nil {
+				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), metrics.FallbackOutcomeFailed)
+				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
+					helpers.Error(credErr),
 					helpers.String("imageID", imageID))
 			} else {
-				registryOptions.Credentials = []image.RegistryCredentials{*gcpCreds}
+				registryOptions.Credentials = []image.RegistryCredentials{*creds}
 				src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
 				outcome := metrics.FallbackOutcomeFailed
 				if err == nil {
 					outcome = metrics.FallbackOutcomeSucceeded
 				}
-				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, outcome)
+				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), outcome)
 			}
 		}
-		// If GCP ADC was not attempted, succeeded in auth but still got 401, or the image is not a GCP registry,
-		// fall back to anonymous access. err/src retain the result of the last attempt.
+		// If no provider matched, its credentials were unavailable, or it succeeded in auth
+		// but still got 401, fall back to anonymous access. err/src retain the last attempt.
 		if err != nil {
 			logger.L().Debug("retrying without credentials",
 				helpers.String("imageID", imageID))

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -185,27 +185,6 @@ func Test_syftAdapter_CreateSBOM(t *testing.T) {
 	}
 }
 
-func TestIsGCPRegistry(t *testing.T) {
-	tests := []struct {
-		imageID string
-		want    bool
-	}{
-		{"gcr.io/foo/bar", true},
-		{"us.gcr.io/foo/bar", true},
-		{"us-docker.pkg.dev/foo/bar", true},
-		{"europe-west1-docker.pkg.dev/project/repo/image:tag", true},
-		{"quay.io/foo/bar", false},
-		{"quay.io/foo/bar-docker.pkg.dev/x", false},
-		{"index.docker.io/library/alpine", false},
-		{"", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.imageID, func(t *testing.T) {
-			assert.Equal(t, tt.want, isGCPRegistry(tt.imageID))
-		})
-	}
-}
-
 func TestFormatResolvedPlatform(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/armosec/armoapi-go v0.0.718
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.35
+	github.com/aws/aws-sdk-go-v2/config v1.32.12
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/deckarep/golang-set/v2 v2.7.0
 	github.com/distribution/distribution v2.8.2+incompatible
@@ -117,14 +119,12 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.12 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eks v1.48.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -30,6 +30,7 @@ const (
 	FallbackCategorySizeClassification = "size_classification"
 
 	FallbackStrategyAnonymous        = "anonymous"
+	FallbackStrategyECR              = "ecr"
 	FallbackStrategyGCPADC           = "gcp_adc"
 	FallbackStrategyImageTooLarge    = "image_too_large"
 	FallbackStrategyIncomplete       = "incomplete"

--- a/internal/registryauth/registryauth.go
+++ b/internal/registryauth/registryauth.go
@@ -1,0 +1,167 @@
+// Package registryauth resolves ambient cloud credentials for container registries that
+// reject anonymous pulls.
+//
+// Both SBOM paths, the in-process Syft adapter and the sidecar scanner, retry a 401 with
+// credentials before giving up and trying anonymous access. They used to carry their own
+// copy of that logic, which is how the in-process path ended up supporting only GCP after
+// the sidecar had been made extensible. The providers live here so a registry added for one
+// path is available to the other.
+package registryauth
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/kubescape/kubevuln/internal/metrics"
+	"golang.org/x/oauth2/google"
+)
+
+var (
+	errNoAuthorizationData         = errors.New("ecr returned no authorization data")
+	errMalformedAuthorizationToken = errors.New("ecr authorization token is not in user:password form")
+)
+
+// Provider supplies registry credentials for hosts it recognizes, so the retry logic can
+// consult cloud-specific auth without hard-coding each one.
+type Provider interface {
+	// Matches reports whether this provider handles the given pull reference.
+	Matches(imageID string) bool
+	// Credentials fetches credentials for a pull reference this provider matches. The
+	// reference is passed in because some registries encode the account or region needed
+	// to request a token in the hostname itself.
+	Credentials(ctx context.Context, imageID string) (*image.RegistryCredentials, error)
+	// Strategy names this provider in fallback metrics, so a fallback is attributed to the
+	// cloud it actually came from.
+	Strategy() string
+}
+
+// Providers is the ordered list of fallbacks consulted on a 401 Unauthorized, before
+// falling back to anonymous access.
+var Providers = []Provider{GCP{}, ECR{}}
+
+// For returns the first provider matching imageID, if any.
+func For(imageID string) (Provider, bool) {
+	for _, p := range Providers {
+		if p.Matches(imageID) {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+func host(imageID string) string {
+	h, _, _ := strings.Cut(imageID, "/")
+	return h
+}
+
+// GCP resolves credentials for GCR and Artifact Registry hosts via Application Default
+// Credentials, so a workload running with Workload Identity needs no pull secret.
+type GCP struct{}
+
+func (GCP) Matches(imageID string) bool { return IsGCPRegistry(imageID) }
+
+func (GCP) Strategy() string { return metrics.FallbackStrategyGCPADC }
+
+func (GCP) Credentials(ctx context.Context, _ string) (*image.RegistryCredentials, error) {
+	return GCPCredsFn(ctx)
+}
+
+// IsGCPRegistry reports whether imageID is hosted on GCR or Artifact Registry.
+func IsGCPRegistry(imageID string) bool {
+	h := host(imageID)
+	return h == "gcr.io" || strings.HasSuffix(h, ".gcr.io") || strings.HasSuffix(h, "-docker.pkg.dev")
+}
+
+func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, err
+	}
+	token, err := creds.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+	return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: token.AccessToken}, nil
+}
+
+// GCPCredsFn is an indirection over gcpCredentials so callers can be unit-tested without a
+// live GCP environment.
+var GCPCredsFn = gcpCredentials
+
+// ecrHost matches an ECR registry hostname and captures its region. Covers the standard,
+// FIPS and China partitions:
+//
+//	123456789012.dkr.ecr.us-east-1.amazonaws.com
+//	123456789012.dkr.ecr-fips.us-east-1.amazonaws.com
+//	123456789012.dkr.ecr.cn-north-1.amazonaws.com.cn
+//
+// ECR Public (public.ecr.aws) is deliberately excluded: it serves anonymous pulls, so the
+// existing anonymous fallback already handles it and requesting a token would be pointless.
+var ecrHost = regexp.MustCompile(`^[0-9]{12}\.dkr\.ecr(?:-fips)?\.([a-z0-9-]+)\.amazonaws\.com(?:\.cn)?$`)
+
+// ECR resolves credentials for Elastic Container Registry hosts via the ambient AWS
+// credential chain, which on EKS means the pod's IAM role.
+//
+// This is the registry where a static pull secret hurts most: an ECR authorization token is
+// valid for 12 hours, so a Secret holding one has to be rotated twice a day to keep working.
+// Requesting a token per scan removes that entirely.
+type ECR struct{}
+
+func (ECR) Matches(imageID string) bool { return ecrRegion(imageID) != "" }
+
+func (ECR) Strategy() string { return metrics.FallbackStrategyECR }
+
+func (ECR) Credentials(ctx context.Context, imageID string) (*image.RegistryCredentials, error) {
+	return ECRCredsFn(ctx, ecrRegion(imageID))
+}
+
+// ecrRegion returns the AWS region encoded in an ECR hostname, or "" if imageID is not an
+// ECR reference. The region cannot be assumed from ambient config: a cluster in one region
+// may well pull from a registry in another.
+func ecrRegion(imageID string) string {
+	m := ecrHost.FindStringSubmatch(host(imageID))
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+func ecrCredentials(ctx context.Context, region string) (*image.RegistryCredentials, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, err
+	}
+	out, err := ecr.NewFromConfig(cfg).GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return nil, err
+	}
+	return credentialsFromAuthorizationToken(out)
+}
+
+// credentialsFromAuthorizationToken decodes ECR's authorization token, which is base64 of
+// "AWS:<password>". Split on the first colon only: the password is opaque and may contain
+// colons of its own.
+func credentialsFromAuthorizationToken(out *ecr.GetAuthorizationTokenOutput) (*image.RegistryCredentials, error) {
+	if out == nil || len(out.AuthorizationData) == 0 || out.AuthorizationData[0].AuthorizationToken == nil {
+		return nil, errNoAuthorizationData
+	}
+	raw, err := base64.StdEncoding.DecodeString(*out.AuthorizationData[0].AuthorizationToken)
+	if err != nil {
+		return nil, err
+	}
+	username, password, found := strings.Cut(string(raw), ":")
+	if !found {
+		return nil, errMalformedAuthorizationToken
+	}
+	return &image.RegistryCredentials{Username: username, Password: password}, nil
+}
+
+// ECRCredsFn is an indirection over ecrCredentials so callers can be unit-tested without a
+// live AWS environment.
+var ECRCredsFn = ecrCredentials

--- a/internal/registryauth/registryauth_test.go
+++ b/internal/registryauth/registryauth_test.go
@@ -1,0 +1,176 @@
+package registryauth
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/kubescape/kubevuln/internal/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsGCPRegistry(t *testing.T) {
+	tests := []struct {
+		imageID string
+		want    bool
+	}{
+		{"gcr.io/foo/bar", true},
+		{"us.gcr.io/foo/bar", true},
+		{"us-docker.pkg.dev/foo/bar", true},
+		{"europe-west1-docker.pkg.dev/project/repo/image:tag", true},
+		{"quay.io/foo/bar", false},
+		{"quay.io/foo/bar-docker.pkg.dev/x", false},
+		{"index.docker.io/library/alpine", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.imageID, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsGCPRegistry(tt.imageID))
+		})
+	}
+}
+
+func TestECRMatchesAndRegion(t *testing.T) {
+	tests := []struct {
+		name       string
+		imageID    string
+		wantRegion string
+	}{
+		{name: "standard", imageID: "123456789012.dkr.ecr.us-east-1.amazonaws.com/team/app:v1", wantRegion: "us-east-1"},
+		{name: "with digest", imageID: "123456789012.dkr.ecr.eu-west-2.amazonaws.com/app@sha256:abc", wantRegion: "eu-west-2"},
+		{name: "fips", imageID: "123456789012.dkr.ecr-fips.us-gov-west-1.amazonaws.com/app:v1", wantRegion: "us-gov-west-1"},
+		{name: "china partition", imageID: "123456789012.dkr.ecr.cn-north-1.amazonaws.com.cn/app:v1", wantRegion: "cn-north-1"},
+		// ECR Public serves anonymous pulls, so the anonymous fallback already covers it.
+		{name: "ecr public is not matched", imageID: "public.ecr.aws/nginx/nginx:latest", wantRegion: ""},
+		{name: "short account id", imageID: "12345.dkr.ecr.us-east-1.amazonaws.com/app:v1", wantRegion: ""},
+		{name: "lookalike host", imageID: "evil.com/123456789012.dkr.ecr.us-east-1.amazonaws.com/app", wantRegion: ""},
+		{name: "suffix lookalike", imageID: "notamazonaws.com/app", wantRegion: ""},
+		{name: "gcp is not ecr", imageID: "gcr.io/foo/bar", wantRegion: ""},
+		{name: "empty", imageID: "", wantRegion: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantRegion, ecrRegion(tt.imageID))
+			assert.Equal(t, tt.wantRegion != "", ECR{}.Matches(tt.imageID))
+		})
+	}
+}
+
+// The region has to come from the image reference: a cluster in one region can pull from a
+// registry in another, so ambient AWS config is not a safe source for it.
+func TestECRCredentialsUsesRegionFromReference(t *testing.T) {
+	orig := ECRCredsFn
+	defer func() { ECRCredsFn = orig }()
+
+	var gotRegion string
+	ECRCredsFn = func(_ context.Context, region string) (*image.RegistryCredentials, error) {
+		gotRegion = region
+		return &image.RegistryCredentials{Username: "AWS", Password: "secret"}, nil
+	}
+
+	creds, err := ECR{}.Credentials(context.Background(), "123456789012.dkr.ecr.ap-south-1.amazonaws.com/app:v1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "ap-south-1", gotRegion)
+	assert.Equal(t, "AWS", creds.Username)
+	assert.Equal(t, "secret", creds.Password)
+}
+
+func TestCredentialsFromAuthorizationToken(t *testing.T) {
+	tokenFor := func(s string) *ecr.GetAuthorizationTokenOutput {
+		encoded := base64.StdEncoding.EncodeToString([]byte(s))
+		return &ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{AuthorizationToken: &encoded}},
+		}
+	}
+
+	t.Run("decodes user and password", func(t *testing.T) {
+		creds, err := credentialsFromAuthorizationToken(tokenFor("AWS:pa55word"))
+		require.NoError(t, err)
+		assert.Equal(t, "AWS", creds.Username)
+		assert.Equal(t, "pa55word", creds.Password)
+	})
+
+	// ECR passwords are opaque blobs that routinely contain colons, so only the first one
+	// separates the user from the password.
+	t.Run("password may contain colons", func(t *testing.T) {
+		creds, err := credentialsFromAuthorizationToken(tokenFor("AWS:aa:bb:cc"))
+		require.NoError(t, err)
+		assert.Equal(t, "AWS", creds.Username)
+		assert.Equal(t, "aa:bb:cc", creds.Password)
+	})
+
+	t.Run("nil output", func(t *testing.T) {
+		_, err := credentialsFromAuthorizationToken(nil)
+		assert.ErrorIs(t, err, errNoAuthorizationData)
+	})
+
+	t.Run("no authorization data", func(t *testing.T) {
+		_, err := credentialsFromAuthorizationToken(&ecr.GetAuthorizationTokenOutput{})
+		assert.ErrorIs(t, err, errNoAuthorizationData)
+	})
+
+	t.Run("token without a colon", func(t *testing.T) {
+		_, err := credentialsFromAuthorizationToken(tokenFor("no-separator"))
+		assert.ErrorIs(t, err, errMalformedAuthorizationToken)
+	})
+
+	t.Run("token is not base64", func(t *testing.T) {
+		bad := "!!!not-base64!!!"
+		_, err := credentialsFromAuthorizationToken(&ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{AuthorizationToken: &bad}},
+		})
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errNoAuthorizationData)
+	})
+}
+
+func TestFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		imageID      string
+		wantFound    bool
+		wantStrategy string
+	}{
+		{name: "gcp", imageID: "gcr.io/foo/bar", wantFound: true, wantStrategy: metrics.FallbackStrategyGCPADC},
+		{name: "ecr", imageID: "123456789012.dkr.ecr.us-east-1.amazonaws.com/app:v1", wantFound: true, wantStrategy: metrics.FallbackStrategyECR},
+		{name: "neither", imageID: "index.docker.io/library/alpine", wantFound: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, ok := For(tt.imageID)
+			require.Equal(t, tt.wantFound, ok)
+			if tt.wantFound {
+				assert.Equal(t, tt.wantStrategy, provider.Strategy())
+			}
+		})
+	}
+}
+
+// Each provider must report a distinct strategy, otherwise a fallback gets attributed to the
+// wrong cloud in the metrics.
+func TestProviderStrategiesAreDistinct(t *testing.T) {
+	seen := map[string]bool{}
+	for _, p := range Providers {
+		s := p.Strategy()
+		assert.NotEmpty(t, s)
+		assert.False(t, seen[s], "duplicate strategy %q", s)
+		seen[s] = true
+	}
+}
+
+func TestGCPCredentialsFailurePropagates(t *testing.T) {
+	orig := GCPCredsFn
+	defer func() { GCPCredsFn = orig }()
+
+	want := errors.New("ADC unavailable")
+	GCPCredsFn = func(context.Context) (*image.RegistryCredentials, error) { return nil, want }
+
+	_, err := GCP{}.Credentials(context.Background(), "gcr.io/foo/bar")
+	assert.ErrorIs(t, err, want)
+}

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -26,15 +26,10 @@ import (
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/metrics"
+	"github.com/kubescape/kubevuln/internal/registryauth"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
-	"golang.org/x/oauth2/google"
 )
-
-func isGCPRegistry(imageID string) bool {
-	host, _, _ := strings.Cut(imageID, "/")
-	return host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") || strings.HasSuffix(host, "-docker.pkg.dev")
-}
 
 // isRegistryRateLimited reports whether err is (or wraps) a registry 429 response.
 //
@@ -81,46 +76,6 @@ func formatResolvedPlatform(os, arch, variant string) string {
 	}
 	return strings.Join(parts, "/")
 }
-func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
-	if err != nil {
-		return nil, err
-	}
-	token, err := creds.TokenSource.Token()
-	if err != nil {
-		return nil, err
-	}
-	return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: token.AccessToken}, nil
-}
-
-// gcpCredsFn is an indirection over gcpCredentials so resolveSource can be
-// unit-tested without a live GCP environment.
-var gcpCredsFn = gcpCredentials
-
-// registryAuthProvider supplies registry credentials for hosts it recognizes, so
-// resolveSource can consult cloud-specific auth fallbacks without hard-coding each
-// one into its retry logic.
-type registryAuthProvider interface {
-	// Matches reports whether this provider handles the given pull reference.
-	Matches(imageID string) bool
-	// Credentials fetches credentials for a host this provider matches.
-	Credentials(ctx context.Context) (*image.RegistryCredentials, error)
-}
-
-// gcpAuthProvider resolves credentials for GCR/Artifact Registry hosts via
-// Application Default Credentials.
-type gcpAuthProvider struct{}
-
-func (gcpAuthProvider) Matches(imageID string) bool { return isGCPRegistry(imageID) }
-
-func (gcpAuthProvider) Credentials(ctx context.Context) (*image.RegistryCredentials, error) {
-	return gcpCredsFn(ctx)
-}
-
-// registryAuthProviders is the ordered list of cloud registry auth fallbacks resolveSource
-// consults on a 401 Unauthorized, before falling back to anonymous access. Add ECR/ACR
-// providers here as they're implemented.
-var registryAuthProviders = []registryAuthProvider{gcpAuthProvider{}}
 
 // sourceGetter abstracts the syft.GetSource call so the fallback ordering in
 // resolveSource is testable with a scripted implementation.
@@ -144,12 +99,12 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
 		usedFallback = true
 		unauthorizedErr := err
-		for _, provider := range registryAuthProviders {
+		for _, provider := range registryauth.Providers {
 			if !provider.Matches(pullRef) {
 				continue
 			}
-			if creds, credErr := provider.Credentials(ctx); credErr != nil || creds == nil {
-				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, metrics.FallbackOutcomeFailed)
+			if creds, credErr := provider.Credentials(ctx, pullRef); credErr != nil || creds == nil {
+				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), metrics.FallbackOutcomeFailed)
 				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
 					helpers.Error(credErr),
 					helpers.String("imageID", imageID))
@@ -160,7 +115,7 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 				if err == nil {
 					outcome = metrics.FallbackOutcomeSucceeded
 				}
-				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyGCPADC, outcome)
+				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), outcome)
 			}
 			break
 		}
@@ -272,7 +227,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// Download image from registry
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))
 	src, err := resolveSource(ctx, func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
-		// Pulls intentionally run on a detached context (see #421); the request ctx is used only for gcpCredentials inside resolveSource.
+		// Pulls intentionally run on a detached context (see #421); the request ctx is used only for the registry auth provider inside resolveSource.
 		ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, req.MaxImageSize)
 		return syft.GetSource(ctxWithSize, ref,
 			syft.DefaultGetSourceConfig().WithRegistryOptions(opts).WithPlatform(imgPlatform).WithSources("registry"))

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -24,6 +24,7 @@ import (
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/metrics"
+	"github.com/kubescape/kubevuln/internal/registryauth"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,27 +115,6 @@ func TestCreateSBOM_ContextCancelled(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestIsGCPRegistry(t *testing.T) {
-	tests := []struct {
-		imageID string
-		want    bool
-	}{
-		{"gcr.io/foo/bar", true},
-		{"us.gcr.io/foo/bar", true},
-		{"us-docker.pkg.dev/foo/bar", true},
-		{"europe-west1-docker.pkg.dev/project/repo/image:tag", true},
-		{"quay.io/foo/bar", false},
-		{"quay.io/foo/bar-docker.pkg.dev/x", false},
-		{"index.docker.io/library/alpine", false},
-		{"", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.imageID, func(t *testing.T) {
-			assert.Equal(t, tt.want, isGCPRegistry(tt.imageID))
-		})
-	}
-}
-
 func TestResolveSource(t *testing.T) {
 	err401 := errors.New("401 Unauthorized")
 	err403 := errors.New("403 Forbidden")
@@ -213,9 +193,9 @@ func TestResolveSource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			orig := gcpCredsFn
-			defer func() { gcpCredsFn = orig }()
-			gcpCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
+			orig := registryauth.GCPCredsFn
+			defer func() { registryauth.GCPCredsFn = orig }()
+			registryauth.GCPCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
 				if tt.adcErr != nil {
 					return nil, tt.adcErr
 				}
@@ -261,9 +241,9 @@ func TestResolveSource_RecordsFallbackMetrics(t *testing.T) {
 	m, err := metrics.New()
 	require.NoError(t, err)
 
-	orig := gcpCredsFn
-	defer func() { gcpCredsFn = orig }()
-	gcpCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
+	orig := registryauth.GCPCredsFn
+	defer func() { registryauth.GCPCredsFn = orig }()
+	registryauth.GCPCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
 		return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "token"}, nil
 	}
 
@@ -288,8 +268,8 @@ func TestResolveSource_RecordsFallbackMetrics(t *testing.T) {
 	assert.True(t, strings.Contains(body, `kubevuln_scan_source_resolution_total{component="sidecar",outcome="fallback_assisted_success"} 1`), body)
 }
 
-// fakeAuthProvider is a scripted registryAuthProvider used to prove
-// resolveSource consults registryAuthProviders generically, not just GCP.
+// fakeAuthProvider is a scripted registryauth.Provider used to prove
+// resolveSource consults registryauth.Providers generically, not just GCP.
 type fakeAuthProvider struct {
 	matchHost string
 	creds     *image.RegistryCredentials
@@ -301,14 +281,16 @@ func (p fakeAuthProvider) Matches(imageID string) bool {
 	return host == p.matchHost
 }
 
-func (p fakeAuthProvider) Credentials(ctx context.Context) (*image.RegistryCredentials, error) {
+func (p fakeAuthProvider) Credentials(ctx context.Context, _ string) (*image.RegistryCredentials, error) {
 	return p.creds, p.err
 }
 
+func (p fakeAuthProvider) Strategy() string { return "fake" }
+
 func TestResolveSource_CustomProvider(t *testing.T) {
-	orig := registryAuthProviders
-	defer func() { registryAuthProviders = orig }()
-	registryAuthProviders = []registryAuthProvider{
+	orig := registryauth.Providers
+	defer func() { registryauth.Providers = orig }()
+	registryauth.Providers = []registryauth.Provider{
 		fakeAuthProvider{
 			matchHost: "my-registry.example.com",
 			creds:     &image.RegistryCredentials{Username: "custom", Password: "token"},
@@ -334,9 +316,9 @@ func TestResolveSource_CustomProvider(t *testing.T) {
 }
 
 func TestResolveSource_ProviderNilCredentialsFallsBackAnonymous(t *testing.T) {
-	orig := registryAuthProviders
-	defer func() { registryAuthProviders = orig }()
-	registryAuthProviders = []registryAuthProvider{
+	orig := registryauth.Providers
+	defer func() { registryauth.Providers = orig }()
+	registryauth.Providers = []registryauth.Provider{
 		fakeAuthProvider{matchHost: "my-registry.example.com"},
 	}
 
@@ -362,9 +344,9 @@ func TestResolveSource_ProviderNilCredentialsFallsBackAnonymous(t *testing.T) {
 }
 
 func TestResolveSource_ProviderMatchesUsesPullRef(t *testing.T) {
-	orig := registryAuthProviders
-	defer func() { registryAuthProviders = orig }()
-	registryAuthProviders = []registryAuthProvider{
+	orig := registryauth.Providers
+	defer func() { registryauth.Providers = orig }()
+	registryauth.Providers = []registryauth.Provider{
 		fakeAuthProvider{
 			matchHost: "gcr.io",
 			creds:     &image.RegistryCredentials{Username: "custom", Password: "token"},


### PR DESCRIPTION
## Overview

Picking up the ECR half of #254. As you noted on the issue, every registry already works through `registryx`; the painful part is authentication, and ECR is where it hurts most: an authorization token is valid for 12 hours, so a Secret holding one has to be rotated twice a day to keep working.

This adds an ECR auth provider that requests a token per scan from the ambient AWS credential chain, which on EKS is the pod's IAM role, so no Secret is needed at all. It plugs into the extension point #500 built, which left this comment:

> `// Add ECR/ACR providers here as they're implemented.`

Two details worth calling out:

- **The region comes from the registry hostname**, not from ambient AWS config. A cluster in one region can pull from a registry in another, so assuming the ambient region would break exactly the multi-region setups this is meant to help. Standard, FIPS and China partition hostnames are all matched.
- **ECR Public (`public.ecr.aws`) is deliberately not matched.** It serves anonymous pulls, so the existing anonymous fallback already covers it and requesting a token would be pointless.

## Additional Information

**The providers move to `internal/registryauth`.** Only the sidecar was pluggable. The in-process Syft adapter carried its own hardcoded GCP-only fallback, with duplicate copies of `isGCPRegistry` and `gcpCredentials` and a duplicate `TestIsGCPRegistry`. Adding ECR to the sidecar alone would have left it working on one scan path and not the other, which is the same "one flow gets a feature the others don't" shape as #484, #501 and #557. Both paths now consult the same provider list, and the duplicated test collapses into one.

**A metric bug is fixed on the way.** Both fallback loops hardcoded `gcp_adc` as the strategy label, including inside the generic provider loop the sidecar already had. An ECR fallback would have been reported as a GCP one. The label now comes from the provider, and a test asserts the strategies are distinct so a future provider cannot silently reuse one.

**ACR is not included.** The interface makes it roughly a 20 line addition now, but ACR auth is a two step exchange (AAD token, then an ACR refresh token) rather than ECR's single call, so it is worth its own PR rather than doubling this one.

**One testing gap, stated plainly.** The sidecar's fallback loop is covered end to end because `resolveSource` takes an injectable `sourceGetter`. The in-process path calls `syft.GetSource` directly with no seam, so its provider lookup is not covered by a unit test here; the substitution is mechanical and the provider logic itself is fully tested. Adding an injection point to `SyftAdapter.CreateSBOM` would be a worthwhile follow-up but is a bigger refactor than this change warrants.

**Dependencies:** `aws-sdk-go-v2/config` and `aws-sdk-go-v2/service/ecr` were already in the module graph as indirect dependencies. The only `go.mod` change is those two lines moving into the direct block; `go.sum` is untouched and no versions change.

## How to Test

```
go test ./internal/registryauth/ ./pkg/sbomscanner/v1/ ./adapters/v1/
```

`TestECRMatchesAndRegion` covers the hostname matching and region extraction, including the negative cases that matter for a credential path: ECR Public, a short account id, and a lookalike host that merely contains an ECR hostname later in the path. `TestCredentialsFromAuthorizationToken` covers the token decode, including a password containing colons, since only the first colon separates user from password. `TestECRCredentialsUsesRegionFromReference` pins that the region is taken from the image reference.

## Related issues/PRs:

* Resolved #254

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic authentication support for GCP Artifact Registry, GCR, and Amazon ECR image sources.
  * Image retrieval now retries with matching ambient credentials before falling back to anonymous access.
* **Bug Fixes**
  * Improved handling of registry-specific credentials, including regional and specialized ECR endpoints.
  * Added validation for malformed or unavailable registry authorization data.
* **Monitoring**
  * Registry authentication attempts now record the strategy used, improving visibility into image pull behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->