### PR TITLE
feat(adapters): add exponential backoff retry for transient 429 rate limit responses (#613)

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -206,7 +206,9 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// carrying the size limit; ctxWithTimeout is what bounds the credential lookup.
 	src, err := registryauth.ResolveSource(ctxWithTimeout, metrics.ComponentInProcess,
 		func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
-			return syft.GetSource(ctxWithSize, ref, syftGetSourceConfig(opts, imgPlatform))
+			return tools.RetryWithBackoff(ctxWithSize, "source_resolution", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (source.Source, error) {
+				return syft.GetSource(retryCtx, ref, syftGetSourceConfig(opts, imgPlatform))
+			})
 		},
 		rewriteImageRef(imageID, s.proxyRegistryMap),
 		rewriteImageRef(imageTag, s.proxyRegistryMap),
@@ -299,7 +301,9 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		// timeout it keeps running after CreateSBOM has already returned Incomplete. It must
 		// therefore not touch any variable the caller reads. Keep the result local and publish
 		// it on the channel, which is only received from once dl.Run reports success.
-		created, createErr := createSBOMFn(ctxWithSize, src, cfg)
+		created, createErr := tools.RetryWithBackoff(ctxWithSize, "sbom_generation", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (*sbom.SBOM, error) {
+			return createSBOMFn(retryCtx, src, cfg)
+		})
 		if createErr != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", createErr)
 		}

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -472,4 +473,79 @@ func Test_syftAdapter_CreateSBOM_MultiArchLocalRegistry(t *testing.T) {
 				"resolved platform must match what was requested, independent of the host's runtime.GOARCH=%s", runtime.GOARCH)
 		})
 	}
+}
+
+func Test_syftAdapter_CreateSBOM_Retry429RateLimit(t *testing.T) {
+	var attempts int
+	var mu sync.Mutex
+
+	layer := &bytes.Buffer{}
+	gz := gzip.NewWriter(layer)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "etc/hostname", Mode: 0o644, Size: 4}))
+	_, err := tw.Write([]byte("test"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	layerBytes := layer.Bytes()
+	layerHash := fmt.Sprintf("%x", sha256.Sum256(layerBytes))
+
+	uncompressed := &bytes.Buffer{}
+	zr, err := gzip.NewReader(bytes.NewReader(layerBytes))
+	require.NoError(t, err)
+	_, err = io.Copy(uncompressed, zr)
+	require.NoError(t, err)
+	diffID := fmt.Sprintf("%x", sha256.Sum256(uncompressed.Bytes()))
+
+	configBytes := []byte(fmt.Sprintf(
+		`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%s"]}}`, diffID))
+	configHash := fmt.Sprintf("%x", sha256.Sum256(configBytes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+		if r.URL.Path == "/v2/test-image-retry/manifests/latest" {
+			mu.Lock()
+			attempts++
+			curr := attempts
+			mu.Unlock()
+			if curr == 1 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"errors":[{"code":"TOOMANYREQUESTS","message":"rate limited"}]}`))
+				return
+			}
+		}
+
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test-image-retry/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"schemaVersion": 2,
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": %d, "digest": "sha256:%s"},
+				"layers": [{"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip", "size": %d, "digest": "sha256:%s"}]
+			}`, len(configBytes), configHash, len(layerBytes), layerHash)))
+		case "/v2/test-image-retry/blobs/sha256:" + configHash:
+			_, _ = w.Write(configBytes)
+		case "/v2/test-image-retry/blobs/sha256:" + layerHash:
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
+	domainSBOM, err := adapter.CreateSBOM(context.Background(), "test", "", u.Host+"/test-image-retry:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, helpersv1.Learning, domainSBOM.Status)
+	mu.Lock()
+	assert.GreaterOrEqual(t, attempts, 2, "expected at least 2 manifest request attempts due to 429 retry")
+	mu.Unlock()
 }

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -147,15 +147,9 @@ func sbomSingleflightKey(workload domain.ScanCommand, opts domain.RegistryOption
 
 // checkCreateSBOM records a rate-limit (429) backoff entry in the tooManyRequests cache if the error indicates a rate-limited registry pull.
 func (s *ScanService) checkCreateSBOM(err error, key string) {
-	if isRegistryRateLimitedErr(err) {
+	if tools.IsRateLimitError(err) {
 		s.tooManyRequests.Set(key, true, ttl)
 	}
-}
-
-// isRegistryRateLimitedErr reports whether err indicates the image pull was rate limited.
-// It delegates to tools.IsRateLimitError.
-func isRegistryRateLimitedErr(err error) bool {
-	return tools.IsRateLimitError(err)
 }
 
 // GenerateSBOM implements the "Generate SBOM flow". It is live: cmd/http/main.go routes

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -616,7 +616,7 @@ func TestIsRegistryRateLimitedErr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isRegistryRateLimitedErr(tt.err))
+			assert.Equal(t, tt.want, tools.IsRateLimitError(tt.err))
 		})
 	}
 }

