### PR TITLE
fix: honor caller cancellation in security-exception and label lookups

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -210,9 +210,7 @@ func NewFakeAPIServerStorage(namespace string, objects ...runtime.Object) *APISe
 // never cached, so a transient apiserver hiccup self-heals on the next call instead of being
 // pinned for the TTL.
 func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
-	// Use a detached context with timeout — the scan context may be canceled
-	// before the CRD listing completes due to rate limiting.
-	listCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	var listErrs []error
@@ -313,7 +311,7 @@ func (a *APIServerStore) GetWorkloadLabels(ctx context.Context, namespace, kind,
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve GroupVersionResource for kind %q: %w", kind, err)
 	}
-	getCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	getCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	obj, err := a.DynamicClient.Resource(gvr).Namespace(namespace).Get(getCtx, name, metav1.GetOptions{})
 	if err != nil {
@@ -331,7 +329,7 @@ func (a *APIServerStore) GetNamespaceLabels(ctx context.Context, name string) (m
 	if name == "" {
 		return nil, nil
 	}
-	getCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	getCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	obj, err := a.DynamicClient.Resource(namespaceGVR).Get(getCtx, name, metav1.GetOptions{})
 	if err != nil {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/akyoto/cache"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/tools"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
@@ -19,8 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/retry"
@@ -2039,6 +2042,131 @@ func TestAPIServerStore_GetSecurityExceptions_DoesNotCacheListFailures(t *testin
 	_, _, err = a.GetSecurityExceptions(context.TODO(), "")
 	require.NoError(t, err, "a failed List() must not be cached, so the next call retries instead of replaying the failure")
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+// ctxCapturingResource wraps a dynamic.ResourceInterface, invoking a hook synchronously with
+// the ctx passed into List/Get, before delegating to the real call. The hook lets a test cancel
+// the caller's ctx *while the K8s API call is in flight* and assert the effect on the ctx the
+// call actually received - the only way to distinguish a derived ctx (context.WithTimeout(ctx,
+// ...), which is canceled immediately) from a context.WithoutCancel-detached one (which is not),
+// since by the time the surrounding APIServerStore method returns, its own `defer cancel()`
+// has already canceled the derived ctx either way.
+type ctxCapturingResource struct {
+	dynamic.ResourceInterface
+	hook func(ctx context.Context)
+}
+
+func (r *ctxCapturingResource) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if r.hook != nil {
+		r.hook(ctx)
+	}
+	return r.ResourceInterface.List(ctx, opts)
+}
+
+func (r *ctxCapturingResource) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if r.hook != nil {
+		r.hook(ctx)
+	}
+	return r.ResourceInterface.Get(ctx, name, opts, subresources...)
+}
+
+// Namespace mutates the receiver in place (rather than returning a fresh wrapper) so that a
+// subsequent List/Get on the namespaced handle still runs through the same hook.
+func (r *ctxCapturingResource) Namespace(ns string) dynamic.ResourceInterface {
+	r.ResourceInterface = r.ResourceInterface.(dynamic.NamespaceableResourceInterface).Namespace(ns)
+	return r
+}
+
+// ctxCapturingDynamicClient wraps a dynamic.Interface, returning the pre-registered
+// ctxCapturingResource for a GVR (see resources) so a test's hook is preserved, or a
+// pass-through one otherwise.
+type ctxCapturingDynamicClient struct {
+	dynamic.Interface
+	resources map[schema.GroupVersionResource]*ctxCapturingResource
+}
+
+func (c *ctxCapturingDynamicClient) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	if c.resources == nil {
+		c.resources = map[schema.GroupVersionResource]*ctxCapturingResource{}
+	}
+	if _, ok := c.resources[gvr]; !ok {
+		c.resources[gvr] = &ctxCapturingResource{ResourceInterface: c.Interface.Resource(gvr)}
+	}
+	return c.resources[gvr]
+}
+
+// requireHookObservesCancellation builds a hook for ctxCapturingResource that, the first time
+// it runs, cancels the caller's ctx and asserts the ctx received by the K8s API call is
+// canceled too - proving it derives from the caller's ctx instead of detaching from it via
+// context.WithoutCancel.
+func requireHookObservesCancellation(t *testing.T, cancel func()) (hook func(ctx context.Context), called *bool) {
+	t.Helper()
+	calledFlag := false
+	return func(ctx context.Context) {
+		calledFlag = true
+		select {
+		case <-ctx.Done():
+			t.Error("ctx passed to the K8s API call must not already be canceled before the caller's ctx is canceled")
+		default:
+		}
+		cancel()
+		assert.ErrorIs(t, ctx.Err(), context.Canceled, "canceling the caller's ctx must cancel the ctx passed to the K8s API call")
+	}, &calledFlag
+}
+
+func TestAPIServerStore_GetSecurityExceptions_HonorsCallerCancellation(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+	wrapped := &ctxCapturingDynamicClient{Interface: dynClient}
+	a := &APIServerStore{DynamicClient: wrapped, Namespace: "kubescape"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hook, called := requireHookObservesCancellation(t, cancel)
+	wrapped.resources = map[schema.GroupVersionResource]*ctxCapturingResource{
+		clusterSecurityExceptionGVR: {ResourceInterface: dynClient.Resource(clusterSecurityExceptionGVR), hook: hook},
+	}
+
+	_, _, err := a.GetSecurityExceptions(ctx, "kubescape")
+	require.NoError(t, err)
+	require.True(t, *called, "the List call the hook was attached to must have run")
+}
+
+func TestAPIServerStore_GetWorkloadLabels_HonorsCallerCancellation(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{})
+	wrapped := &ctxCapturingDynamicClient{Interface: dynClient}
+	a := &APIServerStore{DynamicClient: wrapped, Namespace: "kubescape"}
+
+	podGVR, err := k8sinterface.GetGroupVersionResource("Pod")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hook, called := requireHookObservesCancellation(t, cancel)
+	wrapped.resources = map[schema.GroupVersionResource]*ctxCapturingResource{
+		podGVR: {ResourceInterface: dynClient.Resource(podGVR), hook: hook},
+	}
+
+	_, _ = a.GetWorkloadLabels(ctx, "kubescape", "Pod", "mypod")
+	require.True(t, *called, "the Get call the hook was attached to must have run")
+}
+
+func TestAPIServerStore_GetNamespaceLabels_HonorsCallerCancellation(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{})
+	wrapped := &ctxCapturingDynamicClient{Interface: dynClient}
+	a := &APIServerStore{DynamicClient: wrapped, Namespace: "kubescape"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hook, called := requireHookObservesCancellation(t, cancel)
+	wrapped.resources = map[schema.GroupVersionResource]*ctxCapturingResource{
+		namespaceGVR: {ResourceInterface: dynClient.Resource(namespaceGVR), hook: hook},
+	}
+
+	_, _ = a.GetNamespaceLabels(ctx, "myns")
+	require.True(t, *called, "the Get call the hook was attached to must have run")
 }
 
 func TestAPIServerStore_GetContainerProfile_ctxPropagated(t *testing.T) {


### PR DESCRIPTION
## Overview

`GetSecurityExceptions`, `GetWorkloadLabels`, and `GetNamespaceLabels` in `repositories/apiserver.go` each derived their K8s API call's context with `context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)`. `context.WithoutCancel` strips the caller's cancellation signal, so canceling the caller (shutdown, request abort, upstream deadline) could not stop the in-flight `List`/`Get` call for up to 30 seconds. This PR switches all three to `context.WithTimeout(ctx, 30*time.Second)` so cancellation propagates while still bounding the call at 30 seconds, and adds regression tests proving each lookup now honors a canceled caller context.

## How to Test

Run the new regression tests, which fail against the old `context.WithoutCancel` behavior and pass with this fix:

```bash
go test -v -run "HonorsCallerCancellation" ./repositories/...
```

Verification run against this change:

- `make build` — passed
- `go vet ./...` — passed
- `golangci-lint run ./repositories/...` — passed (two pre-existing findings remain in `repositories/apiserver.go` at unrelated lines 1345 and 1391; confirmed present on `upstream/main` before this change)
- `go test ./...` — all packages pass except `adapters/v1`, which fails on pre-existing, network/registry-platform-dependent tests (`arm64` vs `amd64` image resolution) unrelated to this change

## Related issues/PRs:

* Resolved #576

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
