### PR TITLE
fix(adapters): stop the abandoned Syft goroutine racing CreateSBOM

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -47,6 +47,10 @@ func formatResolvedPlatform(os, arch, variant string) string {
 	return strings.Join(parts, "/")
 }
 
+// createSBOMFn is an indirection over syft.CreateSBOM so the deadline handling in
+// CreateSBOM can be unit-tested without cataloguing a real image.
+var createSBOMFn = syft.CreateSBOM
+
 // SyftAdapter implements SBOMCreator from ports using Syft's API
 type SyftAdapter struct {
 	maxImageSize      int64
@@ -299,6 +303,9 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// generate SBOM
 	// use a deadline to prevent the process from hanging for too long
 	var syftSBOM *sbom.SBOM
+	// Buffered so a goroutine abandoned by the deadline can always publish and exit, even
+	// when nobody is left to receive.
+	generated := make(chan *sbom.SBOM, 1)
 	// ensure no parallel pulls
 	s.pullMutex.Lock()
 	defer s.pullMutex.Unlock()
@@ -328,10 +335,16 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 			// ask Syft to also scan the image for embedded SBOMs
 			cfg.WithCatalogers(pkgcataloging.NewCatalogerReference(sbomcataloger.NewCataloger(), []string{pkgcataloging.ImageTag}))
 		}