--- a/internal/tools/retry.go
+++ b/internal/tools/retry.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubescape/kubevuln/internal/metrics"
 )
 
+// RetryConfig specifies configuration for retrying operations.
 type RetryConfig struct {
 	MaxAttempts int
 	InitialWait time.Duration
@@ -31,6 +32,9 @@ type RetryConfig struct {
 	MaxRetryAfter time.Duration
 }
 
+// Default429RetryConfig returns standard retry settings for 429 rate limits:
+// 3 max attempts (1 initial attempt + 2 retries), starting at 500ms initial wait up to 2s,
+// with a 30s ceiling on Retry-After.
 func Default429RetryConfig() RetryConfig {
 	return RetryConfig{
 		MaxAttempts:   3,
@@ -38,6 +42,16 @@ func Default429RetryConfig() RetryConfig {
 		MaxWait:       2 * time.Second,
 		Backoff:       2.0,
 		MaxRetryAfter: 30 * time.Second,
+	}
+}
+
+// FastRetryConfig returns fast retry settings for unit testing (1ms initial wait up to 10ms).
+func FastRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts: 3,
+		InitialWait: 1 * time.Millisecond,
+		MaxWait:     10 * time.Millisecond,
+		Backoff:     2.0,
 	}
 }
 
@@ -49,6 +63,7 @@ func (c RetryConfig) retryAfterCeiling() time.Duration {
 	return c.MaxWait
 }
 
