### PR TITLE
fix(services): route ScanRegistry's SBOM lookup through getSBOM

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -738,7 +738,12 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	sbom := domain.SBOM{}
 	if cve.Content == nil {
 		if s.storage {
-			sbom, err = s.sbomRepository.GetSBOM(ctx, workload.ImageSlug, s.sbomCreator.Version())
+			// Go through getSBOM rather than the repository directly, as GenerateSBOM,
+			// ScanCP and ScanCVE all do. It is what discards an SBOM that was rejected
+			// under limits which have since changed, so without it a registry scan keeps
+			// serving a cached TooLarge verdict even after the operator raised
+			// maxImageSize, maxSBOMSize or the scanner memory limit to admit that image.
+			sbom, err = s.getSBOM(ctx, workload.ImageSlug, s.sbomCreator.Version())
 			if err != nil {
 				logger.L().Ctx(ctx).Warning("getting SBOM", helpers.Error(err),
 					helpers.String("imageSlug", workload.ImageSlug))

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2431,3 +2431,45 @@ func TestScanService_ScanCVE_CacheHit_DegradedAdditiveSkipsVEX(t *testing.T) {
 
 	assert.Empty(t, repo.vexCalls, "but no VEX document is published from a partial exception set")
 }
+
+// getSBOM discards an SBOM that was rejected under limits which have since changed, so a
+// rescan can admit an image the operator has just made room for. ScanRegistry called the
+// repository directly and skipped that, so it kept serving a cached TooLarge verdict forever:
+// raising maxImageSize had no effect on the registry path while it worked on every other one.
+func TestScanService_ScanRegistry_StaleTooLargeSBOMIsRescanned(t *testing.T) {
+	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
+	repo := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(sbomAdapter, repo, adapters.NewMockCVEAdapter(), repo,
+		&recordingPlatform{}, v1.NewContainerProfileAdapter(repositories.NewMemoryStorage(false, false)),
+		true, false, true, false, false)
+	ctx := context.TODO()
+	s.Ready(ctx)
+
+	ctx, err := s.ValidateScanRegistry(ctx, domain.ScanCommand{
+		ImageSlug:          "imageSlug",
+		ImageTagNormalized: "docker.io/library/nginx:latest",
+	})
+	require.NoError(t, err)
+
+	// Stored when the image-size limit was 1 byte. The current limit differs, so this
+	// verdict no longer reflects the configuration and must not be reused.
+	require.NoError(t, repo.StoreSBOM(ctx, domain.SBOM{
+		Name:               "imageSlug",
+		SBOMCreatorVersion: sbomAdapter.Version(),
+		Status:             helpersv1.TooLarge,
+		Content:            &v1beta1.SyftDocument{},
+		Annotations: map[string]string{
+			domain.StatusReasonAnnotationKey: domain.ReasonImageTooLarge,
+			domain.MaxImageSizeAnnotationKey: "1",
+		},
+	}, false))
+	require.NotEqual(t, "1", fmt.Sprintf("%d", sbomAdapter.GetMaxImageSize()),
+		"the test needs the current limit to differ from the stored one")
+
+	require.NoError(t, s.ScanRegistry(ctx))
+
+	stored, err := repo.GetSBOM(ctx, "imageSlug", sbomAdapter.Version())
+	require.NoError(t, err)
+	assert.NotEqual(t, helpersv1.TooLarge, stored.Status,
+		"the stale TooLarge SBOM must be replaced by a fresh scan, not served again")
+}


### PR DESCRIPTION
## Overview

`getSBOM` discards a stored SBOM whose verdict no longer matches the configuration: an outdated one, or a `TooLarge` one recorded under a `maxImageSize`, `maxSBOMSize` or scanner memory limit that has since changed. `GenerateSBOM`, `ScanCP` and `ScanCVE` all go through it. `ScanRegistry` read the repository directly and skipped it.

The retrieved SBOM feeds the status check a few lines below, which turns a cached `TooLarge` straight into a scan failure, so a registry scan kept serving that verdict indefinitely. An operator raising `maxImageSize` to admit a large image saw it take effect on every path except the registry one, where the image stayed rejected until the stored SBOM was deleted by hand, with nothing logged to explain why the new limit was ignored.

This calls `getSBOM` there too, so the limits are re-evaluated on every path.

## Additional Information

The divergence is invisible at the call site: both spellings return `(domain.SBOM, error)`, and the wrapper is named closely enough to the repository method that reading `ScanRegistry` alone gives no hint anything is missing. It is the same shape as #484, #501 and #557, where a step present in two of the three scan flows was absent from the third.

No behaviour change for a registry scan whose stored SBOM is current: `getSBOM` returns it untouched. The only scans affected are ones already stuck, which now regenerate once.

## How to Test

```
go test ./core/services/ -run TestScanService_ScanRegistry_StaleTooLargeSBOMIsRescanned
```

The test stores a `TooLarge` SBOM annotated with an image-size limit that differs from the current one, asserts up front that the two differ so it cannot pass vacuously, then runs `ScanRegistry` and requires the stored SBOM to have been replaced rather than served again. It fails against the previous code, where `ScanRegistry` returns `incomplete SBOM, skipping CVE scan` and leaves the stored object as it was.

## Related issues/PRs:

* Resolved #608

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
