### PR TITLE
Add GitHub Actions wiring for diff-based lint checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          cache: true
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,37 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.github/workflows/lint.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+
+      - name: Run branch-scoped lint
+        run: PATH="$(go env GOPATH)/bin:$PATH" make lint

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,16 @@ vet:
 	go vet ./...
 
 lint:
-	@base=$$(git merge-base HEAD upstream/main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || true); \
+	@base_ref=$${GITHUB_BASE_REF:-main}; \
+	base=$$(git merge-base HEAD upstream/$$base_ref 2>/dev/null || git merge-base HEAD origin/$$base_ref 2>/dev/null || true); \
 	if [ -n "$$base" ]; then \
-		golangci-lint run --out-format=line-number --issues-exit-code=0 | \
-		go run github.com/golangci/revgrep/cmd/revgrep@latest "$$base"; \
+		golangci-lint run --timeout=5m --new-from-rev="$$base"; \
 	else \
-		golangci-lint run --out-format=line-number --issues-exit-code=0 | \
-		go run github.com/golangci/revgrep/cmd/revgrep@latest; \
+		golangci-lint run --timeout=5m; \
 	fi
 
 lint-all:
-	golangci-lint run
+	golangci-lint run --timeout=5m
 
 verify: build test vet lint
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BINARY_NAME=kubevuln
 IMAGE?=quay.io/kubescape/$(BINARY_NAME)
 TAG=v0.0.0
 
-.PHONY: build test vet lint verify verify-image
+.PHONY: build test vet lint lint-all verify verify-image
 
 build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME) cmd/http/main.go
@@ -18,10 +18,15 @@ vet:
 lint:
 	@base=$$(git merge-base HEAD upstream/main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || true); \
 	if [ -n "$$base" ]; then \
-		golangci-lint run --new-from-rev "$$base"; \
+		golangci-lint run --out-format=line-number --issues-exit-code=0 | \
+		go run github.com/golangci/revgrep/cmd/revgrep@latest "$$base"; \
 	else \
-		golangci-lint run; \
+		golangci-lint run --out-format=line-number --issues-exit-code=0 | \
+		go run github.com/golangci/revgrep/cmd/revgrep@latest; \
 	fi
+
+lint-all:
+	golangci-lint run
 
 verify: build test vet lint
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -442,8 +442,9 @@ kubevuln/
 Use `make verify` as the default contributor check before opening a pull request. It keeps the fast path local and deterministic:
 
 ```bash
-# Build the Linux amd64 binary, run the default Go tests, run go vet, and lint
-# against changes since the branch point on upstream/main or origin/main
+# Build the Linux amd64 binary, run the default Go tests, run go vet, and fail
+# only on lint findings introduced by changes since the branch point on
+# upstream/main or origin/main
 make verify
 ```
 
@@ -453,7 +454,8 @@ make verify
 make build   # CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubevuln cmd/http/main.go
 make test    # go test ./...
 make vet     # go vet ./...
-make lint    # golangci-lint run --new-from-rev "$(git merge-base HEAD upstream/main || git merge-base HEAD origin/main)"
+make lint    # full-tree golangci-lint filtered to findings introduced in this branch
+make lint-all # optional full-tree backlog view
 ```
 
 Keep slower or network-backed checks separate from the fast path:
@@ -475,8 +477,11 @@ go test -tags=integration ./...
 # Format code
 go fmt ./...
 
-# Run linter
-golangci-lint run
+# Run the branch-scoped linter used by the contributor workflow
+make lint
+
+# Optional: inspect the current full-tree lint backlog
+make lint-all
 
 # Fix common issues
 golangci-lint run --fix


### PR DESCRIPTION
## Overview
This PR wires the branch-scoped lint workflow into GitHub Actions for pull requests.

It adds a dedicated PR lint workflow that checks out the repository with full history, installs `golangci-lint`, and runs `make lint` so CI uses the same diff-based lint behavior documented for local contributor verification.

## How to Test
- Open or update a pull request that changes Go sources, `go.mod`, `go.sum`, `Makefile`, or `.github/workflows/lint.yaml`.
- Confirm the new `PR Lint` GitHub Actions workflow runs.
- Confirm the workflow executes `make lint` successfully for changes that do not introduce new lint issues.
- Optionally review `.github/workflows/lint.yaml` and verify the checkout depth and Go setup match the intended local workflow assumptions.

## Related issues/PRs:
* Related #566
* Depends on #567

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes