### PR TITLE
fix: report every singleflight waiter's own SBOM-creation failure

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -1387,6 +1387,14 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 	select {
 	case res := <-ch:
 		if res.Err != nil {
+			// The leader already reported this failure with its own workload identity
+			// from inside the closure. Every other caller sharing the same result would
+			// otherwise go completely unreported to the backend under its own JobID/Wlid
+			// -- singleflight only executes one closure per key, so this is the only
+			// place a waiter's own failure report can still be sent. See #642.
+			if !ran {
+				s.reportWaiterSBOMFailure(workerCtx, res.Err)
+			}
 			return domain.SBOM{}, nil, res.Err
 		}
 		if !ran {
@@ -1397,4 +1405,20 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 	case <-ctx.Done():
 		return domain.SBOM{}, nil, ctx.Err()
 	}
+}
+
+// reportWaiterSBOMFailure re-emits ReportScanFailure for a singleflight caller whose own
+// closure never ran (a "waiter"), using the same reason/error the leader already reported
+// with its own workload identity. err is always the *domain.ScanError the closure in
+// getOrCreateSBOM returns on failure; the classifySBOMError fallback only guards against
+// that invariant changing.
+func (s *ScanService) reportWaiterSBOMFailure(ctx context.Context, err error) {
+	reason := classifySBOMError(err)
+	reportErr := err
+	var scanErr *domain.ScanError
+	if errors.As(err, &scanErr) {
+		reason = scanErr.Reason
+		reportErr = scanErr.Err
+	}
+	_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration, reason, reportErr)
 }

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2916,6 +2916,15 @@ func (p *failureRecordingPlatform) ReportScanFailure(ctx context.Context, failur
 // each carries a distinct JobID/workload identity the backend/dashboard needs to know that
 // specific scan failed.
 func TestScanService_SingleflightSBOMFailure_ReportsEveryWaiter(t *testing.T) {
+	// Pin the scheduler to one P so the goroutines started below cannot run concurrently with
+	// each other or with this goroutine. Under a single P, a goroutine only yields the
+	// processor by blocking (or explicitly calling runtime.Gosched); none of the code between a
+	// waiter's start and its blocking receive on the singleflight result channel does either, so
+	// each waiter runs start-to-block in one uninterrupted turn. That makes startWg.Wait below a
+	// hard guarantee that every waiter has already joined the shared singleflight.DoChan call by
+	// the time it returns, rather than a timing-based approximation of it.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
+
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
@@ -2966,18 +2975,12 @@ func TestScanService_SingleflightSBOMFailure_ReportsEveryWaiter(t *testing.T) {
 		}()
 	}
 
-	startWg.Wait() // ensure all goroutines are running before unblocking the singleflight worker
-	<-started      // wait for the singleflight worker to enter CreateSBOM
-
-	// startWg only proves each goroutine began running, not that it has reached its
-	// singleflight.DoChan call yet -- give the scheduler a generous window to actually get
-	// every waiter registered on the same key before the leader's CreateSBOM is allowed to
-	// return, otherwise a slow-to-schedule waiter can miss the shared call entirely and
-	// trigger its own (spurious) second CreateSBOM execution.
-	for i := 0; i < 1000; i++ {
-		runtime.Gosched()
-	}
-	time.Sleep(50 * time.Millisecond)
+	// With GOMAXPROCS(1) above, this Wait returning already proves every waiter has joined the
+	// shared singleflight.DoChan call: the last one to call startWg.Done can only yield the
+	// processor by blocking on the result channel, so it -- and by the same argument every
+	// waiter before it -- is already parked on <-ch by the time this goroutine runs again.
+	startWg.Wait()
+	<-started // wait for the singleflight worker to enter CreateSBOM
 
 	close(release) // let CreateSBOM return its error
 	wg.Wait()

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2757,15 +2758,20 @@ type blockingSBOMCreator struct {
 	ports.SBOMCreator
 	calls   int
 	onStart func()
+	failErr error
 	mu      sync.Mutex
 }
 
 func (b *blockingSBOMCreator) CreateSBOM(ctx context.Context, name, imageID, imageTag string, options domain.RegistryOptions) (domain.SBOM, error) {
 	b.mu.Lock()
 	b.calls++
+	failErr := b.failErr
 	b.mu.Unlock()
 	if b.onStart != nil {
 		b.onStart()
+	}
+	if failErr != nil {
+		return domain.SBOM{}, failErr
 	}
 	return b.SBOMCreator.CreateSBOM(ctx, name, imageID, imageTag, options)
 }
@@ -2882,4 +2888,106 @@ func TestScanService_SingleflightSBOMDeduplication(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, 1, blockingCreator.calls, "CreateSBOM should be called exactly once for concurrent identical requests")
+}
+
+// failureRecordingPlatform is a minimal, concurrency-safe ports.Platform double that records
+// every ReportScanFailure call's JobID (read from the ctx WorkloadKey each caller passes in),
+// so a test can assert which distinct callers actually had their failure reported.
+type failureRecordingPlatform struct {
+	adapters.MockPlatform
+	mu      sync.Mutex
+	jobIDs  []string
+	reports int
+}
+
+func (p *failureRecordingPlatform) ReportScanFailure(ctx context.Context, failureCase scanfailure.ScanFailureCase, reason string, scanErr error) error {
+	workload, _ := ctx.Value(domain.WorkloadKey{}).(domain.ScanCommand)
+	p.mu.Lock()
+	p.reports++
+	p.jobIDs = append(p.jobIDs, workload.JobID)
+	p.mu.Unlock()
+	return p.MockPlatform.ReportScanFailure(ctx, failureCase, reason, scanErr)
+}
+
+// TestScanService_SingleflightSBOMFailure_ReportsEveryWaiter is a regression test for #642:
+// when N concurrent callers for the same image are deduplicated onto one singleflight
+// execution and that execution fails, every one of the N callers -- not just the "leader"
+// whose closure singleflight actually ran -- must get its own ReportScanFailure call, since
+// each carries a distinct JobID/workload identity the backend/dashboard needs to know that
+// specific scan failed.
+func TestScanService_SingleflightSBOMFailure_ReportsEveryWaiter(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+
+	wantErr := errors.New("registry pull failed")
+	blockingCreator := &blockingSBOMCreator{
+		SBOMCreator: adapters.NewMockSBOMAdapter(false, false, false),
+		failErr:     wantErr,
+		onStart: func() {
+			once.Do(func() { close(started) })
+			<-release
+		},
+	}
+
+	platform := &failureRecordingPlatform{}
+	service := NewScanService(
+		blockingCreator,
+		repositories.NewMemoryStorage(false, false),
+		adapters.NewMockCVEAdapter(),
+		repositories.NewMemoryStorage(false, false),
+		platform,
+		adapters.NewMockRelevancyAdapter(),
+		true, false, true, false, false,
+	)
+
+	const numGoroutines = 5
+	wantJobIDs := make([]string, numGoroutines)
+	var startWg, wg sync.WaitGroup
+	startWg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		jobID := fmt.Sprintf("job-%d", i)
+		wantJobIDs[i] = jobID
+		workload := domain.ScanCommand{
+			JobID:              jobID,
+			ImageSlug:          "library/alpine:latest",
+			ImageTagNormalized: "library/alpine:latest",
+			ImageHash:          "sha256:1234567890",
+		}
+		ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startWg.Done()
+			_, _, err := service.getOrCreateSBOM(ctx, workload)
+			assert.ErrorIs(t, err, wantErr)
+		}()
+	}
+
+	startWg.Wait() // ensure all goroutines are running before unblocking the singleflight worker
+	<-started      // wait for the singleflight worker to enter CreateSBOM
+
+	// startWg only proves each goroutine began running, not that it has reached its
+	// singleflight.DoChan call yet -- give the scheduler a generous window to actually get
+	// every waiter registered on the same key before the leader's CreateSBOM is allowed to
+	// return, otherwise a slow-to-schedule waiter can miss the shared call entirely and
+	// trigger its own (spurious) second CreateSBOM execution.
+	for i := 0; i < 1000; i++ {
+		runtime.Gosched()
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	close(release) // let CreateSBOM return its error
+	wg.Wait()
+
+	assert.Equal(t, 1, blockingCreator.calls, "CreateSBOM should still be called exactly once")
+
+	platform.mu.Lock()
+	defer platform.mu.Unlock()
+	assert.Equal(t, numGoroutines, platform.reports,
+		"every caller sharing the failed singleflight result must get its own ReportScanFailure call")
+	assert.ElementsMatch(t, wantJobIDs, platform.jobIDs,
+		"each ReportScanFailure call must carry the reporting caller's own JobID, not just the leader's")
 }


