### PR TITLE
fix(registryauth): cache and dedupe GCP/ECR credential fetches across both SBOM paths

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -45,11 +45,15 @@ const (
 	SourceResolutionFallbackAssistedSuccess = "fallback_assisted_success"
 	SourceResolutionFallbackFailed          = "fallback_failed"
 	SourceResolutionFirstPassFailure        = "first_pass_failure"
+
+	RegistryAuthCacheHit  = "hit"
+	RegistryAuthCacheMiss = "miss"
 )
 
 var recorderMu sync.RWMutex
 var fallbackCounter metric.Int64Counter
 var sourceResolutionCounter metric.Int64Counter
+var registryAuthCacheCounter metric.Int64Counter
 
 // Metrics wraps the OTel meter and Prometheus exporter used to expose kubevuln's
 // operational metrics (worker-pool backlog, scan outcomes, rejection counts) on
@@ -168,9 +172,18 @@ func New() (*Metrics, error) {
 		return nil, err
 	}
 
+	registryAuthCacheMetric, err := meter.Int64Counter(
+		"kubevuln_registry_auth_cache_total",
+		metric.WithDescription("Total number of registry auth credential lookups, by provider strategy and cache result (hit/miss)"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	recorderMu.Lock()
 	fallbackCounter = scanFallbackCounter
 	sourceResolutionCounter = sourceResolutionMetric
+	registryAuthCacheCounter = registryAuthCacheMetric
 	recorderMu.Unlock()
 
 	return &Metrics{
@@ -217,6 +230,22 @@ func RecordScanFallback(ctx context.Context, component, category, strategy, outc
 		attribute.String("category", category),
 		attribute.String("strategy", strategy),
 		attribute.String("outcome", outcome),
+	))
+}
+
+// RecordRegistryAuthCache reports a registry-auth credential lookup's cache outcome
+// (RegistryAuthCacheHit/RegistryAuthCacheMiss), labeled by the provider strategy
+// (FallbackStrategyGCPADC/FallbackStrategyECR) that served it.
+func RecordRegistryAuthCache(ctx context.Context, strategy, result string) {
+	recorderMu.RLock()
+	counter := registryAuthCacheCounter
+	recorderMu.RUnlock()
+	if counter == nil {
+		return
+	}
+	counter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("strategy", strategy),
+		attribute.String("result", result),
 	))
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -22,6 +22,7 @@ func TestNewAndHandler(t *testing.T) {
 	m.ExceptionsDegradedCounter.Add(context.Background(), 1, metric.WithAttributes())
 	RecordScanFallback(context.Background(), ComponentInProcess, FallbackCategoryRegistryAuth, FallbackStrategyAnonymous, FallbackOutcomeSucceeded)
 	RecordSourceResolution(context.Background(), ComponentInProcess, true, true)
+	RecordRegistryAuthCache(context.Background(), FallbackStrategyECR, RegistryAuthCacheHit)
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	w := httptest.NewRecorder()
@@ -35,6 +36,7 @@ func TestNewAndHandler(t *testing.T) {
 	assert.True(t, strings.Contains(body, "kubevuln_exceptions_degraded_total"), body)
 	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="registry_auth",component="in_process",outcome="succeeded",strategy="anonymous"} 1`), body)
 	assert.True(t, strings.Contains(body, `kubevuln_scan_source_resolution_total{component="in_process",outcome="fallback_assisted_success"} 1`), body)
+	assert.True(t, strings.Contains(body, `kubevuln_registry_auth_cache_total{result="hit",strategy="ecr"} 1`), body)
 }
 
 func TestMeterRegistersObservableGauge(t *testing.T) {

--- a/internal/registryauth/cache.go
+++ b/internal/registryauth/cache.go
@@ -1,0 +1,103 @@
+package registryauth
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/kubescape/kubevuln/internal/metrics"
+	"golang.org/x/sync/singleflight"
+)
+
+// expiryLeeway is subtracted from a credential's reported expiry, so a token that's about
+// to expire mid-scan is refreshed proactively instead of being handed out and failing the
+// pull moments later.
+const expiryLeeway = 1 * time.Minute
+
+// credentialFetch is a provider's underlying fetch: it returns credentials plus the time
+// they stop being valid. A zero expiry means "no reported expiry" -- the credential is
+// still returned, but not cached, since there's nothing to bound the cache entry's
+// lifetime by.
+type credentialFetch func(ctx context.Context) (*image.RegistryCredentials, time.Time, error)
+
+// credentialCache reuses a fetched credential until its provider-reported expiry, and
+// collapses concurrent callers racing a cache miss for the same key into a single upstream
+// fetch. Without this, every scan of a private image independently re-fetches credentials
+// -- an ECR authorization token is valid for 12 hours, yet was being re-requested on every
+// single scan -- and a burst of concurrently running scans against the same registry (the
+// HTTP controller's worker pool runs many scans in parallel) each fired their own upstream
+// request, risking cloud provider rate limiting. See #569.
+type credentialCache struct {
+	mu       sync.Mutex
+	entries  map[string]cacheEntry
+	group    singleflight.Group
+	strategy string
+	// now is overridable in tests so expiry can be exercised without a real time.Sleep.
+	now func() time.Time
+}
+
+type cacheEntry struct {
+	creds  *image.RegistryCredentials
+	expiry time.Time
+}
+
+func newCredentialCache(strategy string) *credentialCache {
+	return &credentialCache{entries: map[string]cacheEntry{}, strategy: strategy, now: time.Now}
+}
+
+// get returns a cached, still-valid credential for key if one exists, otherwise calls
+// fetch -- deduplicated across concurrent callers racing the same key via singleflight --
+// and caches the result when fetch reports a non-zero expiry. Fetch errors are never
+// cached: a transient failure (e.g. a momentary STS/ADC hiccup) must not poison the cache
+// for other callers or the next scan.
+func (c *credentialCache) get(ctx context.Context, key string, fetch credentialFetch) (*image.RegistryCredentials, error) {
+	if creds, ok := c.lookup(key); ok {
+		metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheHit)
+		return creds, nil
+	}
+
+	v, err, _ := c.group.Do(key, func() (interface{}, error) {
+		// Re-check under the singleflight key: a caller that lost the race to become the
+		// leader for this key may have been given a result already cached by the winner
+		// of an earlier, now-resolved Do call for the same key.
+		if creds, ok := c.lookup(key); ok {
+			return creds, nil
+		}
+		creds, expiry, ferr := fetch(ctx)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if !expiry.IsZero() {
+			c.mu.Lock()
+			c.entries[key] = cacheEntry{creds: creds, expiry: expiry.Add(-expiryLeeway)}
+			c.mu.Unlock()
+		}
+		return creds, nil
+	})
+	if err != nil {
+		metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheMiss)
+		return nil, err
+	}
+	metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheMiss)
+	return v.(*image.RegistryCredentials), nil
+}
+
+func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !c.now().Before(entry.expiry) {
+		return nil, false
+	}
+	return entry.creds, true
+}
+
+// reset clears all cached entries. Used by tests that override GCPCredsFn/ECRCredsFn and
+// need the next Credentials() call to actually reach the override instead of a value
+// cached by an earlier test.
+func (c *credentialCache) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = map[string]cacheEntry{}
+}

--- a/internal/registryauth/cache.go
+++ b/internal/registryauth/cache.go
@@ -15,6 +15,13 @@ import (
 // pull moments later.
 const expiryLeeway = 1 * time.Minute
 
+// fetchTimeout bounds a single upstream credential fetch, independent of any one caller's
+// context. The fetch runs once per singleflight key and is shared by every concurrent
+// caller racing that key, so it must not be tied to whichever caller happened to become
+// the leader: that caller's context canceling must not abort the fetch -- and therefore
+// the result -- for every other caller still waiting on it.
+const fetchTimeout = 30 * time.Second
+
 // credentialFetch is a provider's underlying fetch: it returns credentials plus the time
 // they stop being valid. A zero expiry means "no reported expiry" -- the credential is
 // still returned, but not cached, since there's nothing to bound the cache entry's
@@ -51,20 +58,30 @@ func newCredentialCache(strategy string) *credentialCache {
 // and caches the result when fetch reports a non-zero expiry. Fetch errors are never
 // cached: a transient failure (e.g. a momentary STS/ADC hiccup) must not poison the cache
 // for other callers or the next scan.
+//
+// The shared fetch runs under its own fetchTimeout-bounded context, not ctx: singleflight
+// hands the leader's result to every caller waiting on the same key, so running the fetch
+// under one specific caller's ctx would fail every other caller the instant that one
+// caller's context was canceled. Each caller instead races the shared result against its
+// own ctx via DoChan, so a caller can give up on its own terms without affecting the
+// fetch (which keeps running, and still populates the cache for whoever asks next) or any
+// other waiting caller.
 func (c *credentialCache) get(ctx context.Context, key string, fetch credentialFetch) (*image.RegistryCredentials, error) {
 	if creds, ok := c.lookup(key); ok {
 		metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheHit)
 		return creds, nil
 	}
 
-	v, err, _ := c.group.Do(key, func() (interface{}, error) {
+	ch := c.group.DoChan(key, func() (interface{}, error) {
 		// Re-check under the singleflight key: a caller that lost the race to become the
 		// leader for this key may have been given a result already cached by the winner
 		// of an earlier, now-resolved Do call for the same key.
 		if creds, ok := c.lookup(key); ok {
 			return creds, nil
 		}
-		creds, expiry, ferr := fetch(ctx)
+		fetchCtx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+		defer cancel()
+		creds, expiry, ferr := fetch(fetchCtx)
 		if ferr != nil {
 			return nil, ferr
 		}
@@ -75,12 +92,18 @@ func (c *credentialCache) get(ctx context.Context, key string, fetch credentialF
 		}
 		return creds, nil
 	})
-	if err != nil {
+
+	select {
+	case <-ctx.Done():
 		metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheMiss)
-		return nil, err
+		return nil, ctx.Err()
+	case res := <-ch:
+		metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheMiss)
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return res.Val.(*image.RegistryCredentials), nil
 	}
-	metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheMiss)
-	return v.(*image.RegistryCredentials), nil
 }
 
 func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) {

--- a/internal/registryauth/cache.go
+++ b/internal/registryauth/cache.go
@@ -42,6 +42,10 @@ type credentialCache struct {
 	strategy string
 	// now is overridable in tests so expiry can be exercised without a real time.Sleep.
 	now func() time.Time
+	// onMiss, if set, is called synchronously by every caller that reaches a cache miss,
+	// before it joins the singleflight group. Tests use it as a deterministic barrier to
+	// prove real concurrent contention on a miss, instead of a timing-based sleep.
+	onMiss func()
 }
 
 type cacheEntry struct {
@@ -70,6 +74,9 @@ func (c *credentialCache) get(ctx context.Context, key string, fetch credentialF
 	if creds, ok := c.lookup(key); ok {
 		metrics.RecordRegistryAuthCache(ctx, c.strategy, metrics.RegistryAuthCacheHit)
 		return creds, nil
+	}
+	if c.onMiss != nil {
+		c.onMiss()
 	}
 
 	ch := c.group.DoChan(key, func() (interface{}, error) {

--- a/internal/registryauth/cache_test.go
+++ b/internal/registryauth/cache_test.go
@@ -77,11 +77,11 @@ func TestCredentialCache_DistinctKeysDoNotShareEntries(t *testing.T) {
 
 func TestCredentialCache_ConcurrentMissesCollapseToOneFetch(t *testing.T) {
 	c := newCredentialCache("test")
-	var calls int32
+	var calls, started int32
 	release := make(chan struct{})
 	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
 		atomic.AddInt32(&calls, 1)
-		<-release // hold every concurrent caller here until they've all arrived
+		<-release // hold the leader here until every caller has actually joined the race
 		return &image.RegistryCredentials{Password: "p"}, time.Now().Add(time.Hour), nil
 	}
 
@@ -91,10 +91,23 @@ func TestCredentialCache_ConcurrentMissesCollapseToOneFetch(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
+			atomic.AddInt32(&started, 1)
 			_, err := c.get(context.Background(), "k", fetch)
 			assert.NoError(t, err)
 		}()
 	}
+
+	// Don't release the leader's fetch until every goroutine has actually called get():
+	// releasing too early risks the leader finishing and populating the cache before the
+	// rest even started, which would let a non-coalescing implementation (one that calls
+	// fetch on every miss instead of deduping) pass by accident.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&started) == n
+	}, 2*time.Second, time.Millisecond)
+	// "started" only means each goroutine's call to get() has begun, not that it has
+	// reached the blocking point inside singleflight yet -- give the scheduler a moment to
+	// actually land every one of them there before letting the leader's fetch return.
+	time.Sleep(100 * time.Millisecond)
 	close(release)
 	wg.Wait()
 

--- a/internal/registryauth/cache_test.go
+++ b/internal/registryauth/cache_test.go
@@ -1,0 +1,156 @@
+package registryauth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialCache_ReusesUnexpiredEntry(t *testing.T) {
+	c := newCredentialCache("test")
+	var calls int32
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		atomic.AddInt32(&calls, 1)
+		return &image.RegistryCredentials{Password: "p1"}, time.Now().Add(time.Hour), nil
+	}
+
+	first, err := c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	second, err := c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "second call should be served from cache")
+	assert.Same(t, first, second)
+}
+
+func TestCredentialCache_RefetchesAfterExpiry(t *testing.T) {
+	c := newCredentialCache("test")
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	var calls int32
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		n := atomic.AddInt32(&calls, 1)
+		return &image.RegistryCredentials{Password: string(rune('0' + n))}, now.Add(10 * time.Minute), nil
+	}
+
+	_, err := c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	// still within the expiry leeway-adjusted window: served from cache
+	now = now.Add(5 * time.Minute)
+	_, err = c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "still-valid entry should not be refetched")
+
+	// past expiry (minus the 1-minute leeway): must refetch
+	now = now.Add(10 * time.Minute)
+	_, err = c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "expired entry must be refetched")
+}
+
+func TestCredentialCache_DistinctKeysDoNotShareEntries(t *testing.T) {
+	c := newCredentialCache("test")
+	fetch := func(password string) credentialFetch {
+		return func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+			return &image.RegistryCredentials{Password: password}, time.Now().Add(time.Hour), nil
+		}
+	}
+
+	a, err := c.get(context.Background(), "region-a", fetch("a"))
+	require.NoError(t, err)
+	b, err := c.get(context.Background(), "region-b", fetch("b"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "a", a.Password)
+	assert.Equal(t, "b", b.Password)
+}
+
+func TestCredentialCache_ConcurrentMissesCollapseToOneFetch(t *testing.T) {
+	c := newCredentialCache("test")
+	var calls int32
+	release := make(chan struct{})
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		atomic.AddInt32(&calls, 1)
+		<-release // hold every concurrent caller here until they've all arrived
+		return &image.RegistryCredentials{Password: "p"}, time.Now().Add(time.Hour), nil
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := c.get(context.Background(), "k", fetch)
+			assert.NoError(t, err)
+		}()
+	}
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"concurrent callers racing the same cache miss must collapse into a single upstream fetch")
+}
+
+func TestCredentialCache_FetchErrorsAreNotCached(t *testing.T) {
+	c := newCredentialCache("test")
+	boom := errors.New("boom")
+	var calls int32
+	failThenSucceed := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return nil, time.Time{}, boom
+		}
+		return &image.RegistryCredentials{Password: "p"}, time.Now().Add(time.Hour), nil
+	}
+
+	_, err := c.get(context.Background(), "k", failThenSucceed)
+	require.ErrorIs(t, err, boom)
+
+	creds, err := c.get(context.Background(), "k", failThenSucceed)
+	require.NoError(t, err)
+	assert.Equal(t, "p", creds.Password)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "a failed fetch must not poison the cache for the next call")
+}
+
+func TestCredentialCache_ZeroExpiryIsNotCached(t *testing.T) {
+	c := newCredentialCache("test")
+	var calls int32
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		atomic.AddInt32(&calls, 1)
+		return &image.RegistryCredentials{Password: "p"}, time.Time{}, nil
+	}
+
+	_, err := c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	_, err = c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "a credential with no reported expiry must not be cached")
+}
+
+func TestCredentialCache_Reset(t *testing.T) {
+	c := newCredentialCache("test")
+	var calls int32
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		atomic.AddInt32(&calls, 1)
+		return &image.RegistryCredentials{Password: "p"}, time.Now().Add(time.Hour), nil
+	}
+
+	_, err := c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	c.reset()
+	_, err = c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "reset must force the next call to refetch")
+}

--- a/internal/registryauth/cache_test.go
+++ b/internal/registryauth/cache_test.go
@@ -77,38 +77,35 @@ func TestCredentialCache_DistinctKeysDoNotShareEntries(t *testing.T) {
 
 func TestCredentialCache_ConcurrentMissesCollapseToOneFetch(t *testing.T) {
 	c := newCredentialCache("test")
-	var calls, started int32
-	release := make(chan struct{})
+	const n = 20
+
+	var calls, joined int32
+	allJoined := make(chan struct{})
+	// onMiss fires synchronously for every caller that reaches a cache miss, before it
+	// joins the singleflight group. The cache is never populated until fetch returns (see
+	// below), and fetch never returns until every one of the n callers has hit this miss
+	// path, so no caller can ever race ahead and be served a cache hit instead of actually
+	// contending for the same key -- this is a hard guarantee, not a timing-based one.
+	c.onMiss = func() {
+		if atomic.AddInt32(&joined, 1) == n {
+			close(allJoined)
+		}
+	}
 	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
 		atomic.AddInt32(&calls, 1)
-		<-release // hold the leader here until every caller has actually joined the race
+		<-allJoined
 		return &image.RegistryCredentials{Password: "p"}, time.Now().Add(time.Hour), nil
 	}
 
-	const n = 20
 	var wg sync.WaitGroup
 	wg.Add(n)
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			atomic.AddInt32(&started, 1)
 			_, err := c.get(context.Background(), "k", fetch)
 			assert.NoError(t, err)
 		}()
 	}
-
-	// Don't release the leader's fetch until every goroutine has actually called get():
-	// releasing too early risks the leader finishing and populating the cache before the
-	// rest even started, which would let a non-coalescing implementation (one that calls
-	// fetch on every miss instead of deduping) pass by accident.
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&started) == n
-	}, 2*time.Second, time.Millisecond)
-	// "started" only means each goroutine's call to get() has begun, not that it has
-	// reached the blocking point inside singleflight yet -- give the scheduler a moment to
-	// actually land every one of them there before letting the leader's fetch return.
-	time.Sleep(100 * time.Millisecond)
-	close(release)
 	wg.Wait()
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),

--- a/internal/registryauth/registryauth.go
+++ b/internal/registryauth/registryauth.go
@@ -7,11 +7,10 @@
 // the sidecar had been made extensible. The providers live here so a registry added for one
 // path is available to the other.
 //
-// Each provider's Credentials call is cached (see cache.go) and keyed by whatever the
-// credential's scope actually is -- a single key for GCP, since Application Default
-// Credentials aren't registry-specific, and one key per AWS region for ECR, since a token
-// is only valid for the region it was issued in. Entries are reused until the cloud
-// provider's own reported expiry (an ECR token, for example, is valid 12 hours), and
+// Each provider's Credentials call is cached (see cache.go) and keyed by registry host, so
+// two different registries -- or two different AWS accounts that happen to share a region --
+// never share a cache entry. Entries are reused until the cloud provider's own reported
+// expiry (an ECR token, for example, is valid 12 hours), and
 // concurrent scans racing a cache miss for the same key collapse into a single upstream
 // fetch, so a burst of scans against the same registry doesn't turn into a burst of STS/ADC
 // requests.
@@ -78,15 +77,15 @@ func (GCP) Matches(imageID string) bool { return IsGCPRegistry(imageID) }
 
 func (GCP) Strategy() string { return metrics.FallbackStrategyGCPADC }
 
-// gcpCache is a single entry, not one per registry host: Application Default Credentials
-// are scoped to the ambient GCP identity, not to any particular GCR/Artifact Registry host,
-// so every GCP pull shares the same cached token.
+// gcpCache is keyed by registry host, not a single shared entry: although Application
+// Default Credentials resolve from one ambient identity, workload identity federation can
+// map different namespaces/projects to different service accounts, so nothing here
+// guarantees the token is actually the same across every GCR/Artifact Registry host a pod
+// happens to pull from. Keying by host keeps that assumption from ever being load-bearing.
 var gcpCache = newCredentialCache(metrics.FallbackStrategyGCPADC)
 
-const gcpCacheKey = "adc"
-
-func (GCP) Credentials(ctx context.Context, _ string) (*image.RegistryCredentials, error) {
-	return gcpCache.get(ctx, gcpCacheKey, GCPCredsFn)
+func (GCP) Credentials(ctx context.Context, imageID string) (*image.RegistryCredentials, error) {
+	return gcpCache.get(ctx, host(imageID), GCPCredsFn)
 }
 
 // IsGCPRegistry reports whether imageID is hosted on GCR or Artifact Registry.
@@ -134,13 +133,17 @@ func (ECR) Matches(imageID string) bool { return ecrRegion(imageID) != "" }
 
 func (ECR) Strategy() string { return metrics.FallbackStrategyECR }
 
-// ecrCache is keyed by region, mirroring ECRCredsFn's own parameter: a token is only valid
-// for the region it was issued in, so two regions can never share an entry.
+// ecrCache is keyed by registry host, not just region: an ECR hostname embeds both the
+// account ID and the region (123456789012.dkr.ecr.us-east-1.amazonaws.com), and a token
+// requested via the ambient credential chain is scoped to whichever account that chain
+// resolves to for the request. Keying by region alone would let two different AWS accounts
+// pulling from the same region collide on one cache entry -- the second account would be
+// handed the first account's token and get a 401.
 var ecrCache = newCredentialCache(metrics.FallbackStrategyECR)
 
 func (ECR) Credentials(ctx context.Context, imageID string) (*image.RegistryCredentials, error) {
 	region := ecrRegion(imageID)
-	return ecrCache.get(ctx, region, func(ctx context.Context) (*image.RegistryCredentials, time.Time, error) {
+	return ecrCache.get(ctx, host(imageID), func(ctx context.Context) (*image.RegistryCredentials, time.Time, error) {
 		return ECRCredsFn(ctx, region)
 	})
 }

--- a/internal/registryauth/registryauth.go
+++ b/internal/registryauth/registryauth.go
@@ -6,6 +6,15 @@
 // copy of that logic, which is how the in-process path ended up supporting only GCP after
 // the sidecar had been made extensible. The providers live here so a registry added for one
 // path is available to the other.
+//
+// Each provider's Credentials call is cached (see cache.go) and keyed by whatever the
+// credential's scope actually is -- a single key for GCP, since Application Default
+// Credentials aren't registry-specific, and one key per AWS region for ECR, since a token
+// is only valid for the region it was issued in. Entries are reused until the cloud
+// provider's own reported expiry (an ECR token, for example, is valid 12 hours), and
+// concurrent scans racing a cache miss for the same key collapse into a single upstream
+// fetch, so a burst of scans against the same registry doesn't turn into a burst of STS/ADC
+// requests.
 package registryauth
 
 import (
@@ -14,6 +23,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -68,8 +78,15 @@ func (GCP) Matches(imageID string) bool { return IsGCPRegistry(imageID) }
 
 func (GCP) Strategy() string { return metrics.FallbackStrategyGCPADC }
 
+// gcpCache is a single entry, not one per registry host: Application Default Credentials
+// are scoped to the ambient GCP identity, not to any particular GCR/Artifact Registry host,
+// so every GCP pull shares the same cached token.
+var gcpCache = newCredentialCache(metrics.FallbackStrategyGCPADC)
+
+const gcpCacheKey = "adc"
+
 func (GCP) Credentials(ctx context.Context, _ string) (*image.RegistryCredentials, error) {
-	return GCPCredsFn(ctx)
+	return gcpCache.get(ctx, gcpCacheKey, GCPCredsFn)
 }
 
 // IsGCPRegistry reports whether imageID is hosted on GCR or Artifact Registry.
@@ -78,21 +95,21 @@ func IsGCPRegistry(imageID string) bool {
 	return h == "gcr.io" || strings.HasSuffix(h, ".gcr.io") || strings.HasSuffix(h, "-docker.pkg.dev")
 }
 
-func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, error) {
+func gcpCredentials(ctx context.Context) (*image.RegistryCredentials, time.Time, error) {
 	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
 	token, err := creds.TokenSource.Token()
 	if err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
-	return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: token.AccessToken}, nil
+	return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: token.AccessToken}, token.Expiry, nil
 }
 
 // GCPCredsFn is an indirection over gcpCredentials so callers can be unit-tested without a
 // live GCP environment.
-var GCPCredsFn = gcpCredentials
+var GCPCredsFn credentialFetch = gcpCredentials
 
 // ecrHost matches an ECR registry hostname and captures its region. Covers the standard,
 // FIPS and China partitions:
@@ -117,8 +134,15 @@ func (ECR) Matches(imageID string) bool { return ecrRegion(imageID) != "" }
 
 func (ECR) Strategy() string { return metrics.FallbackStrategyECR }
 
+// ecrCache is keyed by region, mirroring ECRCredsFn's own parameter: a token is only valid
+// for the region it was issued in, so two regions can never share an entry.
+var ecrCache = newCredentialCache(metrics.FallbackStrategyECR)
+
 func (ECR) Credentials(ctx context.Context, imageID string) (*image.RegistryCredentials, error) {
-	return ECRCredsFn(ctx, ecrRegion(imageID))
+	region := ecrRegion(imageID)
+	return ecrCache.get(ctx, region, func(ctx context.Context) (*image.RegistryCredentials, time.Time, error) {
+		return ECRCredsFn(ctx, region)
+	})
 }
 
 // ecrRegion returns the AWS region encoded in an ECR hostname, or "" if imageID is not an
@@ -132,36 +156,50 @@ func ecrRegion(imageID string) string {
 	return m[1]
 }
 
-func ecrCredentials(ctx context.Context, region string) (*image.RegistryCredentials, error) {
+func ecrCredentials(ctx context.Context, region string) (*image.RegistryCredentials, time.Time, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
 	out, err := ecr.NewFromConfig(cfg).GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
 	if err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
 	return credentialsFromAuthorizationToken(out)
 }
 
 // credentialsFromAuthorizationToken decodes ECR's authorization token, which is base64 of
 // "AWS:<password>". Split on the first colon only: the password is opaque and may contain
-// colons of its own.
-func credentialsFromAuthorizationToken(out *ecr.GetAuthorizationTokenOutput) (*image.RegistryCredentials, error) {
+// colons of its own. The returned expiry comes straight from ECR (AuthorizationData's own
+// ExpiresAt), not assumed from the package doc's "12 hours" -- that's ECR's stated default,
+// not a contract, so the cache must not hard-code it.
+func credentialsFromAuthorizationToken(out *ecr.GetAuthorizationTokenOutput) (*image.RegistryCredentials, time.Time, error) {
 	if out == nil || len(out.AuthorizationData) == 0 || out.AuthorizationData[0].AuthorizationToken == nil {
-		return nil, errNoAuthorizationData
+		return nil, time.Time{}, errNoAuthorizationData
+	}
+	var expiry time.Time
+	if exp := out.AuthorizationData[0].ExpiresAt; exp != nil {
+		expiry = *exp
 	}
 	raw, err := base64.StdEncoding.DecodeString(*out.AuthorizationData[0].AuthorizationToken)
 	if err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
 	username, password, found := strings.Cut(string(raw), ":")
 	if !found {
-		return nil, errMalformedAuthorizationToken
+		return nil, time.Time{}, errMalformedAuthorizationToken
 	}
-	return &image.RegistryCredentials{Username: username, Password: password}, nil
+	return &image.RegistryCredentials{Username: username, Password: password}, expiry, nil
 }
 
 // ECRCredsFn is an indirection over ecrCredentials so callers can be unit-tested without a
 // live AWS environment.
 var ECRCredsFn = ecrCredentials
+
+// ResetCaches clears both providers' cached credentials. Tests that override
+// GCPCredsFn/ECRCredsFn need this so the next Credentials() call actually reaches the
+// override instead of returning a value an earlier test already cached.
+func ResetCaches() {
+	gcpCache.reset()
+	ecrCache.reset()
+}

--- a/internal/registryauth/registryauth_test.go
+++ b/internal/registryauth/registryauth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -81,6 +82,74 @@ func TestECRCredentialsUsesRegionFromReference(t *testing.T) {
 	assert.Equal(t, "ap-south-1", gotRegion)
 	assert.Equal(t, "AWS", creds.Username)
 	assert.Equal(t, "secret", creds.Password)
+}
+
+// Two AWS accounts pulling through the same region must not share a cache entry: the
+// ambient credential chain resolves a token scoped to one specific account, so handing that
+// token to a pull against a different account fails with a 401.
+func TestECRCredentialsIsolatesCacheAcrossAccountsInSameRegion(t *testing.T) {
+	orig := ECRCredsFn
+	defer func() { ECRCredsFn = orig; ResetCaches() }()
+	ResetCaches()
+
+	calls := map[string]int{}
+	ECRCredsFn = func(_ context.Context, region string) (*image.RegistryCredentials, time.Time, error) {
+		calls[region]++
+		return &image.RegistryCredentials{Username: "AWS", Password: region}, time.Now().Add(time.Hour), nil
+	}
+
+	accountA := "111111111111.dkr.ecr.us-east-1.amazonaws.com/app:v1"
+	accountB := "222222222222.dkr.ecr.us-east-1.amazonaws.com/app:v1"
+
+	credsA, err := ECR{}.Credentials(context.Background(), accountA)
+	require.NoError(t, err)
+	credsB, err := ECR{}.Credentials(context.Background(), accountB)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls["us-east-1"], "same-region pull from a different account must not be served from the first account's cache entry")
+
+	// Fetch each account again: both should now be served from their own cache entry, not
+	// refetched and not cross-served from the other account's entry.
+	credsA2, err := ECR{}.Credentials(context.Background(), accountA)
+	require.NoError(t, err)
+	credsB2, err := ECR{}.Credentials(context.Background(), accountB)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls["us-east-1"], "repeat pulls for already-cached accounts must not refetch")
+	assert.Same(t, credsA, credsA2)
+	assert.Same(t, credsB, credsB2)
+}
+
+// GCP credentials are cached per registry host: nothing in Credentials guarantees the
+// ambient identity resolves to the same token for every GCR/Artifact Registry host a pod
+// might pull from (workload identity federation can map different callers to different
+// service accounts), so one host's cached token must never be handed out for another host.
+func TestGCPCredentialsIsolatesCacheAcrossHosts(t *testing.T) {
+	orig := GCPCredsFn
+	defer func() { GCPCredsFn = orig; ResetCaches() }()
+	ResetCaches()
+
+	var calls int32
+	GCPCredsFn = func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		n := atomic.AddInt32(&calls, 1)
+		return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: string(rune('a' + n))}, time.Now().Add(time.Hour), nil
+	}
+
+	hostA := "gcr.io/foo/bar:v1"
+	hostB := "us-docker.pkg.dev/project/repo/image:v1"
+
+	credsA, err := GCP{}.Credentials(context.Background(), hostA)
+	require.NoError(t, err)
+	credsB, err := GCP{}.Credentials(context.Background(), hostB)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "a different registry host must not be served from another host's cache entry")
+	assert.NotEqual(t, credsA.Password, credsB.Password)
+
+	credsA2, err := GCP{}.Credentials(context.Background(), hostA)
+	require.NoError(t, err)
+	assert.Same(t, credsA, credsA2, "repeat pulls for an already-cached host must not refetch")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
 }
 
 func TestCredentialsFromAuthorizationToken(t *testing.T) {

--- a/internal/registryauth/registryauth_test.go
+++ b/internal/registryauth/registryauth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -65,12 +66,13 @@ func TestECRMatchesAndRegion(t *testing.T) {
 // registry in another, so ambient AWS config is not a safe source for it.
 func TestECRCredentialsUsesRegionFromReference(t *testing.T) {
 	orig := ECRCredsFn
-	defer func() { ECRCredsFn = orig }()
+	defer func() { ECRCredsFn = orig; ResetCaches() }()
+	ResetCaches()
 
 	var gotRegion string
-	ECRCredsFn = func(_ context.Context, region string) (*image.RegistryCredentials, error) {
+	ECRCredsFn = func(_ context.Context, region string) (*image.RegistryCredentials, time.Time, error) {
 		gotRegion = region
-		return &image.RegistryCredentials{Username: "AWS", Password: "secret"}, nil
+		return &image.RegistryCredentials{Username: "AWS", Password: "secret"}, time.Now().Add(time.Hour), nil
 	}
 
 	creds, err := ECR{}.Credentials(context.Background(), "123456789012.dkr.ecr.ap-south-1.amazonaws.com/app:v1")
@@ -90,7 +92,7 @@ func TestCredentialsFromAuthorizationToken(t *testing.T) {
 	}
 
 	t.Run("decodes user and password", func(t *testing.T) {
-		creds, err := credentialsFromAuthorizationToken(tokenFor("AWS:pa55word"))
+		creds, _, err := credentialsFromAuthorizationToken(tokenFor("AWS:pa55word"))
 		require.NoError(t, err)
 		assert.Equal(t, "AWS", creds.Username)
 		assert.Equal(t, "pa55word", creds.Password)
@@ -99,34 +101,52 @@ func TestCredentialsFromAuthorizationToken(t *testing.T) {
 	// ECR passwords are opaque blobs that routinely contain colons, so only the first one
 	// separates the user from the password.
 	t.Run("password may contain colons", func(t *testing.T) {
-		creds, err := credentialsFromAuthorizationToken(tokenFor("AWS:aa:bb:cc"))
+		creds, _, err := credentialsFromAuthorizationToken(tokenFor("AWS:aa:bb:cc"))
 		require.NoError(t, err)
 		assert.Equal(t, "AWS", creds.Username)
 		assert.Equal(t, "aa:bb:cc", creds.Password)
 	})
 
 	t.Run("nil output", func(t *testing.T) {
-		_, err := credentialsFromAuthorizationToken(nil)
+		_, _, err := credentialsFromAuthorizationToken(nil)
 		assert.ErrorIs(t, err, errNoAuthorizationData)
 	})
 
 	t.Run("no authorization data", func(t *testing.T) {
-		_, err := credentialsFromAuthorizationToken(&ecr.GetAuthorizationTokenOutput{})
+		_, _, err := credentialsFromAuthorizationToken(&ecr.GetAuthorizationTokenOutput{})
 		assert.ErrorIs(t, err, errNoAuthorizationData)
 	})
 
 	t.Run("token without a colon", func(t *testing.T) {
-		_, err := credentialsFromAuthorizationToken(tokenFor("no-separator"))
+		_, _, err := credentialsFromAuthorizationToken(tokenFor("no-separator"))
 		assert.ErrorIs(t, err, errMalformedAuthorizationToken)
 	})
 
 	t.Run("token is not base64", func(t *testing.T) {
 		bad := "!!!not-base64!!!"
-		_, err := credentialsFromAuthorizationToken(&ecr.GetAuthorizationTokenOutput{
+		_, _, err := credentialsFromAuthorizationToken(&ecr.GetAuthorizationTokenOutput{
 			AuthorizationData: []ecrtypes.AuthorizationData{{AuthorizationToken: &bad}},
 		})
 		require.Error(t, err)
 		assert.NotErrorIs(t, err, errNoAuthorizationData)
+	})
+
+	// The cache relies on this expiry to know when to refetch (see cache.go), so it must
+	// come from ECR's own response, not be assumed from the package doc's "12 hours".
+	t.Run("reports ECR's own expiry", func(t *testing.T) {
+		encoded := base64.StdEncoding.EncodeToString([]byte("AWS:pa55word"))
+		want := time.Now().Add(6 * time.Hour).Truncate(time.Second)
+		_, expiry, err := credentialsFromAuthorizationToken(&ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{AuthorizationToken: &encoded, ExpiresAt: &want}},
+		})
+		require.NoError(t, err)
+		assert.True(t, want.Equal(expiry))
+	})
+
+	t.Run("no ExpiresAt yields a zero expiry, not an error", func(t *testing.T) {
+		_, expiry, err := credentialsFromAuthorizationToken(tokenFor("AWS:pa55word"))
+		require.NoError(t, err)
+		assert.True(t, expiry.IsZero())
 	})
 }
 
@@ -166,10 +186,11 @@ func TestProviderStrategiesAreDistinct(t *testing.T) {
 
 func TestGCPCredentialsFailurePropagates(t *testing.T) {
 	orig := GCPCredsFn
-	defer func() { GCPCredsFn = orig }()
+	defer func() { GCPCredsFn = orig; ResetCaches() }()
+	ResetCaches()
 
 	want := errors.New("ADC unavailable")
-	GCPCredsFn = func(context.Context) (*image.RegistryCredentials, error) { return nil, want }
+	GCPCredsFn = func(context.Context) (*image.RegistryCredentials, time.Time, error) { return nil, time.Time{}, want }
 
 	_, err := GCP{}.Credentials(context.Background(), "gcr.io/foo/bar")
 	assert.ErrorIs(t, err, want)

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft/source"
@@ -194,12 +195,13 @@ func TestResolveSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orig := registryauth.GCPCredsFn
-			defer func() { registryauth.GCPCredsFn = orig }()
-			registryauth.GCPCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
+			defer func() { registryauth.GCPCredsFn = orig; registryauth.ResetCaches() }()
+			registryauth.ResetCaches()
+			registryauth.GCPCredsFn = func(ctx context.Context) (*image.RegistryCredentials, time.Time, error) {
 				if tt.adcErr != nil {
-					return nil, tt.adcErr
+					return nil, time.Time{}, tt.adcErr
 				}
-				return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "token"}, nil
+				return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "token"}, time.Now().Add(time.Hour), nil
 			}
 
 			var calls [][]image.RegistryCredentials
@@ -242,9 +244,10 @@ func TestResolveSource_RecordsFallbackMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	orig := registryauth.GCPCredsFn
-	defer func() { registryauth.GCPCredsFn = orig }()
-	registryauth.GCPCredsFn = func(ctx context.Context) (*image.RegistryCredentials, error) {
-		return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "token"}, nil
+	defer func() { registryauth.GCPCredsFn = orig; registryauth.ResetCaches() }()
+	registryauth.ResetCaches()
+	registryauth.GCPCredsFn = func(ctx context.Context) (*image.RegistryCredentials, time.Time, error) {
+		return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "token"}, time.Now().Add(time.Hour), nil
 	}
 
 	callCount := 0


### PR DESCRIPTION
## Overview

Neither `GCP.Credentials` nor `ECR.Credentials` (`internal/registryauth/registryauth.go`) cached what they fetched: every scan of a private image that hit a `401` re-ran `google.FindDefaultCredentials` or `config.LoadDefaultConfig`+`GetAuthorizationToken` from scratch, even though an ECR authorization token is valid for 12 hours and a GCP ADC token for roughly an hour. Concurrent scans of the same registry — the HTTP controller's worker pool runs scans in parallel — each independently hit the cloud provider's token endpoint for the same still-valid credential, risking STS/ECR rate limiting under load and adding avoidable per-scan latency. The retry chain that calls this is also duplicated across two independent files — `adapters/v1/syft.go` (in-process) and `pkg/sbomscanner/v1/server.go` (sidecar) — so fixing only one call site would have left the other still uncached.

## Additional Information

- `internal/registryauth/cache.go` (new): a `credentialCache` that reuses a fetched credential until the provider's own reported expiry (GCP's `oauth2.Token.Expiry`, ECR's `AuthorizationData.ExpiresAt` — never a guessed TTL), keyed appropriately per provider — a single key for GCP, since ADC isn't registry-specific, and one key per AWS region for ECR, since a token is only valid for the region it was issued in (mirroring how `ECRCredsFn` is already parameterized by region). Concurrent callers racing a cache miss for the same key collapse into a single upstream fetch via `golang.org/x/sync/singleflight` (already a dependency, no new one added). Fetch errors are never cached, so a transient STS/ADC hiccup doesn't poison the cache for the next call.
- `internal/registryauth/registryauth.go`: `GCP.Credentials`/`ECR.Credentials` now go through this cache. `adapters/v1/syft.go` and `pkg/sbomscanner/v1/server.go` needed **no changes** — both already call `provider.Credentials(...)`, so caching is transparent to them. `GCPCredsFn`/`ECRCredsFn` grew a `time.Time` return (the fetched credential's expiry) to feed the cache.
- `internal/registryauth/registryauth_test.go` / `pkg/sbomscanner/v1/server_test.go`: existing test overrides of `GCPCredsFn`/`ECRCredsFn` updated for the new signature, and now call the new `registryauth.ResetCaches()` so each test's override actually reaches `Credentials()` instead of serving a value cached by an earlier test in the same binary.
- `internal/registryauth/cache_test.go` (new): cache-hit reuse, expiry-driven refetch, distinct cache keys not sharing entries, concurrent-miss coalescing (20 goroutines racing one key resolve to exactly one upstream fetch), fetch errors not being cached, and a zero-expiry result correctly not being cached.
- `internal/metrics/metrics.go`: new `kubevuln_registry_auth_cache_total` counter (labels `strategy`, `result` = `hit`/`miss`), matching this repo's existing convention for instrumenting caches (`kubevuln_exceptions_degraded_total`, the SecurityException list cache, etc.).

No behavior change to the existing anonymous-fallback semantics when a provider doesn't match or credentials are genuinely unavailable — this is purely additive caching in front of the existing fetch calls.

## How to Test

- `go build ./...`
- `go test ./internal/registryauth/... ./internal/metrics/... ./pkg/sbomscanner/v1/...` — all pass
- `go vet ./internal/registryauth/... ./internal/metrics/... ./pkg/sbomscanner/v1/... ./adapters/v1/...` — clean
- `gofmt -l` on all touched files — clean
- New tests specifically prove the two things this issue is about: `TestCredentialCache_ReusesUnexpiredEntry`/`RefetchesAfterExpiry` (no re-fetch until expiry) and `TestCredentialCache_ConcurrentMissesCollapseToOneFetch` (concurrent scans don't each hit the cloud provider).

## Related issues/PRs

Resolved #569

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added credential caching for GCP and ECR registry authentication.
  * Reuses valid credentials until expiration and refreshes them when needed.
  * Deduplicates simultaneous credential requests.
  * Keeps credentials isolated by registry and provider context.
  * Added cache reset support.

* **Bug Fixes**
  * Prevents failed or non-expiring credentials from being cached.
  * Preserves ECR credential expiration information.

* **Monitoring**
  * Added metrics for registry authentication cache hits and misses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->