### PR TITLE
fix(adapters): match an exception policy at most once per CVE

### DIFF
--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -319,12 +319,18 @@ func getCVEExceptionMatchCVENameFromList(srcCVEList []armotypes.VulnerabilityExc
 	var l []armotypes.VulnerabilityExceptionPolicy
 
 	for i := range srcCVEList {
+		if filterFixed && srcCVEList[i].ExpiredOnFix != nil && *srcCVEList[i].ExpiredOnFix {
+			continue
+		}
 		for j := range srcCVEList[i].VulnerabilityPolicies {
 			if strings.EqualFold(srcCVEList[i].VulnerabilityPolicies[j].Name, CVEName) {
-				if filterFixed && srcCVEList[i].ExpiredOnFix != nil && *srcCVEList[i].ExpiredOnFix {
-					continue
-				}
+				// A policy contributes at most once. buildPolicy expands a vulnerability
+				// entry into one VulnerabilityPolicy per id and alias, so an exception
+				// listing an alias equal to its id, or the same alias twice, would
+				// otherwise return the same policy several times, and every consumer
+				// counts it that many times.
 				l = append(l, srcCVEList[i])
+				break
 			}
 		}
 	}

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -705,3 +705,83 @@ func Test_sendSummaryAndVulnerabilities(t *testing.T) {
 		})
 	}
 }
+
+// buildPolicy expands one vulnerability entry into a VulnerabilityPolicy per id and alias,
+// so an exception listing an alias equal to its id, or repeating an alias, used to make the
+// same policy match several times. Every consumer then counted it that many times: duplicate
+// ExceptionApplied entries sent to the backend, and one suppression log line and Kubernetes
+// Event per duplicate.
+func TestGetCVEExceptionMatch_PolicyMatchesAtMostOnce(t *testing.T) {
+	policy := func(names ...string) armotypes.VulnerabilityExceptionPolicy {
+		vp := make([]armotypes.VulnerabilityPolicy, 0, len(names))
+		for _, n := range names {
+			vp = append(vp, armotypes.VulnerabilityPolicy{Name: n})
+		}
+		return armotypes.VulnerabilityExceptionPolicy{
+			PortalBase:            armotypes.PortalBase{Name: "exception"},
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: vp,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		list    []armotypes.VulnerabilityExceptionPolicy
+		cve     string
+		wantLen int
+	}{
+		{
+			name:    "id repeated as its own alias",
+			list:    []armotypes.VulnerabilityExceptionPolicy{policy("CVE-2021-44228", "CVE-2021-44228")},
+			cve:     "CVE-2021-44228",
+			wantLen: 1,
+		},
+		{
+			name:    "the same alias listed twice",
+			list:    []armotypes.VulnerabilityExceptionPolicy{policy("CVE-2021-44228", "GHSA-jfh8", "GHSA-jfh8")},
+			cve:     "GHSA-jfh8",
+			wantLen: 1,
+		},
+		{
+			name:    "case-insensitive duplicates still collapse",
+			list:    []armotypes.VulnerabilityExceptionPolicy{policy("cve-2021-44228", "CVE-2021-44228")},
+			cve:     "CVE-2021-44228",
+			wantLen: 1,
+		},
+		{
+			name:    "distinct policies both still match",
+			list:    []armotypes.VulnerabilityExceptionPolicy{policy("CVE-2021-44228"), policy("CVE-2021-44228")},
+			cve:     "CVE-2021-44228",
+			wantLen: 2,
+		},
+		{
+			name:    "no match",
+			list:    []armotypes.VulnerabilityExceptionPolicy{policy("CVE-2021-44228")},
+			cve:     "CVE-2023-44487",
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCVEExceptionMatchCVENameFromList(tt.list, tt.cve, false)
+			assert.Len(t, got, tt.wantLen)
+		})
+	}
+}
+
+// An ExpiredOnFix policy is skipped as a whole when filterFixed is set, regardless of which
+// of its id/alias entries names the CVE.
+func TestGetCVEExceptionMatch_ExpiredOnFixSkipsWholePolicy(t *testing.T) {
+	expiredOnFix := true
+	p := armotypes.VulnerabilityExceptionPolicy{
+		PortalBase:            armotypes.PortalBase{Name: "exception"},
+		Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+		VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-44228"}, {Name: "GHSA-jfh8"}},
+		ExpiredOnFix:          &expiredOnFix,
+	}
+
+	assert.Empty(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "CVE-2021-44228", true))
+	assert.Empty(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "GHSA-jfh8", true))
+	assert.Len(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "CVE-2021-44228", false), 1)
+}


### PR DESCRIPTION
## Overview

`getCVEExceptionMatchCVENameFromList` appended the whole policy once per matching `VulnerabilityPolicies` entry rather than once per policy. Since `buildPolicy` expands one vulnerability entry into a `VulnerabilityPolicy` per id **and per alias**, an exception whose aliases repeat the id, or list the same alias twice, returned the same policy several times:

```yaml
vulnerabilities:
  - vulnerability:
      id: "CVE-2021-44228"
      aliases: ["CVE-2021-44228", "GHSA-jfh8", "GHSA-jfh8"]
    status: "not_affected"
```

```
matched for CVE-2021-44228: 2   (expected 1)
matched for GHSA-jfh8:      2   (expected 1)
```

The duplicate reaches two consumers: `logSuppression` iterates `suppressingPolicies(matched)`, so one suppressed finding emits two log lines and two Kubernetes Events (#537), and `DomainToArmo` builds `ExceptionApplied` from the same slice, so the backend is told the same exception applied twice. The `matchedBySource` metric path is already safe, since it collects `sourceKind` into a set before counting.

Breaking after the first matching entry fixes it. Two genuinely distinct exceptions matching the same CVE still return two policies.

## Additional Information

The `ExpiredOnFix` check moves out of the inner loop in the same change. It is a property of the policy, not of an individual id or alias entry, so testing it once per policy is equivalent and no longer depends on which entry happened to name the CVE. A test pins that an `ExpiredOnFix` policy is skipped whichever of its entries matches.

## How to Test

```
go test ./adapters/v1/ -run TestGetCVEExceptionMatch
```

`TestGetCVEExceptionMatch_PolicyMatchesAtMostOnce` covers an id repeated as its own alias, the same alias listed twice, case-insensitive duplicates, and the negative cases that must keep working: two distinct policies still return two, and a non-matching CVE returns none. The three duplicate cases fail without the `break` (verified by reverting it). `TestGetCVEExceptionMatch_ExpiredOnFixSkipsWholePolicy` covers the hoisted check. The pre-existing `TestGetCVEExceptionMatchCVENameFromList` is unchanged and still passes.

## Related issues/PRs:

* Resolved #578

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
