### PR TITLE
fix: bound the sbom-scanner sidecar's graceful shutdown with a timeout

### DIFF
--- a/cmd/sbom-scanner/main.go
+++ b/cmd/sbom-scanner/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -21,6 +22,38 @@ import (
 	// registered". See https://github.com/kubescape/kubevuln/issues/378.
 	_ "modernc.org/sqlite"
 )
+
+// shutdownTimeout bounds how long gracefulStopWithTimeout waits for in-flight CreateSBOM RPCs
+// to finish on their own before forcing the connection closed. Matches cmd/http/main.go's
+// shutdownTimeout default so both processes give a comparable grace period before a
+// terminationGracePeriodSeconds-driven SIGKILL would otherwise cut them off mid-shutdown.
+const shutdownTimeout = 20 * time.Second
+
+// gracefulStopWithTimeout waits up to timeout for srv's in-flight RPCs to finish via
+// GracefulStop, then force-closes the server with Stop if the timeout elapses first.
+//
+// GracefulStop alone blocks until every in-flight RPC handler returns on its own. For
+// CreateSBOM that can take as long as the caller-supplied TimeoutSeconds (5 minutes by
+// default, see pkg/sbomscanner/v1/server.go) -- a per-call deadline with no awareness that
+// the process is shutting down. Without this bound, shutdown time is dictated entirely by
+// whatever timeout the in-flight request happened to carry, not by anything under this
+// process's control. See #627.
+func gracefulStopWithTimeout(srv *grpc.Server, timeout time.Duration) {
+	stopped := make(chan struct{})
+	go func() {
+		srv.GracefulStop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		logger.L().Info("gRPC server stopped gracefully")
+	case <-time.After(timeout):
+		logger.L().Warning("graceful shutdown timeout reached, forcing stop",
+			helpers.String("timeout", timeout.String()))
+		srv.Stop()
+	}
+}
 
 func main() {
 	socketPath := os.Getenv("SOCKET_PATH")
@@ -48,7 +81,7 @@ func main() {
 	go func() {
 		sig := <-sigCh
 		logger.L().Info("received signal, shutting down", helpers.String("signal", sig.String()))
-		srv.GracefulStop()
+		gracefulStopWithTimeout(srv, shutdownTimeout)
 		os.Remove(socketPath)
 	}()
 

--- a/cmd/sbom-scanner/shutdown_test.go
+++ b/cmd/sbom-scanner/shutdown_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
+	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// blockingScanner is a minimal SBOMScannerServer whose Health call blocks until release is
+// closed, standing in for a CreateSBOM call that outlives shutdown.
+type blockingScanner struct {
+	pb.UnimplementedSBOMScannerServer
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingScanner) Health(context.Context, *pb.HealthRequest) (*pb.HealthResponse, error) {
+	close(b.started)
+	<-b.release
+	return &pb.HealthResponse{Ready: true}, nil
+}
+
+// TestGracefulStopWithTimeout_ForcesStopWhenRPCOutlivesTimeout guards #627: without a bound,
+// GracefulStop waits for an in-flight RPC to return on its own -- which for CreateSBOM can be
+// as long as the caller-supplied TimeoutSeconds. gracefulStopWithTimeout must force the
+// connection closed once its own timeout elapses, regardless of how long the RPC keeps running.
+func TestGracefulStopWithTimeout_ForcesStopWhenRPCOutlivesTimeout(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := grpc.NewServer()
+	scanner := &blockingScanner{started: make(chan struct{}), release: make(chan struct{})}
+	pb.RegisterSBOMScannerServer(srv, scanner)
+	defer close(scanner.release)
+
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewSBOMScannerClient(conn)
+
+	callDone := make(chan error, 1)
+	go func() {
+		_, callErr := client.Health(context.Background(), &pb.HealthRequest{})
+		callDone <- callErr
+	}()
+
+	select {
+	case <-scanner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RPC never reached the server")
+	}
+
+	const timeout = 200 * time.Millisecond
+	start := time.Now()
+	gracefulStopWithTimeout(srv, timeout)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("gracefulStopWithTimeout blocked for %s, expected it to force-stop near the %s timeout", elapsed, timeout)
+	}
+
+	select {
+	case callErr := <-callDone:
+		if callErr == nil {
+			t.Fatal("expected the forcibly-stopped in-flight RPC to return an error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("in-flight RPC never returned after forced Stop")
+	}
+}
+
+// TestGracefulStopWithTimeout_ReturnsPromptlyWithNoInFlightRPCs is the counterpart to the
+// force-stop case: with nothing in flight, GracefulStop returns almost immediately, and
+// gracefulStopWithTimeout must not wait for its full timeout in that case.
+func TestGracefulStopWithTimeout_ReturnsPromptlyWithNoInFlightRPCs(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := grpc.NewServer()
+	pb.RegisterSBOMScannerServer(srv, sbomscanner.NewScannerServer())
+	go func() { _ = srv.Serve(lis) }()
+
+	const timeout = 5 * time.Second
+	start := time.Now()
+	gracefulStopWithTimeout(srv, timeout)
+	elapsed := time.Since(start)
+
+	if elapsed >= timeout/2 {
+		t.Fatalf("gracefulStopWithTimeout took %s with no in-flight RPCs, expected it to return well under the %s timeout", elapsed, timeout)
+	}
+}


### PR DESCRIPTION
## Overview

`cmd/sbom-scanner/main.go`'s SIGTERM/SIGINT handler called plain `srv.GracefulStop()`, which blocks until every in-flight RPC handler returns on its own. `CreateSBOM` (`pkg/sbomscanner/v1/server.go`) runs under a deadline taken straight from the caller's request (`req.TimeoutSeconds`), defaulting to 5 minutes when unset — that deadline has no idea the process is shutting down, so it keeps running regardless of the signal. Shutdown time ended up dictated entirely by whatever timeout the in-flight scan happened to carry, with no upper bound and no config knob to add one.

This is the sidecar-process counterpart to #467, which bounded the *main* `kubevuln` process's own worker-pool drain — that fix never touched this separate binary.

Fix: added `gracefulStopWithTimeout`, which waits for `GracefulStop` up to a fixed timeout (20s, matching `cmd/http/main.go`'s `shutdownTimeout` default) and falls back to `srv.Stop()` — forcibly closing any still-running RPCs — if the timeout elapses first, so the sidecar exits promptly and predictably instead of hanging on an arbitrary caller-supplied value.

## How to Test

```
go test ./cmd/sbom-scanner/... -v
```

`TestGracefulStopWithTimeout_ForcesStopWhenRPCOutlivesTimeout` starts a real gRPC server with a handler that blocks indefinitely, confirms the call returns near the configured timeout (not once the handler finishes), and confirms the in-flight RPC does return an error afterward (proving `Stop` actually ran). `TestGracefulStopWithTimeout_ReturnsPromptlyWithNoInFlightRPCs` confirms the fast path with nothing in flight doesn't wait for the full timeout.

## Related issues/PRs:

* Resolved #627

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM scanner shutdown handling to allow active operations to finish gracefully.
  * Added a 20-second shutdown limit to prevent the scanner from hanging indefinitely.
  * Ensured prompt shutdown when no operations are in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->