### PR TITLE
feat: populate IgnoreRule provenance fields, not just log them 

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -320,7 +320,7 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 			doc.IgnoredMatches = append(doc.IgnoredMatches, v1beta1.IgnoredMatch{
 				Match: m,
 				AppliedIgnoreRules: []v1beta1.IgnoreRule{
-					{Vulnerability: m.Vulnerability.ID},
+					buildIgnoreRule(m, matched),
 				},
 			})
 			logSuppression(m, matched, recorder)
@@ -339,6 +339,39 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 	}
 	doc.Matches = remaining
 	return matchedBySource
+}
+
+// buildIgnoreRule constructs the IgnoreRule recorded on the manifest for m, populating
+// provenance fields from the first suppressing policy's Attributes (the same values
+// buildSuppressionAttributes calculates and logSuppression already logs), so this
+// information is durably stored on the manifest itself, not only logged. SourceName here
+// carries suppressionRuleID's structured kind/namespace/name form rather than the bare
+// object name, so it stays unambiguous for both namespaced and cluster-scoped exceptions.
+func buildIgnoreRule(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionPolicy) v1beta1.IgnoreRule {
+	rule := v1beta1.IgnoreRule{Vulnerability: m.Vulnerability.ID}
+
+	suppressing := suppressingPolicies(matched)
+	if len(suppressing) == 0 {
+		return rule
+	}
+	p := suppressing[0]
+
+	if kind, ok := p.Attributes["sourceKind"].(string); ok {
+		rule.SourceKind = kind
+	}
+	if ruleID, ok := p.Attributes["ruleId"].(string); ok {
+		rule.SourceName = ruleID
+	}
+	if ns, ok := p.Attributes["sourceNamespace"].(string); ok {
+		rule.SourceNamespace = ns
+	}
+	if just, ok := p.Attributes["justification"].(string); ok {
+		rule.Justification = just
+	}
+	if impact, ok := p.Attributes["impactStatement"].(string); ok {
+		rule.ImpactStatement = impact
+	}
+	return rule
 }
 
 // suppressingPolicies filters matched down to the policies that actually cause suppression,

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -280,6 +280,49 @@ func TestApplySecurityExceptions_MovesToIgnored(t *testing.T) {
 	assert.Equal(t, map[string]int{"SecurityException": 1}, matchedBySource)
 }
 
+// TestApplySecurityExceptions_PopulatesIgnoreRuleProvenance confirms the provenance
+// buildSuppressionAttributes calculates (and logSuppression already logs) is also written
+// onto the stored IgnoreRule itself, not only logged - closing the gap #495's own comment
+// flagged, now that storage#357 gives IgnoreRule fields to hold it.
+func TestApplySecurityExceptions_PopulatesIgnoreRuleProvenance(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}},
+		},
+	}
+	exceptions := domain.CVEExceptions{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "allow-log4shell",
+				Attributes: map[string]interface{}{
+					"sourceKind":      "SecurityException",
+					"ruleId":          "SecurityException/production/allow-log4shell",
+					"sourceNamespace": "production",
+					"justification":   "vulnerable_code_not_present",
+					"impactStatement": "Vulnerable component is not loaded into the memory",
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-44228"}},
+		},
+	}
+
+	ApplySecurityExceptions(doc, exceptions, nil)
+
+	require.Len(t, doc.IgnoredMatches, 1)
+	require.Len(t, doc.IgnoredMatches[0].AppliedIgnoreRules, 1)
+	rule := doc.IgnoredMatches[0].AppliedIgnoreRules[0]
+
+	assert.Equal(t, "CVE-2021-44228", rule.Vulnerability)
+	assert.Equal(t, "SecurityException", rule.SourceKind)
+	assert.Equal(t, "SecurityException/production/allow-log4shell", rule.SourceName,
+		"SourceName carries the structured ruleId form, not the bare object name, so it stays unambiguous for cluster-scoped exceptions too")
+	assert.Equal(t, "production", rule.SourceNamespace)
+	assert.Equal(t, "vulnerable_code_not_present", rule.Justification)
+	assert.Equal(t, "Vulnerable component is not loaded into the memory", rule.ImpactStatement)
+}
+
 // TestApplySecurityExceptions_MatchedCountDedupesPerFinding is a regression test: two
 // SecurityException policies suppressing the same finding (by ID and by alias, say) must
 // count as one match for that sourceKind, not two, since exactly one finding was removed.


### PR DESCRIPTION
## What this does, in simple words

When Kubescape hides a bug because of an exception rule, it already knows
**why** — which rule, which reason, which namespace. But until now, it only
ever whispered that information into a log file. This PR makes it also
write that same information directly onto the actual saved record, so
it's not lost the moment the log rotates.

## Before vs after

**Before** — the saved record only ever had this:
```go
IgnoreRule{
    Vulnerability: "CVE-2021-44228",
}
```

**After** — the exact same information that was already being logged is
now also saved on the record itself:
```go
IgnoreRule{
    Vulnerability:   "CVE-2021-44228",
    SourceKind:      "SecurityException",
    SourceName:      "SecurityException/production/allow-log4shell",
    SourceNamespace: "production",
    Justification:   "vulnerable_code_not_present",
    ImpactStatement: "Vulnerable component is not loaded into the memory",
}
```

## Known limitation

Two other pieces of provenance (`actionStatement`, a typed `response`
field, and `normalizedTarget`) don't have a matching field to write onto
yet, so those still only live in the log for now. That's a separate,
future decision.

## Testing

New test proves all 5 fields land correctly on the saved record. All 9
existing tests still pass. Full repo build, `go vet`, and `go test ./...`
pass — one unrelated flaky network test confirmed clean on retry.

## Related issues/PRs:

* Resolved #554

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed security findings now retain the relevant policy details, including the rule identifier, source, namespace, justification, and impact statement.
  * This improves traceability and makes it easier to understand why a vulnerability was suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->