### PR TITLE
refactor: extract the duplicated cache-hit exception reconciliation into reconcileCachedCVE

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -349,43 +349,9 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 				}
 			}
 		} else {
-			// A cached manifest was filtered against the exception set at store time.
-			// Reconstruct the unfiltered manifest so the CURRENT exception set is
-			// re-evaluated (deleted exceptions and ExpiredOnFix transitions
-			// un-suppress findings) and SubmitCVE/StoreVEX receive the same
-			// unfiltered data a cache miss would produce.
-			prevIgnored := v1.IgnoredMatchKeys(cve.Content)
-			cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-			filteredCve, cveExceptionsComplete = s.applyExceptionsToManifest(ctx, cve)
-
-			if s.storage {
-				curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
-				if !maps.Equal(prevIgnored, curIgnored) {
-					// Persist additions freely, but never persist removals when the
-					// exception set is incomplete: a transient SecurityException CRD
-					// list failure must not look like a deletion and wipe suppression
-					// from the stored manifest.
-					hasRemovals := false
-					for k := range prevIgnored {
-						if _, ok := curIgnored[k]; !ok {
-							hasRemovals = true
-							break
-						}
-					}
-					if cveExceptionsComplete || !hasRemovals {
-						err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-						if err != nil {
-							logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
-								helpers.String("imageSlug", slug))
-						}
-						err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-						if err != nil {
-							logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
-								helpers.String("imageSlug", slug))
-						}
-					}
-				}
-			}
+			// VEX is not published here: ScanCP republishes it later, once
+			// filteredCvep is also available, gated on both exceptionsComplete flags.
+			cve, filteredCve, cveExceptionsComplete = s.reconcileCachedCVE(ctx, cve, slug, false)
 		}
 
 		// generate SBOM' from SBOM and relevant files
@@ -548,57 +514,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 			}
 		}
 	} else {
-		// A cached manifest was filtered against the exception set at store time.
-		// Reconstruct the unfiltered manifest so the CURRENT exception set is
-		// re-evaluated (deleted exceptions and ExpiredOnFix transitions
-		// un-suppress findings) and SubmitCVE/StoreVEX receive the same unfiltered
-		// data a cache miss would produce.
-		prevIgnored := v1.IgnoredMatchKeys(cve.Content)
-		cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
-
-		if s.storage {
-			curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
-			if !maps.Equal(prevIgnored, curIgnored) {
-				// Persist additions freely, but never persist removals when the
-				// exception set is incomplete: a transient SecurityException CRD
-				// list failure must not look like a deletion and wipe suppression
-				// from the stored manifest.
-				hasRemovals := false
-				for k := range prevIgnored {
-					if _, ok := curIgnored[k]; !ok {
-						hasRemovals = true
-						break
-					}
-				}
-				if exceptionsComplete || !hasRemovals {
-					err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-					if err != nil {
-						logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
-							helpers.String("imageSlug", workload.ImageSlug))
-					}
-					err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-					if err != nil {
-						logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
-							helpers.String("imageSlug", workload.ImageSlug))
-					}
-					// The stored manifest just changed, so the VEX document describing it is
-					// now stale. Republish it, but only from a known-complete exception set,
-					// the same rule the cache-miss path follows.
-					//
-					// The manifest is persisted on the looser `exceptionsComplete ||
-					// !hasRemovals` condition because a partial set can only under-suppress,
-					// never wrongly un-suppress, so additions are safe to keep. A VEX document
-					// is a published assertion about which CVEs are suppressed, and one built
-					// from a partial set understates that. Leaving the previous document in
-					// place, written when the set was complete, beats replacing it with a
-					// weaker claim, so the two can briefly disagree until a complete scan.
-					if exceptionsComplete {
-						s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
-					}
-				}
-			}
-		}
+		cve, _, _ = s.reconcileCachedCVE(ctx, cve, workload.ImageSlug, true)
 	}
 
 	// submit CVE manifest to platform, only if we have a wlid
