### PR TITLE
Add diagnostics endpoint for scan mode and backend versions

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -19,6 +19,7 @@ import (
 	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/config"
 	"github.com/kubescape/kubevuln/controllers"
+	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"github.com/kubescape/kubevuln/core/services"
 	"github.com/kubescape/kubevuln/internal/metrics"
@@ -78,6 +79,7 @@ func main() {
 		}
 	}
 	var sbomAdapter ports.SBOMCreator
+	scanMode := domain.ScanModeInProcess
 	if socketPath := os.Getenv("SBOM_SCANNER_SOCKET"); socketPath != "" {
 		logger.L().Info("connecting to SBOM scanner sidecar", helpers.String("socket", socketPath))
 		scannerClient, err := sbomscanner.NewSBOMScannerClient(ctx, socketPath, c.ScannerReadinessTimeout)
@@ -92,6 +94,7 @@ func main() {
 		} else {
 			memoryLimit := os.Getenv("SCANNER_MEMORY_LIMIT")
 			sbomAdapter = v1.NewSidecarSBOMAdapter(scannerClient, c.ScanTimeout, c.MaxImageSize, c.MaxSBOMSize, c.ScanEmbeddedSboms, memoryLimit, c.ProxyRegistryMap)
+			scanMode = domain.ScanModeSidecar
 		}
 	} else {
 		sbomAdapter = v1.NewSyftAdapter(c.ScanTimeout, c.MaxImageSize, c.MaxSBOMSize, c.ScanEmbeddedSboms, c.ProxyRegistryMap)
@@ -154,6 +157,18 @@ func main() {
 		service.SetEventRecorder(eventRecorder)
 	}
 	controller := controllers.NewHTTPController(service, c.ScanConcurrency)
+	controller = controller.WithDiagnostics(func(diagCtx context.Context) domain.Diagnostics {
+		return domain.Diagnostics{
+			ScanMode:                scanMode,
+			SBOMCreatorVersion:      sbomAdapter.Version(),
+			CVEScannerVersion:       cveAdapter.Version(),
+			CVEDBVersion:            cveAdapter.DBVersion(diagCtx),
+			ScanTimeout:             c.ScanTimeout.String(),
+			ScannerReadinessTimeout: c.ScannerReadinessTimeout.String(),
+			StorageEnabled:          c.Storage,
+			RiskAcceptanceEnabled:   c.RiskAcceptance,
+		}
+	})
 
 	m, err := metrics.New()
 	if err != nil {
@@ -186,6 +201,7 @@ func main() {
 
 	router.GET("/v1/liveness", controller.Alive)
 	router.GET("/v1/readiness", controller.Ready)
+	router.GET("/v1/diagnostics", controller.Diagnostics)
 	router.GET("/metrics", gin.WrapH(m.Handler()))
 
 	group := router.Group(apis.VulnerabilityScanCommandVersion)

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -30,6 +30,7 @@ type HTTPController struct {
 	scanService ports.ScanService
 	workerPool  *workerpool.WorkerPool
 	metrics     *metrics.Metrics
+	diagnostics func(ctx context.Context) domain.Diagnostics
 }
 
 // NewHTTPController initializes the HTTPController struct with the injected scanService
@@ -58,6 +59,16 @@ func (h *HTTPController) WithMetrics(m *metrics.Metrics) (*HTTPController, error
 		return h, err
 	}
 	return h, nil
+}
+
+// WithDiagnostics attaches the callback the Diagnostics handler uses to report the
+// scan mode and backend versions currently in effect. A callback (rather than a
+// fixed value) is required because the CVE DB version changes as the background
+// updater in GrypeAdapter refreshes it (see adapters/v1/grype.go). It is a no-op to
+// call the handler without this having been set, returning the struct's zero value.
+func (h *HTTPController) WithDiagnostics(f func(ctx context.Context) domain.Diagnostics) *HTTPController {
+	h.diagnostics = f
+	return h
 }
 
 // recordScan records the outcome and duration of a background scan job for the given endpoint.
@@ -173,6 +184,17 @@ func (h HTTPController) Ready(c *gin.Context) {
 	}
 
 	_, _ = problem.Of(http.StatusOK).WriteTo(c.Writer)
+}
+
+// Diagnostics reports the scan mode and backend versions resolved at startup, so
+// operators can query the running configuration directly instead of inferring it
+// from logs. See domain.Diagnostics for the excluded (credential) fields.
+func (h HTTPController) Diagnostics(c *gin.Context) {
+	if h.diagnostics == nil {
+		c.JSON(http.StatusOK, domain.Diagnostics{})
+		return
+	}
+	c.JSON(http.StatusOK, h.diagnostics(c.Request.Context()))
 }
 
 // ScanCP unmarshalls the payload and calls scanService.ScanCP

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -121,6 +121,49 @@ func TestHTTPController_Ready(t *testing.T) {
 	}
 }
 
