### PR TITLE
fix(adapters): resolve IntroducedInLayer for packages outside the base layer

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -98,6 +98,9 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 		parentLayer := map[string]string{
 			dummyLayer: parentLayerHash,
 		}
+		// ...and one of layer to its position in the image, so the earliest layer a package
+		// appears in can be picked directly rather than by walking the chain from the root.
+		layerPosition := map[string]int{}
 
 		target, err := NewTargetFromSource(grypeDocument.Source)
 		if err != nil {
@@ -106,9 +109,10 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 
 		if target.IsImageTarget() {
 			imageMetadata := target.GetImageMetadata()
-			for _, layer := range imageMetadata.Layers {
+			for i, layer := range imageMetadata.Layers {
 				parentLayer[layer.Digest] = parentLayerHash
 				parentLayerHash = layer.Digest
+				layerPosition[layer.Digest] = i
 			}
 		}
 
@@ -202,10 +206,15 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 
 			// fill extra layer information
 			for i, v := range vulnerabilityResults {
+				// The package is introduced by the earliest layer it appears in. This used to
+				// walk the parent chain from "", which meant it only ever resolved for a
+				// package present in the image's first layer: for anything added by a later
+				// layer no element could start the chain, and the result stayed empty.
 				earlyLayer := ""
+				earlyPosition := 0
 				for j, layer := range v.Layers {
-					if layer.ParentLayerHash == earlyLayer {
-						earlyLayer = layer.LayerHash
+					if position, ok := layerPosition[layer.LayerHash]; ok && (earlyLayer == "" || position < earlyPosition) {
+						earlyLayer, earlyPosition = layer.LayerHash, position
 					}
 					if l, ok := data[layer.LayerHash]; ok {
 						if layer.LayerInfo == nil {
@@ -215,6 +224,11 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 						vulnerabilityResults[i].Layers[j].CreatedTime = l.CreatedTime
 						vulnerabilityResults[i].Layers[j].LayerOrder = l.LayerOrder
 					}
+				}
+				if earlyLayer == "" && len(v.Layers) > 0 {
+					// No layer of this package is one of the image's own, which is the case
+					// for a match with no locations: it is given the placeholder layer above.
+					earlyLayer = v.Layers[0].LayerHash
 				}
 				vulnerabilityResults[i].IntroducedInLayer = earlyLayer
 			}

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_domainToArmo(t *testing.T) {
@@ -365,6 +366,57 @@ func Test_linkToVuln(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, linkToVuln(tt.id))
+		})
+	}
+}
+
+// threeLayerSource describes an image with three layers, so a package can be placed in one
+// that is not the base.
+const threeLayerSource = `{"userInput":"","imageID":"","manifestDigest":"","mediaType":"","tags":null,"imageSize":0,"layers":[{"mediaType":"","digest":"sha256:l1","size":0},{"mediaType":"","digest":"sha256:l2","size":0},{"mediaType":"","digest":"sha256:l3","size":0}],"manifest":null,"config":null,"repoDigests":null,"architecture":"","os":""}`
+
+func layeredDocument(fileSystemIDs ...string) v1beta1.GrypeDocument {
+	locations := make([]v1beta1.SyftCoordinates, 0, len(fileSystemIDs))
+	for _, id := range fileSystemIDs {
+		locations = append(locations, v1beta1.SyftCoordinates{FileSystemID: id})
+	}
+	return v1beta1.GrypeDocument{
+		Source: &v1beta1.Source{Target: json.RawMessage(threeLayerSource)},
+		Matches: []v1beta1.Match{{
+			Vulnerability: v1beta1.Vulnerability{
+				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-21300"},
+			},
+			Artifact: v1beta1.GrypePackage{Name: "pkg", Locations: locations},
+		}},
+	}
+}
+
+// IntroducedInLayer is the earliest layer a package appears in. It used to be resolved by
+// walking the parent chain from "", which only ever completed for a package present in the
+// image's first layer: nothing could start the chain for one added later, so every package
+// outside the base layer reported no introducing layer at all.
+func Test_domainToArmo_introducedInLayer(t *testing.T) {
+	tests := []struct {
+		name      string
+		locations []string
+		want      string
+	}{
+		{"base layer", []string{"sha256:l1"}, "sha256:l1"},
+		{"middle layer", []string{"sha256:l2"}, "sha256:l2"},
+		{"top layer", []string{"sha256:l3"}, "sha256:l3"},
+		{"several layers, earliest wins", []string{"sha256:l3", "sha256:l2"}, "sha256:l2"},
+		{"several layers, already ordered", []string{"sha256:l2", "sha256:l3"}, "sha256:l2"},
+		{"layer not in the image", []string{"sha256:unknown"}, "sha256:unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{ImageHash: "h", ImageTagNormalized: "t"})
+			ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+			ctx = context.WithValue(ctx, domain.ScanIDKey{}, "scan-1")
+
+			got, err := DomainToArmo(ctx, layeredDocument(tt.locations...), nil)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.want, got[0].IntroducedInLayer)
 		})
 	}
 }


### PR DESCRIPTION
## Overview

`IntroducedInLayer` was resolved by walking the parent chain from `""`. the image's first layer is the only one whose parent is `""`, so the walk could only ever start if the package appeared in that layer. for a package added by any later build step nothing matched, the loop never advanced, and the field went out empty.

that is most packages. the base layer holds the distro packages, so those resolved; anything installed later, which is usually where the interesting findings are, reported nothing. the field ships on every vulnerability in `CommonContainerVulnerabilityResult`, so a consumer pointing at the build step that introduced a CVE got an empty string.

the position of each layer in `imageMetadata.Layers` is already known where `parentLayer` is built, so this records it there and picks the earliest layer the package appears in directly. no walking, and it does not care what order `Artifact.Locations` comes back in.

## Additional Information

a match with no locations is given a placeholder layer earlier in the function, and that layer is not one of the image's own, so it has no position. it keeps resolving to itself, which is what the walk did for it before. `Test_domainToArmo`'s existing case is exactly that shape, which is why it passed while the real case was broken, so it is worth keeping as its own path rather than folding it in.

`parentLayer` is still built and used, it feeds `ParentLayerHash` on each layer. only the `IntroducedInLayer` resolution changes.

## How to Test

`go test ./adapters/v1/ -run Test_domainToArmo -count=1`

`Test_domainToArmo_introducedInLayer` puts a package in each layer of a three layer image in turn, then in several layers at once to check the earliest is chosen regardless of the order the locations arrive in, plus a layer the image does not have.

four of the six cases fail before this:

```
middle layer                     expected: "sha256:l2"  actual: ""
top layer                        expected: "sha256:l3"  actual: ""
several layers, earliest wins    expected: "sha256:l2"  actual: ""
several layers, already ordered  expected: "sha256:l2"  actual: ""
```

the two that pass beforehand are the base layer and the unknown layer, which are the shapes the old walk could handle.

## Related issues/PRs:

* Resolved #643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability reporting to identify the earliest image layer where a package was introduced.
  * Added fallback handling when no matching image layer is available, improving consistency for unknown package layers.

* **Tests**
  * Expanded coverage for base, middle, top, multiple, and unknown package-layer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->