### PR TITLE
fix(adapters): use the shared ignore predicate in Summarize

### DIFF
--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -227,9 +227,13 @@ func Summarize(report v1.ScanResultReport, vulnerabilities []containerscan.Commo
 	vulnsList := make([]containerscan.ShortVulnerabilityResult, 0)
 
 	for i := range vulnerabilities {
-		isIgnored := len(vulnerabilities[i].ExceptionApplied) > 0 &&
-			len(vulnerabilities[i].ExceptionApplied[0].Actions) > 0 &&
-			vulnerabilities[i].ExceptionApplied[0].Actions[0] == armotypes.Ignore
+		// Same predicate ApplySecurityExceptions uses to decide suppression for the stored
+		// manifest. Reading only ExceptionApplied[0].Actions[0] would answer a narrower
+		// question: getCVEExceptionMatchCVENameFromList appends every policy matching the
+		// CVE name without filtering on actions, so the first one is not necessarily the
+		// one carrying Ignore, and the two surfaces would then disagree about whether the
+		// finding is suppressed.
+		isIgnored := hasIgnoreAction(vulnerabilities[i].ExceptionApplied)
 
 		severitiesStats := exculdedSeveritiesStats
 		if !isIgnored {

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -705,3 +705,77 @@ func Test_sendSummaryAndVulnerabilities(t *testing.T) {
 		})
 	}
 }
+
+// Summarize and ApplySecurityExceptions must answer "is this CVE suppressed?" the same way.
+// getCVEExceptionMatchCVENameFromList appends every policy whose VulnerabilityPolicies name
+// the CVE, without filtering on actions, so ExceptionApplied[0] is not necessarily the policy
+// carrying Ignore. Reading only the first policy's first action made the stored manifest hide
+// a finding the backend summary still counted as active.
+func TestSummarize_IgnoreMatchesManifestPredicate(t *testing.T) {
+	ignoring := armotypes.VulnerabilityExceptionPolicy{
+		PortalBase: armotypes.PortalBase{Name: "ignoring-policy"},
+		Actions:    []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+	}
+
+	tests := []struct {
+		name            string
+		applied         []armotypes.VulnerabilityExceptionPolicy
+		wantTotalCount  int64
+		wantSuppressedT string
+	}{
+		{
+			name:           "no policies leaves the finding active",
+			applied:        nil,
+			wantTotalCount: 1,
+		},
+		{
+			name:           "a single ignoring policy suppresses",
+			applied:        []armotypes.VulnerabilityExceptionPolicy{ignoring},
+			wantTotalCount: 0,
+		},
+		{
+			name: "ignore carried by a later policy still suppresses",
+			applied: []armotypes.VulnerabilityExceptionPolicy{
+				{PortalBase: armotypes.PortalBase{Name: "no-actions"}},
+				ignoring,
+			},
+			wantTotalCount: 0,
+		},
+		{
+			name: "ignore carried by a later action still suppresses",
+			applied: []armotypes.VulnerabilityExceptionPolicy{
+				{
+					PortalBase: armotypes.PortalBase{Name: "multi-action"},
+					Actions:    []armotypes.VulnerabilityExceptionPolicyActions{"alert_only", armotypes.Ignore},
+				},
+			},
+			wantTotalCount: 0,
+		},
+		{
+			name: "policies without any ignore action leave the finding active",
+			applied: []armotypes.VulnerabilityExceptionPolicy{
+				{PortalBase: armotypes.PortalBase{Name: "alert-only"}, Actions: []armotypes.VulnerabilityExceptionPolicyActions{"alert_only"}},
+			},
+			wantTotalCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vulns := []containerscan.CommonContainerVulnerabilityResult{{
+				Vulnerability: containerscan.Vulnerability{
+					Name:             "CVE-2021-44228",
+					Severity:         "Critical",
+					ExceptionApplied: tt.applied,
+				},
+			}}
+
+			summary, _ := Summarize(v1.ScanResultReport{}, vulns, domain.ScanCommand{}, false, nil)
+
+			assert.Equal(t, tt.wantTotalCount, summary.SeverityStats.TotalCount)
+			// Whatever Summarize decided must match what the manifest path would decide.
+			assert.Equal(t, hasIgnoreAction(tt.applied), summary.SeverityStats.TotalCount == 0,
+				"Summarize and ApplySecurityExceptions must agree on suppression")
+		})
+	}
+}


### PR DESCRIPTION
## Overview

`Summarize` decided whether a CVE was suppressed by reading only `ExceptionApplied[0].Actions[0]`, while `ApplySecurityExceptions` decides it with `hasIgnoreAction`, which scans every policy and every action.

`getCVEExceptionMatchCVENameFromList` appends every policy whose `VulnerabilityPolicies` name the CVE and never filters on actions, so `ExceptionApplied[0]` is not necessarily the policy carrying `Ignore`. When it is not, the stored `VulnerabilityManifest` hides the finding while the summary sent to the backend counts it toward `TotalCount` and the active severity stats, so the two surfaces disagree about the same CVE.

This calls `hasIgnoreAction` instead, so both paths answer the question the same way. It is a one-line change reusing a helper that already lives in the same package.

## Additional Information

Reachability is limited today, and worth stating plainly rather than overselling: `buildPolicy` always sets exactly `[Ignore]` for CRD-derived policies, and `armotypes.VulnerabilityExceptionPolicyActions` currently defines only `Ignore`. Triggering it needs a cloud-sourced policy with empty or non-standard `Actions` ordered ahead of an ignoring one. So this is a latent inconsistency rather than something firing in every cluster.

It is the same failure mode as #449, fixed in #533: two surfaces computing the same predicate differently, leaving the manifest and the backend report disagreeing about whether a finding is suppressed.

## How to Test

```
go test ./adapters/v1/ -run TestSummarize_IgnoreMatchesManifestPredicate
```

Five cases. Two of them, where `Ignore` is carried by a later policy or a later action, fail on `main` (verified by reverting the change and re-running). Each case additionally asserts that `Summarize`'s answer equals `hasIgnoreAction`'s for the same input, so the two predicates cannot drift apart again without a test failing.

## Related issues/PRs:

* Resolved #572

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vulnerability suppression so findings are ignored whenever any applied exception policy includes an Ignore action.
  * Ensured findings remain active when no Ignore action is present.
* **Tests**
  * Added coverage for multiple policies and actions to verify consistent suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->