@@ -712,57 +628,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 			}
 		}
 	} else {
-		// A cached manifest was filtered against the exception set at store time.
-		// Reconstruct the unfiltered manifest so the CURRENT exception set is
-		// re-evaluated (deleted exceptions and ExpiredOnFix transitions
-		// un-suppress findings) and SubmitCVE/StoreVEX receive the same
-		// unfiltered data a cache miss would produce.
-		prevIgnored := v1.IgnoredMatchKeys(cve.Content)
-		cve.Content = v1.RestoreSuppressedMatches(cve.Content)
-		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
-
-		if s.storage {
-			curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
-			if !maps.Equal(prevIgnored, curIgnored) {
-				// Persist additions freely, but never persist removals when the
-				// exception set is incomplete: a transient SecurityException CRD
-				// list failure must not look like a deletion and wipe suppression
-				// from the stored manifest.
-				hasRemovals := false
-				for k := range prevIgnored {
-					if _, ok := curIgnored[k]; !ok {
-						hasRemovals = true
-						break
-					}
-				}
-				if exceptionsComplete || !hasRemovals {
-					err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-					if err != nil {
-						logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
-							helpers.String("imageSlug", workload.ImageSlug))
-					}
-					err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-					if err != nil {
-						logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
-							helpers.String("imageSlug", workload.ImageSlug))
-					}
-					// The stored manifest just changed, so the VEX document describing it is
-					// now stale. Republish it, but only from a known-complete exception set,
-					// the same rule the cache-miss path follows.
-					//
-					// The manifest is persisted on the looser `exceptionsComplete ||
-					// !hasRemovals` condition because a partial set can only under-suppress,
-					// never wrongly un-suppress, so additions are safe to keep. A VEX document
-					// is a published assertion about which CVEs are suppressed, and one built
-					// from a partial set understates that. Leaving the previous document in
-					// place, written when the set was complete, beats replacing it with a
-					// weaker claim, so the two can briefly disagree until a complete scan.
-					if exceptionsComplete {
-						s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
-					}
-				}
-			}
-		}
+		cve, _, _ = s.reconcileCachedCVE(ctx, cve, workload.ImageSlug, true)
 	}
 
 	// report scan success to platform
@@ -806,6 +672,75 @@ func (s *ScanService) storeVEX(ctx context.Context, cve, cvep domain.CVEManifest
 		logger.L().Ctx(ctx).Warning("storing VEX", helpers.Error(err),
 			helpers.String("imageSlug", imageSlug))
 	}
+}
+
+// reconcileCachedCVE re-evaluates a CVE manifest retrieved from the cache (cve.Content
+// non-nil) against the CURRENT SecurityException set, since it was filtered against
+// whatever set was active when it was originally stored: a deleted exception or an
+// ExpiredOnFix transition since then must still un-suppress findings on a cache hit,
+// the same as it would on a fresh scan.
+//
+// ScanCP, ScanCVE, and ScanRegistry each used to carry their own copy of this
+// sequence, and that duplication is exactly why the same class of bug (#469, #501,
+// #557) kept resurfacing in one flow after being fixed in another — see #638.
+//
+// Returns the input cve with suppressed matches restored (so SubmitCVE/StoreVEX
+// receive the same unfiltered data a cache miss would produce, matching every
+// caller's existing use of the mutated cve.Content after this call), the freshly
+// filtered copy, and whether the exception set used to filter it was known-complete.
+//
+// When storage is enabled and the filtered result's suppressions actually changed,
+// persists the updated manifest and, if publishVEX is true, republishes its VEX
+// document — subject to the removal-safety rule below. publishVEX lets ScanCP opt
+// out: it republishes VEX later itself, once relevancy-filtered results are also
+// available, using the exceptionsComplete this call returns.
+func (s *ScanService) reconcileCachedCVE(ctx context.Context, cve domain.CVEManifest, imageSlug string, publishVEX bool) (restoredCve, filteredCve domain.CVEManifest, exceptionsComplete bool) {
+	prevIgnored := v1.IgnoredMatchKeys(cve.Content)
+	cve.Content = v1.RestoreSuppressedMatches(cve.Content)
+	filteredCve, exceptionsComplete = s.applyExceptionsToManifest(ctx, cve)
+
+	if s.storage {
+		curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
+		if !maps.Equal(prevIgnored, curIgnored) {
+			// Persist additions freely, but never persist removals when the
+			// exception set is incomplete: a transient SecurityException CRD
+			// list failure must not look like a deletion and wipe suppression
+			// from the stored manifest.
+			hasRemovals := false
+			for k := range prevIgnored {
+				if _, ok := curIgnored[k]; !ok {
+					hasRemovals = true
+					break
+				}
+			}
+			if exceptionsComplete || !hasRemovals {
+				if err := s.cveRepository.StoreCVE(ctx, filteredCve, false); err != nil {
+					logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
+						helpers.String("imageSlug", imageSlug))
+				}
+				if err := s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false); err != nil {
+					logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
+						helpers.String("imageSlug", imageSlug))
+				}
+				// The stored manifest just changed, so the VEX document describing it is
+				// now stale. Republish it, but only from a known-complete exception set,
+				// the same rule the cache-miss path follows.
+				//
+				// The manifest is persisted on the looser `exceptionsComplete ||
+				// !hasRemovals` condition because a partial set can only under-suppress,
+				// never wrongly un-suppress, so additions are safe to keep. A VEX document
+				// is a published assertion about which CVEs are suppressed, and one built
+				// from a partial set understates that. Leaving the previous document in
+				// place, written when the set was complete, beats replacing it with a
+				// weaker claim, so the two can briefly disagree until a complete scan.
+				if publishVEX && exceptionsComplete {
+					s.storeVEX(ctx, filteredCve, filteredCve, false, imageSlug)
+				}
+			}
+		}
+	}
+
+	return cve, filteredCve, exceptionsComplete
 }
 
 // applyExceptionsToManifest returns a filtered copy of the CVE manifest with


