### PR TITLE
fix(sbomscanner): round the scan timeout up when sending it to the sidecar

### DIFF
--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -88,6 +88,29 @@ func NewSBOMScannerClient(ctx context.Context, socketPath string, readinessTimeo
 	return c, nil
 }
 
+// timeoutSecondsForWire converts a scan timeout to the whole seconds the scanner protocol
+// carries, rounding up so a configured timeout is never shortened.
+//
+// Truncating instead inverts the setting at the low end: the server treats a non-positive
+// TimeoutSeconds as unset and falls back to a five minute default, so a sub-second timeout
+// truncated to zero produces a far longer deadline than the one configured, not a shorter
+// one. The in-process adapter passes the same scanTimeout straight to deadline.New and
+// honours it exactly, so the two SBOM paths would otherwise read one config value very
+// differently.
+//
+// A non-positive timeout is passed through as zero, which is the value that legitimately
+// means "use the server default".
+func timeoutSecondsForWire(timeout time.Duration) int64 {
+	if timeout <= 0 {
+		return 0
+	}
+	seconds := timeout / time.Second
+	if timeout%time.Second != 0 {
+		seconds++
+	}
+	return int64(seconds)
+}
+
 func (c *sbomScannerClient) CreateSBOM(ctx context.Context, req ScanRequest) (*ScanResult, error) {
 	// Map domain credentials to proto
 	creds := make([]*pb.RegistryCredentials, len(req.Options.Credentials))
@@ -110,7 +133,7 @@ func (c *sbomScannerClient) CreateSBOM(ctx context.Context, req ScanRequest) (*S
 		MaxImageSize:          req.MaxImageSize,
 		MaxSbomSize:           req.MaxSBOMSize,
 		EnableEmbeddedSboms:   req.EnableEmbeddedSBOMs,
-		TimeoutSeconds:        int64(req.Timeout.Seconds()),
+		TimeoutSeconds:        timeoutSecondsForWire(req.Timeout),
 	}
 
 	resp, err := c.client.CreateSBOM(ctx, pbReq)

--- a/pkg/sbomscanner/v1/client_test.go
+++ b/pkg/sbomscanner/v1/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/stretchr/testify/assert"
@@ -79,4 +80,38 @@ func TestCreateSBOM_PassesThroughUnrelatedError(t *testing.T) {
 	assert.NotErrorIs(t, err, context.DeadlineExceeded)
 	assert.NotErrorIs(t, err, ErrScannerCrashed)
 	assert.NotErrorIs(t, err, ErrScannerUnavailable)
+}
+
+// The scanner protocol carries the scan timeout as whole seconds, and the server treats a
+// non-positive TimeoutSeconds as unset and substitutes a five minute default. Truncating
+// therefore inverts the setting at the low end: a sub-second timeout became zero and turned
+// into a far longer deadline than the one configured. The in-process adapter passes the same
+// scanTimeout straight to deadline.New, so the two paths read one config value differently.
+func TestTimeoutSecondsForWire(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    int64
+	}{
+		{name: "the 5 minute default is exact", timeout: 5 * time.Minute, want: 300},
+		{name: "whole seconds are exact", timeout: 90 * time.Second, want: 90},
+		{name: "sub-second rounds up rather than reading as unset", timeout: 500 * time.Millisecond, want: 1},
+		{name: "one nanosecond still counts as a timeout", timeout: time.Nanosecond, want: 1},
+		{name: "fractional rounds up rather than shortening", timeout: 1500 * time.Millisecond, want: 2},
+		{name: "just under a whole second rounds up", timeout: 2999 * time.Millisecond, want: 3},
+		{name: "zero means use the server default", timeout: 0, want: 0},
+		{name: "negative means use the server default", timeout: -1 * time.Second, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := timeoutSecondsForWire(tt.timeout)
+			assert.Equal(t, tt.want, got)
+			if tt.timeout > 0 {
+				assert.NotZero(t, got, "a positive timeout must never reach the server as unset")
+				assert.GreaterOrEqual(t, time.Duration(got)*time.Second, tt.timeout,
+					"the wire value must not shorten the configured timeout")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Overview

The scanner protocol carries the scan timeout as whole seconds, and the client truncated to get there:

```go
TimeoutSeconds: int64(req.Timeout.Seconds()),
```

The server treats a non-positive `TimeoutSeconds` as unset and substitutes a five minute default, so truncation inverts the setting at the low end:

| configured `scanTimeout` | on the wire | deadline actually used |
|---|---|---|
| `500ms` | 0 | **5 minutes** |
| `1500ms` | 1 | 1 second |
| `90s` | 90 | 90 seconds |

A sub-second timeout therefore produces a much longer deadline than the one configured, not a shorter one, and fractional values are quietly shortened.

The in-process adapter passes the same `scanTimeout` straight to `deadline.New` and honours it exactly, so one config value behaved very differently depending on which SBOM path was in use.

This rounds up instead, so the wire value never shortens the configured timeout and a positive timeout never reads as unset. A non-positive timeout still passes through as zero, which is the value that legitimately means "use the server default".

## How to Test

```
go test ./pkg/sbomscanner/v1/ -run TestTimeoutSecondsForWire
```

Eight cases, five of which fail against the previous truncation (verified by reverting). Alongside the expected values, each positive input is asserted to reach the wire as non-zero and to be no shorter than what was configured, which are the two properties the bug violated.

The five minute default and whole-second values are covered too, so the common path is pinned as exact rather than merely non-broken.

## Related issues/PRs:

* Resolved #586

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
