### PR TITLE
fix(config): honor env-only trustedVendors/proxyRegistryMap overrides

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -156,12 +156,44 @@ func LoadConfig(path string) (Config, error) {
 			config.CVEMatchingMode, CVEMatchingOff, CVEMatchingOn, CVEMatchingAdaptive)
 	}
 
+	// Same AutomaticEnv/Unmarshal gap as cveMatchingMode above, but for slice/map
+	// fields: Unmarshal silently drops env-only values for []string and
+	// map[string]string, so an env-only TRUSTEDVENDORS/PROXYREGISTRYMAP would
+	// otherwise be lost. Read through viper's getters when the field was
+	// actually set (via file or env) rather than trusting the unmarshalled
+	// struct field alone.
+	if v.IsSet("trustedVendors") {
+		config.TrustedVendors = trustedVendorsFromViper(v)
+	}
 	if len(config.TrustedVendors) == 0 {
 		// copy to avoid aliasing the package-level default slice
 		config.TrustedVendors = append([]string{}, defaultTrustedVendors...)
 	}
 
+	if v.IsSet("proxyRegistryMap") {
+		config.ProxyRegistryMap = v.GetStringMapString("proxyRegistryMap")
+	}
+
 	return config, nil
+}
+
+// trustedVendorsFromViper resolves trustedVendors regardless of whether it came
+// from the JSON config file (already a []interface{}, handled fine by
+// GetStringSlice) or from a TRUSTEDVENDORS environment variable (a plain string,
+// which GetStringSlice does not split): env values are a comma-separated list,
+// e.g. TRUSTEDVENDORS=echo,chainguard.
+func trustedVendorsFromViper(v *viper.Viper) []string {
+	raw, ok := v.Get("trustedVendors").(string)
+	if !ok {
+		return v.GetStringSlice("trustedVendors")
+	}
+	var vendors []string
+	for _, part := range strings.Split(raw, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			vendors = append(vendors, part)
+		}
+	}
+	return vendors
 }
 
 type clusterDataBackendServicesConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -171,7 +171,11 @@ func LoadConfig(path string) (Config, error) {
 	}
 
 	if v.IsSet("proxyRegistryMap") {
-		config.ProxyRegistryMap = v.GetStringMapString("proxyRegistryMap")
+		proxyMap, err := proxyRegistryMapFromViper(v)
+		if err != nil {
+			return Config{}, err
+		}
+		config.ProxyRegistryMap = proxyMap
 	}
 
 	return config, nil
@@ -194,6 +198,26 @@ func trustedVendorsFromViper(v *viper.Viper) []string {
 		}
 	}
 	return vendors
+}
+
+// proxyRegistryMapFromViper resolves proxyRegistryMap regardless of whether it
+// came from the JSON config file (already a map[string]interface{}, handled
+// fine by GetStringMapString) or from a PROXYREGISTRYMAP environment variable
+// (a plain JSON-object string, e.g. PROXYREGISTRYMAP={"docker.io":"mirror"}).
+// GetStringMapString discards JSON decode errors and silently returns an empty
+// map, which would disable registry mirroring on a malformed env value without
+// any indication why, so the env case is parsed explicitly here and any error
+// is surfaced to the caller instead.
+func proxyRegistryMapFromViper(v *viper.Viper) (map[string]string, error) {
+	raw, ok := v.Get("proxyRegistryMap").(string)
+	if !ok {
+		return v.GetStringMapString("proxyRegistryMap"), nil
+	}
+	var proxyMap map[string]string
+	if err := json.Unmarshal([]byte(raw), &proxyMap); err != nil {
+		return nil, fmt.Errorf("invalid proxyRegistryMap: %w", err)
+	}
+	return proxyMap, nil
 }
 
 type clusterDataBackendServicesConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -255,3 +255,27 @@ func TestLoadConfigProxyRegistryMap(t *testing.T) {
 	}
 	assert.Equal(t, expected, config.ProxyRegistryMap)
 }
