### PR TITLE
fix: decode the Auth field when converting registry credentials

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"maps"
@@ -1090,14 +1091,36 @@ func registryCredentialsFromCredentialsList(credentials []registry.AuthConfig) [
 		if cred.RegistryToken != "" {
 			rc.Token = cred.RegistryToken
 		}
-		if cred.Username != "" && cred.Password != "" {
-			rc.Username = cred.Username
-			rc.Password = cred.Password
+		username, password := cred.Username, cred.Password
+		if username == "" && password == "" && cred.Auth != "" {
+			username, password = credentialsFromAuth(cred.Auth)
+		}
+		if username != "" && password != "" {
+			rc.Username = username
+			rc.Password = password
 		}
 
 		registryCredentials[i] = rc
 	}
 	return registryCredentials
+}
+
+// credentialsFromAuth decodes the standard Docker "auth" field: base64 of "username:password".
+// It's the canonical field in a .dockerconfigjson pull secret; username/password are only
+// supplementary and are often absent. Kubernetes' documented way to reuse an existing docker
+// login (kubectl create secret generic --from-file=.dockerconfigjson=~/.docker/config.json)
+// produces entries where only auth is set, so falling back to it here is required for those
+// credentials to reach the registry pull at all, rather than being silently dropped.
+func credentialsFromAuth(auth string) (username, password string) {
+	decoded, err := base64.StdEncoding.DecodeString(auth)
+	if err != nil {
+		return "", ""
+	}
+	username, password, found := strings.Cut(string(decoded), ":")
+	if !found {
+		return "", ""
+	}
+	return username, password
 }
 
 // parseAuthorityFromServerAddress extracts the authority host:port from a server address.

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1206,9 +1207,16 @@ func Test_registryCredentialsFromCredentialsList(t *testing.T) {
 			Username:      "armosec+testrobot2",
 			Password:      "dummyPassword111",
 		},
+		{
+			// Mirrors a .dockerconfigjson entry produced by reusing an existing
+			// `docker login` (kubectl create secret generic --from-file=.dockerconfigjson=...):
+			// only Auth is set, Username/Password are empty. See #611.
+			ServerAddress: "registry.example.com",
+			Auth:          base64.StdEncoding.EncodeToString([]byte("registryuser:registrypass")),
+		},
 	}
 	registryCredentials := registryCredentialsFromCredentialsList(creds)
-	assert.Equal(t, 3, len(registryCredentials))
+	assert.Equal(t, 4, len(registryCredentials))
 	assert.Equal(t, "quay.io", registryCredentials[0].Authority)
 	assert.Equal(t, "armosec+testrobot1", registryCredentials[0].Username)
 	assert.Equal(t, "dummyPassword", registryCredentials[0].Password)
@@ -1218,6 +1226,50 @@ func Test_registryCredentialsFromCredentialsList(t *testing.T) {
 	assert.Equal(t, "quay.io", registryCredentials[2].Authority)
 	assert.Equal(t, "armosec+testrobot2", registryCredentials[2].Username)
 	assert.Equal(t, "dummyPassword111", registryCredentials[2].Password)
+	assert.Equal(t, "registry.example.com", registryCredentials[3].Authority)
+	assert.Equal(t, "registryuser", registryCredentials[3].Username)
+	assert.Equal(t, "registrypass", registryCredentials[3].Password)
+}
+
+func Test_credentialsFromAuth(t *testing.T) {
+	tests := []struct {
+		name         string
+		auth         string
+		wantUsername string
+		wantPassword string
+	}{
+		{
+			name:         "valid base64 user:pass",
+			auth:         base64.StdEncoding.EncodeToString([]byte("user:pass")),
+			wantUsername: "user",
+			wantPassword: "pass",
+		},
+		{
+			name:         "password containing a colon is preserved",
+			auth:         base64.StdEncoding.EncodeToString([]byte("user:pass:word")),
+			wantUsername: "user",
+			wantPassword: "pass:word",
+		},
+		{
+			name: "empty auth",
+			auth: "",
+		},
+		{
+			name: "not valid base64",
+			auth: "not-base64!!!",
+		},
+		{
+			name: "decodes but has no colon separator",
+			auth: base64.StdEncoding.EncodeToString([]byte("userpass")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			username, password := credentialsFromAuth(tt.auth)
+			assert.Equal(t, tt.wantUsername, username)
+			assert.Equal(t, tt.wantPassword, password)
+		})
+	}
 }
 
 func Test_parseAuthorityFromServerAddress(t *testing.T) {


### PR DESCRIPTION
## Overview

`registryCredentialsFromCredentialsList` (`core/services/scan.go`) only read `Username`/`Password`/`RegistryToken` off each incoming `registry.AuthConfig` entry, never `Auth` — the base64 `"username:password"` field Docker treats as the canonical credential.

Kubernetes' documented way to reuse an existing Docker login (`kubectl create secret generic regcred --from-file=.dockerconfigjson=~/.docker/config.json`, see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials) produces a pull secret where each registry entry has only `auth` set, no separate `username`/`password`. Any workload using that pattern reached kubevuln with `Username`/`Password` empty and the real credential sitting unused in `Auth`, so the resulting `domain.RegistryCredentials` came out completely empty and the pull went out anonymous instead of authenticated.

`optionsFromWorkload` is the single place `workload.CredentialsList` gets converted, and its output feeds both SBOM paths (in-process `SyftAdapter` and the `SidecarSBOMAdapter`), so this affected both.

Fix: when `Username`/`Password` are both empty but `Auth` is set, base64-decode it and split on the first `:` to recover username/password. Malformed `Auth` (bad base64, no `:` separator) falls back to empty credentials, same as before.

## How to Test

- `go test ./core/services/... -run 'Test_registryCredentialsFromCredentialsList|Test_credentialsFromAuth'`
- `go build ./...`
- `go test ./...`
- `golangci-lint run --new-from-rev=<merge-base with main>`

## Related issues/PRs:

* Resolved #611

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Docker registry credential handling when credentials are provided only as a Base64-encoded value.
  - Preserved passwords containing colons during credential decoding.
  - Safely ignored empty, invalid, or malformed credential values.

- **Tests**
  - Added coverage for valid credentials, passwords with colons, and invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->