### PR DESCRIPTION
## Overview

`ScanService.getOrCreateSBOM` deduplicates concurrent SBOM-creation requests for the same image via `singleflight.Group.DoChan`. When creation fails, only the caller whose closure singleflight actually executed (the "leader") got a `ReportScanFailure` call, using its own workload identity from inside the closure. Every other caller sharing that same failed result received `res.Err` back and returned it up its own call stack without any further backend call.

Since `ReportScanFailure` builds its report entirely from `ctx.Value(domain.WorkloadKey{})` (JobID, Wlid, ContainerName, etc.), those waiters' scans never got reported to the backend under their own identity. From the dashboard's perspective, N-1 of N concurrently-deduplicated scans simply never resolve — no failure, no completion signal at all.

**Root cause:** the failure-reporting side effect (`ReportScanFailure`) lived inside the singleflight closure, which only the leader executes. The dedup mechanics correctly share one SBOM/error result across callers, but the report was never re-emitted per distinct caller after that shared result is delivered.

**Fix:** after `res := <-ch` is received in `getOrCreateSBOM`, if `res.Err != nil` and this caller wasn't the leader (`!ran`), it now calls a small helper, `reportWaiterSBOMFailure`, which re-emits `ReportScanFailure` using the waiter's own `ctx` and the reason/error already classified on the shared `*domain.ScanError`. The leader's own report (sent inside the closure) is not duplicated. No change to the success path or to single-caller (non-deduplicated) failures.

## How to Test

```
go test ./core/services/... -run TestScanService_SingleflightSBOM -v
```

`TestScanService_SingleflightSBOMFailure_ReportsEveryWaiter` runs 5 concurrent goroutines with distinct `JobID`s calling `getOrCreateSBOM` for the same image against a `CreateSBOM` that blocks then fails; it asserts `CreateSBOM` is called exactly once (dedup preserved) and that all 5 distinct `JobID`s show up in the recorded `ReportScanFailure` calls.

`go build ./...`, `go vet ./core/services/...`, and `go test ./core/services/...` all pass, including the existing `TestScanService_SingleflightSBOMDeduplication`.

## Related issues/PRs:

* Resolved #642

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure reporting when concurrent SBOM generation requests fail.
  * Each affected scan now receives an individual failure report with the correct job details.
  * Prevented missing or incomplete error classification for non-primary requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->