-		syftSBOM, err = syft.CreateSBOM(ctxWithSize, src, cfg)
-		if err != nil {
-			return fmt.Errorf("failed to generate SBOM: %w", err)
+		// This closure can outlive the call: deadline.Run cannot stop its work function and
+		// documents as much, and Syft's cataloguers do not observe cancellation either, so on
+		// timeout it keeps running after CreateSBOM has already returned Incomplete. It must
+		// therefore not touch any variable the caller reads. Keep the result local and publish
+		// it on the channel, which is only received from once dl.Run reports success.
+		created, createErr := createSBOMFn(ctxWithSize, src, cfg)
+		if createErr != nil {
+			return fmt.Errorf("failed to generate SBOM: %w", createErr)
 		}
+		generated <- created
 		return nil
 	})
 	switch {
@@ -342,7 +355,9 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		domainSBOM.Status = helpersv1.Incomplete
 		return domainSBOM, nil
 	case err == nil:
-		// continue
+		// dl.Run reports success only once the work function returned nil, which it does
+		// after publishing, so this receive cannot block.
+		syftSBOM = <-generated
 	default:
 		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		// also mark as incomplete if we failed to extract packages

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -1,9 +1,21 @@
 package v1
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -395,4 +407,90 @@ func Test_syftAdapter_CreateSBOM_TimeoutContext(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, helpersv1.Incomplete, sbom.Status)
+}
+
+// mockRegistryImage serves a minimal single-layer image so syft.GetSource resolves without a
+// network, letting a test reach CreateSBOM's deadline handling. Returns the registry host.
+func mockRegistryImage(t *testing.T) string {
+	t.Helper()
+
+	layer := &bytes.Buffer{}
+	gz := gzip.NewWriter(layer)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "etc/hostname", Mode: 0o644, Size: 4}))
+	_, err := tw.Write([]byte("test"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	layerBytes := layer.Bytes()
+	layerHash := fmt.Sprintf("%x", sha256.Sum256(layerBytes))
+
+	uncompressed := &bytes.Buffer{}
+	zr, err := gzip.NewReader(bytes.NewReader(layerBytes))
+	require.NoError(t, err)
+	_, err = io.Copy(uncompressed, zr)
+	require.NoError(t, err)
+	diffID := fmt.Sprintf("%x", sha256.Sum256(uncompressed.Bytes()))
+
+	configBytes := []byte(fmt.Sprintf(
+		`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%s"]}}`, diffID))
+	configHash := fmt.Sprintf("%x", sha256.Sum256(configBytes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test-image/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"schemaVersion": 2,
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": %d, "digest": "sha256:%s"},
+				"layers": [{"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip", "size": %d, "digest": "sha256:%s"}]
+			}`, len(configBytes), configHash, len(layerBytes), layerHash)))
+		case "/v2/test-image/blobs/sha256:" + configHash:
+			_, _ = w.Write(configBytes)
+		case "/v2/test-image/blobs/sha256:" + layerHash:
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	return u.Host
+}
+
+// deadline.Run cannot stop its work function, and Syft's cataloguers do not observe
+// cancellation, so on timeout the Syft goroutine keeps running and finishes after CreateSBOM
+// has already returned Incomplete. The work function must therefore share nothing with the
+// caller. Run under -race, this fails if it writes a variable the caller reads.
+func Test_syftAdapter_CreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft(t *testing.T) {
+	host := mockRegistryImage(t)
+
+	finished := make(chan struct{})
+	orig := createSBOMFn
+	defer func() { createSBOMFn = orig }()
+	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		time.Sleep(1500 * time.Millisecond)
+		defer close(finished)
+		return &sbom.SBOM{}, nil
+	}
+
+	adapter := NewSyftAdapter(1*time.Second, 1<<30, 1<<30, false, nil)
+	domainSBOM, err := adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, helpersv1.Incomplete, domainSBOM.Status, "the deadline must surface as Incomplete")
+
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stand-in Syft never finished")
+	}
+	assert.Equal(t, helpersv1.Incomplete, domainSBOM.Status, "the late write must not affect the result")
 }


### PR DESCRIPTION
## Overview

The in-process adapter has the same defect #581 fixed on the sidecar path.

`deadline.Run` cannot stop its work function and documents that, and Syft's cataloguers do not observe cancellation, so on timeout the Syft goroutine keeps running and eventually executes:

```go
syftSBOM, err = syft.CreateSBOM(ctxWithSize, src, cfg)
```

assigning two variables the caller reads, after the caller has already read `err` and returned `Incomplete`.

Beyond the race itself, the write to `err` can land before the caller reads it in the `switch`. The caller then takes `case err == nil` and continues to `v1beta1.StripSBOM(syftSBOM)` and `s.syftToDomain(*syftSBOM)`. Nothing orders the two writes, so `syftSBOM` may still be nil there and the scan panics.

Passing a cancellable context to Syft, as #583 now does, does not close this: the cataloguers ignore it, which is why the deadline wrapper exists in the first place.

This keeps the work function's result local and publishes it on a buffered channel the caller only receives from once `dl.Run` reports success, so nothing is shared with a goroutine that can outlive the call. The receive cannot block: `dl.Run` returns nil only after the work function returned nil, which it does after publishing.

Behaviour on both paths is unchanged. The success path was never racy, because `deadline.Run` passes the return value over a channel, which orders the write before the read.

## Additional Information

`syft.CreateSBOM` moves behind a `createSBOMFn` package variable so the deadline path is reachable from a test, mirroring what #581 did for the sidecar.

The test needed source resolution to succeed, which this package had no harness for, so it adds `mockRegistryImage`: a local `httptest` registry serving a minimal single-layer image. That keeps the test hermetic, unlike the existing `CreateSBOM` tests which reference a real Docker Hub image, and it is reusable for any future test that needs to get past `syft.GetSource`.

## How to Test

```
go test -race ./adapters/v1/ -run Test_syftAdapter_CreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft
```

The test substitutes a stand-in for Syft that outlives a 1 second deadline and then returns a result exactly as the real cataloguer would, and waits for that late completion before finishing, so the write happens inside the window the race lived in.

Against the previous code it reports:

```
WARNING: DATA RACE
Write at 0x00c000880850 by goroutine 71:
--- FAIL: Test_syftAdapter_CreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft
```

and it passes here.

## Related issues/PRs:

* Resolved #600
* In-process half of #580, fixed for the sidecar in #581

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM generation timeout handling.
  * Timed-out scans now return an incomplete result without blocking or altering results after the operation ends.
  * Preserved successful scan results when completion occurs before the deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->