### PR DESCRIPTION
## Overview

`ScanCP`, `ScanCVE`, and `ScanRegistry` (`core/services/scan.go`) each carried their own near-identical ~40-50 line block that re-evaluates a cached CVE manifest against the current SecurityException set: snapshot which CVEs are currently suppressed, restore suppressed matches, re-filter, diff old vs. new suppression to decide what's safe to persist, and — for `ScanCVE`/`ScanRegistry` — republish VEX under a removal-safety rule. The `ScanCVE` and `ScanRegistry` copies were byte-identical except for a single comment line-wrap.

This duplication is why the same class of bug kept resurfacing in one flow after being fixed in another: #469, #501, and #557 are three separate, previously closed issues against this exact block, each a fix applied to one function that had to be independently re-discovered and re-applied to a second flow later.

This PR extracts the sequence into a single `reconcileCachedCVE` method. The one real behavioral difference between callers — whether to republish VEX at that point — is now an explicit `publishVEX` parameter: `ScanCVE` and `ScanRegistry` pass `true` (matching their prior behavior), `ScanCP` passes `false` since it republishes VEX later itself, once relevancy-filtered (`cvep`) results are also available, gated on both exception-completeness flags.

No behavior change — this is a pure refactor, verified against the existing regression suite (see below).

## How to Test

```
go test ./core/services/... -run 'TestScanService_ScanCP$|TestScanService_ScanCVE$|TestScanService_ScanRegistry$|TestScanService_ScanRegistry_StorageAndExceptions|CacheHit|CacheMiss' -v
```

This exercises 54 individual test cases across `scan_test.go`'s existing coverage of cache-hit/cache-miss behavior for all three flows — deleted/added exceptions, `ExpiredOnFix` transitions, degraded exception fetches (partial CRD-list failures), and VEX republish gating — all passing unmodified against the refactored code.

```
go test ./...
```

Full suite passes except three environment-dependent tests requiring a local Docker/testcontainers Grype-DB fixture (`TestScanService_NginxTest`, `Test_grypeAdapter_DBVersion`, `Test_grypeAdapter_ScanSBOM`), unrelated to this change.

## Related issues/PRs:

* Resolved #638

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when reconciling cached vulnerability results across scan types.
  * Preserved suppressed findings when security exception data is incomplete.
  * Ensured updated exceptions are applied correctly to cached results.
  * Improved VEX publication timing so only relevant, complete results are republished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->