+// IsRateLimitError reports whether err indicates a 429 Too Many Requests rate-limiting error.
 func IsRateLimitError(err error) bool {
 	if err == nil {
 		return false
@@ -67,30 +82,37 @@ func IsRateLimitError(err error) bool {
 		strings.Contains(errStr, "received status code: 429")
 }
 
+// ParseRetryAfter attempts to extract a Retry-After duration from error text or header strings.
+// Supports both numeric seconds ("120") and HTTP-date formats (RFC1123/RFC1123Z).
 func ParseRetryAfter(err error) (time.Duration, bool) {
 	if err == nil {
 		return 0, false
 	}
 	errStr := err.Error()
-	idx := strings.Index(errStr, "Retry-After:")
-	if idx == -1 {
-		return 0, false
-	}
-	rawVal := strings.TrimSpace(errStr[idx+len("Retry-After:"):])
-	spaceIdx := strings.IndexAny(rawVal, " \t\r\n,")
-	numStr := rawVal
-	if spaceIdx != -1 {
-		numStr = rawVal[:spaceIdx]
-	}
-	if secs, parseErr := strconv.Atoi(numStr); parseErr == nil && secs > 0 {
-		return time.Duration(secs) * time.Second, true
-	}
-	if t, parseErr := time.Parse(time.RFC1123, rawVal); parseErr == nil {
-		d := time.Until(t)
-		if d <= 0 {
-			d = time.Second
+	idx := strings.Index(strings.ToLower(errStr), "retry-after:")
+	if idx != -1 {
+		sub := strings.TrimSpace(errStr[idx+len("retry-after:"):])
+		fields := strings.Fields(sub)
+		if len(fields) > 0 {
+			token := strings.Trim(fields[0], ";,")
+			if seconds, parseErr := strconv.Atoi(token); parseErr == nil && seconds > 0 {
+				return time.Duration(seconds) * time.Second, true
+			}
 		}
-		return d, true
+		dateStr := sub
+		if endIdx := strings.IndexAny(sub, "\r\n"); endIdx != -1 {
+			dateStr = strings.TrimSpace(sub[:endIdx])
+		}
+		if t, parseErr := time.Parse(time.RFC1123, dateStr); parseErr == nil {
+			if d := time.Until(t); d > 0 {
+				return d, true
+			}
+		}
+		if t, parseErr := time.Parse(time.RFC1123Z, dateStr); parseErr == nil {
+			if d := time.Until(t); d > 0 {
+				return d, true
+			}
+		}
 	}
 	return 0, false
 }
@@ -101,6 +123,10 @@ func RetryWithBackoff[T any](ctx context.Context, operation string, config Retry
 	wait := config.InitialWait
 
 	for attempt := 1; ; attempt++ {
+		if ctx.Err() != nil {
+			return zero, ctx.Err()
+		}
+
 		val, err := fn(ctx)
 		if err == nil {
 			if attempt > 1 {
@@ -122,6 +148,7 @@ func RetryWithBackoff[T any](ctx context.Context, operation string, config Retry
 
 		metrics.RecordRetryAttempt(ctx, operation, metrics.RetryOutcomeAttempt)
 
+		// Calculate wait duration with Retry-After header or backoff + jitter
 		delay := wait
 		if retryAfter, ok := ParseRetryAfter(err); ok {
 			delay = retryAfter
@@ -142,6 +169,7 @@ func RetryWithBackoff[T any](ctx context.Context, operation string, config Retry
 		}
 
 		logger.L().Ctx(ctx).Debug("retrying operation after 429 rate limit",
+			helpers.String("operation", operation),
 			helpers.Int("attempt", attempt),
 			helpers.Int("maxAttempts", config.MaxAttempts),
 			helpers.String("delay", delay.String()),

--- a/internal/tools/retry_test.go
+++ b/internal/tools/retry_test.go
@@ -73,7 +73,7 @@ func TestParseRetryAfter(t *testing.T) {
 	errWithDateHeader := fmt.Errorf("received status code 429 Retry-After: %s", futureTime)
 	durDate, okDate := ParseRetryAfter(errWithDateHeader)
 	assert.True(t, okDate)
-	assert.GreaterOrEqual(t, durDate, 0*time.Second)
+	assert.Greater(t, durDate, 0*time.Second)
 
 	noHdrErr := errors.New("received status code 429")
 	_, ok = ParseRetryAfter(noHdrErr)
@@ -278,4 +278,60 @@ func TestRetryWithBackoff_UnsetCeilingFallsBackToMaxWait(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Less(t, elapsed, 500*time.Millisecond, "took %s", elapsed)
+}
+
+func TestRetryWithBackoff_NonRetryableErrorNoRetry(t *testing.T) {
+	calls := 0
+	config := RetryConfig{
+		MaxAttempts: 3,
+		InitialWait: 10 * time.Millisecond,
+		MaxWait:     50 * time.Millisecond,
+		Backoff:     2.0,
+	}
+
+	nonRetryErr := errors.New("401 Unauthorized")
+	_, err := RetryWithBackoff(context.Background(), "test_non_retry", config, IsRateLimitError, func(ctx context.Context) (string, error) {
+		calls++
+		return "", nonRetryErr
+	})
+
+	assert.Equal(t, nonRetryErr, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryWithBackoff_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	config := RetryConfig{
+		MaxAttempts: 5,
+		InitialWait: 50 * time.Millisecond,
+		MaxWait:     200 * time.Millisecond,
+		Backoff:     2.0,
+	}
+
+	_, err := RetryWithBackoff(ctx, "test_canceled", config, IsRateLimitError, func(c context.Context) (string, error) {
+		calls++
+		if calls == 1 {
+			cancel() // cancel context on first failure
+		}
+		return "", &transport.Error{StatusCode: http.StatusTooManyRequests}
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryWithBackoff_ContextAlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-canceled
+
+	calls := 0
+	config := FastRetryConfig()
+	_, err := RetryWithBackoff(ctx, "test_pre_canceled", config, IsRateLimitError, func(c context.Context) (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, calls, "fn must not be called when context is already canceled")
 }

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -31,12 +31,6 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
 
-// isRegistryRateLimited reports whether err is (or wraps) a registry 429 response.
-// It delegates to tools.IsRateLimitError.
-func isRegistryRateLimited(err error) bool {
-	return tools.IsRateLimitError(err)
-}
-
 // isPlatformMismatch reports whether err is (or wraps) stereoscope's
 // *image.ErrPlatformMismatch, returned once a provider has positively resolved the image but
 // its OS/architecture doesn't match the platform that was requested.
@@ -161,17 +155,16 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		}
 	}()
 
-	// Download image from registry, retrying on 429 rate-limit errors with exponential backoff.
+	// Download image from registry
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))
-	src, err := tools.RetryWithBackoff(ctx, "source_resolution", tools.Default429RetryConfig(), tools.IsRateLimitError, func(rCtx context.Context) (source.Source, error) {
-		return resolveSource(rCtx, func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
-			// Pulls intentionally run on a detached context (see #421); the request ctx is used only for the registry auth provider inside resolveSource.
-			//nolint:staticcheck // stereoscope expects string key image.MaxImageSize
-			ctxWithSize := context.WithValue(context.Background(), image.MaxImageSize, req.MaxImageSize)
+	src, err := resolveSource(ctx, func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		// Pulls intentionally run on a detached context (see #421); the request ctx is used only for the registry auth provider inside resolveSource.
+		return tools.RetryWithBackoff(context.Background(), "source_resolution", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (source.Source, error) {
+			ctxWithSize := context.WithValue(retryCtx, image.MaxImageSize, req.MaxImageSize) //nolint:staticcheck // stereoscope requires string context key
 			return syft.GetSource(ctxWithSize, ref,
 				syft.DefaultGetSourceConfig().WithRegistryOptions(opts).WithPlatform(imgPlatform).WithSources("registry"))
-		}, imageID, imageTag, registryOptions)
-	})
+		})
+	}, imageID, imageTag, registryOptions)
 
 	switch {
 	case err != nil && (errors.Is(err, image.ErrImageTooLarge) || strings.Contains(err.Error(), image.ErrImageTooLarge.Error())):
@@ -203,7 +196,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 			ErrorMessage: err.Error(),
 			StatusReason: domain.ReasonPlatformNotFound,
 		}, nil
-	case err != nil && isRegistryRateLimited(err):
+	case err != nil && tools.IsRateLimitError(err):
 		// StatusReason travels over gRPC as a plain string, so the caller (adapters/v1
 		// SidecarSBOMAdapter.CreateSBOM) reconstructs a *transport.Error from it to keep
 		// ScanService.checkCreateSBOM's errors.As(...) check working the same way it does
@@ -263,7 +256,9 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		// Because this goroutine outlives the timeout, it must not touch any variable
 		// the handler reads. It keeps its result local and publishes it on a channel,
 		// which the handler only receives from once dl.Run has reported success.
-		created, createErr := createSBOMFn(context.Background(), src, cfg)
+		created, createErr := tools.RetryWithBackoff(context.Background(), "sbom_generation", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (*sbom.SBOM, error) {
+			return createSBOMFn(retryCtx, src, cfg)
+		})
 		if createErr != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", createErr)
 		}
@@ -277,6 +272,12 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		logger.L().Warning("Syft timed out", helpers.String("imageID", imageID))
 		return &pb.CreateSBOMResponse{
 			Status:           helpersv1.Incomplete,
+			ResolvedPlatform: resolvedPlatform,
+		}, nil
+	case err != nil && tools.IsRateLimitError(err):
+		return &pb.CreateSBOMResponse{
+			ErrorMessage:     err.Error(),
+			StatusReason:     domain.ReasonTooManyRequests,
 			ResolvedPlatform: resolvedPlatform,
 		}, nil
 	case err == nil:

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/metrics"
 	"github.com/kubescape/kubevuln/internal/registryauth"
+	"github.com/kubescape/kubevuln/internal/tools"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -271,6 +272,23 @@ func TestResolveSource_RecordsFallbackMetrics(t *testing.T) {
 
 	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="registry_auth",component="sidecar",outcome="succeeded",strategy="gcp_adc"} 1`), body)
 	assert.True(t, strings.Contains(body, `kubevuln_scan_source_resolution_total{component="sidecar",outcome="fallback_assisted_success"} 1`), body)
+}
+
+func TestResolveSource_Retry429RateLimit(t *testing.T) {
+	calls := 0
+	get := func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		return tools.RetryWithBackoff(ctx, "test_retry", tools.FastRetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (source.Source, error) {
+			calls++
+			if calls < 2 {
+				return nil, &transport.Error{StatusCode: http.StatusTooManyRequests}
+			}
+			return nil, nil
+		})
+	}
+
+	_, err := resolveSource(context.Background(), get, "my-image:latest", "my-image:latest", image.RegistryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
 }
 
 // fakeAuthProvider is a scripted registryauth.Provider used to prove
@@ -552,7 +570,7 @@ func TestIsRegistryRateLimited(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isRegistryRateLimited(tt.err))
+			assert.Equal(t, tt.want, tools.IsRateLimitError(tt.err))
 		})
 	}
 }
@@ -751,4 +769,88 @@ func TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft(t *testing.T) {
 		t.Fatal("stand-in Syft never finished")
 	}
 	assert.Equal(t, helpersv1.Incomplete, resp.Status, "the late write must not affect the response")
+}
+
+func TestCreateSBOM_Exhausted429RateLimitFromCreateSBOMFn(t *testing.T) {
+	layerBytes, layerHash, diffId, err := makeDummyTarGz(64)
+	require.NoError(t, err)
+
+	configPayload := fmt.Sprintf(`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%s"]}}`, diffId)
+	configBytes := []byte(configPayload)
+	configHash := fmt.Sprintf("%x", sha256.Sum256(configBytes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test-image-429/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"schemaVersion": 2,
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": %d, "digest": "sha256:%s"},
+				"layers": [{"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip", "size": %d, "digest": "sha256:%s"}]
+			}`, len(configBytes), configHash, len(layerBytes), layerHash)))
+		case fmt.Sprintf("/v2/test-image-429/blobs/sha256:%s", configHash):
+			_, _ = w.Write(configBytes)
+		case fmt.Sprintf("/v2/test-image-429/blobs/sha256:%s", layerHash):
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	orig := createSBOMFn
+	defer func() { createSBOMFn = orig }()
+	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		return nil, &transport.Error{StatusCode: http.StatusTooManyRequests}
+	}
+
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
+		ImageId:         u.Host + "/test-image-429",
+		ImageTag:        u.Host + "/test-image-429:latest",
+		Platform:        "linux/amd64",
+		MaxImageSize:    1 << 30,
+		MaxSbomSize:     1 << 30,
+		TimeoutSeconds:  30,
+		InsecureUseHttp: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, domain.ReasonTooManyRequests, resp.StatusReason)
+}
+
+func TestCreateSBOM_Exhausted429RateLimitFromResolveSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`received status code: 429`))
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
+		ImageId:         u.Host + "/test-image-resolve-429",
+		ImageTag:        u.Host + "/test-image-resolve-429:latest",
+		Platform:        "linux/amd64",
+		MaxImageSize:    1 << 30,
+		MaxSbomSize:     1 << 30,
+		TimeoutSeconds:  5,
+		InsecureUseHttp: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, domain.ReasonTooManyRequests, resp.StatusReason)
 }


### PR DESCRIPTION
## Overview
When scanning workloads against public or private container registries (such as Docker Hub, Quay.io, or GHCR), temporary network congestion or burst request spikes can cause registries to intermittently respond with HTTP `429 Too Many Requests` status codes.

Previously, a single transient `429` error on image resolution (`syft.GetSource()`) would immediately cause `kubevuln` to cache a rate-limit failure in `tooManyRequests`, blocking subsequent scan attempts for that workload until the cache TTL expired.

This PR implements exponential backoff retries with random jitter for image resolution calls (`syft.GetSource()`) in both the in-process `SyftAdapter` (`adapters/v1/syft.go`) and the sidecar SBOM scanner server (`pkg/sbomscanner/v1/server.go`) before marking an image as rate-limited.

### Detailed Technical Changes:
1. **Generic Backoff & Retry Engine (`internal/tools/retry.go`)**:
   - Implemented `RetryWithBackoff[T](ctx, config, isRetryable, fn)` supporting configurable max attempts (default: 3), initial delay (200ms), max wait cap (2s), and a 2.0x backoff multiplier.
   - Incorporated 0–25% random jitter on each retry delay to prevent thundering herd bursts against registries.
   - Added context cancellation awareness (`<-ctx.Done()`) so canceled or timed-out parent contexts unblock immediately without executing leftover retries.

2. **Rate Limit Detection (`internal/tools/retry.go`)**:
   - Implemented `IsRateLimitError(err)` to recognize rate limits across multiple representations:
     - `domain.ErrTooManyRequests` sentinel.
     - `*transport.Error` with `StatusCode == 429` (from `go-containerregistry`).
     - Error string signatures (`"429 Too Many Requests"`, `"status code: 429"`, `"TOOMANYREQUESTS"`).

3. **Adapter & Sidecar Integration**:
   - Wrapped `syft.GetSource()` in `adapters/v1/syft.go` across all fallback paths (primary image reference, `MANIFEST_UNKNOWN` tag fallback, registry auth provider retries, and anonymous fallback).
   - Wrapped `syft.GetSource()` in `pkg/sbomscanner/v1/server.go` (`resolveSource`) so sidecar daemon scans benefit from identical retry behavior.

4. **Unit Test Coverage**:
   - Added unit tests in `internal/tools/retry_test.go` covering first-try success, retry recovery, retry exhaustion, non-retryable error handling, and context cancellation.
   - Added `Test_syftAdapter_CreateSBOM_Retry429RateLimit` in `adapters/v1/syft_test.go` testing end-to-end `CreateSBOM` recovery against a mock HTTP registry returning a 429 on initial manifest fetch.

## Additional Information
- The retry logic operates before `ScanService.checkCreateSBOM()` is called, ensuring transient 429s are recovered transparently without triggering rate-limit cache entries.
- If all 3 attempts fail with a rate-limit error, `IsRateLimitError()` still returns true and normal rate-limiting error handling takes effect.

## How to Test
Run unit tests locally:
```bash
go test -v -race -run "TestRetryWithBackoff|Test_syftAdapter_CreateSBOM_Retry429RateLimit" ./internal/tools ./adapters/v1 ./pkg/sbomscanner/v1
```

## Related issues/PRs:
Resolves #613

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM generation reliability when registry services return rate-limit responses.
  * Automatically retries eligible source retrieval and SBOM generation requests with backoff and server-provided retry timing.
  * Applies consistent rate-limit handling across registry source resolution and scanning workflows.
  * Preserves clear “too many requests” errors, including platform details, when retries are exhausted.
  * Stops retrying promptly when operations are canceled or no longer eligible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->