### PR TITLE
docs: add the three instruments missing from the API metrics table

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -143,6 +143,9 @@ GET /metrics
 | `kubevuln_exceptions_matched_total` | counter | `sourceKind` (`SecurityException`/`ClusterSecurityException`) | Total number of CVE findings suppressed by a SecurityException/ClusterSecurityException |
 | `kubevuln_exceptions_expired_total` | counter | `sourceKind` | Total number of SecurityException/ClusterSecurityException CRDs skipped because their `expiresAt` has passed |
 | `kubevuln_exceptions_active` | gauge | - | Number of CVE exception policies (cloud + CRD-based) in force for the most recently evaluated scan |
+| `kubevuln_scan_fallbacks_total` | counter | `component` (`in_process`/`sidecar`), `category` (`registry_auth`/`platform`/`size_classification`), `strategy` (`anonymous`/`ecr`/`gcp_adc`/`image_too_large`/`incomplete`/`platform_mismatch`/`sbom_too_large`), `outcome` (`classified`/`failed`/`succeeded`) | Fallbacks taken while resolving or classifying a scan, such as retrying a 401 with cloud credentials or falling back to anonymous access |
+| `kubevuln_scan_source_resolution_total` | counter | `component`, `outcome` (`first_pass_success`/`fallback_assisted_success`/`fallback_failed`/`first_pass_failure`) | Whether pulling the image succeeded outright or only after a fallback, which is what distinguishes a healthy registry from one that works only by retry |
+| `kubevuln_registry_auth_cache_total` | counter | `strategy` (`ecr`/`gcp_adc`), `result` (`hit`/`miss`) | Registry auth credential lookups served from cache versus fetched from the cloud provider |
 
 `reason` is `"none"` for a `success`/`partial` outcome, and otherwise one of the bounded
 `scanfailure.Reason*` constants from [`armoapi-go/scanfailure`](https://github.com/armosec/armoapi-go)


### PR DESCRIPTION
## Overview

The Instruments table in `docs/API.md` enumerates what `/metrics` exposes, but three counters were added without being listed, so an operator reading it has no way to know they exist:

- `kubevuln_scan_fallbacks_total`
- `kubevuln_scan_source_resolution_total`
- `kubevuln_registry_auth_cache_total`

The first two are what the section's own closing paragraph is already describing, where it says an operator watching only `/metrics` can distinguish a registry auth failure from an oversized image. The table was missing the metrics its surrounding prose depends on.

Label vocabularies are taken from the constants in `internal/metrics` rather than summarised, since each is a closed set and an operator writing a PromQL query needs the exact values.

## Additional Information

Documentation only, no code change.

Checked in both directions: every `kubevuln_*` instrument defined in the code is now in the table, and every metric the table names exists in the code. `kubevuln_worker_pool_queue_depth` is registered in `controllers/http.go` rather than `internal/metrics`, which is why it is defined in a different place from the rest but was already documented correctly.

## Related issues/PRs:

* Documents instruments added in #546, #553 and #571

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
