### PR TITLE
fix(config): warn when storage is enabled but riskAcceptance isn't, document both undocumented fields

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -120,6 +120,13 @@ func main() {
 			logger.L().Warning("failed to get k8s config for SecurityException events")
 		}
 	} else {
+		// storage alone means an operator has SecurityException/ClusterSecurityException CRDs
+		// reachable but riskAcceptance unset -- without this log, that combination silently
+		// no-ops (see #562): the NoOpSecurityExceptionRepository below always returns empty
+		// results, indistinguishable at runtime from "no CRDs exist in this cluster".
+		if storage != nil {
+			logger.L().Warning("SecurityException CRD integration disabled: storage is enabled but riskAcceptance is not set; SecurityException/ClusterSecurityException CRDs will not be applied")
+		}
 		seRepo = &repositories.NoOpSecurityExceptionRepository{}
 	}
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -195,6 +195,7 @@ The main configuration file. All options can be overridden via environment varia
 | `storage` | bool | `false` | Enable Kubernetes storage backend (stores SBOMs/CVEs as CRDs) |
 | `namespace` | string | `kubescape` | Kubernetes namespace for storage |
 | `storeFilteredSbom` | bool | `false` | Store relevancy-filtered SBOMs |
+| `riskAcceptance` | bool | `false` | Enable `SecurityException`/`ClusterSecurityException` CRD integration (exception matching, VEX suppression, suppression Events/metrics) — requires `storage: true` as well. See [security-exception-design.md](security-exception-design.md). If `storage` is enabled but this is left unset, matching CRDs are silently ignored: a warning is logged at startup, but no error or metric flags it, so double-check this is set before relying on `SecurityException`/`ClusterSecurityException` CRDs. |
 
 #### Feature Flags
 
@@ -204,6 +205,7 @@ The main configuration file. All options can be overridden via environment varia
 | `nodeSbomGeneration` | bool | `false` | Enable node-level SBOM generation |
 | `partialRelevancy` | bool | `false` | Enable partial relevancy matching |
 | `vexGeneration` | bool | `false` | Generate VEX (Vulnerability Exploitability eXchange) documents |
+| `proxyRegistryMap` | map[string]string | `{}` | Maps a registry hostname to an internal mirror for image pulls, e.g. `{"docker.io": "my-mirror.example.com"}`. Applied to every SBOM-generation path (in-process and sidecar). Config keys are parsed with a `::` delimiter specifically so hostnames containing `.` are treated as a single map key instead of being split into nested keys (see #359/#361) — no special escaping needed in `docker.io`-style keys. |
 
 ### Complete Schema
 
@@ -246,6 +248,15 @@ The main configuration file. All options can be overridden via environment varia
       "default": false
     },
     "partialRelevancy": {
+      "type": "boolean",
+      "default": false
+    },
+    "proxyRegistryMap": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
+    "riskAcceptance": {
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
## Overview

`riskAcceptance` (`config/config.go:60`) is the single switch that gates all of kubevuln's `SecurityException`/`ClusterSecurityException` CRD integration — exception matching, VEX suppression, the `VulnerabilitySuppressed` K8s Event, and the `kubevuln_exceptions_*` Prometheus metrics all depend on it. When it's unset (its Go zero value `false`), `cmd/http/main.go` silently falls back to `repositories.NoOpSecurityExceptionRepository`, which always returns empty results, no error — with zero log output on that path. An operator who has deployed `SecurityException`/`ClusterSecurityException` CRDs per `docs/security-exception-design.md` has no way to discover, short of reading `main.go`, that they're being silently ignored.

Compounding this: `riskAcceptance` was completely absent from `docs/CONFIGURATION.md`, which otherwise documents every other `Config` field. Cross-checking all 22 `mapstructure`-tagged fields in `config/config.go` against the doc's Complete Schema showed exactly two omissions: `riskAcceptance` and `proxyRegistryMap`. `proxyRegistryMap` being undocumented already caused a real production incident (#359, a crash-loop from Viper's key delimiter splitting a `docker.io`-style key — fixed by #361, but never documented).

## Additional Information

- `cmd/http/main.go`: logs a warning (`"SecurityException CRD integration disabled: storage is enabled but riskAcceptance is not set; SecurityException/ClusterSecurityException CRDs will not be applied"`) in the branch that results from `riskAcceptance` being unset, but only when `storage` is enabled — that's the actual misconfiguration case; when `storage` is disabled, no SecurityException integration is expected either way, so no new warning fires there. Mirrors the existing `"SecurityException CRD integration enabled"` info log on the opposite branch.
- `docs/CONFIGURATION.md`: added `riskAcceptance` to the Storage Options table (with a cross-reference to `security-exception-design.md` and a note about the now-fixed silent-no-op behavior) and `proxyRegistryMap` to the Feature Flags table (with a note on the `::` key delimiter fix from #361), plus both fields to the Complete Schema JSON block.

No behavior change for any already-correct configuration — this is additive observability (one log line) and documentation only.

## How to Test

- `go build ./...`
- `go test ./cmd/http/... ./config/...` — pass
- `gofmt -l cmd/http/main.go` — clean
- Manually: set `storage: true` without `riskAcceptance`, start kubevuln, confirm the new warning appears in the logs at startup instead of nothing.

## Related issues/PRs

Resolved #562

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a startup warning when storage is enabled without risk acceptance, clarifying that SecurityException integrations will not be applied.
  - Added configuration options for risk acceptance and proxy registry mappings.

- **Documentation**
  - Documented the new configuration options, including defaults, behavior, and schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->