### PR TITLE
fix(services): persist TooLarge SBOM markers and stop double-storing

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -181,8 +181,9 @@ func isRegistryRateLimitedErr(err error) bool {
 		strings.Contains(errStr, "429 Too Many Requests")
 }
 
-// GenerateSBOM implements the "Generate SBOM flow"
-// FIXME check if we still use this method
+// GenerateSBOM implements the "Generate SBOM flow". It is live: cmd/http/main.go routes
+// POST v1/generateSBOM here, through ValidateGenerateSBOM and the same rejection and scan
+// metrics as the other flows.
 func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 	ctx, span := otel.Tracer("").Start(ctx, "ScanService.GenerateSBOM")
 	defer span.End()
@@ -195,27 +196,28 @@ func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 		return domain.ErrCastingWorkload
 	}
 
-	sbom, created, err := s.getOrCreateSBOM(ctx, workload)
+	sbom, storeErr, err := s.getOrCreateSBOM(ctx, workload)
 	if err != nil {
 		return err
 	}
 
 	// do not treat a timed out or too-large SBOM as a successful scan — mirrors the same
-	// check in ScanCP/ScanCVE/ScanRegistry, which this flow had lost track of (see #540)
+	// check in ScanCP/ScanCVE/ScanRegistry, which this flow had lost track of (see #540).
+	// Ahead of storeErr so the size verdict stays the reported reason, as it did when the
+	// store lived below this check.
 	if sbom.Status == helpersv1.Incomplete || sbom.Status == helpersv1.TooLarge {
 		reason := classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations)
 		_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration, reason, nil)
 		return &domain.ScanError{Reason: reason, Err: domain.ErrIncompleteSBOM}
 	}
 
-	// store SBOM if newly created
-	if s.storage && created {
-		err = s.sbomRepository.StoreSBOM(ctx, sbom, false)
-		if err != nil {
-			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost,
-				scanfailure.ReasonSBOMStorageFailed, err)
-			return &domain.ScanError{Reason: scanfailure.ReasonSBOMStorageFailed, Err: err}
-		}
+	// getOrCreateSBOM already stored what it created, so there is nothing to write here.
+	// Storing is the whole point of this endpoint though, so unlike the scan flows, which
+	// carry on with an SBOM they could not persist, a failure there is reported as one.
+	if storeErr != nil {
+		_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost,
+			scanfailure.ReasonSBOMStorageFailed, storeErr)
+		return &domain.ScanError{Reason: scanfailure.ReasonSBOMStorageFailed, Err: storeErr}
 	}
 
 	return nil
@@ -1340,9 +1342,20 @@ func (s *ScanService) getSBOM(ctx context.Context, name string, creatorVersion s
 
 // getOrCreateSBOM retrieves an existing SBOM from storage, or creates and stores one via singleflight
 // deduplication if multiple goroutines race to build an SBOM for the same image.
-func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanCommand) (domain.SBOM, bool, error) {
+// sbomCreation is what the singleflight worker hands back: the SBOM, plus whether storing
+// it failed. Every caller racing a key gets the same one, so a waiter learns the outcome of
+// the shared store rather than repeating it.
+type sbomCreation struct {
+	sbom     domain.SBOM
+	storeErr error
+}
+
+// getOrCreateSBOM returns the SBOM for workload and the error from storing it, if it was
+// created and stored here. A non-nil store error is not fatal on its own: the SBOM is still
+// usable, and only GenerateSBOM, which exists to store it, treats it as a failure.
+func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanCommand) (domain.SBOM, error, error) {
 	if !s.sbomGeneration {
-		return domain.SBOM{}, false, nil
+		return domain.SBOM{}, nil, nil
 	}
 
 	opts := optionsFromWorkload(ctx, workload)
@@ -1362,7 +1375,7 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 		// Re-check storage inside singleflight worker in case another worker stored it while we waited
 		if s.storage {
 			if sbom, err := s.getSBOM(workerCtx, workload.ImageSlug, s.sbomCreator.Version()); err == nil && sbom.Content != nil {
-				return sbom, nil
+				return sbomCreation{sbom: sbom}, nil
 			}
 		}
 
@@ -1393,27 +1406,40 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 			return domain.SBOM{}, &domain.ScanError{Reason: reason, Err: err}
 		}
 
