### PR TITLE
fix(services): match relevant-file paths that carry a wildcard placeholder

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -98,6 +98,9 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 		parentLayer := map[string]string{
 			dummyLayer: parentLayerHash,
 		}
+		// ...and one of layer to its position in the image, so the earliest layer a package
+		// appears in can be picked directly rather than by walking the chain from the root.
+		layerPosition := map[string]int{}
 
 		target, err := NewTargetFromSource(grypeDocument.Source)
 		if err != nil {
@@ -106,9 +109,10 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 
 		if target.IsImageTarget() {
 			imageMetadata := target.GetImageMetadata()
-			for _, layer := range imageMetadata.Layers {
+			for i, layer := range imageMetadata.Layers {
 				parentLayer[layer.Digest] = parentLayerHash
 				parentLayerHash = layer.Digest
+				layerPosition[layer.Digest] = i
 			}
 		}
 
@@ -202,10 +206,15 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 
 			// fill extra layer information
 			for i, v := range vulnerabilityResults {
+				// The package is introduced by the earliest layer it appears in. This used to
+				// walk the parent chain from "", which meant it only ever resolved for a
+				// package present in the image's first layer: for anything added by a later
+				// layer no element could start the chain, and the result stayed empty.
 				earlyLayer := ""
+				earlyPosition := 0
 				for j, layer := range v.Layers {
-					if layer.ParentLayerHash == earlyLayer {
-						earlyLayer = layer.LayerHash
+					if position, ok := layerPosition[layer.LayerHash]; ok && (earlyLayer == "" || position < earlyPosition) {
+						earlyLayer, earlyPosition = layer.LayerHash, position
 					}
 					if l, ok := data[layer.LayerHash]; ok {
 						if layer.LayerInfo == nil {
@@ -215,6 +224,11 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 						vulnerabilityResults[i].Layers[j].CreatedTime = l.CreatedTime
 						vulnerabilityResults[i].Layers[j].LayerOrder = l.LayerOrder
 					}
+				}
+				if earlyLayer == "" && len(v.Layers) > 0 {
+					// No layer of this package is one of the image's own, which is the case
+					// for a match with no locations: it is given the placeholder layer above.
+					earlyLayer = v.Layers[0].LayerHash
 				}
 				vulnerabilityResults[i].IntroducedInLayer = earlyLayer
 			}

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_domainToArmo(t *testing.T) {
@@ -365,6 +366,57 @@ func Test_linkToVuln(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, linkToVuln(tt.id))
+		})
+	}
+}
+
+// threeLayerSource describes an image with three layers, so a package can be placed in one
+// that is not the base.
+const threeLayerSource = `{"userInput":"","imageID":"","manifestDigest":"","mediaType":"","tags":null,"imageSize":0,"layers":[{"mediaType":"","digest":"sha256:l1","size":0},{"mediaType":"","digest":"sha256:l2","size":0},{"mediaType":"","digest":"sha256:l3","size":0}],"manifest":null,"config":null,"repoDigests":null,"architecture":"","os":""}`
+
+func layeredDocument(fileSystemIDs ...string) v1beta1.GrypeDocument {
+	locations := make([]v1beta1.SyftCoordinates, 0, len(fileSystemIDs))
+	for _, id := range fileSystemIDs {
+		locations = append(locations, v1beta1.SyftCoordinates{FileSystemID: id})
+	}
+	return v1beta1.GrypeDocument{
+		Source: &v1beta1.Source{Target: json.RawMessage(threeLayerSource)},
+		Matches: []v1beta1.Match{{
+			Vulnerability: v1beta1.Vulnerability{
+				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-21300"},
+			},
+			Artifact: v1beta1.GrypePackage{Name: "pkg", Locations: locations},
+		}},
+	}
+}
+
+// IntroducedInLayer is the earliest layer a package appears in. It used to be resolved by
+// walking the parent chain from "", which only ever completed for a package present in the
+// image's first layer: nothing could start the chain for one added later, so every package
+// outside the base layer reported no introducing layer at all.
+func Test_domainToArmo_introducedInLayer(t *testing.T) {
+	tests := []struct {
+		name      string
+		locations []string
+		want      string
+	}{
+		{"base layer", []string{"sha256:l1"}, "sha256:l1"},
+		{"middle layer", []string{"sha256:l2"}, "sha256:l2"},
+		{"top layer", []string{"sha256:l3"}, "sha256:l3"},
+		{"several layers, earliest wins", []string{"sha256:l3", "sha256:l2"}, "sha256:l2"},
+		{"several layers, already ordered", []string{"sha256:l2", "sha256:l3"}, "sha256:l2"},
+		{"layer not in the image", []string{"sha256:unknown"}, "sha256:unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{ImageHash: "h", ImageTagNormalized: "t"})
+			ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+			ctx = context.WithValue(ctx, domain.ScanIDKey{}, "scan-1")
+
+			got, err := DomainToArmo(ctx, layeredDocument(tt.locations...), nil)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.want, got[0].IntroducedInLayer)
 		})
 	}
 }

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -1066,11 +1066,20 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 	addedFileIDs := mapset.NewSet[string]()
 	addedRelationshipIDs := mapset.NewSet[string]()
 
