### PR TITLE
fix(repositories): do not let an external VEX statement suppress our own

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1177,6 +1177,14 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		for _, v := range cve.Content.Matches {
 			found := false
 			for _, s := range vexDoc.Statements {
+				// Only our own statements count as already present. An external one is
+				// another author's assessment, and every step below that maintains a
+				// statement (mark-affected, mark-ignored, reset-to-baseline) is local-only,
+				// so treating it as ours would drop kubescape's assessment of this
+				// vulnerability from the document instead of recording it alongside theirs.
+				if !isLocalStatement(s.ID) {
+					continue
+				}
 				if s.Vulnerability.Name != v.Vulnerability.ID {
 					continue
 				}
@@ -1223,6 +1231,14 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		for _, v := range cve.Content.IgnoredMatches {
 			found := false
 			for _, s := range vexDoc.Statements {
+				// Only our own statements count as already present. An external one is
+				// another author's assessment, and every step below that maintains a
+				// statement (mark-affected, mark-ignored, reset-to-baseline) is local-only,
+				// so treating it as ours would drop kubescape's assessment of this
+				// vulnerability from the document instead of recording it alongside theirs.
+				if !isLocalStatement(s.ID) {
+					continue
+				}
 				if s.Vulnerability.Name != v.Vulnerability.ID {
 					continue
 				}

--- a/repositories/apiserver_external_test.go
+++ b/repositories/apiserver_external_test.go
@@ -104,3 +104,77 @@ func TestAPIServerStore_updateVEX_preservesExternalStatements(t *testing.T) {
 	}
 	assert.True(t, foundLegacy, "Legacy statement should remain in the document")
 }
+
+// #595 made updateVEX leave external statements alone, but the dedup that decides whether
+// to append kubevuln's own statement still scans every statement rather than only the local
+// ones. An external statement covering a vulnerability kubevuln also found therefore
+// suppresses kubevuln's statement for it entirely, and since every assessment step
+// (mark-affected, mark-ignored, reset-to-baseline) is local-only, that vulnerability ends up
+// with no kubescape assessment in the document at all.
+func TestAPIServerStore_updateVEX_externalStatementDoesNotSuppressLocalOne(t *testing.T) {
+	cveManifestFull := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	})
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Take one statement kubevuln generated, so the vulnerability and package are ones the
+	// manifest really contains, and swap it for an external statement covering the same pair.
+	var target v1beta1.Statement
+	for _, s := range vexContainer.Spec.Statements {
+		if isLocalStatement(s.ID) && len(s.Products) > 0 && len(s.Products[0].Subcomponents) > 0 {
+			target = s
+			break
+		}
+	}
+	require.NotEmpty(t, target.Vulnerability.Name, "expected the first pass to generate statements")
+	pkg := target.Products[0].Subcomponents[0].ID
+
+	external := *target.DeepCopy()
+	external.ID = "https://chainguard.dev/vex/statement/" + target.Vulnerability.Name
+	external.Status = v1beta1.Status(vex.StatusAffected)
+	external.ImpactStatement = "External feed assessed this one"
+
+	kept := make([]v1beta1.Statement, 0, len(vexContainer.Spec.Statements))
+	for _, s := range vexContainer.Spec.Statements {
+		if s.ID != target.ID {
+			kept = append(kept, s)
+		}
+	}
+	vexContainer.Spec.Statements = append(kept, external)
+	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(ctx, vexContainer, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+	updated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	foundLocal, foundExternal := false, false
+	for _, s := range updated.Spec.Statements {
+		if s.Vulnerability.Name != target.Vulnerability.Name {
+			continue
+		}
+		if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 || s.Products[0].Subcomponents[0].ID != pkg {
+			continue
+		}
+		if isLocalStatement(s.ID) {
+			foundLocal = true
+			continue
+		}
+		foundExternal = true
+		assert.Equal(t, external.Status, s.Status, "the external statement must still be untouched")
+		assert.Equal(t, external.ImpactStatement, s.ImpactStatement)
+	}
+	assert.True(t, foundExternal, "the external statement must survive")
+	assert.True(t, foundLocal, "kubescape must still record its own assessment alongside the external one")
+}


### PR DESCRIPTION
## Overview

#595 put `isLocalStatement` on the three places in `updateVEX` that modify a statement, but not on the two that decide whether to append one. so an external statement counted as "we already have this", and kubevuln skipped adding its own statement for a vulnerability an external feed happened to cover.

that goes further than not overwriting. every step that maintains an assessment is local-only, so with no local statement to work on, `markRelevantVulnerabilitiesAsAffectedInVex` never marks it affected even when relevancy says the package is loaded, `markIgnoredVulnerabilitiesInVex` never reflects a SecurityException on it, and the reset loop skips it. the vulnerability ends up in the document with the external author's view and no kubescape assessment at all, so one external statement silently drops a finding from kubescape's output.

this puts the same guard on both dedup loops, so kubevuln records its assessment alongside the external one instead of in place of it, and the external statement is still left exactly as it was.

## Additional Information

it also makes the `Products[0].Subcomponents[0]` comparison right rather than lucky. statements kubevuln builds always carry exactly one product and one subcomponent, so index 0 is the whole statement. an external one can list many, and was being compared on its first subcomponent only.

no change when there is no external VEX, which is why the existing tests are untouched.

## How to Test

`go test ./repositories/ -count=1`

`TestAPIServerStore_updateVEX_externalStatementDoesNotSuppressLocalOne` runs `StoreVEX` on the nginx testdata, takes a statement kubevuln generated so the vulnerability and package are ones the manifest really contains, swaps it for an external statement covering the same pair, and runs `StoreVEX` again. it asserts both statements are present afterwards and that the external one is unmodified.

before this it fails on the local one:

```
Should be true
kubescape must still record its own assessment alongside the external one
```

`TestAPIServerStore_updateVEX_preservesExternalStatements` from #595 still passes. its external statement is for a vulnerability the manifest does not contain, so it never reaches the dedup.

## Related issues/PRs:

* Resolved #632
* Follow-up to #595
