### PR TITLE
fix(config): bind env for the keys that have no default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,32 @@ func LoadConfig(path string) (Config, error) {
 
 	v.AutomaticEnv()
 
+	// AutomaticEnv on its own does not make a key reachable by Unmarshal. viper can only
+	// unmarshal keys it knows about, from the config file, a default, or an explicit
+	// binding, and it cannot enumerate the environment, so a key that appears in none of
+	// those is silently dropped. Everything with a SetDefault above is already covered;
+	// these are the remaining fields, which clusterData.json does not always carry. Without
+	// this, STORAGE=true on a config file that has no "storage" key reads back as false and
+	// kubevuln runs with storage off while looking correctly configured. Same gap #593 fixed
+	// for trustedVendors and proxyRegistryMap by reading through viper's getters.
+	//
+	// cveMatchingMode and useDefaultMatchers are deliberately left out: they are resolved
+	// through IsSet below, which already handles the env case.
+	for _, key := range []string{
+		"accountID",
+		"clusterName",
+		"keepLocal",
+		"nodeSbomGeneration",
+		"partialRelevancy",
+		"riskAcceptance",
+		"storage",
+		"storeFilteredSbom",
+	} {
+		if err := v.BindEnv(key); err != nil {
+			return Config{}, fmt.Errorf("binding %s to the environment: %w", key, err)
+		}
+	}
+
 	err := v.ReadInConfig()
 	if err != nil {
 		return Config{}, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -291,3 +291,49 @@ func TestLoadConfigProxyRegistryMapEnv_Invalid(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "proxyRegistryMap")
 }
+
+// TestLoadConfigEnvOnlyFieldsWithoutDefaults verifies that a field carried only by the
+// environment reaches the struct. AutomaticEnv does not achieve that on its own: viper
+// unmarshals the keys it knows about, and it cannot enumerate the environment, so a key
+// with no default and no entry in clusterData.json was dropped. STORAGE is the one that
+// matters most, since kubevuln would then run with storage off while looking configured
+// for it.
+func TestLoadConfigEnvOnlyFieldsWithoutDefaults(t *testing.T) {
+	tests := []struct {
+		name  string
+		env   string
+		value string
+		got   func(Config) bool
+	}{
+		{"storage", "STORAGE", "true", func(c Config) bool { return c.Storage }},
+		{"keepLocal", "KEEPLOCAL", "true", func(c Config) bool { return c.KeepLocal }},
+		{"riskAcceptance", "RISKACCEPTANCE", "true", func(c Config) bool { return c.RiskAcceptance }},
+		{"storeFilteredSbom", "STOREFILTEREDSBOM", "true", func(c Config) bool { return c.StoreFilteredSbom }},
+		{"nodeSbomGeneration", "NODESBOMGENERATION", "true", func(c Config) bool { return c.NodeSbomGeneration }},
+		{"partialRelevancy", "PARTIALRELEVANCY", "true", func(c Config) bool { return c.PartialRelevancy }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Setenv(tt.env, tt.value)
+			c, err := LoadConfig("testdata")
+			require.NoError(t, err)
+			assert.True(t, tt.got(c), "%s set in the environment must reach the config", tt.env)
+		})
+	}
+}
+
+// Binding those keys to the environment must not change where a value comes from when the
+// environment is silent, nor the usual precedence when it is not.
+func TestLoadConfigEnvBindingKeepsFilePrecedence(t *testing.T) {
+	viper.Reset()
+	c, err := LoadConfig("testdata")
+	require.NoError(t, err)
+	assert.Equal(t, "12345", c.AccountID, "the file value must still be used when the environment is silent")
+
+	viper.Reset()
+	t.Setenv("ACCOUNTID", "from-env")
+	c, err = LoadConfig("testdata")
+	require.NoError(t, err)
+	assert.Equal(t, "from-env", c.AccountID, "the environment must still win over the file")
+}


### PR DESCRIPTION
## Overview

binds the config keys that have no `SetDefault` to the environment, so an env-only value reaches the struct.

`AutomaticEnv` only affects viper's getters. `Unmarshal` walks the keys viper knows about, from the config file, a default, or an explicit binding, and it cannot enumerate the environment, so a key in none of those was silently dropped. whether an env override worked came down to whether the field happened to have a default set above it. the comment on the `cveMatchingMode` resolution already documents the gap, and #593 worked around it for `trustedVendors` and `proxyRegistryMap` by reading through viper's getters.

six fields were still affected. `storage` is the one that stings: `STORAGE=true` on a `clusterData.json` with no `storage` key left kubevuln running with storage off, writing nothing to the apiserver, while the deployment looked correctly configured. `riskAcceptance` silently dropped the SecurityException path. `accountID` and `clusterName` were in the same position and are bound too, though those are normally in the file.

## Additional Information

`BindEnv` rather than `SetDefault`, because a default would make `IsSet` report the key as set even when nothing set it, and that presence detection is load-bearing here. the comment above `cveMatchingMode` calls it out. `BindEnv` leaves `IsSet` false when the variable is absent, so nothing else shifts.

`cveMatchingMode` and `useDefaultMatchers` are deliberately not bound. they are resolved through `IsSet` and already handle env, and binding them would be churn on logic that works.

precedence is unchanged: environment over file over default. there is a test for that, since binding keys is exactly the kind of change that could quietly invert it.

## How to Test

`go test ./config/ -count=1`

- `TestLoadConfigEnvOnlyFieldsWithoutDefaults` sets each variable on its own against the existing `testdata`, whose `clusterData.json` carries none of these keys, and asserts it lands. all six subtests fail before this.
- `TestLoadConfigEnvBindingKeepsFilePrecedence` asserts `accountID` still comes from the file when the environment is silent, and that the environment still wins when it is not.

the existing env tests for `TRUSTEDVENDORS`, `PROXYREGISTRYMAP`, `CVEMATCHINGMODE` and `USEDEFAULTMATCHERS` are untouched and still pass.

## Related issues/PRs:

* Resolved #639
* Follow-up to #593


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment-based configuration values now load correctly for boolean settings.
  - Environment variables override configuration file values when provided, while file values remain unchanged when variables are unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->