-	// filter relevant files with dynamic paths, indexed by segment count since
-	// CompareDynamic only ever matches paths with the same number of segments
+	// Split the relevant files that carry a placeholder, because the two kinds behave
+	// differently. DynamicIdentifier ("⋯") stands for exactly one segment, so such a path
+	// can only ever match one with the same number of segments and is indexed by that count
+	// (see #448). WildcardIdentifier ("*") stands for zero or more segments: the detector
+	// produces it by collapsing runs of "⋯" (so "/a/⋯/⋯/b" is stored as "/a/*/b"),
+	// and it can match a path with any number of segments, so no bucket holds it and it has
+	// to be compared against every file.
 	dynamicPathsBySegmentCount := make(map[int][]string)
+	var wildcardPaths []string
 	relevantFiles.Each(func(file string) bool {
-		if strings.Contains(file, dynamicpathdetector.DynamicIdentifier) {
+		switch {
+		case strings.Contains(file, dynamicpathdetector.WildcardIdentifier):
+			wildcardPaths = append(wildcardPaths, file)
+		case strings.Contains(file, dynamicpathdetector.DynamicIdentifier):
 			segmentCount := strings.Count(file, "/")
 			dynamicPathsBySegmentCount[segmentCount] = append(dynamicPathsBySegmentCount[segmentCount], file)
 		}
@@ -1087,13 +1096,13 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 				filteredSBOM.Content.Files = append(filteredSBOM.Content.Files, f)
 				continue
 			}
-			// then try dynamic match (expensive lookup), limited to candidates with a matching segment count
-			for _, dynamicPath := range dynamicPathsBySegmentCount[strings.Count(f.Location.RealPath, "/")] {
-				if dynamicpathdetector.CompareDynamic(dynamicPath, f.Location.RealPath) {
-					addedFileIDs.Add(f.ID)
-					filteredSBOM.Content.Files = append(filteredSBOM.Content.Files, f)
-					break
-				}
+			// then try dynamic match (expensive lookup): the one bucket a fixed-width
+			// placeholder path could be in, plus the wildcard paths, which fit no bucket
+			realPath := f.Location.RealPath
+			if matchesAnyDynamicPath(realPath, dynamicPathsBySegmentCount[strings.Count(realPath, "/")]) ||
+				matchesAnyDynamicPath(realPath, wildcardPaths) {
+				addedFileIDs.Add(f.ID)
+				filteredSBOM.Content.Files = append(filteredSBOM.Content.Files, f)
 			}
 		}
 	}
@@ -1150,6 +1159,17 @@ func filterSBOM(sbom domain.SBOM, instanceID instanceidhandler.IInstanceID, wlid
 	}
 
 	return filteredSBOM, nil
+}
+
+// matchesAnyDynamicPath reports whether path is matched by any of the placeholder-carrying
+// relevant-file paths in candidates.
+func matchesAnyDynamicPath(path string, candidates []string) bool {
+	for _, candidate := range candidates {
+		if dynamicpathdetector.CompareDynamic(candidate, path) {
+			return true
+		}
+	}
+	return false
 }
 
 // getRelationshipID returns a unique string identifier for a Syft relationship.

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2144,6 +2144,70 @@ func TestScanService_ScanCP_CacheHit_DeletedExceptionRestoresSuppressedMatch(t *
 // order). This constructs a 3-level containment chain - file F is owned by pkg-A, pkg-A is
 // contained in pkg-B, pkg-B is contained in pkg-C - with the relationships listed
 // outermost-first (C->B, B->A, A->F), the ordering that reproduced the bug.
+// RelevantFiles carries two kinds of placeholder. DynamicIdentifier ("⋯") is one segment,
+// so those paths keep their segment count and the #448 bucket is right for them.
+// WildcardIdentifier ("*") is zero or more segments, and the detector produces it by
+// collapsing runs of "⋯", so "/a/⋯/⋯/b" reaches us as "/a/*/b". Those were not
+// picked up as dynamic at all, so the file, its package and everything above it were dropped
+// and the relevancy scan called a loaded package not relevant.
+func TestFilterSBOM_WildcardRelevantPaths(t *testing.T) {
+	instanceID, err := instanceidhandlerv1.GenerateInstanceIDFromString(
+		"apiVersion-apps/v1/namespace-default/kind-Deployment/name-probe/containerName-probe",
+	)
+	require.NoError(t, err)
+
+	d := dynamicpathdetector.DynamicIdentifier
+	w := dynamicpathdetector.WildcardIdentifier
+
+	tests := []struct {
+		name    string
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"one segment placeholder", "/usr/lib/" + d + "/mod.so", "/usr/lib/python3/mod.so", true},
+		{"one segment placeholder cannot span two", "/usr/lib/" + d + "/mod.so", "/usr/lib/a/b/mod.so", false},
+		{"wildcard spanning several segments", "/usr/lib/" + w + "/mod.so", "/usr/lib/a/b/mod.so", true},
+		{"wildcard spanning none", "/usr/lib/" + w + "/mod.so", "/usr/lib/mod.so", true},
+		{"trailing wildcard", "/usr/lib/" + w, "/usr/lib/a/b/c", true},
+		{"both placeholders together", "/usr/lib/" + d + "/" + w + "/mod.so", "/usr/lib/a/b/c/mod.so", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbom := domain.SBOM{
+				Content: &v1beta1.SyftDocument{
+					Files: []v1beta1.SyftFile{
+						{ID: "file-F", Location: v1beta1.Coordinates{RealPath: tt.path}},
+					},
+					Artifacts: []v1beta1.SyftPackage{
+						{PackageBasicData: v1beta1.PackageBasicData{ID: "pkg-A", Name: "A"}},
+					},
+					ArtifactRelationships: []v1beta1.SyftRelationship{
+						{Parent: "pkg-A", Child: "file-F", Type: "contains"},
+					},
+				},
+			}
+
+			relevantFiles := mapset.NewSet[string]()
+			relevantFiles.Add(tt.pattern)
+
+			filtered, err := filterSBOM(sbom, instanceID, "wlid://x", relevantFiles, map[string]string{}, helpersv1.Full)
+			require.NoError(t, err)
+
+			if !tt.want {
+				assert.Empty(t, filtered.Content.Files, "%q must not match %q", tt.pattern, tt.path)
+				assert.Empty(t, filtered.Content.Artifacts)
+				return
+			}
+			require.Len(t, filtered.Content.Files, 1, "the file matched by %q must survive the filter", tt.pattern)
+			assert.Equal(t, tt.path, filtered.Content.Files[0].Location.RealPath)
+			require.Len(t, filtered.Content.Artifacts, 1, "and so must the package that owns it")
+			assert.Equal(t, "pkg-A", filtered.Content.Artifacts[0].ID)
+		})
+	}
+}
+
 func TestFilterSBOM_TransitiveClosure(t *testing.T) {
 	instanceID, err := instanceidhandlerv1.GenerateInstanceIDFromString(
 		"apiVersion-apps/v1/namespace-default/kind-Deployment/name-probe/containerName-probe",


### PR DESCRIPTION
## Overview

`filterSBOM` only recognised one of the two placeholders a relevant-file path can carry. it collected paths containing `DynamicIdentifier` (`⋯`, one segment) and ignored `WildcardIdentifier` (`*`, zero or more segments), which the detector produces by collapsing runs of `⋯`, so `/a/⋯/⋯/b` reaches us as `/a/*/b` through `containerProfile.Spec.Opens`.

such a path was never compared with `CompareDynamic` at all. it only got the exact string equality check, which a pattern cannot pass, so the file was dropped from the filtered SBOM, its package went with it, and the relevancy scan reported a package that is loaded as not relevant. a path carrying both, `/usr/lib/⋯/*/mod.so`, was collected but then bucketed by its own segment count, which the `*` makes wrong.

the segment-count index from #448 is correct for `⋯`: it really is one segment and cannot match across counts. so this keeps that index for paths carrying only `⋯` and compares the `*` ones against every file, since no bucket can hold them.

## Additional Information

the two groups are matched separately rather than by concatenating the bucket with the wildcard list, since appending to a slice that came out of the map would write into that bucket's spare capacity and corrupt it for later files.

the `*` list is only the relevant-file paths that contain a `*`, not the whole set, so the extra work is bounded by how many collapsed patterns a profile actually has rather than by the file count.

## How to Test

`go test ./core/services/ -run TestFilterSBOM -count=1`

`TestFilterSBOM_WildcardRelevantPaths` runs a file and the package that owns it through the filter for each placeholder shape.

four of the six fail before this, all of them `*` cases:

```
wildcard spanning several segments   "/usr/lib/*/mod.so"    vs /usr/lib/a/b/mod.so
wildcard spanning none               "/usr/lib/*/mod.so"    vs /usr/lib/mod.so
trailing wildcard                    "/usr/lib/*"           vs /usr/lib/a/b/c
both placeholders together           "/usr/lib/⋯/*/mod.so"  vs /usr/lib/a/b/c/mod.so
```

the other two are the `⋯` cases, one that must match and one that must not, and they pass before and after: the point is to keep #448's index working and to not start over-matching in its place.

## Related issues/PRs:

* Resolved #645
* Follow-up to #448