+
+// TestLoadConfigTrustedVendorsEnv verifies an env-only TRUSTEDVENDORS override is
+// honored instead of being silently dropped and replaced by defaultTrustedVendors
+// (AutomaticEnv values for []string fields are not populated by Unmarshal, so the
+// resolution must read through viper's getters, same as cveMatchingMode).
+func TestLoadConfigTrustedVendorsEnv(t *testing.T) {
+	viper.Reset()
+	t.Setenv("TRUSTEDVENDORS", "foo, bar")
+	c, err := LoadConfig("testdata")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"foo", "bar"}, c.TrustedVendors)
+}
+
+// TestLoadConfigProxyRegistryMapEnv verifies an env-only PROXYREGISTRYMAP override
+// (a JSON object string) is honored instead of being silently dropped
+// (AutomaticEnv values for map[string]string fields are not populated by
+// Unmarshal, so the resolution must read through viper's getters).
+func TestLoadConfigProxyRegistryMapEnv(t *testing.T) {
+	viper.Reset()
+	t.Setenv("PROXYREGISTRYMAP", `{"docker.io":"env-mirror.example.com"}`)
+	c, err := LoadConfig("testdata")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"docker.io": "env-mirror.example.com"}, c.ProxyRegistryMap)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -279,3 +279,15 @@ func TestLoadConfigProxyRegistryMapEnv(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"docker.io": "env-mirror.example.com"}, c.ProxyRegistryMap)
 }
