### PR TITLE
fix(adapters): clamp the SBOM size limit sent to the sidecar scanner

### DIFF
--- a/adapters/v1/sidecar.go
+++ b/adapters/v1/sidecar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -26,6 +27,27 @@ const (
 	// maxCrashRetries was hit (see #473).
 	retryCountTTL = 1 * time.Hour
 )
+
+// sbomSizeLimitForWire narrows the configured SBOM size limit to the int32 the scanner
+// protocol carries.
+//
+// A plain conversion silently wraps once maxSBOMSize passes math.MaxInt32, and the wrapped
+// value is then compared against a real SBOM size: 2 GiB becomes negative and 4 GiB becomes
+// zero, so every SBOM is classified TooLarge and no image is scanned at all, while 5 GiB
+// becomes 1 GiB and quietly enforces a limit far below the configured one. Raising the limit
+// is exactly when an operator would least expect scans to start failing, and the in-process
+// adapter has no such ceiling, so the same configuration behaves differently on the two paths.
+//
+// Clamp instead, so the limit is at worst the largest the protocol can express.
+func sbomSizeLimitForWire(maxSBOMSize int) int32 {
+	if maxSBOMSize > math.MaxInt32 {
+		logger.L().Warning("configured maxSBOMSize exceeds the scanner protocol limit, clamping",
+			helpers.Int("maxSBOMSize", maxSBOMSize),
+			helpers.Int("clamped", math.MaxInt32))
+		return math.MaxInt32
+	}
+	return int32(maxSBOMSize)
+}
 
 // crashRetry tracks a per-image crash-retry count and when it was last touched, so stale
 // entries (images that crashed once and were never retried) can be evicted.
@@ -108,7 +130,7 @@ func (s *SidecarSBOMAdapter) CreateSBOM(ctx context.Context, name, imageID, imag
 		ImageTag:            pullImageTag,
 		Options:             options,
 		MaxImageSize:        s.maxImageSize,
-		MaxSBOMSize:         int32(s.maxSBOMSize),
+		MaxSBOMSize:         sbomSizeLimitForWire(s.maxSBOMSize),
 		EnableEmbeddedSBOMs: s.scanEmbeddedSBOMs,
 		Timeout:             s.scanTimeout,
 	}

--- a/adapters/v1/sidecar_test.go
+++ b/adapters/v1/sidecar_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -358,4 +359,37 @@ func TestSidecarSBOMAdapter_CreateSBOM_CrashRetry_EvictsStaleEntries(t *testing.
 	defer adapter.mu.Unlock()
 	assert.NotContains(t, adapter.retryCount, "one-shot-image:latest", "stale entry must be evicted")
 	assert.Contains(t, adapter.retryCount, "another-image:latest")
+}
+
+// The scanner protocol carries the SBOM size limit as an int32, so a configured maxSBOMSize
+// above math.MaxInt32 wraps on a plain conversion. 2 GiB and 6 GiB become negative and 4 GiB
+// becomes zero, each of which makes the scanner classify every SBOM as TooLarge and stop
+// scanning entirely, while 5 GiB silently becomes a 1 GiB limit. Clamping keeps the limit at
+// the largest value the protocol can express instead.
+func TestSBOMSizeLimitForWire(t *testing.T) {
+	const giB = 1024 * 1024 * 1024
+
+	tests := []struct {
+		name        string
+		maxSBOMSize int
+		want        int32
+	}{
+		{name: "default 20MiB is unchanged", maxSBOMSize: 20 * 1024 * 1024, want: 20 * 1024 * 1024},
+		{name: "zero is unchanged", maxSBOMSize: 0, want: 0},
+		{name: "exactly MaxInt32 is unchanged", maxSBOMSize: math.MaxInt32, want: math.MaxInt32},
+		{name: "one over MaxInt32 clamps", maxSBOMSize: math.MaxInt32 + 1, want: math.MaxInt32},
+		{name: "2 GiB clamps instead of going negative", maxSBOMSize: 2 * giB, want: math.MaxInt32},
+		{name: "4 GiB clamps instead of becoming zero", maxSBOMSize: 4 * giB, want: math.MaxInt32},
+		{name: "5 GiB clamps instead of silently becoming 1 GiB", maxSBOMSize: 5 * giB, want: math.MaxInt32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sbomSizeLimitForWire(tt.maxSBOMSize)
+			assert.Equal(t, tt.want, got)
+			if tt.maxSBOMSize > 0 {
+				assert.Positive(t, got, "a positive configured limit must stay positive on the wire")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Overview

`config.MaxSBOMSize` is an `int`, the scanner protocol carries the limit as an `int32`, and the sidecar adapter converted between them with a plain `int32(...)`. That wraps silently once the configured value passes `math.MaxInt32`, and the wrapped value is then compared against a real SBOM size:

| configured `maxSBOMSize` | on the wire | effect |
|---|---|---|
| 2 GiB | -2147483648 | every SBOM is TooLarge, nothing is scanned |
| 4 GiB | 0 | every SBOM is TooLarge, nothing is scanned |
| 5 GiB | 1073741824 | a silent 1 GiB limit, far below what was asked for |

So raising the limit breaks scanning instead of relaxing it, and the failure reports `SBOM exceeds size limit`, pointing the operator at the setting they just raised. The in-process adapter compares against the `int` directly and has no such ceiling, so the same configuration behaves differently on the two SBOM paths.

Clamp to `math.MaxInt32` and log when it happens, so the limit is at worst the largest value the protocol can express.

## Additional Information

Two related things are deliberately **not** in this PR:

`scannerServer.CreateSBOM` treats a non-positive `MaxSbomSize` as a limit rather than as "no limit", unlike `TimeoutSeconds` immediately above it, which falls back to a default when non-positive. A client that simply does not set the field gets nothing scanned. Adding that guard needs a seam to stub Syft so the size check is actually reached in a test; without one the test passes vacuously, because cataloguing a synthetic image returns `Incomplete` before the size check runs. #581 adds exactly that seam, so this is worth doing as a follow-up on top of it rather than shipping untested here.

There is also no validation on `MaxSBOMSize` in `config`, so nothing warns at startup. The clamp makes the runtime behaviour safe regardless, but a startup warning would surface the mistake sooner.

## How to Test

```
go test ./adapters/v1/ -run TestSBOMSizeLimitForWire
```

Seven cases: the 20 MiB default and zero pass through unchanged, `math.MaxInt32` is the boundary that must not clamp, and 2/4/5 GiB are the wrap cases. Four of them fail against the previous conversion (verified by reverting the clamp). Each positive input is additionally asserted to stay positive on the wire, which is the property the bug violated.

## Related issues/PRs:

* Resolved #584

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented excessively large SBOM size limits from causing invalid values during scanner communication.
  * Preserved zero, default, and valid in-range size limits while safely capping oversized values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->