### PR TITLE
fix: respect parent context and apply scanTimeout in SyftAdapter.CreateSBOM

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -188,7 +188,15 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// download image
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))
 
-	ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, s.maxImageSize)
+	ctxWithTimeout := ctx
+	if s.scanTimeout > 0 {
+		var cancel context.CancelFunc
+		ctxWithTimeout, cancel = context.WithTimeout(ctx, s.scanTimeout)
+		defer cancel()
+	}
+
+	//nolint:staticcheck // stereoscope expects string key image.MaxImageSize
+	ctxWithSize := context.WithValue(ctxWithTimeout, image.MaxImageSize, s.maxImageSize)
 	pullRef := rewriteImageRef(imageID, s.proxyRegistryMap)
 	usedFallback := false
 	src, err := syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
@@ -206,7 +214,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		usedFallback = true
 		unauthorizedErr := err
 		if provider, ok := registryauth.For(pullRef); ok {
-			if creds, credErr := provider.Credentials(ctx, pullRef); credErr != nil || creds == nil {
+			if creds, credErr := provider.Credentials(ctxWithTimeout, pullRef); credErr != nil || creds == nil {
 				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), metrics.FallbackOutcomeFailed)
 				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
 					helpers.Error(credErr),
@@ -242,6 +250,14 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	metrics.RecordSourceResolution(ctx, metrics.ComponentInProcess, usedFallback, err == nil)
 
 	switch {
+	// Note: stereoscope/oci-registry wraps deadline errors in a custom error type that does not implement Unwrap(),
+	// so strings.Contains check is required alongside errors.Is.
+	case err != nil && (errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "context deadline exceeded")):
+		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
+		logger.L().Ctx(ctx).Warning("Syft timed out during image resolution",
+			helpers.String("imageID", imageID))
+		domainSBOM.Status = helpersv1.Incomplete
+		return domainSBOM, nil
 	case err != nil && (errors.Is(err, image.ErrImageTooLarge) || strings.Contains(err.Error(), image.ErrImageTooLarge.Error())):
 		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyImageTooLarge, metrics.FallbackOutcomeClassified)
 		logger.L().Ctx(ctx).Warning("Image exceeds size limit",
@@ -312,14 +328,14 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 			// ask Syft to also scan the image for embedded SBOMs
 			cfg.WithCatalogers(pkgcataloging.NewCatalogerReference(sbomcataloger.NewCataloger(), []string{pkgcataloging.ImageTag}))
 		}
-		syftSBOM, err = syft.CreateSBOM(context.Background(), src, cfg)
+		syftSBOM, err = syft.CreateSBOM(ctxWithSize, src, cfg)
 		if err != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", err)
 		}
 		return nil
 	})
 	switch {
-	case errors.Is(err, deadline.ErrTimedOut):
+	case errors.Is(err, deadline.ErrTimedOut) || errors.Is(err, context.DeadlineExceeded) || (err != nil && strings.Contains(err.Error(), "context deadline exceeded")):
 		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		logger.L().Ctx(ctx).Warning("Syft timed out",
 			helpers.String("imageID", imageID))

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -3,7 +3,9 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -371,4 +373,26 @@ func TestRewriteImageRef(t *testing.T) {
 			assert.Equal(t, tt.want, rewriteImageRef(tt.imageRef, tt.proxyMap))
 		})
 	}
+}
+
+func Test_syftAdapter_CreateSBOM_CanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
+	_, err := adapter.CreateSBOM(ctx, "test", "library/alpine@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501", "library/alpine:latest", domain.RegistryOptions{})
+
+	require.True(t, errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "context canceled"))
+}
+
+func Test_syftAdapter_CreateSBOM_TimeoutContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	<-ctx.Done() // wait for context deadline
+
+	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
+	sbom, err := adapter.CreateSBOM(ctx, "test", "library/alpine@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501", "library/alpine:latest", domain.RegistryOptions{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, helpersv1.Incomplete, sbom.Status)
 }


### PR DESCRIPTION


**Description:**

Derive image resolution and SBOM generation context from the parent `ctx` and apply `s.scanTimeout` using `context.WithTimeout`. If context deadline is exceeded during image download, mark status as `Incomplete` instead of hanging indefinitely.

## Overview
- **Current behavior:** `SyftAdapter.CreateSBOM()` in `adapters/v1/syft.go` called `context.WithValue(context.Background(), ...)` and `syft.CreateSBOM(context.Background(), ...)`. This completely dropped the parent `ctx` (ignoring parent cancellations like SIGTERM) and failed to apply `s.scanTimeout` during image source resolution. If a registry connection stalled, worker threads would block indefinitely.
- **Future behavior:** Context is derived from the parent `ctx` and respects `s.scanTimeout` via `context.WithTimeout`. If context deadline is exceeded during image download, the SBOM status is set to `helpersv1.Incomplete` cleanly.

## How to Test
1. Run `go test -run Test_syftAdapter_CreateSBOM_CanceledContext ./adapters/v1` to verify immediate cancellation when parent context is canceled.
2. Run `go test -run Test_syftAdapter_CreateSBOM ./adapters/v1` to verify timeout behavior.

## Related issues/PRs:
* Resolved #582

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

*(Note: Remember to open the PR against the `dev` branch on `kubescape/kubevuln`!)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan cancellation and timeout handling.
  * Incomplete scans caused by image-resolution or generation timeouts are now reported consistently without misleading errors.
  * Scan status, metrics, and logs now better reflect interrupted or timed-out operations.

* **Tests**
  * Added coverage for already-canceled requests and expired scan timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->