### PR TITLE
fix(controllers): key registry scans on the normalized image reference

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -365,16 +365,24 @@ func (h HTTPController) ScanRegistry(c *gin.Context) {
 }
 
 func registryScanCommandToScanCommand(c wssc.RegistryScanCommand) domain.ScanCommand {
+	imageTagNormalized := tools.NormalizeReference(c.ImageTag)
 	command := domain.ScanCommand{
 		CredentialsList:    c.Credentialslist,
 		ImageTag:           c.ImageTag,
-		ImageTagNormalized: tools.NormalizeReference(c.ImageTag),
+		ImageTagNormalized: imageTagNormalized,
 		JobID:              c.JobID,
 		ParentJobID:        c.ParentJobID,
 		Args:               c.Args,
 		Session:            sessionChainToSession(c.Session),
 	}
-	if slug, err := names.ImageInfoToSlug(c.ImageTag, "nohash"); err == nil {
+	// Derive the slug from the normalized reference, as the in-cluster path does. ImageSlug
+	// is the storage key for the SBOM and the CVE manifest, so deriving it from the raw tag
+	// gave the same image a different key per reference form ("nginx:latest" and
+	// "docker.io/library/nginx:latest" are the same image), and every equivalent form missed
+	// the cache and regenerated the SBOM from scratch. The rate-limit and exception caches
+	// already key on the normalized reference, so this also stops the caches disagreeing
+	// about which image they are talking about.
+	if slug, err := names.ImageInfoToSlug(imageTagNormalized, "nohash"); err == nil {
 		command.ImageSlug = slug
 	}
 	return command

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -756,3 +756,45 @@ func TestHTTPController_MetricsEndpoint_RecordsScanFailureReason(t *testing.T) {
 		})
 	}
 }
+
+// ImageSlug is the storage key for the SBOM and the CVE manifest, so equivalent references to
+// the same image must produce the same slug. Deriving it from the raw tag gave each reference
+// form its own key, so every form missed the cache and regenerated the SBOM from scratch, and
+// the rate-limit and exception caches (which key on the normalized reference) disagreed with
+// storage about which image was in play.
+func Test_registryScanCommandToScanCommand_SlugIsStableAcrossEquivalentReferences(t *testing.T) {
+	equivalent := []string{
+		"nginx",
+		"nginx:latest",
+		"library/nginx:latest",
+		"docker.io/library/nginx:latest",
+		"index.docker.io/library/nginx:latest",
+	}
+
+	var slugs []string
+	for _, ref := range equivalent {
+		cmd := registryScanCommandToScanCommand(wssc.RegistryScanCommand{
+			ImageScanParams: wssc.ImageScanParams{ImageTag: ref},
+		})
+		assert.NotEmpty(t, cmd.ImageSlug, "slug must resolve for %q", ref)
+		slugs = append(slugs, cmd.ImageSlug)
+	}
+
+	for i, got := range slugs {
+		assert.Equal(t, slugs[0], got,
+			"%q and %q are the same image and must share a storage key", equivalent[0], equivalent[i])
+	}
+}
+
+// A different image must still get a different key.
+func Test_registryScanCommandToScanCommand_SlugDistinguishesImages(t *testing.T) {
+	slugFor := func(ref string) string {
+		return registryScanCommandToScanCommand(wssc.RegistryScanCommand{
+			ImageScanParams: wssc.ImageScanParams{ImageTag: ref},
+		}).ImageSlug
+	}
+
+	assert.NotEqual(t, slugFor("nginx:latest"), slugFor("nginx:1.25"))
+	assert.NotEqual(t, slugFor("nginx:latest"), slugFor("alpine:latest"))
+	assert.NotEqual(t, slugFor("docker.io/library/nginx:latest"), slugFor("quay.io/library/nginx:latest"))
+}


### PR DESCRIPTION
## Overview

`registryScanCommandToScanCommand` derived `ImageSlug` from the raw `ImageTag` while setting `ImageTagNormalized` from the normalized one, so the two disagreed about which image the command referred to.

`ImageSlug` is the storage key for both the SBOM and the CVE manifest, so every equivalent reference to one image got its own key:

| `ImageTag` in the request | `ImageSlug` |
|---|---|
| `nginx` | `nginx-nohash` |
| `nginx:latest` | `nginx-latest-nohash` |
| `docker.io/library/nginx:latest` | `docker.io-library-nginx-latest-nohash` |

Scanning the same image under a different form therefore missed the cache entirely and regenerated the SBOM from scratch, which is the 30s+ pull and catalogue that caching exists to avoid, and left several stored objects describing one image.

It also put storage out of step with the other caches keyed off the same command: `rateLimitCacheKey` and the exceptions cache key both use `ImageTagNormalized` already, so the backoff and the exception set treated two such requests as the same image while storage did not.

This derives the slug from the normalized reference, as `websocketScanCommandToScanCommand` already does for the in-cluster path.

## Additional Information

Objects stored under a raw-derived slug are orphaned by this change and will be rescanned once under the normalized key. That is a one-time cost and self-healing, and it only affects registry scans that used a non-canonical reference, which are the ones already paying for a full rescan on every run.

The in-cluster path is untouched. Note the two paths still produce different slugs for the same image by design, since that one embeds the image digest while registry scans have none and use `"nohash"`.

## How to Test

```
go test ./controllers/ -run Test_registryScanCommandToScanCommand
```

`SlugIsStableAcrossEquivalentReferences` covers the five forms that resolve to the same image (`nginx`, `nginx:latest`, `library/nginx:latest`, `docker.io/library/nginx:latest`, `index.docker.io/library/nginx:latest`) and asserts they share a key. It fails against the previous code.

`SlugDistinguishesImages` is the guard on the other side, so a fix that collapsed everything to one key would not pass: different tags, different repositories and different registries must still differ.

The pre-existing `Test_registryScanCommandToScanCommand` is unchanged and still passes. It already exercised two of these equivalent forms but only asserted `ImageTagNormalized`, never `ImageSlug`, which is why this went unnoticed.

## Related issues/PRs:

* Resolved #606

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
