### PR TITLE
fix: add scan status endpoint

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -212,6 +212,7 @@ func main() {
 		group.POST("/"+apis.ApplicationProfileScanCommandPath, controller.ScanCP)
 		group.POST("/"+apis.ContainerScanCommandPath, controller.ScanCVE)
 		group.POST("/"+apis.RegistryScanCommandPath, controller.ScanRegistry)
+		group.GET("/scanStatus/:jobID", controller.ScanStatus)
 	}
 
 	srv := &http.Server{

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	wssc "github.com/armosec/armoapi-go/apis"
@@ -27,11 +28,12 @@ import (
 // HTTPController maps ScanService ports to gin handlers that can be mapped to paths and methods
 // this mapping is usually done in main()
 type HTTPController struct {
-	scanService ports.ScanService
-	workerPool  *workerpool.WorkerPool
-	metrics     *metrics.Metrics
-	diagnostics func(ctx context.Context) domain.Diagnostics
-	statuses    *scanStatusStore
+	scanService  ports.ScanService
+	workerPool   *workerpool.WorkerPool
+	metrics      *metrics.Metrics
+	diagnostics  func(ctx context.Context) domain.Diagnostics
+	statuses     *scanStatusStore
+	statusesOnce sync.Once
 }
 
 // NewHTTPController initializes the HTTPController struct with the injected scanService
@@ -74,10 +76,19 @@ func (h *HTTPController) WithDiagnostics(f func(ctx context.Context) domain.Diag
 }
 
 func (h *HTTPController) ensureStatuses() *scanStatusStore {
-	if h.statuses == nil {
-		h.statuses = newScanStatusStore()
-	}
+	h.statusesOnce.Do(func() {
+		if h.statuses == nil {
+			h.statuses = newScanStatusStore()
+		}
+	})
 	return h.statuses
+}
+
+func (h *HTTPController) claimTrackedJob(jobID string) bool {
+	if jobID == "" {
+		return true
+	}
+	return h.ensureStatuses().markRunning(jobID)
 }
 
 // recordScan records the outcome and duration of a background scan job for the given endpoint.
@@ -167,7 +178,7 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		if !h.ensureStatuses().markRunning(newScan.JobID) {
+		if !h.claimTrackedJob(newScan.JobID) {
 			return
 		}
 		start := time.Now()
@@ -263,7 +274,7 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		if !h.ensureStatuses().markRunning(newScan.JobID) {
+		if !h.claimTrackedJob(newScan.JobID) {
 			return
 		}
 		start := time.Now()
@@ -325,7 +336,7 @@ func (h *HTTPController) ScanCVE(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		if !h.ensureStatuses().markRunning(newScan.JobID) {
+		if !h.claimTrackedJob(newScan.JobID) {
 			return
 		}
 		start := time.Now()
@@ -423,7 +434,7 @@ func (h *HTTPController) ScanRegistry(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		if !h.ensureStatuses().markRunning(newScan.JobID) {
+		if !h.claimTrackedJob(newScan.JobID) {
 			return
 		}
 		start := time.Now()

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -167,7 +167,9 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		h.ensureStatuses().markRunning(newScan.JobID)
+		if !h.ensureStatuses().markRunning(newScan.JobID) {
+			return
+		}
 		start := time.Now()
 		err = h.scanService.GenerateSBOM(bgCtx)
 		outcome := "success"
@@ -261,7 +263,9 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		h.ensureStatuses().markRunning(newScan.JobID)
+		if !h.ensureStatuses().markRunning(newScan.JobID) {
+			return
+		}
 		start := time.Now()
 		err = h.scanService.ScanCP(bgCtx)
 		if err != nil {
@@ -321,7 +325,9 @@ func (h *HTTPController) ScanCVE(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		h.ensureStatuses().markRunning(newScan.JobID)
+		if !h.ensureStatuses().markRunning(newScan.JobID) {
+			return
+		}
 		start := time.Now()
 		err = h.scanService.ScanCVE(bgCtx)
 		outcome := "success"
@@ -417,7 +423,9 @@ func (h *HTTPController) ScanRegistry(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
-		h.ensureStatuses().markRunning(newScan.JobID)
+		if !h.ensureStatuses().markRunning(newScan.JobID) {
+			return
+		}
 		start := time.Now()
 		err = h.scanService.ScanRegistry(bgCtx)
 		outcome := "success"

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -31,6 +31,7 @@ type HTTPController struct {
 	workerPool  *workerpool.WorkerPool
 	metrics     *metrics.Metrics
 	diagnostics func(ctx context.Context) domain.Diagnostics
+	statuses    *scanStatusStore
 }
 
 // NewHTTPController initializes the HTTPController struct with the injected scanService
@@ -38,6 +39,7 @@ func NewHTTPController(scanService ports.ScanService, concurrency int) *HTTPCont
 	return &HTTPController{
 		scanService: scanService,
 		workerPool:  workerpool.New(concurrency),
+		statuses:    newScanStatusStore(),
 	}
 }
 
@@ -69,6 +71,13 @@ func (h *HTTPController) WithMetrics(m *metrics.Metrics) (*HTTPController, error
 func (h *HTTPController) WithDiagnostics(f func(ctx context.Context) domain.Diagnostics) *HTTPController {
 	h.diagnostics = f
 	return h
+}
+
+func (h *HTTPController) ensureStatuses() *scanStatusStore {
+	if h.statuses == nil {
+		h.statuses = newScanStatusStore()
+	}
+	return h.statuses
 }
 
 // recordScan records the outcome and duration of a background scan job for the given endpoint.
@@ -125,7 +134,7 @@ func (h HTTPController) recordRejection(ctx context.Context, endpoint string, er
 }
 
 // GenerateSBOM unmarshalls the payload and calls scanService.GenerateSBOM
-func (h HTTPController) GenerateSBOM(c *gin.Context) {
+func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var websocketScanCommand wssc.WebsocketScanCommand
@@ -151,10 +160,14 @@ func (h HTTPController) GenerateSBOM(c *gin.Context) {
 		return
 	}
 
+	h.ensureStatuses().recordAccepted(newScan.JobID, "generateSBOM")
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
-	bgCtx := context.WithoutCancel(ctx)
+	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
+		h.ensureStatuses().markPhase(newScan.JobID, phase)
+	}))
 	h.workerPool.Submit(func() {
+		h.ensureStatuses().markRunning(newScan.JobID)
 		start := time.Now()
 		err = h.scanService.GenerateSBOM(bgCtx)
 		outcome := "success"
@@ -162,6 +175,11 @@ func (h HTTPController) GenerateSBOM(c *gin.Context) {
 			outcome = "error"
 		}
 		h.recordScan(bgCtx, "generateSBOM", start, outcome, err)
+		if err != nil {
+			h.ensureStatuses().markFailed(newScan.JobID, scanFailureReason(outcome, err))
+		} else {
+			h.ensureStatuses().markSucceeded(newScan.JobID)
+		}
 		if err != nil {
 			logger.L().Ctx(bgCtx).Error("service error - GenerateSBOM", helpers.Error(err),
 				helpers.String("imageSlug", newScan.ImageSlug),
@@ -189,7 +207,7 @@ func (h HTTPController) Ready(c *gin.Context) {
 // Diagnostics reports the scan mode and backend versions resolved at startup, so
 // operators can query the running configuration directly instead of inferring it
 // from logs. See domain.Diagnostics for the excluded (credential) fields.
-func (h HTTPController) Diagnostics(c *gin.Context) {
+func (h *HTTPController) Diagnostics(c *gin.Context) {
 	if h.diagnostics == nil {
 		c.JSON(http.StatusOK, domain.Diagnostics{})
 		return
@@ -197,8 +215,18 @@ func (h HTTPController) Diagnostics(c *gin.Context) {
 	c.JSON(http.StatusOK, h.diagnostics(c.Request.Context()))
 }
 
+// ScanStatus reports the current lifecycle state for a previously accepted scan job.
+func (h *HTTPController) ScanStatus(c *gin.Context) {
+	status, ok := h.ensureStatuses().get(c.Param("jobID"))
+	if !ok {
+		_, _ = problem.Of(http.StatusNotFound).Append(problem.Detailf("jobID=%s", c.Param("jobID"))).WriteTo(c.Writer)
+		return
+	}
+	c.JSON(http.StatusOK, status)
+}
+
 // ScanCP unmarshalls the payload and calls scanService.ScanCP
-func (h HTTPController) ScanCP(c *gin.Context) {
+func (h *HTTPController) ScanCP(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var websocketScanCommand wssc.WebsocketScanCommand
@@ -226,21 +254,27 @@ func (h HTTPController) ScanCP(c *gin.Context) {
 		return
 	}
 
+	h.ensureStatuses().recordAccepted(newScan.JobID, "scanCP")
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
-	bgCtx := context.WithoutCancel(ctx)
+	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
+		h.ensureStatuses().markPhase(newScan.JobID, phase)
+	}))
 	h.workerPool.Submit(func() {
+		h.ensureStatuses().markRunning(newScan.JobID)
 		start := time.Now()
 		err = h.scanService.ScanCP(bgCtx)
 		if err != nil {
 			if errors.Is(err, domain.ErrPartialContainerProfile) {
 				h.recordScan(bgCtx, "scanCP", start, "partial", err)
+				h.ensureStatuses().markSucceeded(newScan.JobID)
 				logger.L().Ctx(bgCtx).Warning("service warning - ScanCP", helpers.Error(err),
 					helpers.String("wlid", newScan.Wlid),
 					helpers.String("name", name),
 					helpers.String("namespace", namespace))
 			} else {
 				h.recordScan(bgCtx, "scanCP", start, "error", err)
+				h.ensureStatuses().markFailed(newScan.JobID, scanFailureReason("error", err))
 				logger.L().Ctx(bgCtx).Error("service error - ScanCP", helpers.Error(err),
 					helpers.String("wlid", newScan.Wlid),
 					helpers.String("name", name),
@@ -248,12 +282,13 @@ func (h HTTPController) ScanCP(c *gin.Context) {
 			}
 		} else {
 			h.recordScan(bgCtx, "scanCP", start, "success", nil)
+			h.ensureStatuses().markSucceeded(newScan.JobID)
 		}
 	})
 }
 
 // ScanCVE unmarshalls the payload and calls scanService.ScanCVE
-func (h HTTPController) ScanCVE(c *gin.Context) {
+func (h *HTTPController) ScanCVE(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var websocketScanCommand wssc.WebsocketScanCommand
@@ -279,10 +314,14 @@ func (h HTTPController) ScanCVE(c *gin.Context) {
 		return
 	}
 
+	h.ensureStatuses().recordAccepted(newScan.JobID, "scanCVE")
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
-	bgCtx := context.WithoutCancel(ctx)
+	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
+		h.ensureStatuses().markPhase(newScan.JobID, phase)
+	}))
 	h.workerPool.Submit(func() {
+		h.ensureStatuses().markRunning(newScan.JobID)
 		start := time.Now()
 		err = h.scanService.ScanCVE(bgCtx)
 		outcome := "success"
@@ -290,6 +329,11 @@ func (h HTTPController) ScanCVE(c *gin.Context) {
 			outcome = "error"
 		}
 		h.recordScan(bgCtx, "scanCVE", start, outcome, err)
+		if err != nil {
+			h.ensureStatuses().markFailed(newScan.JobID, scanFailureReason(outcome, err))
+		} else {
+			h.ensureStatuses().markSucceeded(newScan.JobID)
+		}
 		if err != nil {
 			logger.L().Ctx(bgCtx).Error("service error - ScanCVE", helpers.Error(err),
 				helpers.String("wlid", newScan.Wlid),
@@ -340,7 +384,7 @@ func sessionChainToSession(s wssc.SessionChain) domain.Session {
 	}
 }
 
-func (h HTTPController) ScanRegistry(c *gin.Context) {
+func (h *HTTPController) ScanRegistry(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	var registryScanCommand wssc.RegistryScanCommand
@@ -366,10 +410,14 @@ func (h HTTPController) ScanRegistry(c *gin.Context) {
 		return
 	}
 
+	h.ensureStatuses().recordAccepted(newScan.JobID, "scanRegistry")
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
-	bgCtx := context.WithoutCancel(ctx)
+	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
+		h.ensureStatuses().markPhase(newScan.JobID, phase)
+	}))
 	h.workerPool.Submit(func() {
+		h.ensureStatuses().markRunning(newScan.JobID)
 		start := time.Now()
 		err = h.scanService.ScanRegistry(bgCtx)
 		outcome := "success"
@@ -377,6 +425,11 @@ func (h HTTPController) ScanRegistry(c *gin.Context) {
 			outcome = "error"
 		}
 		h.recordScan(bgCtx, "scanRegistry", start, outcome, err)
+		if err != nil {
+			h.ensureStatuses().markFailed(newScan.JobID, scanFailureReason(outcome, err))
+		} else {
+			h.ensureStatuses().markSucceeded(newScan.JobID)
+		}
 		if err != nil {
 			logger.L().Ctx(bgCtx).Error("service error - ScanRegistry", helpers.Error(err),
 				helpers.String("imageSlug", newScan.ImageSlug),
@@ -413,10 +466,11 @@ func registryScanCommandToScanCommand(c wssc.RegistryScanCommand) domain.ScanCom
 // cancellation (see #450) and would otherwise block Stop() indefinitely. timeout should
 // be kept safely under the pod's terminationGracePeriodSeconds so this path has a
 // chance to log before the kubelet SIGKILLs the process.
-func (h HTTPController) Shutdown(timeout time.Duration) {
+func (h *HTTPController) Shutdown(timeout time.Duration) {
 	logger.L().Info("purging SBOM creation queue",
 		helpers.String("remaining jobs", strconv.Itoa(h.workerPool.WaitingQueueSize())),
 		helpers.String("timeout", timeout.String()))
+	h.ensureStatuses().markAbandonedQueued(domain.ScanReasonShutdownAbandoned)
 
 	drained := make(chan struct{})
 	go func() {

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -803,5 +804,175 @@ func TestHTTPController_MetricsEndpoint_RecordsScanFailureReason(t *testing.T) {
 			wantDurationSeries := `kubevuln_scan_duration_seconds_count{endpoint="` + tt.endpoint + `",outcome="error",reason="` + tt.wantReason + `"} 1`
 			assert.True(t, strings.Contains(body, wantDurationSeries), body)
 		})
+	}
+}
+
+type statusFlowScanService struct {
+	*services.MockScanService
+	err       error
+	blockCh   <-chan struct{}
+	startedCh chan<- struct{}
+	phase     string
+}
+
+func (s statusFlowScanService) GenerateSBOM(ctx context.Context) error {
+	if s.phase != "" {
+		domain.UpdateScanPhase(ctx, s.phase)
+	}
+	if s.startedCh != nil {
+		select {
+		case s.startedCh <- struct{}{}:
+		default:
+		}
+	}
+	if s.blockCh != nil {
+		<-s.blockCh
+	}
+	return s.err
+}
+
+func (s statusFlowScanService) ValidateGenerateSBOM(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
+	return ctx, nil
+}
+
+func TestHTTPController_ScanStatus_Succeeded(t *testing.T) {
+	c := NewHTTPController(statusFlowScanService{
+		MockScanService: services.NewMockScanService(true),
+		phase:           "result_upload",
+	}, 1)
+	t.Cleanup(func() { c.Shutdown(5 * time.Second) })
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+	router.GET("/v1/scanStatus/:jobID", c.ScanStatus)
+
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:1","jobID":"job-success"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var status domain.ScanStatus
+	require.Eventually(t, func() bool {
+		req, _ = http.NewRequest("GET", "/v1/scanStatus/job-success", nil)
+		w = httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			return false
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+			return false
+		}
+		return status.State == domain.ScanStateSucceeded
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, "generateSBOM", status.Endpoint)
+	assert.Equal(t, "completed", status.Phase)
+	assert.True(t, status.AcceptedAt.Before(status.FinishedAt) || status.AcceptedAt.Equal(status.FinishedAt))
+	assert.False(t, status.StartedAt.IsZero())
+	assert.False(t, status.FinishedAt.IsZero())
+	assert.Empty(t, status.Reason)
+}
+
+func TestHTTPController_ScanStatus_Failed(t *testing.T) {
+	c := NewHTTPController(statusFlowScanService{
+		MockScanService: services.NewMockScanService(true),
+		err:             &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: errors.New("boom")},
+	}, 1)
+	t.Cleanup(func() { c.Shutdown(5 * time.Second) })
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+	router.GET("/v1/scanStatus/:jobID", c.ScanStatus)
+
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:2","jobID":"job-failed"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var status domain.ScanStatus
+	require.Eventually(t, func() bool {
+		req, _ = http.NewRequest("GET", "/v1/scanStatus/job-failed", nil)
+		w = httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			return false
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+			return false
+		}
+		return status.State == domain.ScanStateFailed
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, scanfailure.ReasonCVEMatchingFailed, status.Reason)
+	assert.Equal(t, "completed", status.Phase)
+	assert.False(t, status.FinishedAt.IsZero())
+}
+
+func TestHTTPController_ScanStatus_AbandonedOnShutdown(t *testing.T) {
+	blocked := make(chan struct{})
+	started := make(chan struct{}, 1)
+	release := func() {
+		select {
+		case <-blocked:
+		default:
+			close(blocked)
+		}
+	}
+	c := NewHTTPController(statusFlowScanService{
+		MockScanService: services.NewMockScanService(true),
+		blockCh:         blocked,
+		startedCh:       started,
+	}, 1)
+	t.Cleanup(release)
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+	router.GET("/v1/scanStatus/:jobID", c.ScanStatus)
+
+	firstReq, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:3","jobID":"job-running"}`))
+	firstW := httptest.NewRecorder()
+	router.ServeHTTP(firstW, firstReq)
+	require.Equal(t, http.StatusOK, firstW.Code, firstW.Body.String())
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first job did not start in time")
+	}
+
+	secondReq, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:4","jobID":"job-abandoned"}`))
+	secondW := httptest.NewRecorder()
+	router.ServeHTTP(secondW, secondReq)
+	require.Equal(t, http.StatusOK, secondW.Code, secondW.Body.String())
+
+	done := make(chan struct{})
+	go func() {
+		c.Shutdown(20 * time.Millisecond)
+		close(done)
+	}()
+
+	var status domain.ScanStatus
+	require.Eventually(t, func() bool {
+		req, _ := http.NewRequest("GET", "/v1/scanStatus/job-abandoned", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			return false
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+			return false
+		}
+		return status.State == domain.ScanStateAbandoned
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, domain.ScanReasonShutdownAbandoned, status.Reason)
+	assert.Equal(t, string(domain.ScanStateAbandoned), status.Phase)
+	assert.False(t, status.FinishedAt.IsZero())
+
+	release()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not finish in time")
 	}
 }

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -867,7 +867,9 @@ func TestHTTPController_ScanStatus_Succeeded(t *testing.T) {
 
 	assert.Equal(t, "generateSBOM", status.Endpoint)
 	assert.Equal(t, "completed", status.Phase)
-	assert.True(t, status.AcceptedAt.Before(status.FinishedAt) || status.AcceptedAt.Equal(status.FinishedAt))
+	require.NotNil(t, status.StartedAt)
+	require.NotNil(t, status.FinishedAt)
+	assert.True(t, status.AcceptedAt.Before(*status.FinishedAt) || status.AcceptedAt.Equal(*status.FinishedAt))
 	assert.False(t, status.StartedAt.IsZero())
 	assert.False(t, status.FinishedAt.IsZero())
 	assert.Empty(t, status.Reason)
@@ -905,6 +907,7 @@ func TestHTTPController_ScanStatus_Failed(t *testing.T) {
 
 	assert.Equal(t, scanfailure.ReasonCVEMatchingFailed, status.Reason)
 	assert.Equal(t, "completed", status.Phase)
+	require.NotNil(t, status.FinishedAt)
 	assert.False(t, status.FinishedAt.IsZero())
 }
 
@@ -967,6 +970,7 @@ func TestHTTPController_ScanStatus_AbandonedOnShutdown(t *testing.T) {
 
 	assert.Equal(t, domain.ScanReasonShutdownAbandoned, status.Reason)
 	assert.Equal(t, string(domain.ScanStateAbandoned), status.Phase)
+	require.NotNil(t, status.FinishedAt)
 	assert.False(t, status.FinishedAt.IsZero())
 
 	release()

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -525,6 +525,36 @@ func TestHTTPController_ContextCancellationIsDetached(t *testing.T) {
 	}
 }
 
+func TestHTTPController_GenerateSBOM_EmptyJobIDStillRuns(t *testing.T) {
+	spy := &contextSpyScanService{
+		generateSBOMCh: make(chan struct{}),
+	}
+
+	c := HTTPController{
+		scanService: spy,
+		workerPool:  workerpool.New(1),
+	}
+	defer c.Shutdown(5 * time.Second)
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{
+		"imageTag": "k8s.gcr.io/kube-proxy:v1.24.3",
+		"imageHash": "k8s.gcr.io/kube-proxy@sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+	}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	select {
+	case <-spy.generateSBOMCh:
+		assert.NoError(t, spy.lastGenerateSBOMCtx.Err())
+	case <-time.After(1 * time.Second):
+		t.Fatal("GenerateSBOM worker was not executed in time")
+	}
+}
+
 func TestValidationStatusCode(t *testing.T) {
 	assert.Equal(t, http.StatusTooManyRequests, validationStatusCode(domain.ErrTooManyRequests))
 	assert.Equal(t, http.StatusBadRequest, validationStatusCode(domain.ErrMissingCpInfo))
@@ -567,7 +597,11 @@ func TestHTTPController_GenerateSBOM_TooManyRequests(t *testing.T) {
 }
 
 func TestHTTPController_MetricsEndpoint(t *testing.T) {
-	c := NewHTTPController(services.NewMockScanService(true), 1)
+	startedC := make(chan struct{}, 1)
+	c := NewHTTPController(scanErrorService{
+		MockScanService: services.NewMockScanService(true),
+		startedC:        startedC,
+	}, 1)
 	m, err := metrics.New()
 	require.NoError(t, err)
 	_, err = c.WithMetrics(m)
@@ -583,6 +617,11 @@ func TestHTTPController_MetricsEndpoint(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	select {
+	case <-startedC:
+	case <-time.After(1 * time.Second):
+		t.Fatal("scan worker was not executed in time")
+	}
 
 	c.Shutdown(5 * time.Second)
 
@@ -701,12 +740,34 @@ func TestHTTPController_MetricsEndpoint_InvalidRequestDoesNotCountAsRejection(t 
 // metrics (see #540).
 type scanErrorService struct {
 	*services.MockScanService
-	err error
+	err      error
+	startedC chan<- struct{}
 }
 
-func (s scanErrorService) GenerateSBOM(context.Context) error { return s.err }
-func (s scanErrorService) ScanCVE(context.Context) error      { return s.err }
-func (s scanErrorService) ScanRegistry(context.Context) error { return s.err }
+func (s scanErrorService) signalStarted() {
+	if s.startedC == nil {
+		return
+	}
+	select {
+	case s.startedC <- struct{}{}:
+	default:
+	}
+}
+
+func (s scanErrorService) GenerateSBOM(context.Context) error {
+	s.signalStarted()
+	return s.err
+}
+
+func (s scanErrorService) ScanCVE(context.Context) error {
+	s.signalStarted()
+	return s.err
+}
+
+func (s scanErrorService) ScanRegistry(context.Context) error {
+	s.signalStarted()
+	return s.err
+}
 
 func (s scanErrorService) ValidateGenerateSBOM(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
 	return ctx, nil
@@ -771,9 +832,14 @@ func TestHTTPController_MetricsEndpoint_RecordsScanFailureReason(t *testing.T) {
 			if tt.unclassified {
 				scanErr = errors.New("boom")
 			}
+			startedC := make(chan struct{}, 1)
 			c := &HTTPController{
-				scanService: scanErrorService{MockScanService: services.NewMockScanService(true), err: scanErr},
-				workerPool:  workerpool.New(1),
+				scanService: scanErrorService{
+					MockScanService: services.NewMockScanService(true),
+					err:             scanErr,
+					startedC:        startedC,
+				},
+				workerPool: workerpool.New(1),
 			}
 			m, err := metrics.New()
 			require.NoError(t, err)
@@ -790,6 +856,11 @@ func TestHTTPController_MetricsEndpoint_RecordsScanFailureReason(t *testing.T) {
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			select {
+			case <-startedC:
+			case <-time.After(1 * time.Second):
+				t.Fatal("scan worker was not executed in time")
+			}
 
 			c.Shutdown(5 * time.Second)
 

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -1,0 +1,129 @@
+package controllers
+
+import (
+	"sync"
+	"time"
+
+	"github.com/kubescape/kubevuln/core/domain"
+)
+
+type scanStatusStore struct {
+	mu    sync.RWMutex
+	items map[string]domain.ScanStatus
+}
+
+func newScanStatusStore() *scanStatusStore {
+	return &scanStatusStore{items: make(map[string]domain.ScanStatus)}
+}
+
+func (s *scanStatusStore) recordAccepted(jobID, endpoint string) {
+	if jobID == "" {
+		return
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[jobID] = domain.ScanStatus{
+		JobID:      jobID,
+		Endpoint:   endpoint,
+		State:      domain.ScanStateQueued,
+		Phase:      string(domain.ScanStateQueued),
+		AcceptedAt: now,
+		UpdatedAt:  now,
+	}
+}
+
+func (s *scanStatusStore) markRunning(jobID string) {
+	if jobID == "" {
+		return
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	status, ok := s.items[jobID]
+	if !ok {
+		return
+	}
+	status.State = domain.ScanStateRunning
+	if status.Phase == "" || status.Phase == string(domain.ScanStateQueued) {
+		status.Phase = string(domain.ScanStateRunning)
+	}
+	if status.StartedAt.IsZero() {
+		status.StartedAt = now
+	}
+	status.UpdatedAt = now
+	s.items[jobID] = status
+}
+
+func (s *scanStatusStore) markPhase(jobID, phase string) {
+	if jobID == "" || phase == "" {
+		return
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	status, ok := s.items[jobID]
+	if !ok {
+		return
+	}
+	if status.State == domain.ScanStateSucceeded || status.State == domain.ScanStateFailed || status.State == domain.ScanStateAbandoned {
+		return
+	}
+	status.Phase = phase
+	status.UpdatedAt = now
+	s.items[jobID] = status
+}
+
+func (s *scanStatusStore) markSucceeded(jobID string) {
+	s.markTerminal(jobID, domain.ScanStateSucceeded, "")
+}
+
+func (s *scanStatusStore) markFailed(jobID, reason string) {
+	s.markTerminal(jobID, domain.ScanStateFailed, reason)
+}
+
+func (s *scanStatusStore) markAbandonedQueued(reason string) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for jobID, status := range s.items {
+		if status.State != domain.ScanStateQueued {
+			continue
+		}
+		status.State = domain.ScanStateAbandoned
+		status.Phase = string(domain.ScanStateAbandoned)
+		status.Reason = reason
+		status.FinishedAt = now
+		status.UpdatedAt = now
+		s.items[jobID] = status
+	}
+}
+
+func (s *scanStatusStore) markTerminal(jobID string, state domain.ScanState, reason string) {
+	if jobID == "" {
+		return
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	status, ok := s.items[jobID]
+	if !ok {
+		return
+	}
+	status.State = state
+	status.Phase = "completed"
+	status.Reason = reason
+	if status.StartedAt.IsZero() {
+		status.StartedAt = now
+	}
+	status.FinishedAt = now
+	status.UpdatedAt = now
+	s.items[jobID] = status
+}
+
+func (s *scanStatusStore) get(jobID string) (domain.ScanStatus, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	status, ok := s.items[jobID]
+	return status, ok
+}

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -9,6 +9,15 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 )
 
+// defaultScanStatusTTL bounds how long a terminal (succeeded/failed/abandoned) record
+// is retained after it finished, and defaultScanStatusMaxEntries caps the total number
+// of records regardless of age. Without both, scanStatusStore.items would grow without
+// bound over the lifetime of a long-running kubevuln pod.
+const (
+	defaultScanStatusTTL        = time.Hour
+	defaultScanStatusMaxEntries = 10000
+)
+
 type scanStatusStore struct {
 	mu         sync.RWMutex
 	items      map[string]domain.ScanStatus

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"container/heap"
+	"slices"
 	"sync"
 	"time"
 
@@ -8,12 +10,90 @@ import (
 )
 
 type scanStatusStore struct {
-	mu    sync.RWMutex
-	items map[string]domain.ScanStatus
+	mu         sync.RWMutex
+	items      map[string]domain.ScanStatus
+	ttl        time.Duration
+	maxEntries int
+}
+
+type candidate struct {
+	jobID      string
+	finishedAt time.Time
 }
 
 func newScanStatusStore() *scanStatusStore {
-	return &scanStatusStore{items: make(map[string]domain.ScanStatus)}
+	return &scanStatusStore{
+		items:      make(map[string]domain.ScanStatus),
+		ttl:        defaultScanStatusTTL,
+		maxEntries: defaultScanStatusMaxEntries,
+	}
+}
+
+// evictLocked removes terminal records older than s.ttl, then, if still over
+// s.maxEntries, removes the oldest terminal records until the cap is met. Active
+// (queued/running) records are never evicted. Callers must hold s.mu for writing.
+func (s *scanStatusStore) evictLocked(now time.Time) {
+	for jobID, status := range s.items {
+		if !isTerminal(status.State) {
+			continue
+		}
+		if status.FinishedAt != nil && now.Sub(*status.FinishedAt) > s.ttl {
+			delete(s.items, jobID)
+		}
+	}
+
+	overflow := len(s.items) - s.maxEntries
+	if overflow <= 0 {
+		return
+	}
+
+	selected := make(candidateHeap, 0, overflow)
+	for jobID, status := range s.items {
+		if !isTerminal(status.State) || status.FinishedAt == nil {
+			continue
+		}
+		cand := candidate{jobID: jobID, finishedAt: *status.FinishedAt}
+		if len(selected) < overflow {
+			heap.Push(&selected, cand)
+			continue
+		}
+		if cand.finishedAt.Before(selected[0].finishedAt) {
+			selected[0] = cand
+			heap.Fix(&selected, 0)
+		}
+	}
+	slices.SortFunc([]candidate(selected), func(a, b candidate) int {
+		return a.finishedAt.Compare(b.finishedAt)
+	})
+	for _, cand := range selected {
+		delete(s.items, cand.jobID)
+	}
+}
+
+type candidateHeap []candidate
+
+func (h candidateHeap) Len() int { return len(h) }
+
+func (h candidateHeap) Less(i, j int) bool {
+	return h[i].finishedAt.After(h[j].finishedAt)
+}
+
+func (h candidateHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *candidateHeap) Push(x any) {
+	*h = append(*h, x.(candidate))
+}
+
+func (h *candidateHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+func isTerminal(state domain.ScanState) bool {
+	return state == domain.ScanStateSucceeded || state == domain.ScanStateFailed || state == domain.ScanStateAbandoned
 }
 
 func (s *scanStatusStore) recordAccepted(jobID, endpoint string) {
@@ -31,28 +111,31 @@ func (s *scanStatusStore) recordAccepted(jobID, endpoint string) {
 		AcceptedAt: now,
 		UpdatedAt:  now,
 	}
+	s.evictLocked(now)
 }
 
-func (s *scanStatusStore) markRunning(jobID string) {
+func (s *scanStatusStore) markRunning(jobID string) bool {
 	if jobID == "" {
-		return
+		return false
 	}
 	now := time.Now().UTC()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	status, ok := s.items[jobID]
-	if !ok {
-		return
+	if !ok || status.State != domain.ScanStateQueued {
+		return false
 	}
 	status.State = domain.ScanStateRunning
 	if status.Phase == "" || status.Phase == string(domain.ScanStateQueued) {
 		status.Phase = string(domain.ScanStateRunning)
 	}
-	if status.StartedAt.IsZero() {
-		status.StartedAt = now
+	if status.StartedAt == nil {
+		startedAt := now
+		status.StartedAt = &startedAt
 	}
 	status.UpdatedAt = now
 	s.items[jobID] = status
+	return true
 }
 
 func (s *scanStatusStore) markPhase(jobID, phase string) {
@@ -93,7 +176,8 @@ func (s *scanStatusStore) markAbandonedQueued(reason string) {
 		status.State = domain.ScanStateAbandoned
 		status.Phase = string(domain.ScanStateAbandoned)
 		status.Reason = reason
-		status.FinishedAt = now
+		finishedAt := now
+		status.FinishedAt = &finishedAt
 		status.UpdatedAt = now
 		s.items[jobID] = status
 	}
@@ -110,20 +194,27 @@ func (s *scanStatusStore) markTerminal(jobID string, state domain.ScanState, rea
 	if !ok {
 		return
 	}
+	if isTerminal(status.State) {
+		return
+	}
 	status.State = state
 	status.Phase = "completed"
 	status.Reason = reason
-	if status.StartedAt.IsZero() {
-		status.StartedAt = now
+	if status.StartedAt == nil {
+		startedAt := now
+		status.StartedAt = &startedAt
 	}
-	status.FinishedAt = now
+	finishedAt := now
+	status.FinishedAt = &finishedAt
 	status.UpdatedAt = now
 	s.items[jobID] = status
+	s.evictLocked(now)
 }
 
 func (s *scanStatusStore) get(jobID string) (domain.ScanStatus, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.evictLocked(time.Now().UTC())
 	status, ok := s.items[jobID]
 	return status, ok
 }

--- a/controllers/scan_status_test.go
+++ b/controllers/scan_status_test.go
@@ -1,0 +1,127 @@
+package controllers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kubescape/kubevuln/core/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanStatusStore_EvictsExpiredTerminalEntries(t *testing.T) {
+	s := newScanStatusStore()
+	s.ttl = time.Millisecond
+
+	s.recordAccepted("stale", "generateSBOM")
+	s.markSucceeded("stale")
+
+	// Backdate FinishedAt directly so eviction has something to expire, since
+	// markSucceeded stamps it with time.Now() and the TTL is tiny.
+	s.mu.Lock()
+	stale := s.items["stale"]
+	finishedAt := time.Now().UTC().Add(-time.Hour)
+	stale.FinishedAt = &finishedAt
+	s.items["stale"] = stale
+	s.mu.Unlock()
+
+	// A queued (non-terminal) job must survive eviction regardless of age.
+	s.recordAccepted("active", "generateSBOM")
+	s.mu.Lock()
+	active := s.items["active"]
+	active.AcceptedAt = time.Now().UTC().Add(-time.Hour)
+	active.UpdatedAt = active.AcceptedAt
+	s.items["active"] = active
+	s.mu.Unlock()
+
+	// Trigger eviction via recordAccepted's lazy sweep.
+	s.recordAccepted("new", "generateSBOM")
+
+	_, ok := s.get("stale")
+	require.False(t, ok, "expired terminal entry should have been evicted")
+
+	_, ok = s.get("active")
+	require.True(t, ok, "non-terminal entry must never be evicted regardless of age")
+
+	_, ok = s.get("new")
+	require.True(t, ok)
+}
+
+func TestScanStatusStore_GetEvictsExpiredTerminalEntries(t *testing.T) {
+	s := newScanStatusStore()
+	s.ttl = time.Millisecond
+
+	s.recordAccepted("stale", "generateSBOM")
+	s.markSucceeded("stale")
+
+	s.mu.Lock()
+	stale := s.items["stale"]
+	finishedAt := time.Now().UTC().Add(-time.Hour)
+	stale.FinishedAt = &finishedAt
+	s.items["stale"] = stale
+	s.mu.Unlock()
+
+	_, ok := s.get("stale")
+	require.False(t, ok, "expired terminal entry should not be returned on lookup")
+}
+
+func TestScanStatusStore_EvictsOldestTerminalEntriesOverCap(t *testing.T) {
+	s := newScanStatusStore()
+	s.maxEntries = 3
+
+	for i := 0; i < 3; i++ {
+		jobID := fmt.Sprintf("job-%d", i)
+		s.recordAccepted(jobID, "generateSBOM")
+		s.markSucceeded(jobID)
+		s.mu.Lock()
+		st := s.items[jobID]
+		finishedAt := time.Now().UTC().Add(time.Duration(i) * time.Second)
+		st.FinishedAt = &finishedAt
+		s.items[jobID] = st
+		s.mu.Unlock()
+	}
+
+	require.Len(t, s.items, 3)
+
+	// Adding a 4th entry pushes the store over cap; the oldest terminal
+	// record (job-0) must be evicted to make room.
+	s.recordAccepted("job-3", "generateSBOM")
+
+	s.mu.RLock()
+	count := len(s.items)
+	s.mu.RUnlock()
+	require.LessOrEqual(t, count, s.maxEntries+1, "store must not grow unbounded past the cap")
+
+	_, ok := s.get("job-0")
+	require.False(t, ok, "oldest terminal entry should have been evicted to satisfy the cap")
+
+	_, ok = s.get("job-3")
+	require.True(t, ok, "newly accepted job must be retained")
+}
+
+func TestScanStatusStore_MarkRunningOnlyClaimsQueuedJobs(t *testing.T) {
+	s := newScanStatusStore()
+	s.recordAccepted("job", "generateSBOM")
+	s.markAbandonedQueued(domain.ScanReasonShutdownAbandoned)
+
+	status, ok := s.get("job")
+	require.True(t, ok)
+	require.Equal(t, domain.ScanStateAbandoned, status.State)
+
+	// A worker racing shutdown must not revive an abandoned job back to running.
+	require.False(t, s.markRunning("job"))
+
+	status, ok = s.get("job")
+	require.True(t, ok)
+	require.Equal(t, domain.ScanStateAbandoned, status.State, "abandoned state must remain terminal")
+
+	s.markSucceeded("job")
+	status, ok = s.get("job")
+	require.True(t, ok)
+	require.Equal(t, domain.ScanStateAbandoned, status.State, "terminal jobs must reject later success writes")
+
+	s.markFailed("job", "unexpected_error")
+	status, ok = s.get("job")
+	require.True(t, ok)
+	require.Equal(t, domain.ScanStateAbandoned, status.State, "terminal jobs must reject later failure writes")
+}

--- a/core/domain/scan_status.go
+++ b/core/domain/scan_status.go
@@ -1,0 +1,45 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+type ScanState string
+
+const (
+	ScanStateQueued    ScanState = "queued"
+	ScanStateRunning   ScanState = "running"
+	ScanStateSucceeded ScanState = "succeeded"
+	ScanStateFailed    ScanState = "failed"
+	ScanStateAbandoned ScanState = "abandoned"
+
+	ScanReasonShutdownAbandoned = "shutdown_abandoned"
+)
+
+type ScanStatus struct {
+	JobID      string    `json:"jobID"`
+	Endpoint   string    `json:"endpoint"`
+	State      ScanState `json:"state"`
+	Phase      string    `json:"phase"`
+	Reason     string    `json:"reason,omitempty"`
+	AcceptedAt time.Time `json:"acceptedAt"`
+	StartedAt  time.Time `json:"startedAt,omitempty"`
+	FinishedAt time.Time `json:"finishedAt,omitempty"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+type scanPhaseUpdaterKey struct{}
+
+func WithScanPhaseUpdater(ctx context.Context, update func(string)) context.Context {
+	return context.WithValue(ctx, scanPhaseUpdaterKey{}, update)
+}
+
+func UpdateScanPhase(ctx context.Context, phase string) {
+	if phase == "" {
+		return
+	}
+	if update, ok := ctx.Value(scanPhaseUpdaterKey{}).(func(string)); ok && update != nil {
+		update(phase)
+	}
+}

--- a/core/domain/scan_status.go
+++ b/core/domain/scan_status.go
@@ -18,15 +18,15 @@ const (
 )
 
 type ScanStatus struct {
-	JobID      string    `json:"jobID"`
-	Endpoint   string    `json:"endpoint"`
-	State      ScanState `json:"state"`
-	Phase      string    `json:"phase"`
-	Reason     string    `json:"reason,omitempty"`
-	AcceptedAt time.Time `json:"acceptedAt"`
-	StartedAt  time.Time `json:"startedAt,omitempty"`
-	FinishedAt time.Time `json:"finishedAt,omitempty"`
-	UpdatedAt  time.Time `json:"updatedAt"`
+	JobID      string     `json:"jobID"`
+	Endpoint   string     `json:"endpoint"`
+	State      ScanState  `json:"state"`
+	Phase      string     `json:"phase"`
+	Reason     string     `json:"reason,omitempty"`
+	AcceptedAt time.Time  `json:"acceptedAt"`
+	StartedAt  *time.Time `json:"startedAt,omitempty"`
+	FinishedAt *time.Time `json:"finishedAt,omitempty"`
+	UpdatedAt  time.Time  `json:"updatedAt"`
 }
 
 type scanPhaseUpdaterKey struct{}

--- a/core/domain/scan_status_test.go
+++ b/core/domain/scan_status_test.go
@@ -1,0 +1,28 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanStatusJSON_OmitsZeroLifecycleTimestamps(t *testing.T) {
+	status := ScanStatus{
+		JobID:      "job-queued",
+		Endpoint:   "generateSBOM",
+		State:      ScanStateQueued,
+		Phase:      string(ScanStateQueued),
+		AcceptedAt: time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC),
+	}
+
+	body, err := json.Marshal(status)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.NotContains(t, got, "startedAt")
+	require.NotContains(t, got, "finishedAt")
+}

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -297,6 +297,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 
 		// check if we need SBOM
 		if cve.Content == nil || s.storage {
+			domain.UpdateScanPhase(mainCtx, "sbom_generation")
 			var sbomErr error
 			sbom, _, sbomErr = s.getOrCreateSBOM(ctx, subWorkload)
 			if sbomErr != nil {
@@ -324,6 +325,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		var cveExceptionsComplete bool
 		// if CVE manifest is not available, create it
 		if cve.Content == nil {
+			domain.UpdateScanPhase(mainCtx, "cve_matching")
 			// scan for CVE
 			cve, err = s.cveScanner.ScanSBOM(ctx, sbom)
 			if err != nil {
@@ -339,6 +341,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 
 			// store filtered CVE
 			if s.storage {
+				domain.UpdateScanPhase(mainCtx, "result_storage")
 				err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
 				if err != nil {
 					logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
@@ -414,6 +417,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 		}
 		// submit CVE manifest to platform
+		domain.UpdateScanPhase(mainCtx, "result_upload")
 		err = s.platform.SubmitCVE(ctx, cve, cvep)
 		if err != nil {
 			logger.L().Ctx(ctx).Warning("submitting CVEs", helpers.Error(err),

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -195,6 +195,7 @@ func (s *ScanService) GenerateSBOM(ctx context.Context) error {
 	if !ok {
 		return domain.ErrCastingWorkload
 	}
+	domain.UpdateScanPhase(ctx, "sbom_generation")
 
 	sbom, storeErr, err := s.getOrCreateSBOM(ctx, workload)
 	if err != nil {
@@ -246,6 +247,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		helpers.String("name", name),
 		helpers.String("namespace", namespace),
 		helpers.String("jobID", workload.JobID))
+	domain.UpdateScanPhase(mainCtx, "relevancy_lookup")
 
 	scans, err := s.relevancyProvider.GetContainerRelevancyScans(mainCtx, namespace, name, s.partialRelevancy)
 	if err != nil {
@@ -444,6 +446,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 	logger.L().Info("scan started",
 		helpers.String("imageSlug", workload.ImageSlug),
 		helpers.String("jobID", workload.JobID))
+	domain.UpdateScanPhase(ctx, "cve_lookup")
 
 	// check if CVE manifest is already available
 	var err error
@@ -459,6 +462,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 	sbom := domain.SBOM{}
 	// check if we need SBOM
 	if cve.Content == nil {
+		domain.UpdateScanPhase(ctx, "sbom_generation")
 		var sbomErr error
 		sbom, _, sbomErr = s.getOrCreateSBOM(ctx, workload)
 		if sbomErr != nil {
@@ -485,6 +489,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 
 	// if CVE manifest is not available, create it
 	if cve.Content == nil {
+		domain.UpdateScanPhase(ctx, "cve_matching")
 		// scan for CVE
 		cve, err = s.cveScanner.ScanSBOM(ctx, sbom)
 		if err != nil {
@@ -498,6 +503,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 
 		// store filtered CVE
 		if s.storage {
+			domain.UpdateScanPhase(ctx, "result_storage")
 			err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
 			if err != nil {
 				logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
@@ -521,6 +527,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 
 	// submit CVE manifest to platform, only if we have a wlid
 	if workload.Wlid != "" {
+		domain.UpdateScanPhase(ctx, "result_upload")
 		err = s.platform.SubmitCVE(ctx, cve, domain.CVEManifest{})
 		if err != nil {
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost,
@@ -551,6 +558,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	logger.L().Info("registry scan started",
 		helpers.String("imageSlug", workload.ImageSlug),
 		helpers.String("jobID", workload.JobID))
+	domain.UpdateScanPhase(ctx, "scan_started")
 
 	// report to platform
 	err := s.platform.SendStatus(ctx, domain.Started)
@@ -562,6 +570,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	// check if CVE manifest is already available
 	cve := domain.CVEManifest{}
 	if s.storage {
+		domain.UpdateScanPhase(ctx, "cve_lookup")
 		cve, err = s.cveRepository.GetCVE(ctx, workload.ImageSlug, s.sbomCreator.Version(), s.cveScanner.Version(), s.cveScanner.DBVersion(ctx))
 		if err != nil {
 			logger.L().Ctx(ctx).Warning("getting CVE", helpers.Error(err),
@@ -571,6 +580,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 
 	sbom := domain.SBOM{}
 	if cve.Content == nil {
+		domain.UpdateScanPhase(ctx, "sbom_generation")
 		var sbomErr error
 		sbom, _, sbomErr = s.getOrCreateSBOM(ctx, workload)
 		if sbomErr != nil {
@@ -595,6 +605,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		}
 
 		// scan for CVE
+		domain.UpdateScanPhase(ctx, "cve_matching")
 		cve, err = s.cveScanner.ScanSBOM(ctx, sbom)
 		if err != nil {
 			repErr := s.platform.ReportError(ctx, err)
@@ -612,6 +623,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 
 		// store filtered CVE
 		if s.storage {
+			domain.UpdateScanPhase(ctx, "result_storage")
 			err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
 			if err != nil {
 				logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
@@ -634,6 +646,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 	}
 
 	// report scan success to platform
+	domain.UpdateScanPhase(ctx, "result_upload")
 	err = s.platform.SendStatus(ctx, domain.Success)
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("telemetry error", helpers.Error(err),

--- a/docs/API.md
+++ b/docs/API.md
@@ -168,6 +168,53 @@ curl http://localhost:8080/metrics
 
 All scan endpoints accept a JSON payload and return immediately with a `200 OK` status. The actual scanning is performed asynchronously in a worker pool.
 
+### Get Scan Status
+
+Look up the current lifecycle state for a previously submitted `jobID`.
+
+```
+GET /v1/scanStatus/:jobID
+```
+
+#### Response Body
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `jobID` | string | Submitted job identifier |
+| `endpoint` | string | Async scan endpoint handling this job |
+| `state` | string | One of `queued`, `running`, `succeeded`, `failed`, or `abandoned` |
+| `phase` | string | Current service phase, for example `sbom_generation`, `cve_matching`, or `result_upload` |
+| `reason` | string | Machine readable terminal reason for `failed` or `abandoned` jobs |
+| `acceptedAt` | string | RFC3339 timestamp when the request was accepted |
+| `startedAt` | string | RFC3339 timestamp when execution began |
+| `finishedAt` | string | RFC3339 timestamp when the job reached a terminal state |
+| `updatedAt` | string | RFC3339 timestamp of the latest lifecycle transition |
+
+#### Response
+
+| Status | Description |
+|--------|-------------|
+| `200 OK` | Job status found |
+| `404 Not Found` | Unknown `jobID` |
+
+#### Example
+
+```bash
+curl http://localhost:8080/v1/scanStatus/sbom-gen-001
+```
+
+```json
+{
+  "jobID": "sbom-gen-001",
+  "endpoint": "generateSBOM",
+  "state": "running",
+  "phase": "sbom_generation",
+  "acceptedAt": "2026-08-12T12:00:00Z",
+  "startedAt": "2026-08-12T12:00:01Z",
+  "updatedAt": "2026-08-12T12:00:01Z"
+}
+```
+
 ### Generate SBOM
 
 Generate a Software Bill of Materials (SBOM) for a container image.

--- a/docs/API.md
+++ b/docs/API.md
@@ -172,7 +172,7 @@ All scan endpoints accept a JSON payload and return immediately with a `200 OK` 
 
 Look up the current lifecycle state for a previously submitted `jobID`.
 
-```
+```http
 GET /v1/scanStatus/:jobID
 ```
 
@@ -183,11 +183,11 @@ GET /v1/scanStatus/:jobID
 | `jobID` | string | Submitted job identifier |
 | `endpoint` | string | Async scan endpoint handling this job |
 | `state` | string | One of `queued`, `running`, `succeeded`, `failed`, or `abandoned` |
-| `phase` | string | Current service phase, for example `sbom_generation`, `cve_matching`, or `result_upload` |
+| `phase` | string | Current service phase. Reported values include `queued`, `running`, `relevancy_lookup`, `cve_lookup`, `sbom_generation`, `sbom_storage`, `cve_matching`, `result_storage`, `result_upload`, `completed`, and `abandoned` |
 | `reason` | string | Machine readable terminal reason for `failed` or `abandoned` jobs |
 | `acceptedAt` | string | RFC3339 timestamp when the request was accepted |
-| `startedAt` | string | RFC3339 timestamp when execution began |
-| `finishedAt` | string | RFC3339 timestamp when the job reached a terminal state |
+| `startedAt` | string | RFC3339 timestamp when execution began. Omitted while the job is still queued |
+| `finishedAt` | string | RFC3339 timestamp when the job reached a terminal state. Omitted until the job succeeds, fails, or is abandoned |
 | `updatedAt` | string | RFC3339 timestamp of the latest lifecycle transition |
 
 #### Response


### PR DESCRIPTION
## Overview
This adds a read only scan status API keyed by `jobID` so callers can tell whether an async scan is queued, running, succeeded, failed, or abandoned during shutdown.

The controller now keeps an in memory status record for accepted jobs, updates it through worker pool lifecycle transitions, and exposes `GET /v1/scanStatus/:jobID`. The scan service also publishes coarse phase updates such as `sbom_generation`, `cve_matching`, `result_storage`, and `result_upload` so the status payload shows current execution progress instead of only terminal state.

Focused controller coverage was added for a completed scan, a failed scan with a machine readable reason, and a queued scan abandoned during shutdown. API documentation was updated for the new endpoint.

## Additional Information
This PR is scoped to the async scan status feature only. Unrelated local files in the worktree were left untouched.

## How to Test
- `go test ./controllers -run 'TestHTTPController_ScanStatus_|TestHTTPController_MetricsEndpoint_RecordsScanFailureReason|TestHTTPController_GenerateSBOM|TestHTTPController_ScanCVE|TestHTTPController_Shutdown_BoundedByTimeout'`
- `go test ./cmd/http ./controllers ./core/services`
- `go vet ./...`
- `make lint`
- `make verify`  
  This currently fails in pre existing `adapters/v1` golden tests on this arm64 environment because those tests expect amd64 image metadata and digests. The changed areas in this PR pass independently.

## Related issues/PRs:
* Resolved #635

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to check vulnerability scan status by job ID.
  - Scan statuses now include queued, running, succeeded, failed, and abandoned states.
  - Added progress phases, timestamps, and failure or shutdown reasons.
  - Scan results now indicate successful completion even when partial results are available.
  - Added diagnostics visibility for scan operations.

- **Documentation**
  - Documented the scan-status endpoint, response fields, lifecycle states, and example response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->