-		// store SBOM in storage before completing so all waiting callers share the stored result
-		if s.storage && sbom.Content != nil {
-			if storeErr := s.sbomRepository.StoreSBOM(workerCtx, sbom, false); storeErr != nil {
+		// store SBOM in storage before completing so all waiting callers share the stored
+		// result.
+		//
+		// TooLarge is stored despite having no document. StoreSBOM keeps it as a status-only
+		// marker, and getSBOM re-checks that marker against the current maxImageSize and
+		// maxSBOMSize, so it stops applying once the limits are raised. Persisting it is what
+		// saves pulling a known-oversized image again to reach the answer already on record.
+		//
+		// Incomplete is deliberately not stored. It means the scan timed out, which is
+		// transient, and getSBOM has no staleness rule for it, so a stored one would read
+		// back as a cache hit forever and block regeneration until the object was deleted by
+		// hand or the scanner version moved.
+		var storeErr error
+		if s.storage && (sbom.Content != nil || sbom.Status == helpersv1.TooLarge) {
+			if storeErr = s.sbomRepository.StoreSBOM(workerCtx, sbom, false); storeErr != nil {
 				logger.L().Ctx(workerCtx).Warning("storing singleflight deduplicated SBOM", helpers.Error(storeErr),
 					helpers.String("imageSlug", workload.ImageSlug))
 			}
 		}
 
-		return sbom, nil
+		return sbomCreation{sbom: sbom, storeErr: storeErr}, nil
 	})
 
 	select {
 	case res := <-ch:
 		if res.Err != nil {
-			return domain.SBOM{}, false, res.Err
+			return domain.SBOM{}, nil, res.Err
 		}
 		if !ran {
 			metrics.RecordSingleflightHit(ctx, "sbom_generation")
 		}
-		return res.Val.(domain.SBOM), !res.Shared, nil
+		created := res.Val.(sbomCreation)
+		return created.sbom, created.storeErr, nil
 	case <-ctx.Done():
-		return domain.SBOM{}, false, ctx.Err()
+		return domain.SBOM{}, nil, ctx.Err()
 	}
 }

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -225,6 +225,98 @@ func TestScanService_getOrCreateSBOM_SameTagDifferentDigestsAreNotShared(t *test
 	assert.Equal(t, int32(2), atomic.LoadInt32(&creator.calls), "two digests are two images, not one")
 }
 
