### PR TITLE
fix(backend): capture non-200 response body snippet and fix dead 429 logging (#596)

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -145,7 +145,14 @@ func httpPostWithContext(ctx context.Context, httpClient httputils.IHttpClient, 
 		}
 		if resp.StatusCode != http.StatusOK {
 			defer resp.Body.Close()
-			retryErr := fmt.Errorf("received status code: %d", resp.StatusCode)
+			bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			bodyStr := strings.TrimSpace(string(bodyBytes))
+			var retryErr error
+			if bodyStr != "" {
+				retryErr = fmt.Errorf("received status code: %d, body: %s", resp.StatusCode, bodyStr)
+			} else {
+				retryErr = fmt.Errorf("received status code: %d", resp.StatusCode)
+			}
 			if !shouldRetryReport(resp) {
 				return nil, backoff.Permanent(retryErr)
 			}

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -27,6 +28,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kinbiko/jsonassert"
 	beClientV1 "github.com/kubescape/backend/pkg/client/v1"
+	"github.com/kubescape/go-logger"
 	sysreport "github.com/kubescape/backend/pkg/server/v1/systemreports"
 	"github.com/kubescape/kubevuln/core/domain"
 	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
@@ -1359,4 +1361,80 @@ func TestBackendAdapter_SendStatusAbortsPromptlyOnCtxCancellation(t *testing.T) 
 	cancel()
 	err := backend.SendStatus(ctx, 0)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestHttpPostWithContext_IncludesResponseBodyInError verifies that httpPostWithContext captures non-200 response body snippets up to 512 bytes and truncates beyond that boundary.
+func TestHttpPostWithContext_IncludesResponseBodyInError(t *testing.T) {
+	// Marker 'B' is at byte index 512 (the 513th byte), proving truncation occurs at exactly 512 bytes.
+	longBody := strings.Repeat("A", 512) + "B" + "EXCLUSIVE_TAIL_HEADER"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(longBody))
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := httpPostWithContext(ctx, http.DefaultClient, ts.URL, nil, []byte("data"), 100*time.Millisecond)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "received status code: 429")
+	assert.Contains(t, err.Error(), strings.Repeat("A", 512))
+	assert.NotContains(t, err.Error(), "B")
+	assert.NotContains(t, err.Error(), "EXCLUSIVE_TAIL_HEADER")
+}
+
+// TestHttpPostWithContext_EmptyResponseBody verifies the status-code-only error format when non-200 response body is empty.
+func TestHttpPostWithContext_EmptyResponseBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := httpPostWithContext(ctx, http.DefaultClient, ts.URL, nil, []byte("data"), 100*time.Millisecond)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, "received status code: 500", err.Error())
+}
+
+// TestBackendAdapter_PostResults_429RateLimitLogging verifies that postResults detects 429 rate-limiting errors and logs vendor guidance.
+func TestBackendAdapter_PostResults_429RateLimitLogging(t *testing.T) {
+	backend := &BackendAdapter{
+		httpPostFunc: func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error) {
+			return nil, fmt.Errorf("received status code: 429, body: quota exceeded")
+		},
+	}
+
+	report := v1.ScanResultReport{
+		Designators: identifiers.PortalDesignator{
+			Attributes: map[string]string{
+				identifiers.AttributeCustomerGUID: "test-guid",
+			},
+		},
+	}
+
+	// Capture logger output to verify the rate-limit guidance log message
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	logger.InitLogger("pretty")
+
+	err := backend.postResults(context.Background(), report, "http://localhost", "nginx:latest", "wlid://cluster-a/namespace-b/deployment-c")
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+	logger.InitLogger("pretty")
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	logOutput := buf.String()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "429")
+	assert.Contains(t, err.Error(), "quota exceeded")
+	assert.Contains(t, logOutput, "failed sending vulnerabilities report due to rate limiting (429 Too Many Requests)")
 }

--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"sync"
@@ -133,20 +132,25 @@ func (a *BackendAdapter) postResults(
 
 	resp, err := a.httpPostFunc(ctx, a.getHTTPClient(), urlBase.String(), a.getRequestHeaders(), payload, 60*time.Second)
 	if err != nil {
-		logger.L().Ctx(ctx).Error("failed posting to event", helpers.Error(err),
-			helpers.String("image", imagetag),
-			helpers.String("wlid", wlid))
+		errStr := err.Error()
+		if strings.Contains(errStr, "429") || strings.Contains(errStr, "Too Many Requests") {
+			logger.L().Ctx(ctx).Error("failed sending vulnerabilities report due to rate limiting (429 Too Many Requests). Please ask your vendor for support",
+				helpers.Error(err),
+				helpers.String("image", imagetag),
+				helpers.String("wlid", wlid))
+		} else {
+			logger.L().Ctx(ctx).Error("failed posting to event", helpers.Error(err),
+				helpers.String("image", imagetag),
+				helpers.String("wlid", wlid))
+		}
 		return err
 	}
 	defer resp.Body.Close()
 	body, err := httputils.HttpRespToString(resp)
 	if err != nil {
-		if resp.StatusCode == http.StatusTooManyRequests {
-			logger.L().Ctx(ctx).Error("failed sending vulnerabilities report due to rate limiting (429 Too Many Requests). Please ask your vendor for support", helpers.Error(err), helpers.String("body", body))
-		} else {
-			logger.L().Ctx(ctx).Error("failed sending vulnerabilities report", helpers.Error(err), helpers.String("body", body))
-		}
-
+		logger.L().Ctx(ctx).Error("failed reading response body from event receiver", helpers.Error(err),
+			helpers.String("image", imagetag),
+			helpers.String("wlid", wlid))
 		return err
 	}
 	logger.L().Debug(fmt.Sprintf("posting to event receiver image %s wlid %s finished successfully response body: %s", imagetag, wlid, body)) // systest dependent

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -364,17 +364,20 @@ func (h HTTPController) ScanRegistry(c *gin.Context) {
 	})
 }
 
