### PR TITLE
chore(repositories): give the timestamp annotation key a constant

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -43,6 +43,15 @@ import (
 const (
 	vulnerabilityManifestSummaryKindPlural string = "vulnerabilitymanifests"
 	vulnSummaryContNameFormat              string = "%s-%s-%s" // "<kind>-<name>-<container-name>"
+
+	// timestampMetadataKey is the scan time, in Unix seconds, stamped on every summary
+	// manifest kubevuln writes. It lives here rather than coming from
+	// k8s-interface/instanceidhandler/v1/helpers, like every other metadata key on these
+	// objects, because that package has no key for it: its nearest neighbour,
+	// ReportTimestampMetadataKey ("kubescape.io/report-timestamp"), is a different key
+	// written by a different component. Changing the string would orphan the annotation on
+	// already-stored manifests, so it stays as it is.
+	timestampMetadataKey string = "kubescape.io/timestamp"
 )
 
 // securityExceptionListCacheCleaningInterval/TTL bound how stale the raw SecurityException/
@@ -603,7 +612,7 @@ func enrichSummaryManifestObjectAnnotations(ctx context.Context, annotations map
 	if !ok {
 		return nil, domain.ErrMissingTimestamp
 	}
-	enrichedAnnotations["kubescape.io/timestamp"] = strconv.FormatInt(timestamp, 10) // TODO: use a constant
+	enrichedAnnotations[timestampMetadataKey] = strconv.FormatInt(timestamp, 10)
 	enrichedAnnotations[helpersv1.WlidMetadataKey] = workload.Wlid
 	enrichedAnnotations[helpersv1.ContainerNameMetadataKey] = workload.ContainerName
 

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1030,11 +1030,19 @@ func TestAPIServerStore_enrichSummaryManifestObjectAnnotations(t *testing.T) {
 		assert.Equal(t, exist, true)
 		assert.Equal(t, val, tests[i].workload.ContainerName)
 
-		val, exist = enrichedAnnotations["kubescape.io/timestamp"]
+		val, exist = enrichedAnnotations[timestampMetadataKey]
 		assert.Equal(t, exist, true)
 		assert.Equal(t, val, "1734957372")
 	}
 
+}
+
+// The key is part of the shape of every summary manifest already in storage: changing it
+// would strand the old annotation on those objects and silently stop anything reading it.
+// Worth pinning explicitly, since the code and the test above both go through the constant
+// now and would agree with each other whatever it said.
+func TestTimestampMetadataKeyIsStable(t *testing.T) {
+	assert.Equal(t, "kubescape.io/timestamp", timestampMetadataKey)
 }
 
 func TestAPIServerStore_getCVESummaryK8sResourceName(t *testing.T) {


### PR DESCRIPTION
## Overview

closes the `// TODO: use a constant` on `kubescape.io/timestamp` in `enrichSummaryManifestObjectAnnotations`, the only metadata key kubevuln writes as a bare string. the two lines under it and every other key on these objects come from `helpersv1`.

it is a local constant rather than a swap to an existing one because `k8s-interface/instanceidhandler/v1/helpers` has no key for this. `ReportTimestampMetadataKey` (`kubescape.io/report-timestamp`) is the closest and is a different key, written by a different component onto container profiles. the comment on the constant says that, so the next person does not have to go looking for the upstream key that would have replaced it.

no behaviour change, the annotation kubevuln writes is byte for byte the same.

## Additional Information

the refactor costs one thing on its own: `apiserver_test.go` had the key as a literal, so it was accidentally pinning the value, and reading it through the constant instead means the code and the test now agree with each other whatever the string says. `TestTimestampMetadataKeyIsStable` puts that back explicitly.

worth having, because this key is stamped on every `VulnerabilityManifestSummary` already in storage. changing the string would leave the old annotation on all of them and stop anything reading it, and nothing would fail.

## How to Test

`go test ./repositories/ -count=1`

`TestAPIServerStore_enrichSummaryManifestObjectAnnotations` covers the annotation itself and is unchanged apart from reading through the constant. `TestTimestampMetadataKeyIsStable` fails if the string changes.

## Related issues/PRs:

* Resolved #620
