### PR TITLE
fix(adapters): give the summary a stable severity stats order

### DIFF
--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -319,8 +320,22 @@ func Summarize(report v1.ScanResultReport, vulnerabilities []containerscan.Commo
 	for sever := range exculdedSeveritiesStats {
 		summary.ExcludedSeveritiesStats = append(summary.ExcludedSeveritiesStats, exculdedSeveritiesStats[sever])
 	}
+	// Both were collected in a map, whose iteration order Go randomises, so without this the
+	// same findings produce a differently ordered summary on every scan. That summary is the
+	// payload posted to the backend, so a consumer diffing two reports for the same image
+	// sees the severity stats move around when nothing about the image changed.
+	sortBySeverity(summary.SeveritiesStats)
+	sortBySeverity(summary.ExcludedSeveritiesStats)
 
 	return &summary, vulnerabilities
+}
+
+// sortBySeverity orders severity stats by severity name, so a summary built from the same
+// findings is byte for byte the same each time.
+func sortBySeverity(stats []containerscan.SeverityStats) {
+	sort.Slice(stats, func(i, j int) bool {
+		return stats[i].Severity < stats[j].Severity
+	})
 }
 
 func getCVEExceptionMatchCVENameFromList(srcCVEList []armotypes.VulnerabilityExceptionPolicy, CVEName string, filterFixed bool) []armotypes.VulnerabilityExceptionPolicy {

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/armosec/utils-k8s-go/armometadata"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/pointer"
 )
 
@@ -559,9 +559,8 @@ func Test_summarize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, _ := Summarize(tt.args.report, tt.args.vulnerabilities, tt.args.workload, tt.args.hasRelevancy, tt.args.imageManifest)
-			sort.Slice(got.SeveritiesStats, func(i, j int) bool {
-				return got.SeveritiesStats[i].Severity < got.SeveritiesStats[j].Severity
-			})
+			// No sorting here on purpose: Summarize orders the severity stats itself now, and
+			// this asserting on the order directly is what keeps it that way.
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -858,4 +857,53 @@ func TestGetCVEExceptionMatch_ExpiredOnFixSkipsWholePolicy(t *testing.T) {
 	assert.Empty(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "CVE-2021-44228", true))
 	assert.Empty(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "GHSA-jfh8", true))
 	assert.Len(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "CVE-2021-44228", false), 1)
+}
+
+// Summarize collected its severity stats in a map and emitted them in iteration order, which
+// Go randomises, so the summary posted to the backend came out ordered differently on every
+// scan of the same image. The existing table test used to sort the result before comparing,
+// which hid it.
+func TestSummarize_SeverityStatsOrderIsStable(t *testing.T) {
+	report := v1.ScanResultReport{Designators: identifiers.PortalDesignator{Attributes: map[string]string{}}}
+	workload := domain.ScanCommand{Wlid: "wlid://cluster-x/namespace-y/deployment-z"}
+
+	// One vulnerability per severity, half of them suppressed, so both the reported and the
+	// excluded stats end up with several entries to order.
+	severities := []string{"Critical", "High", "Medium", "Low", "Negligible"}
+	var vulnerabilities []containerscan.CommonContainerVulnerabilityResult
+	for i, severity := range severities {
+		v := containerscan.CommonContainerVulnerabilityResult{
+			Vulnerability: containerscan.Vulnerability{Name: "CVE-0000-" + severity, Severity: severity},
+		}
+		if i%2 == 0 {
+			v.ExceptionApplied = []armotypes.VulnerabilityExceptionPolicy{
+				{Actions: []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore}},
+			}
+		}
+		vulnerabilities = append(vulnerabilities, v)
+	}
+
+	order := func(stats []containerscan.SeverityStats) []string {
+		out := make([]string, 0, len(stats))
+		for _, s := range stats {
+			out = append(out, s.Severity)
+		}
+		return out
+	}
+
+	// Repeated because a single run could land in the right order by chance.
+	var firstReported, firstExcluded []string
+	for i := 0; i < 20; i++ {
+		got, _ := Summarize(report, append([]containerscan.CommonContainerVulnerabilityResult(nil), vulnerabilities...), workload, false, nil)
+		require.NotEmpty(t, got.SeveritiesStats)
+		require.NotEmpty(t, got.ExcludedSeveritiesStats)
+		if i == 0 {
+			firstReported, firstExcluded = order(got.SeveritiesStats), order(got.ExcludedSeveritiesStats)
+			assert.IsIncreasing(t, firstReported, "reported severity stats must be ordered")
+			assert.IsIncreasing(t, firstExcluded, "excluded severity stats must be ordered")
+			continue
+		}
+		assert.Equal(t, firstReported, order(got.SeveritiesStats), "same findings must give the same order every time")
+		assert.Equal(t, firstExcluded, order(got.ExcludedSeveritiesStats))
+	}
 }


### PR DESCRIPTION
## Overview

`Summarize` built `SeveritiesStats` and `ExcludedSeveritiesStats` by ranging over a map, and go randomises map iteration, so the same findings came out in a different order on every run. that summary is the payload posted to the backend, so two scans of an unchanged image reported their severity stats in a different order each time and anything diffing consecutive reports saw movement that was not there.

both are now sorted by severity name before they go on the summary.

## Additional Information

the existing table test was sorting `SeveritiesStats` itself before comparing, which is the test normalising away something the code should not have been doing. that sort is removed, so the assertion pins the order rather than hiding it. it only ever sorted the reported stats, so `ExcludedSeveritiesStats` was neither ordered nor asserted.

sorting by severity name rather than by rank, since that is what the test was already doing and it needs no severity-to-score table to stay stable.

`parseSeverities` in `repositories/apiserver.go`, which builds the stored CRD summary, walks a slice rather than a map, so it was never affected and is untouched.

## How to Test

`go test ./adapters/v1/ -run Summarize -count=1`

`TestSummarize_SeverityStatsOrderIsStable` builds one vulnerability per severity with every other one suppressed, so both lists have several entries, then calls `Summarize` twenty times and asserts the order is sorted and identical each time. repeated because a single call can land in the right order by chance.

before this it fails on the excluded list being unordered, and on later runs disagreeing with the first.

`Test_summarize`'s expectations are unchanged, they just no longer need the sort in front of them.

## Related issues/PRs:

* Resolved #647


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Severity statistics are now consistently returned in ascending severity-name order.
  * Ordering remains stable for both reported and excluded statistics, including when findings are suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->