+// registryScanCommandToScanCommand converts a RegistryScanCommand into a domain.ScanCommand, populating normalized image reference, image hash, and image slug.
 func registryScanCommandToScanCommand(c wssc.RegistryScanCommand) domain.ScanCommand {
+	imageTagNormalized := tools.NormalizeReference(c.ImageTag)
 	command := domain.ScanCommand{
 		CredentialsList:    c.Credentialslist,
+		ImageHash:          v1.NormalizeImageID("", c.ImageTag),
 		ImageTag:           c.ImageTag,
-		ImageTagNormalized: tools.NormalizeReference(c.ImageTag),
+		ImageTagNormalized: imageTagNormalized,
 		JobID:              c.JobID,
 		ParentJobID:        c.ParentJobID,
 		Args:               c.Args,
 		Session:            sessionChainToSession(c.Session),
 	}
-	if slug, err := names.ImageInfoToSlug(c.ImageTag, "nohash"); err == nil {
+	if slug, err := names.ImageInfoToSlug(imageTagNormalized, "nohash"); err == nil {
 		command.ImageSlug = slug
 	}
 	return command

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/gammazero/workerpool"
 	"github.com/gin-gonic/gin"
+	"github.com/kubescape/k8s-interface/names"
+	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/core/services"
@@ -338,6 +340,10 @@ func Test_registryScanCommandToScanCommand(t *testing.T) {
 		assert.Equal(t, tests[i].Credentialslist, scanComm.CredentialsList)
 		assert.Equal(t, tests[i].ImageTag, scanComm.ImageTag)
 		assert.Equal(t, tools.NormalizeReference(tests[i].ImageTag), scanComm.ImageTagNormalized)
+		assert.Equal(t, v1.NormalizeImageID("", tests[i].ImageTag), scanComm.ImageHash)
+		expectedSlug, err := names.ImageInfoToSlug(tools.NormalizeReference(tests[i].ImageTag), "nohash")
+		require.NoError(t, err)
+		assert.Equal(t, expectedSlug, scanComm.ImageSlug)
 		assert.Equal(t, tests[i].JobID, scanComm.JobID)
 		assert.Equal(t, tests[i].ParentJobID, scanComm.ParentJobID)
 	}


### PR DESCRIPTION
## Overview

Fixes event-receiver error response body handling and resolves registry scan command image hash initialization (#596).

### Problem
1. `httpPostWithContext` discarded non-200 HTTP response bodies immediately upon receiving a failure status (closing `resp.Body` without reading it), returning only `received status code: <code >`.
2. `postResults` attempted to inspect `resp.StatusCode` after `httpPostFunc` returned an error (which returns `resp = nil`). As a result, early error returns prevented lines 142–151 from executing, rendering the `429 Too Many Requests` vendor guidance log dead code.
3. `registryScanCommandToScanCommand` left `command.ImageHash` uninitialized (`""`) and passed unnormalized `c.ImageTag` to `names.ImageInfoToSlug`, leading to missing hash attributes in scan failure/telemetry reports.

### Solution
1. **Response Snippet Capture (`adapters/v1/backend.go`)**: Updated `httpPostWithContext` to read up to 512 bytes of response body on non-200 responses and append it to the returned `error` message (e.g. `received status code: 429, body: <snippet>`).
2. **Clean 429 Log Handling (`adapters/v1/backend_utils.go`)**: Refactored `postResults` to inspect error strings for `429` / `Too Many Requests` and log rate-limit guidance without dereferencing a nil `*http.Response` pointer.
3. **Registry Command Normalization (`controllers/http.go`)**: Updated `registryScanCommandToScanCommand` to populate `ImageHash` using `v1.NormalizeImageID("", c.ImageTag)` and pass `tools.NormalizeReference(c.ImageTag)` to `names.ImageInfoToSlug`.
4. **Unit Tests (`adapters/v1/backend_test.go`, `controllers/http_test.go`)**: Added unit tests verifying body snippet inclusion on 429 responses, rate-limit log triggering, and registry command hash/slug normalization.

## How to Test

Run the unit test suite covering `httpPostWithContext`, `postResults`, and `registryScanCommandToScanCommand`:
```bash
go test -v -count=1 ./adapters/v1 -run "TestHttpPostWithContext|TestBackendAdapter_PostResults"
go test -v -count=1 ./controllers -run "Test_registryScanCommandToScanCommand"
```

## Related issues/PRs:

* Fixes #596

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed-request errors by including available response details, limited to keep messages concise.
  * Added clearer rate-limit guidance for HTTP 429 responses.
  * Standardized registry image references for more consistent identification and reporting.

* **Tests**
  * Added coverage for response-body details, empty responses, rate-limit errors, and normalized image information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->