+
+// TestLoadConfigProxyRegistryMapEnv_Invalid verifies a malformed PROXYREGISTRYMAP
+// env value fails config loading with an error instead of GetStringMapString's
+// default behavior of silently discarding the decode error and returning an
+// empty map, which would disable registry mirroring with no indication why.
+func TestLoadConfigProxyRegistryMapEnv_Invalid(t *testing.T) {
+	viper.Reset()
+	t.Setenv("PROXYREGISTRYMAP", `{"docker.io":`)
+	_, err := LoadConfig("testdata")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "proxyRegistryMap")
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -185,7 +185,7 @@ The main configuration file. All options can be overridden via environment varia
 |--------|------|---------|-------------|
 | `listingURL` | string | `https://grype.anchore.io/databases` | Grype vulnerability database URL |
 | `cveMatchingMode` | string | `adaptive` | CPE matching policy: `off` (Grype defaults everywhere), `on` (aggressive CPE matching everywhere), or `adaptive` (CPE matching everywhere except trusted-vendor images, which fall back to Grype defaults). See [CVE Matching Mode](#cve-matching-mode). |
-| `trustedVendors` | []string | `["echo","chainguard","wolfi","minimos"]` | Distro identifiers (as recognised by Grype's distro detection) treated as trusted vendors in `adaptive` mode. Override to add/remove vendors without a release. |
+| `trustedVendors` | []string | `["echo","chainguard","wolfi","minimos"]` | Distro identifiers (as recognised by Grype's distro detection) treated as trusted vendors in `adaptive` mode. Override to add/remove vendors without a release. Via `TRUSTEDVENDORS` env var, use a comma-separated list, e.g. `TRUSTEDVENDORS=echo,chainguard`. |
 | `useDefaultMatchers` | bool | `false` | **Deprecated**, kept for backward compatibility. Maps to `cveMatchingMode`: `true` -> `off`, `false` -> `on`. An explicit `cveMatchingMode` always wins. |
 
 #### Storage Options
@@ -205,7 +205,7 @@ The main configuration file. All options can be overridden via environment varia
 | `nodeSbomGeneration` | bool | `false` | Enable node-level SBOM generation |
 | `partialRelevancy` | bool | `false` | Enable partial relevancy matching |
 | `vexGeneration` | bool | `false` | Generate VEX (Vulnerability Exploitability eXchange) documents |
-| `proxyRegistryMap` | map[string]string | `{}` | Maps a registry hostname to an internal mirror for image pulls, e.g. `{"docker.io": "my-mirror.example.com"}`. Applied to every SBOM-generation path (in-process and sidecar). Config keys are parsed with a `::` delimiter specifically so hostnames containing `.` are treated as a single map key instead of being split into nested keys (see #359/#361) — no special escaping needed in `docker.io`-style keys. |
+| `proxyRegistryMap` | map[string]string | `{}` | Maps a registry hostname to an internal mirror for image pulls, e.g. `{"docker.io": "my-mirror.example.com"}`. Applied to every SBOM-generation path (in-process and sidecar). Config keys are parsed with a `::` delimiter specifically so hostnames containing `.` are treated as a single map key instead of being split into nested keys (see #359/#361) — no special escaping needed in `docker.io`-style keys. Via `PROXYREGISTRYMAP` env var, pass the whole map as a JSON object string, e.g. `PROXYREGISTRYMAP={"docker.io":"my-mirror.example.com"}`. |
 
 ### Complete Schema
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -205,7 +205,7 @@ The main configuration file. All options can be overridden via environment varia
 | `nodeSbomGeneration` | bool | `false` | Enable node-level SBOM generation |
 | `partialRelevancy` | bool | `false` | Enable partial relevancy matching |
 | `vexGeneration` | bool | `false` | Generate VEX (Vulnerability Exploitability eXchange) documents |
-| `proxyRegistryMap` | map[string]string | `{}` | Maps a registry hostname to an internal mirror for image pulls, e.g. `{"docker.io": "my-mirror.example.com"}`. Applied to every SBOM-generation path (in-process and sidecar). Config keys are parsed with a `::` delimiter specifically so hostnames containing `.` are treated as a single map key instead of being split into nested keys (see #359/#361) — no special escaping needed in `docker.io`-style keys. Via `PROXYREGISTRYMAP` env var, pass the whole map as a JSON object string, e.g. `PROXYREGISTRYMAP={"docker.io":"my-mirror.example.com"}`. |
+| `proxyRegistryMap` | map[string]string | `{}` | Maps a registry hostname to an internal mirror for image pulls, e.g. `{"docker.io": "my-mirror.example.com"}`. Applied to every SBOM-generation path (in-process and sidecar). Config keys are parsed with a `::` delimiter specifically so hostnames containing `.` are treated as a single map key instead of being split into nested keys (see #359/#361) — no special escaping needed in `docker.io`-style keys. Via `PROXYREGISTRYMAP` env var, pass the whole map as a JSON object string, e.g. `PROXYREGISTRYMAP='{"docker.io":"my-mirror.example.com"}'` (single-quote in shells so the double quotes reach the process unescaped; malformed JSON now fails config loading with an error instead of silently disabling mirroring). |
 
 ### Complete Schema
 


### PR DESCRIPTION
## Overview

`viper.AutomaticEnv()` makes an env-only value visible via `IsSet`/`Get`, but `Unmarshal` does not populate slice/map struct fields from it. This gap is already documented and worked around for `cveMatchingMode` in `LoadConfig`, but the same workaround was never applied to `trustedVendors`/`proxyRegistryMap`:

- `TRUSTEDVENDORS` set purely via env var was silently dropped, and `TrustedVendors` quietly reverted to `defaultTrustedVendors`.
- `PROXYREGISTRYMAP` set purely via env var was silently dropped, and `ProxyRegistryMap` stayed empty (no fallback at all) — registry mirroring never activated.

Both are now resolved through viper's getters when `IsSet`, matching the existing `cveMatchingMode` pattern:
- `TRUSTEDVENDORS` is parsed as a comma-separated list (`GetStringSlice` does not split env-var strings, only JSON-file-sourced arrays).
- `PROXYREGISTRYMAP` is parsed as a JSON object string via `GetStringMapString` (which already handles both the JSON-file map shape and a JSON-string env var).

Docs updated with the expected env-var formats for both fields.

## How to Test

- `go build ./...`
- `go vet ./...`
- `golangci-lint run --new-from-rev upstream/main` — 0 issues
- `go test ./...` — all passing (the one pre-existing failure, `TestScanService_NginxTest`, requires a Docker-pulled Grype DB fixture and is unrelated to this change, which only touches `config/`)
- New tests: `TestLoadConfigTrustedVendorsEnv`, `TestLoadConfigProxyRegistryMapEnv` — verify env-only overrides are honored instead of silently dropped

## Related issues/PRs

* Resolved #588

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment-variable configuration for trusted vendors and proxy registry mappings is now loaded correctly.
  * Trusted vendor values support comma-separated entries with whitespace trimming.
  * Default trusted vendors continue to apply when no values are configured.

* **Documentation**
  * Added guidance for configuring trusted vendors and proxy registry mappings through environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->