### PR TITLE
fix(tools): stop SanitizeLabel producing labels that get dropped

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -34,13 +34,21 @@ func PackageVersion(name string) string {
 var offendingChars = regexp.MustCompile("[@:/ ._]")
 
 // SanitizeLabel sanitizes a string to be a valid DNS1123 label.
+//
+// Lowercasing and trimming both ends matter because LabelsFromImageID drops any label that
+// fails validation, so anything this leaves invalid disappears silently rather than being
+// stored in a degraded form:
+//
+//   - A DNS1123 label must be lowercase, while an image tag may legally contain uppercase
+//     (the reference grammar allows [a-zA-Z0-9_][a-zA-Z0-9._-]*), so a tag such as v1.0-RC1
+//     produced an invalid label.
+//   - A DNS1123 label must start and end alphanumeric, and adjacent offending characters
+//     collapse into several dashes (v1_. becomes v1--), so stripping a single trailing dash
+//     was not enough. Truncation at 63 can also land on a dash, and a leading offending
+//     character produces a leading one.
 func SanitizeLabel(s string) string {
-	s2 := truncate.Truncate(offendingChars.ReplaceAllString(s, "-"), 63, "", truncate.PositionEnd)
-	// remove trailing dash
-	if len(s2) > 0 && s2[len(s2)-1] == '-' {
-		return s2[:len(s2)-1]
-	}
-	return s2
+	s2 := truncate.Truncate(offendingChars.ReplaceAllString(strings.ToLower(s), "-"), 63, "", truncate.PositionEnd)
+	return strings.Trim(s2, "-")
 }
 
 // LabelsFromImageID returns a map of labels from an image ID.

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -31,7 +31,12 @@ func PackageVersion(name string) string {
 	return "unknown"
 }
 
-var offendingChars = regexp.MustCompile("[@:/ ._]")
+// offendingChars matches everything a DNS1123 label may not contain, rather than an
+// enumerated set. Listing the characters seen in image references ("[@:/ ._]") left anything
+// unlisted to pass through unchanged and fail validation, so the label was dropped: "foo+bar"
+// and non-ASCII input both survived substitution intact. Applied after lowercasing, so no
+// uppercase reaches it.
+var offendingChars = regexp.MustCompile("[^a-z0-9-]")
 
 // SanitizeLabel sanitizes a string to be a valid DNS1123 label.
 //

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,8 +1,10 @@
 package tools
 
 import (
+	"k8s.io/apimachinery/pkg/util/validation"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -311,4 +313,64 @@ func TestCleanupStaleTempDirs(t *testing.T) {
 func TestCleanupStaleTempDirs_NonexistentDir(t *testing.T) {
 	_, err := CleanupStaleTempDirs(path.Join(t.TempDir(), "does-not-exist"), "stereoscope-", time.Hour)
 	require.Error(t, err)
+}
+
+// LabelsFromImageID drops any label that fails DNS1123 validation, so a value SanitizeLabel
+// leaves invalid disappears silently instead of being stored in a degraded form. These are
+// the inputs that used to produce one.
+func TestSanitizeLabel_AlwaysProducesAValidLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "already valid is unchanged", input: "nginx-1-25", want: "nginx-1-25"},
+		{name: "offending characters become dashes", input: "nginx:1.25", want: "nginx-1-25"},
+		// The reference grammar allows uppercase in a tag, but a DNS1123 label must be lowercase.
+		{name: "uppercase tag is lowercased", input: "v1.0-RC1", want: "v1-0-rc1"},
+		{name: "mixed case repository", input: "Registry.IO/Team/App", want: "registry-io-team-app"},
+		// Adjacent offending characters collapse into several dashes, so stripping one is not enough.
+		{name: "several trailing dashes are all stripped", input: "registry.io/team/app:v1_.", want: "registry-io-team-app-v1"},
+		{name: "leading offending character is stripped", input: "_myapp", want: "myapp"},
+		{name: "leading and trailing together", input: ".myapp.", want: "myapp"},
+		{name: "interior dashes are preserved", input: "foo._bar", want: "foo--bar"},
+		{name: "all offending characters yield empty", input: "...", want: ""},
+		{name: "empty stays empty", input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeLabel(tt.input)
+			assert.Equal(t, tt.want, got)
+			if got != "" {
+				assert.Empty(t, validation.IsDNS1123Label(got),
+					"SanitizeLabel must return a valid DNS1123 label, got %q", got)
+			}
+		})
+	}
+}
+
+// Truncation at 63 characters can land on a dash, which would otherwise leave the label
+// ending in one and therefore invalid.
+func TestSanitizeLabel_TruncationNeverEndsOnADash(t *testing.T) {
+	// 62 characters, so the 63rd is the separator introduced for the dot.
+	input := strings.Repeat("a", 62) + ".suffix"
+
+	got := SanitizeLabel(input)
+
+	assert.LessOrEqual(t, len(got), 63)
+	assert.Empty(t, validation.IsDNS1123Label(got), "got %q", got)
+	assert.Equal(t, strings.Repeat("a", 62), got)
+}
+
+// The labels these feed are dropped when invalid, so an image whose tag carries uppercase
+// used to lose its image-tag label entirely.
+func TestLabelsFromImageID_UppercaseTagIsKept(t *testing.T) {
+	labels := LabelsFromImageID("registry.io/team/app:v1.0-RC1")
+
+	assert.Equal(t, "v1-0-rc1", labels[helpersv1.ImageTagMetadataKey])
+	assert.Equal(t, "registry-io-team-app", labels[helpersv1.ImageNameMetadataKey])
+	for key, value := range labels {
+		assert.Empty(t, validation.IsDNS1123Label(value), "label %q has invalid value %q", key, value)
+	}
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -335,6 +335,10 @@ func TestSanitizeLabel_AlwaysProducesAValidLabel(t *testing.T) {
 		{name: "leading and trailing together", input: ".myapp.", want: "myapp"},
 		{name: "interior dashes are preserved", input: "foo._bar", want: "foo--bar"},
 		{name: "all offending characters yield empty", input: "...", want: ""},
+		// Not an enumerated set: anything a DNS1123 label may not contain is replaced.
+		{name: "unlisted ascii is replaced", input: "foo+bar", want: "foo-bar"},
+		{name: "tilde is replaced", input: "foo~bar", want: "foo-bar"},
+		{name: "non-ascii is replaced", input: "café", want: "caf"},
 		{name: "empty stays empty", input: "", want: ""},
 	}
 


### PR DESCRIPTION
## Overview

`SanitizeLabel` is documented as returning a valid DNS1123 label, and `LabelsFromImageID` deletes any label that fails validation. So anything `SanitizeLabel` leaves invalid is dropped silently rather than stored in a degraded form, and two ordinary inputs produced one:

```
"myapp:v1.0-RC1"             ->  "myapp-v1-0-RC1"            invalid, label dropped
"registry.io/team/app:v1_."  ->  "registry-io-team-app-v1-"  invalid, label dropped
```

A DNS1123 label must be lowercase, but the reference grammar allows uppercase in a tag, so a tag like `v1.0-RC1` lost its `image-tag` label entirely. A DNS1123 label must also start and end alphanumeric, and adjacent offending characters each become a dash, so `v1_.` became `v1--` and stripping a single trailing dash left one behind. Truncation at 63 characters can land on a dash for the same reason, and a leading offending character produces a leading dash, which was never handled.

Lowercase before substituting, and trim dashes from both ends rather than removing one.

## Additional Information

Lowercasing changes the stored value for inputs that carried uppercase, but the alternative is the current behaviour of storing nothing at all, and DNS1123 leaves no way to preserve case. Two tags differing only in case now map to the same label value; that is acceptable here because nothing selects on these labels for identity, object names carry that.

No code in this repository selects on these labels, so nothing changes internally. The impact is on operators and external tooling filtering by them.

## How to Test

```
go test ./internal/tools/ -run 'TestSanitizeLabel|TestLabelsFromImageID'
```

`TestSanitizeLabel_AlwaysProducesAValidLabel` covers the uppercase and trailing-dash inputs above, plus leading offending characters, interior dashes that must be preserved, and the all-offending and empty inputs. Every non-empty result is additionally asserted to pass `validation.IsDNS1123Label`, which is the contract that was being broken rather than just the expected strings.

`TestSanitizeLabel_TruncationNeverEndsOnADash` covers truncation landing on a separator, and `TestLabelsFromImageID_UppercaseTagIsKept` covers the end-to-end case where the label used to disappear.

Eight of these fail against the previous implementation (verified by reverting). The pre-existing `TestLabelsFromImageID` is unchanged and still passes.

## Related issues/PRs:

* Resolved #589

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label normalization by converting text to lowercase, replacing invalid characters, enforcing length limits, and removing leading or trailing dashes.
  * Ensured generated labels remain valid DNS-compatible labels, including labels derived from uppercase image tags.

* **Tests**
  * Added coverage for normalization, truncation, empty results, DNS validity, and uppercase image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->