### PR TITLE
fix(cmd): give metrics shutdown its own context instead of reusing the expired one

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -235,8 +235,13 @@ func main() {
 	// doesn't silently run past the pod's terminationGracePeriodSeconds
 	controller.Shutdown(c.ShutdownTimeout)
 
-	if err := m.Shutdown(srvCtx); err != nil {
-		logger.L().Ctx(srvCtx).Error("metrics provider shutdown error", helpers.Error(err))
+	// srvCtx's 5s budget is spent by now (controller.Shutdown alone can take up to
+	// ShutdownTimeout, 20s by default), so reusing it here would hand the meter
+	// provider an already-expired context and skip the final metrics flush.
+	metricsCtx, metricsCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer metricsCancel()
+	if err := m.Shutdown(metricsCtx); err != nil {
+		logger.L().Ctx(metricsCtx).Error("metrics provider shutdown error", helpers.Error(err))
 	}
 
 	logger.L().Info("kubevuln exiting")


### PR DESCRIPTION
## Summary

In `cmd/http/main.go`'s graceful shutdown sequence, `srvCtx` is created with a 5-second timeout and used for `srv.Shutdown`. `controller.Shutdown(c.ShutdownTimeout)` then runs next, and can take up to `ShutdownTimeout` (20s by default). By the time `m.Shutdown(srvCtx)` runs afterward, `srvCtx` has almost always already expired, so the OTel meter provider shutdown gets a `Done()` context and skips its final metrics flush — while an error is still logged even though nothing actually failed.

This fixes it by giving the metrics shutdown its own fresh 5-second context instead of reusing the spent one.

## Test plan

- [x] `go build ./cmd/http/...`
- [x] `go vet ./cmd/http/...`
- Manual review of the shutdown sequence; no existing test covers this shutdown path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown handling to ensure metrics services have sufficient time to stop cleanly.
  * Metrics shutdown errors are now logged reliably, even when the main server shutdown context has expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->