### PR TITLE
fix(services): key the SBOM singleflight on the image, not the tag

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -105,8 +105,18 @@ func NewScanService(sbomCreator ports.SBOMCreator, sbomRepository ports.SBOMRepo
 // does not cause a cross-tenant denial-of-service for workloads that use valid imagePullSecrets
 // to bypass the rate limit. ImageHash is avoided because ScanRegistry payloads never populate it.
 func rateLimitCacheKey(workload domain.ScanCommand) string {
-	if len(workload.CredentialsList) == 0 {
+	fingerprint := credentialsFingerprint(workload)
+	if fingerprint == "" {
 		return workload.ImageTagNormalized
+	}
+	return fmt.Sprintf("%s|%s", workload.ImageTagNormalized, fingerprint)
+}
+
+// credentialsFingerprint hashes the workload's credentials, so that keys built from it keep
+// callers holding different credentials apart. Empty when the workload carries none.
+func credentialsFingerprint(workload domain.ScanCommand) string {
+	if len(workload.CredentialsList) == 0 {
+		return ""
 	}
 	h := sha256.New()
 	for _, cred := range workload.CredentialsList {
@@ -119,7 +129,21 @@ func rateLimitCacheKey(workload domain.ScanCommand) string {
 			len(cred.RegistryToken), cred.RegistryToken,
 			len(cred.ServerAddress), cred.ServerAddress)
 	}
-	return fmt.Sprintf("%s|%x", workload.ImageTagNormalized, h.Sum(nil))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// sbomSingleflightKey identifies the SBOM a caller is about to produce, so concurrent
+// callers only share work when they are asking for the same one.
+//
+// It keys on ImageSlug rather than the image tag. The slug carries the image digest and is
+// what the SBOM is stored under, so it is the identity of the object being created. The tag
+// is not: a mutable tag can point at two different digests at the same time, during a
+// rollout or after a repush, and those are different images that must not share a result.
+// rateLimitCacheKey leaves the digest out on purpose, because a registry rate limits by
+// repository rather than by digest, which makes it the wrong identity here.
+func sbomSingleflightKey(workload domain.ScanCommand, opts domain.RegistryOptions) string {
+	return fmt.Sprintf("%s|%s|%s|http:%t|skiptls:%t", workload.ImageSlug, credentialsFingerprint(workload),
+		opts.Platform, opts.InsecureUseHTTP, opts.InsecureSkipTLSVerify)
 }
 
 // checkCreateSBOM records a rate-limit (429) backoff entry in the tooManyRequests cache if the error indicates a rate-limited registry pull.
@@ -1299,7 +1323,7 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 	}
 
 	opts := optionsFromWorkload(ctx, workload)
-	key := fmt.Sprintf("%s|%s|http:%t|skiptls:%t", rateLimitCacheKey(workload), opts.Platform, opts.InsecureUseHTTP, opts.InsecureSkipTLSVerify)
+	key := sbomSingleflightKey(workload, opts)
 
 	// Detach workerCtx from caller cancellation so the singleflight worker job completes for all waiters even if the leader cancels early
 	workerCtx := context.WithoutCancel(ctx)

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/scanfailure"
@@ -152,6 +154,72 @@ func TestScanService_GenerateSBOM(t *testing.T) {
 			}
 		})
 	}
