### PR TITLE
fix(adapters): log the SBOM size limit under its own name

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -377,7 +377,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	if sz > s.maxSBOMSize {
 		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategySBOMTooLarge, metrics.FallbackOutcomeClassified)
 		logger.L().Ctx(ctx).Warning("SBOM exceeds size limit",
-			helpers.Int("maxImageSize", s.maxSBOMSize),
+			helpers.Int("maxSBOMSize", s.maxSBOMSize),
 			helpers.Int("size", sz),
 			helpers.String("imageID", imageID))
 		domainSBOM.Status = helpersv1.TooLarge


### PR DESCRIPTION
## Overview

the in-process `SBOM exceeds size limit` warning printed `s.maxSBOMSize` but labelled it `maxImageSize`. defaults are 512 MiB and 20 MiB, so on a default setup the line reads `maxImageSize=20971520` while maxImageSize is actually 536870912. you'd raise the wrong option and nothing would change.

the sidecar already logs the same message with the right field name, so the two paths disagreed too.

## Additional Information

no test, nothing here asserts log output and a capture harness would be bigger than the fix. the guard right above is `if sz > s.maxSBOMSize` and the annotation two lines below is already `MaxSBOMSizeAnnotationKey`, so the field name was the only thing naming the wrong option.

swept the rest of the repo for the same mismatch, no others.

## How to Test

`go test ./adapters/v1/` passes unchanged, only the log field name differs:

```
before:  SBOM exceeds size limit  maxImageSize=20971520
after:   SBOM exceeds size limit  maxSBOMSize=20971520
```

## Related issues/PRs:

* Resolved #615
