### PR TITLE
fix(services): count only the scans singleflight spared, not the leader

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -1304,7 +1304,14 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 	// Detach workerCtx from caller cancellation so the singleflight worker job completes for all waiters even if the leader cancels early
 	workerCtx := context.WithoutCancel(ctx)
 
+	// ran reports whether this caller's own closure was the one singleflight executed.
+	// singleflight's res.Shared cannot answer that: it means the result was handed to more
+	// than one caller, so it is true for the leader too, and counting on it would report the
+	// caller that did the work as one of the callers that were spared it. Only read in the
+	// res branch below, where receiving happens-after the closure returns.
+	ran := false
 	ch := s.sfGroup.DoChan(key, func() (interface{}, error) {
+		ran = true
 		// Re-check storage inside singleflight worker in case another worker stored it while we waited
 		if s.storage {
 			if sbom, err := s.getSBOM(workerCtx, workload.ImageSlug, s.sbomCreator.Version()); err == nil && sbom.Content != nil {
@@ -1355,7 +1362,7 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 		if res.Err != nil {
 			return domain.SBOM{}, false, res.Err
 		}
-		if res.Shared {
+		if !ran {
 			metrics.RecordSingleflightHit(ctx, "sbom_generation")
 		}
 		return res.Val.(domain.SBOM), !res.Shared, nil

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	v1 "github.com/kubescape/kubevuln/adapters/v1"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
+	"github.com/kubescape/kubevuln/internal/metrics"
 	"github.com/kubescape/kubevuln/internal/tools"
 	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/kubevuln/repositories"
@@ -2490,6 +2492,66 @@ func (b *blockingSBOMCreator) CreateSBOM(ctx context.Context, name, imageID, ima
 		b.onStart()
 	}
 	return b.SBOMCreator.CreateSBOM(ctx, name, imageID, imageTag, options)
+}
+
+// kubevuln_singleflight_hits_total is meant to count requests that singleflight spared
+// from doing the work. res.Shared does not identify those: it means the result went to more
+// than one caller, which is true of the leader as well, so a burst of N collapsing to one
+// creation reported N deduplicated requests instead of N-1.
+func TestScanService_SingleflightHitsCountOnlyDeduplicatedCallers(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	creator := &blockingSBOMCreator{
+		SBOMCreator: adapters.NewMockSBOMAdapter(false, false, false),
+		onStart: func() {
+			once.Do(func() { close(started) })
+			<-release
+		},
+	}
+
+	// storage off, so a caller that arrives late and starts its own round reaches CreateSBOM
+	// rather than being served by the worker's storage re-check. That keeps "callers that
+	// ran the work" equal to CreateSBOM calls, which is what the assertion below leans on.
+	store := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(creator, store, adapters.NewMockCVEAdapter(), store, adapters.NewMockPlatform(false, nil), adapters.NewMockRelevancyAdapter(), false, false, true, false, false)
+
+	workload := domain.ScanCommand{
+		ImageSlug:          "library-alpine-latest-1234567890ab",
+		ImageTagNormalized: "library/alpine:latest",
+		ImageHash:          "sha256:1234567890ab",
+	}
+
+	const callers = 5
+	var startWg, wg sync.WaitGroup
+	startWg.Add(callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startWg.Done()
+			_, _, err := s.getOrCreateSBOM(context.TODO(), workload)
+			assert.NoError(t, err)
+		}()
+	}
+	startWg.Wait()
+	<-started
+	close(release)
+	wg.Wait()
+
+	// Every caller either did the work or was spared it, so the two must add up, whether or
+	// not one of them was late enough to start a round of its own.
+	creator.mu.Lock()
+	ranTheWork := creator.calls
+	creator.mu.Unlock()
+	w := httptest.NewRecorder()
+	m.Handler().ServeHTTP(w, httptest.NewRequest("GET", "/metrics", nil))
+	assert.Contains(t, w.Body.String(),
+		fmt.Sprintf(`kubevuln_singleflight_hits_total{target="sbom_generation"} %d`, callers-ranTheWork),
+		"the caller that did the work is not one of the callers it spared")
 }
 
 func TestScanService_SingleflightSBOMDeduplication(t *testing.T) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -146,6 +146,7 @@ GET /metrics
 | `kubevuln_scan_fallbacks_total` | counter | `component` (`in_process`/`sidecar`), `category` (`registry_auth`/`platform`/`size_classification`), `strategy` (`anonymous`/`ecr`/`gcp_adc`/`image_too_large`/`incomplete`/`platform_mismatch`/`sbom_too_large`), `outcome` (`classified`/`failed`/`succeeded`) | Fallbacks taken while resolving or classifying a scan, such as retrying a 401 with cloud credentials or falling back to anonymous access |
 | `kubevuln_scan_source_resolution_total` | counter | `component`, `outcome` (`first_pass_success`/`fallback_assisted_success`/`fallback_failed`/`first_pass_failure`) | Whether pulling the image succeeded outright or only after a fallback, which is what distinguishes a healthy registry from one that works only by retry |
 | `kubevuln_registry_auth_cache_total` | counter | `strategy` (`ecr`/`gcp_adc`), `result` (`hit`/`miss`) | Registry auth credential lookups served from cache versus fetched from the cloud provider |
+| `kubevuln_singleflight_hits_total` | counter | `target` (`sbom_generation`) | Scan requests that arrived while the same work was already in flight and were served by it, so they did not generate an SBOM of their own. Counts the requests spared the work, not the one doing it |
 
 `reason` is `"none"` for a `success`/`partial` outcome, and otherwise one of the bounded
 `scanfailure.Reason*` constants from [`armoapi-go/scanfailure`](https://github.com/armosec/armoapi-go)


### PR DESCRIPTION
## Overview

`kubevuln_singleflight_hits_total` was recorded on `res.Shared`, which is not "you were deduplicated". in `golang.org/x/sync/singleflight` it is `c.dups > 0`, evaluated once and sent to every waiting channel, so the leader sees it as well. five concurrent scans of one image collapse to one `CreateSBOM` and four spared requests, and the counter said five. for two racing requests, which is the ordinary case, it reported two where one was deduplicated.

the leader is the only caller whose closure singleflight actually runs, so a flag set inside it separates the two cleanly, and `res.Shared` is not needed at all.

also adds the metric to the table in `docs/API.md`, which lists the other ten.

## Additional Information

`ran` is a plain bool. each caller passes its own closure to `DoChan` and singleflight runs exactly one of them, so a caller either owns the write or there is no write at all, and it is only read in the `res` branch where the receive happens-after the closure returns. same reasoning as `#619`, which fixes the equivalent confusion in the registry auth cache, where every coalesced waiter was recorded as an upstream fetch. the two are independent, no shared code.

## How to Test

`go test ./core/services/ -race -count=1`

`TestScanService_SingleflightHitsCountOnlyDeduplicatedCallers` runs five callers against one image on the blocking creator #610 already uses, then asserts the hits equal the callers that did not run the work.

it asserts `callers - CreateSBOM calls` rather than a fixed four, so it holds even if one caller arrives late enough to start a round of its own, and it runs with storage off so that a late caller reaches `CreateSBOM` instead of being served by the worker's storage re-check, which would break that identity.

against main it fails with the number from the issue:

```
kubevuln_singleflight_hits_total{target="sbom_generation"} 5
  does not contain
kubevuln_singleflight_hits_total{target="sbom_generation"} 4
```

`TestScanService_SingleflightSBOMDeduplication` from #610 is untouched and still passes.

## Related issues/PRs:

* Resolved #630
* Follow-up to #610


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SBOM-generation metrics so only requests that reuse work already in progress are counted as singleflight hits.
  * Improved metric accuracy for concurrent and late-arriving SBOM requests.

* **Documentation**
  * Documented the `kubevuln_singleflight_hits_total` Prometheus metric, including its target label and purpose for monitoring deduplicated SBOM-generation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->