+func TestHTTPController_Diagnostics(t *testing.T) {
+	tests := []struct {
+		name         string
+		diagnostics  func(ctx context.Context) domain.Diagnostics
+		expectedBody string
+	}{
+		{
+			name:         "not configured",
+			diagnostics:  nil,
+			expectedBody: `{"scanMode":"","sbomCreatorVersion":"","cveScannerVersion":"","cveDBVersion":"","scanTimeout":"","scannerReadinessTimeout":"","storageEnabled":false,"riskAcceptanceEnabled":false}`,
+		},
+		{
+			name: "sidecar mode with storage and risk acceptance enabled",
+			diagnostics: func(context.Context) domain.Diagnostics {
+				return domain.Diagnostics{
+					ScanMode:                domain.ScanModeSidecar,
+					SBOMCreatorVersion:      "syft-1.2.3",
+					CVEScannerVersion:       "grype-4.5.6-matching-adaptive",
+					CVEDBVersion:            "db-2026-08-11",
+					ScanTimeout:             "5m0s",
+					ScannerReadinessTimeout: "1m0s",
+					StorageEnabled:          true,
+					RiskAcceptanceEnabled:   true,
+				}
+			},
+			expectedBody: `{"scanMode":"sidecar","sbomCreatorVersion":"syft-1.2.3","cveScannerVersion":"grype-4.5.6-matching-adaptive","cveDBVersion":"db-2026-08-11","scanTimeout":"5m0s","scannerReadinessTimeout":"1m0s","storageEnabled":true,"riskAcceptanceEnabled":true}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := HTTPController{diagnostics: tt.diagnostics}
+			router := gin.Default()
+			path := "/v1/diagnostics"
+			router.GET(path, c.Diagnostics)
+			req, _ := http.NewRequest("GET", path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code, w.Code)
+			assert.JSONEq(t, tt.expectedBody, w.Body.String(), w.Body.String())
+		})
+	}
+}
+
 func TestHTTPController_ScanCVE(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/core/domain/diagnostics.go
+++ b/core/domain/diagnostics.go
@@ -1,0 +1,23 @@
+package domain
+
+// Diagnostics reports the SBOM/CVE scan configuration that was resolved at startup,
+// so operators can query which mode and versions a running pod is actually using
+// instead of inferring it from logs. It intentionally excludes credentials and any
+// other secret-derived configuration.
+type Diagnostics struct {
+	ScanMode                string `json:"scanMode"`
+	SBOMCreatorVersion      string `json:"sbomCreatorVersion"`
+	CVEScannerVersion       string `json:"cveScannerVersion"`
+	CVEDBVersion            string `json:"cveDBVersion"`
+	ScanTimeout             string `json:"scanTimeout"`
+	ScannerReadinessTimeout string `json:"scannerReadinessTimeout"`
+	StorageEnabled          bool   `json:"storageEnabled"`
+	RiskAcceptanceEnabled   bool   `json:"riskAcceptanceEnabled"`
+}
+
+const (
+	// ScanModeSidecar indicates SBOM generation runs through the sbom-scanner sidecar.
+	ScanModeSidecar = "sidecar"
+	// ScanModeInProcess indicates SBOM generation runs in-process via Syft.
+	ScanModeInProcess = "in-process"
+)


### PR DESCRIPTION
## Overview

Adds a new `GET /v1/diagnostics` endpoint, separate from `/v1/liveness` and `/v1/readiness`, that reports the SBOM scan configuration actually in effect on a running pod: whether the sidecar or in process Syft path was resolved at startup, the Syft and Grype library versions, the current Grype vulnerability DB version, the configured scan and scanner readiness timeouts, and whether storage and risk acceptance (SecurityException CRD integration) are enabled. Today this information is only available by reading startup logs.

The CVE DB version is refreshed periodically in the background by the Grype adapter, so the handler reads it live on every request instead of caching a value from startup. The response never includes credentials or other secret derived configuration.

<!-- 
## Additional Information
-->

The values are collected in `cmd/http/main.go` where the SBOM adapter (sidecar vs Syft) and the Grype adapter are already constructed, and passed into `HTTPController` through a small `WithDiagnostics` callback, mirroring the existing `WithMetrics` pattern. The handler itself just serializes the resulting `domain.Diagnostics` struct as JSON.

<!--
## How to Test
-->

Run the service locally and curl the new endpoint:

```
CONFIG_DIR=.dev/config go run ./cmd/http
curl http://localhost:8080/v1/diagnostics
```

<!--
## Related issues/PRs:
-->

* Resolved #598

<!--
## Checklist before requesting a review
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostics endpoint at `/v1/diagnostics`.
  * Exposes SBOM and CVE scan modes, component versions, timeout settings, storage configuration, and risk-acceptance settings.
  * Diagnostics exclude credentials and other secret-derived values.
  * Returns an empty diagnostics response when no configuration is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->