### PR TITLE
fix(sbomscanner): stop the abandoned Syft goroutine racing the handler

### DIFF
--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -77,6 +77,10 @@ func formatResolvedPlatform(os, arch, variant string) string {
 	return strings.Join(parts, "/")
 }
 
+// createSBOMFn is an indirection over syft.CreateSBOM so the deadline handling in
+// CreateSBOM can be unit-tested without cataloguing a real image.
+var createSBOMFn = syft.CreateSBOM
+
 // sourceGetter abstracts the syft.GetSource call so the fallback ordering in
 // resolveSource is testable with a scripted implementation.
 type sourceGetter func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error)
@@ -295,6 +299,9 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		timeout = 5 * time.Minute
 	}
 	dl := deadline.New(timeout)
+	// Buffered so the abandoned goroutine below can always publish and exit, even when
+	// nobody is left to receive.
+	generated := make(chan *sbom.SBOM, 1)
 	err = dl.Run(func(stopper <-chan struct{}) error {
 		defer func(src source.Source) {
 			if err := src.Close(); err != nil {
@@ -314,12 +321,17 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		// NOTE: Syft's cataloguers do not support context cancellation (see
 		// https://github.com/anchore/syft/issues/3705). The deadline.Run wrapper
 		// will return ErrTimedOut, but the Syft goroutine may continue until it
-		// finishes naturally. This is an accepted tradeoff — the sidecar's memory
+		// finishes naturally. This is an accepted tradeoff, the sidecar's memory
 		// limit will OOM-kill the container if resource usage grows unbounded.
-		syftSBOM, err = syft.CreateSBOM(context.Background(), src, cfg)
-		if err != nil {
-			return fmt.Errorf("failed to generate SBOM: %w", err)
+		//
+		// Because this goroutine outlives the timeout, it must not touch any variable
+		// the handler reads. It keeps its result local and publishes it on a channel,
+		// which the handler only receives from once dl.Run has reported success.
+		created, createErr := createSBOMFn(context.Background(), src, cfg)
+		if createErr != nil {
+			return fmt.Errorf("failed to generate SBOM: %w", createErr)
 		}
+		generated <- created
 		return nil
 	})
 
@@ -332,7 +344,9 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 			ResolvedPlatform: resolvedPlatform,
 		}, nil
 	case err == nil:
-		// continue
+		// dl.Run only reports success once the work function returned nil, which it does
+		// after publishing, so this receive cannot block.
+		syftSBOM = <-generated
 	default:
 		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		return &pb.CreateSBOMResponse{

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -17,8 +17,11 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
@@ -668,4 +671,82 @@ func TestCreateSBOM_PlatformMismatch_LocalRegistry(t *testing.T) {
 	assert.Contains(t, resp.ErrorMessage, "mismatched platform")
 	assert.Equal(t, domain.ReasonPlatformNotFound, resp.StatusReason)
 	assert.Empty(t, resp.Status)
+}
+
+// TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft covers the deadline path: deadline.Run
+// does not (and documents that it cannot) stop the work function, and Syft's cataloguers do
+// not observe cancellation, so on timeout the Syft goroutine keeps running and finishes after
+// the handler has already returned Incomplete.
+//
+// The work function must therefore share nothing with the handler. Run under -race, this test
+// fails if the goroutine writes a variable the handler reads.
+func TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft(t *testing.T) {
+	layerBytes, layerHash, diffId, err := makeDummyTarGz(64)
+	require.NoError(t, err)
+
+	configPayload := fmt.Sprintf(`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%s"]}}`, diffId)
+	configBytes := []byte(configPayload)
+	configHash := fmt.Sprintf("%x", sha256.Sum256(configBytes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test-image/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"schemaVersion": 2,
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": %d, "digest": "sha256:%s"},
+				"layers": [{"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip", "size": %d, "digest": "sha256:%s"}]
+			}`, len(configBytes), configHash, len(layerBytes), layerHash)))
+		case fmt.Sprintf("/v2/test-image/blobs/sha256:%s", configHash):
+			_, _ = w.Write(configBytes)
+		case fmt.Sprintf("/v2/test-image/blobs/sha256:%s", layerHash):
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	// Stand in for Syft: outlive the deadline, then return a result exactly as the real
+	// cataloguer would once it finishes naturally.
+	finished := make(chan struct{})
+	orig := createSBOMFn
+	defer func() { createSBOMFn = orig }()
+	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		time.Sleep(1500 * time.Millisecond)
+		defer close(finished)
+		return &sbom.SBOM{}, nil
+	}
+
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
+		ImageId:         u.Host + "/test-image",
+		ImageTag:        u.Host + "/test-image:latest",
+		Platform:        "linux/amd64",
+		MaxImageSize:    1 << 30,
+		MaxSbomSize:     1 << 30,
+		TimeoutSeconds:  1,
+		InsecureUseHttp: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, helpersv1.Incomplete, resp.Status, "the deadline must surface as Incomplete")
+
+	// Let the abandoned goroutine finish while the handler's result is being read, which is
+	// the window the race lived in.
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stand-in Syft never finished")
+	}
+	assert.Equal(t, helpersv1.Incomplete, resp.Status, "the late write must not affect the response")
 }


### PR DESCRIPTION
## Overview

`deadline.Run` cannot stop its work function, and documents that: on timeout it closes the stopper channel, returns `ErrTimedOut` and leaves the goroutine running. The work function cannot respect the stopper either, since Syft's cataloguers do not observe cancellation, which the note already in `CreateSBOM` records.

So on timeout the Syft goroutine keeps running and eventually executes:

```go
syftSBOM, err = syft.CreateSBOM(context.Background(), src, cfg)
```

assigning two variables the handler reads, after the handler has already read `err` and returned `Incomplete`.

Beyond the race itself, the write to `err` can land before the handler reads it in the `switch`. The handler then takes `case err == nil` and falls through to `v1beta1.StripSBOM(syftSBOM)` and `syftToDomain(*syftSBOM)`. Nothing orders the two writes, so `syftSBOM` may still be nil there and the sidecar panics.

This keeps the work function's result local and publishes it on a buffered channel that the handler receives from only once `dl.Run` has reported success, so nothing is shared with a goroutine that can outlive the call. The receive cannot block: `dl.Run` returns nil only after the work function returned nil, which it does after publishing.

Behaviour on both paths is unchanged. The success path was never racy, because `deadline.Run` passes the work function's return value over a channel, which orders the write before the handler's read.

## Additional Information

`syft.CreateSBOM` moves behind a `createSBOMFn` package variable so the deadline path is reachable from a test, mirroring the `sourceGetter` indirection this file already uses for `syft.GetSource`.

## How to Test

```
go test -race ./pkg/sbomscanner/v1/ -run TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft
```

The test serves a small image from the local mock registry the other tests in this file already use, substitutes a stand-in for Syft that outlives a 1 second deadline and then returns a result exactly as the real cataloguer would, and waits for that late completion before finishing so the write happens inside the window the race lived in.

Against the previous code it reports:

```
WARNING: DATA RACE
Write at 0x00c0004a6380 by goroutine 84:
--- FAIL: TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft
```

and it passes here. `go test -race ./pkg/sbomscanner/v1/` is clean.

## Related issues/PRs:

* Resolved #580

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SBOM generation timeout handling to prevent late-running operations from altering completed responses.
  - Ensured timed-out requests consistently remain marked as incomplete, even after background processing finishes.

- **Tests**
  - Added regression coverage for timeout behavior and protection against race conditions during delayed SBOM generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->