### PR TITLE
fix: give ParseImageManifest the same LayerOrder indexing as parseLayersPayload

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -352,13 +352,19 @@ func ParseImageManifest(grypeDocument *v1beta1.GrypeDocument) (*containerscan.Im
 		Layers:       []containerscan.ESLayer{},
 	}
 
+	// LayerOrder counts real, layer-producing history entries only, matching
+	// parseLayersPayload's indexing (which builds the layerMap DomainToArmo attaches to
+	// each vulnerability). History also contains metadata-only entries (ENV, LABEL, CMD,
+	// etc.) that don't produce a layer; counting those too, as the raw loop index would,
+	// gives every real layer a different LayerOrder here than in the vulnerability report
+	// for the same layer hash, breaking any lookup that correlates the two by LayerOrder.
 	layerIndex := 0
-	for i, historyLayer := range config.History {
+	for _, historyLayer := range config.History {
 		layerInfo := containerscan.ESLayer{
 			LayerInfo: &containerscan.LayerInfo{
 				CreatedBy:   historyLayer.CreatedBy,
 				CreatedTime: &historyLayer.Created.Time,
-				LayerOrder:  i,
+				LayerOrder:  layerIndex,
 			},
 		}
 		if !historyLayer.EmptyLayer && layerIndex < len(rawManifest.Layers) {

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -200,6 +200,62 @@ func Test_parseLayersPayload(t *testing.T) {
 	}
 }
 
+// Test_layerOrder_consistentBetweenManifestAndVulnerabilities guards #617: a vulnerability's
+// LayerOrder (via parseLayersPayload, which DomainToArmo attaches to each vulnerability) and
+// the same layer's LayerOrder in ParseImageManifest's output must agree, so a consumer can
+// correlate a vulnerability to its build step. History mixes metadata-only entries (no layer)
+// between real, layer-producing ones, which is what previously made the two disagree.
+func Test_layerOrder_consistentBetweenManifestAndVulnerabilities(t *testing.T) {
+	config := containerRegistryV1.ConfigFile{
+		History: []containerRegistryV1.History{
+			{CreatedBy: "FROM base", EmptyLayer: false},
+			{CreatedBy: "ENV FOO=bar", EmptyLayer: true},
+			{CreatedBy: "LABEL x=y", EmptyLayer: true},
+			{CreatedBy: "COPY app /app", EmptyLayer: false},
+			{CreatedBy: "CMD [\"/app\"]", EmptyLayer: true},
+		},
+		RootFS: containerRegistryV1.RootFS{
+			DiffIDs: []containerRegistryV1.Hash{
+				{Algorithm: "sha256", Hex: "aaaa000000000000000000000000000000000000000000000000000000000000"},
+				{Algorithm: "sha256", Hex: "bbbb000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+	}
+	configBytes, err := json.Marshal(config)
+	assert.NoError(t, err)
+
+	imageMetadata := source.ImageMetadata{
+		RawConfig: configBytes,
+		Layers: []source.LayerMetadata{
+			{Digest: "sha256:aaaa000000000000000000000000000000000000000000000000000000000000", Size: 100},
+			{Digest: "sha256:bbbb000000000000000000000000000000000000000000000000000000000000", Size: 200},
+		},
+	}
+	targetBytes, err := json.Marshal(imageMetadata)
+	assert.NoError(t, err)
+
+	layerMap, err := parseLayersPayload(imageMetadata)
+	assert.NoError(t, err)
+
+	imageManifest, err := ParseImageManifest(&v1beta1.GrypeDocument{
+		Source: &v1beta1.Source{Type: "image", Target: targetBytes},
+	})
+	assert.NoError(t, err)
+
+	checked := 0
+	for _, layer := range imageManifest.Layers {
+		if layer.LayerHash == "" {
+			continue
+		}
+		vulnLayer, ok := layerMap[layer.LayerHash]
+		assert.True(t, ok, "layer %s missing from parseLayersPayload's map", layer.LayerHash)
+		assert.Equal(t, vulnLayer.LayerOrder, layer.LayerOrder,
+			"LayerOrder for layer %s disagrees between ParseImageManifest and parseLayersPayload", layer.LayerHash)
+		checked++
+	}
+	assert.Equal(t, 2, checked, "expected to check both real layers")
+}
+
 func Test_suggestedVersion(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/adapters/v1/testdata/nginx-image-manifest.json
+++ b/adapters/v1/testdata/nginx-image-manifest.json
@@ -22,42 +22,42 @@
       "parentLayerHash":"",
       "createdBy":"LABEL maintainer=NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":2
+      "layerOrder":1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NGINX_VERSION=1.27.0",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":3
+      "layerOrder":1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NJS_VERSION=0.8.4",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":4
+      "layerOrder":1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NJS_RELEASE=2~bookworm",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":5
+      "layerOrder":1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV PKG_RELEASE=2~bookworm",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":6
+      "layerOrder":1
     },
     {
       "layerHash":"sha256:3a0cf035bbfcc7852c38d4d236673b6a0d9454e5f2621800814d1633e729ea20",
       "parentLayerHash":"",
       "createdBy":"RUN /bin/sh -c set -x     \u0026\u0026 groupadd --system --gid 101 nginx     \u0026\u0026 useradd --system --gid nginx --no-create-home --home /nonexistent --comment \"nginx user\" --shell /bin/false --uid 101 nginx     \u0026\u0026 apt-get update     \u0026\u0026 apt-get install --no-install-recommends --no-install-suggests -y gnupg1 ca-certificates     \u0026\u0026     NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62;     NGINX_GPGKEY_PATH=/etc/apt/keyrings/nginx-archive-keyring.gpg;     export GNUPGHOME=\"$(mktemp -d)\";     found='';     for server in         hkp://keyserver.ubuntu.com:80         pgp.mit.edu     ; do         echo \"Fetching GPG key $NGINX_GPGKEY from $server\";         gpg1 --keyserver \"$server\" --keyserver-options timeout=10 --recv-keys \"$NGINX_GPGKEY\" \u0026\u0026 found=yes \u0026\u0026 break;     done;     test -z \"$found\" \u0026\u0026 echo \u003e\u00262 \"error: failed to fetch GPG key $NGINX_GPGKEY\" \u0026\u0026 exit 1;     gpg1 --export \"$NGINX_GPGKEY\" \u003e \"$NGINX_GPGKEY_PATH\" ;     rm -rf \"$GNUPGHOME\";     apt-get remove --purge --auto-remove -y gnupg1 \u0026\u0026 rm -rf /var/lib/apt/lists/*     \u0026\u0026 dpkgArch=\"$(dpkg --print-architecture)\"     \u0026\u0026 nginxPackages=\"         nginx=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-xslt=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-geoip=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-image-filter=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${NJS_RELEASE}     \"     \u0026\u0026 case \"$dpkgArch\" in         amd64|arm64)             echo \"deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx\" \u003e\u003e /etc/apt/sources.list.d/nginx.list             \u0026\u0026 apt-get update             ;;         *)             echo \"deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx\" \u003e\u003e /etc/apt/sources.list.d/nginx.list                         \u0026\u0026 tempDir=\"$(mktemp -d)\"             \u0026\u0026 chmod 777 \"$tempDir\"                         \u0026\u0026 savedAptMark=\"$(apt-mark showmanual)\"                         \u0026\u0026 apt-get update             \u0026\u0026 apt-get build-dep -y $nginxPackages             \u0026\u0026 (                 cd \"$tempDir\"                 \u0026\u0026 DEB_BUILD_OPTIONS=\"nocheck parallel=$(nproc)\"                     apt-get source --compile $nginxPackages             )                         \u0026\u0026 apt-mark showmanual | xargs apt-mark auto \u003e /dev/null             \u0026\u0026 { [ -z \"$savedAptMark\" ] || apt-mark manual $savedAptMark; }                         \u0026\u0026 ls -lAFh \"$tempDir\"             \u0026\u0026 ( cd \"$tempDir\" \u0026\u0026 dpkg-scanpackages . \u003e Packages )             \u0026\u0026 grep '^Package: ' \"$tempDir/Packages\"             \u0026\u0026 echo \"deb [ trusted=yes ] file://$tempDir ./\" \u003e /etc/apt/sources.list.d/temp.list             \u0026\u0026 apt-get -o Acquire::GzipIndexes=false update             ;;     esac         \u0026\u0026 apt-get install --no-install-recommends --no-install-suggests -y                         $nginxPackages                         gettext-base                         curl     \u0026\u0026 apt-get remove --purge --auto-remove -y \u0026\u0026 rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list         \u0026\u0026 if [ -n \"$tempDir\" ]; then         apt-get purge -y --auto-remove         \u0026\u0026 rm -rf \"$tempDir\" /etc/apt/sources.list.d/temp.list;     fi     \u0026\u0026 ln -sf /dev/stdout /var/log/nginx/access.log     \u0026\u0026 ln -sf /dev/stderr /var/log/nginx/error.log     \u0026\u0026 mkdir /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":7,
+      "layerOrder":1,
       "size":95802212
     },
     {
@@ -65,7 +65,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY docker-entrypoint.sh / # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":8,
+      "layerOrder":2,
       "size":1620
     },
     {
@@ -73,7 +73,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":9,
+      "layerOrder":3,
       "size":2125
     },
     {
@@ -81,7 +81,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 15-local-resolvers.envsh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":10,
+      "layerOrder":4,
       "size":336
     },
     {
@@ -89,7 +89,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 20-envsubst-on-templates.sh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":11,
+      "layerOrder":5,
       "size":3018
     },
     {
@@ -97,7 +97,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 30-tune-worker-processes.sh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":12,
+      "layerOrder":6,
       "size":4619
     },
     {
@@ -105,28 +105,28 @@
       "parentLayerHash":"",
       "createdBy":"ENTRYPOINT [\"/docker-entrypoint.sh\"]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":13
+      "layerOrder":7
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"EXPOSE map[80/tcp:{}]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":14
+      "layerOrder":7
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"STOPSIGNAL SIGQUIT",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":15
+      "layerOrder":7
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"CMD [\"nginx\" \"-g\" \"daemon off;\"]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":16
+      "layerOrder":7
     }
   ]
 }


### PR DESCRIPTION
## Overview

`adapters/v1/domain_to_armo.go` has two functions that both compute `LayerOrder` for image layers in the same scan report, using two different index spaces:

- `parseLayersPayload` (feeds `DomainToArmo`, which attaches `LayerOrder` to every vulnerability's `Layers[]`) numbers layers by their position among **real, layer-producing** `History` entries only, skipping metadata-only ones (`ENV`, `LABEL`, `CMD`, etc.).
- `ParseImageManifest` (feeds `Summary.ImageManifest.Layers[]`, attached to the same report by `Summarize`) numbered **every** `History` entry, including the metadata-only ones.

Since almost any real Dockerfile mixes both kinds of instructions, the same physical layer got a different `LayerOrder` in the two places it appears in one report, so correlating "which build step introduced this vulnerability" via `LayerOrder` pointed at the wrong layer.

Fix: `ParseImageManifest` now counts only real layers when assigning `LayerOrder`, the same way `parseLayersPayload` does, so both agree on every shared layer hash.

Also updated `testdata/nginx-image-manifest.json` (a real image history with metadata-only entries interleaved between real layers) to the corrected expected values, and added a test that builds a mixed-history fixture and asserts `ParseImageManifest` and `parseLayersPayload` produce the same `LayerOrder` for every layer hash they share.

## How to Test

```
go test ./adapters/v1/... -run 'TestParseImageManifest|Test_parseLayersPayload|Test_layerOrder_consistentBetweenManifestAndVulnerabilities' -v
```

## Related issues/PRs:

* Resolved #617

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected container image layer ordering when metadata-only history entries are present.
  * Improved consistency between manifest layers and vulnerability layer information.
  * Updated image layer metadata to reflect the corrected ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->