+// sizeCappedSBOMCreator mirrors the TooLarge path in adapters/v1/syft.go, which returns
+// before Content is ever assigned: the SBOM carries a status and the annotations getSBOM
+// re-checks against the current limits, but no document. NewMockSBOMAdapter cannot stand in
+// here, as it always fills Content.
+type sizeCappedSBOMCreator struct {
+	calls int
+	// status is what the adapter settled on, TooLarge or Incomplete. Both come back with no
+	// document; only TooLarge carries the limit annotations getSBOM re-checks.
+	status string
+}
+
+func (c *sizeCappedSBOMCreator) CreateSBOM(_ context.Context, name, _, _ string, _ domain.RegistryOptions) (domain.SBOM, error) {
+	c.calls++
+	sbom := domain.SBOM{
+		Name:               name,
+		SBOMCreatorVersion: c.Version(),
+		Status:             c.status,
+	}
+	if c.status == helpersv1.TooLarge {
+		sbom.Annotations = map[string]string{
+			domain.StatusReasonAnnotationKey: domain.ReasonImageTooLarge,
+			domain.MaxImageSizeAnnotationKey: "512",
+		}
+	}
+	return sbom, nil
+}
+
+func (c *sizeCappedSBOMCreator) Version() string        { return "Mock SBOM 1.0" }
+func (c *sizeCappedSBOMCreator) GetMaxImageSize() int64 { return 512 }
+func (c *sizeCappedSBOMCreator) GetMaxSBOMSize() int    { return 0 }
+func (c *sizeCappedSBOMCreator) GetMemoryLimit() string { return "" }
+
+func generateSBOMContext(t *testing.T, s *ScanService) context.Context {
+	t.Helper()
+	ctx, err := s.ValidateGenerateSBOM(context.TODO(), domain.ScanCommand{
+		ImageSlug: "imageSlug",
+		ImageHash: "k8s.gcr.io/kube-proxy@sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+	})
+	require.NoError(t, err)
+	return ctx
+}
+
+// A TooLarge or Incomplete SBOM has no Content, so gating the store on Content meant the
+// verdict was never written and every later scan of that image pulled it again to reach the
+// same answer. StoreSBOM persists it as a status-only marker precisely so it can be reused.
+func TestScanService_GenerateSBOM_RemembersTooLargeVerdict(t *testing.T) {
+	creator := &sizeCappedSBOMCreator{status: helpersv1.TooLarge}
+	storage := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(creator, storage, adapters.NewMockCVEAdapter(), storage, adapters.NewMockPlatform(false, nil), adapters.NewMockRelevancyAdapter(), true, false, true, false, false)
+	ctx := generateSBOMContext(t, s)
+
+	assert.ErrorIs(t, s.GenerateSBOM(ctx), domain.ErrIncompleteSBOM)
+	require.Equal(t, 1, storage.SBOMStores(), "the verdict must be persisted")
+	require.Equal(t, 1, creator.calls)
+
+	assert.ErrorIs(t, s.GenerateSBOM(ctx), domain.ErrIncompleteSBOM, "still a failure")
+	assert.Equal(t, 1, creator.calls, "the stored verdict must be reused, not recomputed")
+	assert.Equal(t, 1, storage.SBOMStores(), "and not written again on the way through")
+}
+
+// Incomplete is the other status that comes back without a document, but it means the scan
+// timed out, and getSBOM has no staleness rule for it. Stored, it would read back as a
+// cache hit at the same scanner version forever and no retry would ever happen.
+func TestScanService_GenerateSBOM_DoesNotPersistIncompleteVerdict(t *testing.T) {
+	creator := &sizeCappedSBOMCreator{status: helpersv1.Incomplete}
+	storage := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(creator, storage, adapters.NewMockCVEAdapter(), storage, adapters.NewMockPlatform(false, nil), adapters.NewMockRelevancyAdapter(), true, false, true, false, false)
+	ctx := generateSBOMContext(t, s)
+
+	assert.ErrorIs(t, s.GenerateSBOM(ctx), domain.ErrIncompleteSBOM)
+	assert.Equal(t, 0, storage.SBOMStores(), "a timeout must not be persisted")
+
+	assert.ErrorIs(t, s.GenerateSBOM(ctx), domain.ErrIncompleteSBOM)
+	assert.Equal(t, 2, creator.calls, "and must be retried on the next scan")
+}
+
+// getOrCreateSBOM stores what it creates, so storing again in the flow wrote the same
+// document to the apiserver twice.
+func TestScanService_GenerateSBOM_StoresCreatedSBOMOnce(t *testing.T) {
+	storage := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(adapters.NewMockSBOMAdapter(false, false, false), storage, adapters.NewMockCVEAdapter(), storage, adapters.NewMockPlatform(false, nil), adapters.NewMockRelevancyAdapter(), true, false, true, false, false)
+	ctx := generateSBOMContext(t, s)
+
+	require.NoError(t, s.GenerateSBOM(ctx))
+	assert.Equal(t, 1, storage.SBOMStores(), "a newly created SBOM must be stored once")
+
+	// the second call is served from storage, and StoreSBOM is a Create that falls back to
+	// Get plus a full Update of the spec, so writing it back is not free
+	require.NoError(t, s.GenerateSBOM(ctx))
+	assert.Equal(t, 1, storage.SBOMStores(), "an SBOM read back from storage must not be stored again")
+}
+
 func TestScanService_ScanCP(t *testing.T) {
 	tests := []struct {
 		createSBOMError bool

--- a/repositories/memory.go
+++ b/repositories/memory.go
@@ -32,6 +32,7 @@ type MemoryStore struct {
 	cveManifests map[cveID]domain.CVEManifest
 	sboms        map[sbomID]domain.SBOM
 	summaryStubs []string // statuses passed to StoreCVESummaryStub, recorded for tests
+	sbomStores   int      // number of StoreSBOM calls, recorded for tests
 	getError     bool
 	storeError   bool
 }
@@ -41,6 +42,12 @@ var _ ports.ContainerProfileRepository = (*MemoryStore)(nil)
 var _ ports.CVERepository = (*MemoryStore)(nil)
 
 var _ ports.SBOMRepository = (*MemoryStore)(nil)
+
+// SBOMStores reports how many times StoreSBOM was called, so a test can tell an SBOM that
+// was written from one that was only read back.
+func (m *MemoryStore) SBOMStores() int {
+	return m.sbomStores
+}
 
 // NewMemoryStorage initializes the MemoryStore struct and its maps
 func NewMemoryStorage(getError, storeError bool) *MemoryStore {
@@ -196,6 +203,13 @@ func (m *MemoryStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion stri
 		SBOMCreatorVersion: SBOMCreatorVersion,
 	}
 	if value, ok := m.sboms[id]; ok {
+		if value.Content == nil {
+			// APIServerStore always reads back a document (Content: &manifest.Spec.Syft),
+			// including for a status-only marker stored with no content, and callers treat a
+			// nil Content as "not in storage". Without this, a stored TooLarge marker would
+			// look absent here but present in production.
+			value.Content = &v1beta1.SyftDocument{}
+		}
 		return value, nil
 	}
 	return domain.SBOM{}, nil
@@ -205,6 +219,8 @@ func (m *MemoryStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion stri
 func (m *MemoryStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, _ bool) error {
 	_, span := otel.Tracer("").Start(ctx, "MemoryStore.StoreSBOM")
 	defer span.End()
+
+	m.sbomStores++
 
 	if m.storeError {
 		return domain.ErrMockError


### PR DESCRIPTION
*rebased and rewritten on top of #610, which landed while this was open and moved all four flows onto `getOrCreateSBOM`. the earlier version of this PR described the pre-#610 code.*

## Overview

three fixes in `getOrCreateSBOM`, all about what reaches storage.

**store a TooLarge verdict, which has no content.** the worker gated its store on `sbom.Content != nil`, but the syft adapter returns TooLarge and Incomplete before `Content` is assigned, so the verdict was never written. `StoreSBOM` persists a content-less SBOM as a status-only marker on purpose, and `getSBOM` re-checks that marker against the current `maxImageSize`/`maxSBOMSize` so it stops applying when the limits change. with nothing ever written, that path could not run and every scan of an oversized image re-pulled it to reach the answer it already had. before #610 the scan flows stored unconditionally inside the create branch, so the marker did get written.

Incomplete stays unstored, which is the one place this does not simply restore the pre-#610 behaviour. that status is a timeout rather than a verdict, and `getSBOM` has no staleness rule for it, so a stored one would read back as a cache hit at the same scanner version forever and no retry would ever happen. raised by both bots on the first version of this, and they were right.

**return the store error instead of `!res.Shared`.** `GenerateSBOM` gated its own store on that flag, which is singleflight's "this result was not shared", not "this call created something". so a call that was not deduplicated stored a newly created SBOM twice, and stored a cached one that had just been read back. the worker already stores what it creates, so what the flow actually needs is whether that store failed. it now gets exactly that, and keeps reporting `ReasonSBOMStorageFailed` without repeating the write.

the scan flows are untouched: they take `sbom, _, err` as before, and still ignore a store failure and carry on with an SBOM they could not persist. only `GenerateSBOM`, whose purpose is to store, treats it as a failure.

## Additional Information

the status check stays ahead of the store error, so a too-large image is still reported as `ReasonSBOMTooLarge` rather than a storage failure, which is the precedence it had when the store sat below that check.

`MemoryStore.GetSBOM` returned whatever was put in, so a stored marker read back with nil `Content` and looked absent, while `APIServerStore` always returns `Content: &manifest.Spec.Syft` and reads it back as present. that gap is why the missing marker was invisible in tests, so the double now matches the real store. it also counts `StoreSBOM` calls, same idea as the `summaryStubs` field already there. `MemoryStore` is test-only.

`NewMockSBOMAdapter` always fills `Content`, including for its Incomplete case, so it cannot represent this at all. the new test uses a small creator that mirrors syft's TooLarge path instead.

also replaces the `// FIXME check if we still use this method` above `GenerateSBOM` with the answer, since I had to work it out anyway: `cmd/http/main.go` routes `POST v1/generateSBOM` to it, through `ValidateGenerateSBOM` and the same rejection and scan metrics as the other flows.

## How to Test

`go test ./... -count=1`

- `TestScanService_GenerateSBOM_RemembersTooLargeVerdict` asserts the marker is stored and that a second call reuses it instead of calling `CreateSBOM` again. before this: 0 stores, 2 creations.
- `TestScanService_GenerateSBOM_DoesNotPersistIncompleteVerdict` asserts a timeout is not written and is retried on the next scan.
- `TestScanService_GenerateSBOM_StoresCreatedSBOMOnce` asserts one store for a newly created SBOM and none for one served from storage. before this: 2, then 3.

the existing table test is unchanged, including `phase 2, store SBOM failed`, which still gets `ReasonSBOMStorageFailed` now that the error comes back through `getOrCreateSBOM`.

## Related issues/PRs:

* Resolved #622
* Follow-up to #610