+}
+
+// perImageSBOMCreator names each SBOM after the slug it was asked for, and holds every
+// caller inside CreateSBOM until all of them have arrived, so the callers provably contend
+// rather than finishing one after another.
+type perImageSBOMCreator struct {
+	calls   int32
+	arrived int32
+	total   int32
+	all     chan struct{}
+}
+
+func (c *perImageSBOMCreator) CreateSBOM(_ context.Context, name, _, _ string, _ domain.RegistryOptions) (domain.SBOM, error) {
+	atomic.AddInt32(&c.calls, 1)
+	if atomic.AddInt32(&c.arrived, 1) == c.total {
+		close(c.all)
+	}
+	// Bounded, because the point of the test is that both callers get here. If they are
+	// merged onto one key only one ever does, and an unbounded wait would hang instead of
+	// failing on the assertion below.
+	select {
+	case <-c.all:
+	case <-time.After(2 * time.Second):
+	}
+	return domain.SBOM{Name: name, SBOMCreatorVersion: c.Version(), Content: &v1beta1.SyftDocument{}}, nil
+}
+
+func (c *perImageSBOMCreator) Version() string        { return "Mock SBOM 1.0" }
+func (c *perImageSBOMCreator) GetMaxImageSize() int64 { return 0 }
+func (c *perImageSBOMCreator) GetMaxSBOMSize() int    { return 0 }
+func (c *perImageSBOMCreator) GetMemoryLimit() string { return "" }
+
+// A mutable tag can point at two digests at once, mid-rollout or after a repush. Those are
+// different images, stored under different slugs, so they must not be deduplicated into one
+// another: the loser would be handed an SBOM for an image it is not scanning, and since the
+// CVE manifest takes its name from the SBOM, its findings would be filed under the other
+// image's slug.
+func TestScanService_getOrCreateSBOM_SameTagDifferentDigestsAreNotShared(t *testing.T) {
+	creator := &perImageSBOMCreator{total: 2, all: make(chan struct{})}
+	store := repositories.NewMemoryStorage(false, false)
+	// storage off: this is about which callers share a key, and MemoryStore's maps are
+	// unguarded, so two workers storing at once race the double rather than the code.
+	s := NewScanService(creator, store, adapters.NewMockCVEAdapter(), store, adapters.NewMockPlatform(false, nil), adapters.NewMockRelevancyAdapter(), false, false, true, false, false)
+
+	workloads := []domain.ScanCommand{
+		{ImageTagNormalized: "repo/app:latest", ImageHash: "sha256:aaaaaaaaaaaa", ImageSlug: "repo-app-latest-aaaaaaaaaaaa"},
+		{ImageTagNormalized: "repo/app:latest", ImageHash: "sha256:bbbbbbbbbbbb", ImageSlug: "repo-app-latest-bbbbbbbbbbbb"},
+	}
+
+	names := make([]string, len(workloads))
+	var wg sync.WaitGroup
+	for i := range workloads {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sbom, _, err := s.getOrCreateSBOM(context.TODO(), workloads[i])
+			assert.NoError(t, err)
+			names[i] = sbom.Name
+		}(i)
+	}
+	wg.Wait()
+
+	for i, w := range workloads {
+		assert.Equal(t, w.ImageSlug, names[i], "each workload must get the SBOM for its own image")
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&creator.calls), "two digests are two images, not one")
 }
 
 func TestScanService_ScanCP(t *testing.T) {


### PR DESCRIPTION
## Overview

keys the SBOM singleflight on `ImageSlug` instead of `rateLimitCacheKey`.

`rateLimitCacheKey` is the image tag plus a credentials hash, and it leaves the digest out deliberately, which is correct for a rate-limit backoff because a registry rate limits by repository. it is the wrong identity for deciding which callers are doing the same work. the SBOM is stored under `ImageSlug`, which carries the digest, so two scans of one mutable tag at two different digests are different work but shared a key. that happens on a repush, or during a rollout where old and new pods are scanned together by the worker pool.

the loser was handed the leader's SBOM, named for the leader's image, and `adapters/v1/grype.go` takes `CVEManifest.Name` straight from `sbom.Name`, so its findings were filed under the other image's slug while its own slug got nothing. no error anywhere.

`ImageSlug` is the identity of the object being produced, and all three validators already reject an empty one with `ErrMissingImageInfo`, so it is always populated by the time `getOrCreateSBOM` runs.

## Additional Information

the credentials hash stays in the key, so a caller holding working credentials still does not inherit a failure from one without. it moved into a `credentialsFingerprint` helper shared with `rateLimitCacheKey`, whose output is unchanged, so the rate-limit cache and its tests are unaffected.

the new test runs with storage off. `MemoryStore`'s maps are unguarded, and now that two same-tag callers correctly get separate keys their workers store concurrently, which trips the race detector on the double rather than on anything in the code. worth knowing about, since #610 introduced the first concurrency these doubles have had to deal with, but it is a test-only gap and out of scope here.

## How to Test

`go test ./core/services/ -race -count=1`

`TestScanService_getOrCreateSBOM_SameTagDifferentDigestsAreNotShared` runs two callers for one tag at two digests and asserts each gets the SBOM for its own image, and that both images are built.

without this, it fails in 2s with:

```
expected: "repo-app-latest-aaaaaaaaaaaa"
actual  : "repo-app-latest-bbbbbbbbbbbb"
each workload must get the SBOM for its own image
```

the barrier the test uses to force contention is bounded for that reason: merged onto one key only one caller ever reaches `CreateSBOM`, and an unbounded wait would hang rather than fail.

`TestScanService_SingleflightSBOMDeduplication` from #610 is untouched and still passes, so same-image dedup, which is the point of the singleflight, still works.

## Related issues/PRs:

* Resolved #628
* Follow-up to #610
