### PR TITLE
fix(adapters): restore the test build after the exception stats change

### DIFF
--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -1012,7 +1012,7 @@ func TestConvertAffectedSuppression(t *testing.T) {
 				},
 			}
 
-			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+			policies, _ := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 
 			if tt.wantSuppressed {
 				require.Len(t, policies, 1)
@@ -1043,7 +1043,7 @@ func TestConvertResolvingStatusesUnchangedByAffected(t *testing.T) {
 				},
 			}
 
-			policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+			policies, _ := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 
 			require.Len(t, policies, 1, "no actionStatement or response should be needed")
 		})
@@ -1067,7 +1067,7 @@ func TestConvertAffectedRecordsProvenance(t *testing.T) {
 		},
 	}
 
-	policies := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
+	policies, _ := ConvertToVulnerabilityExceptionPolicies(exceptions, nil, ExceptionTarget{})
 
 	require.Len(t, policies, 1)
 	assert.Equal(t, "WAF mitigation in place, ticket SEC-1234", policies[0].Attributes["actionStatement"])


### PR DESCRIPTION
## Overview

`main` currently fails to build its tests:

```
$ go test ./adapters/v1/
adapters/v1/securityexception_test.go:1015:16: assignment mismatch: 1 variable but ConvertToVulnerabilityExceptionPolicies returns 2 values
adapters/v1/securityexception_test.go:1046:16: assignment mismatch: 1 variable but ConvertToVulnerabilityExceptionPolicies returns 2 values
adapters/v1/securityexception_test.go:1070:14: assignment mismatch: 1 variable but ConvertToVulnerabilityExceptionPolicies returns 2 values
FAIL    github.com/kubescape/kubevuln/adapters/v1 [build failed]
```

`ConvertToVulnerabilityExceptionPolicies` gained a second return value in #553, which updated every call site that existed when it was written. #543 merged immediately before it (`5674f1c`, then `6c4e519`) and added three more call sites, so the two together leave the package uncompilable.

Neither PR is at fault and both were green on their own branches. The conflict is semantic rather than textual, so git merged them without complaint and nothing caught it until they were on `main` together.

This discards the stats value in the three affected tests, matching how every other call site in the file already ignores it.

## How to Test

```
go test ./adapters/v1/
```

Fails to build on `main`, passes here. The full suite (`go test ./...`) is green with this change.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
