### PR TITLE
fix(adapters): normalize trusted vendor slugs before matching distros

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -97,10 +97,32 @@ func NewGrypeAdapter(listingURL string, matchingMode config.CVEMatchingMode, tru
 }
 
 // buildTrustedVendorSet maps configured vendor slugs to Grype distro types.
+//
+// Grype's distro types are lowercase slugs that it compares verbatim, so a configured slug
+// is normalised rather than taken as written: "Wolfi", or one with the whitespace a JSON
+// list easily carries, would otherwise sit in the set as a key no distro ever matches, and
+// the vendor would stay untrusted with nothing to say so. A slug that is not one of Grype's
+// types cannot match either, so it is called out for the same reason: adaptive mode is meant
+// to turn CPE matching off for these vendors, and a typo silently leaves it on.
 func buildTrustedVendorSet(vendors []string) map[distro.Type]bool {
+	known := make(map[distro.Type]bool, len(distro.All))
+	for _, t := range distro.All {
+		known[t] = true
+	}
+
 	set := make(map[distro.Type]bool, len(vendors))
 	for _, v := range vendors {
-		set[distro.Type(v)] = true
+		slug := distro.Type(strings.ToLower(strings.TrimSpace(v)))
+		if slug == "" {
+			continue
+		}
+		if !known[slug] {
+			// Kept in the set regardless: it can never match, and dropping it would be a
+			// second silent behaviour rather than a reported one.
+			logger.L().Warning("trusted vendor is not a distro Grype recognizes, it will never match",
+				helpers.String("vendor", v))
+		}
+		set[slug] = true
 	}
 	return set
 }

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -313,3 +313,42 @@ func Test_grypeAdapter_Ready_singleFlightUnderConcurrency(t *testing.T) {
 	waitForNotUpdating(t, g)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent Ready() calls must not launch more than one background load")
 }
+
+// Grype's distro types are lowercase slugs compared verbatim, so a configured vendor was
+// only trusted when written exactly that way. "Wolfi", or a slug with the whitespace a JSON
+// list easily carries, went into the set as a key nothing matches, and adaptive mode quietly
+// kept CPE matching on for a vendor the operator had asked it to trust.
+func TestBuildTrustedVendorSet_NormalizesSlugs(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		trusted    bool
+	}{
+		{"canonical", "wolfi", true},
+		{"capitalised", "Wolfi", true},
+		{"upper case", "WOLFI", true},
+		{"leading space", " wolfi", true},
+		{"trailing space", "wolfi ", true},
+		{"a different vendor", "chainguard", false},
+		{"not a distro at all", "not-a-distro", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GrypeAdapter{
+				matchingMode:   config.CVEMatchingAdaptive,
+				trustedVendors: buildTrustedVendorSet([]string{tt.configured}),
+			}
+			// useDefaultMatchers is true exactly when the distro is trusted, which is what
+			// turns the CPE matchers off for it.
+			assert.Equal(t, tt.trusted, g.resolveUseDefaultMatchers(&distro.Distro{Type: distro.Wolfi}),
+				"vendor %q against a wolfi image", tt.configured)
+		})
+	}
+}
+
+// An empty entry is dropped rather than becoming a key that matches a distro with no type.
+func TestBuildTrustedVendorSet_SkipsEmpty(t *testing.T) {
+	set := buildTrustedVendorSet([]string{"", "   ", "wolfi"})
+	assert.Equal(t, map[distro.Type]bool{distro.Wolfi: true}, set)
+}


### PR DESCRIPTION
## Overview

`buildTrustedVendorSet` converted each configured slug straight to a `distro.Type`. Grype's types are lowercase slugs it compares verbatim, so `"Wolfi"`, `"WOLFI"` or `"wolfi "` went into the set as keys no distro ever matches and the vendor stayed untrusted.

the failure is silent, and it undoes the setting: adaptive mode is what turns CPE matching off for a trusted vendor, so the image keeps being matched by CPE and reporting the false positives the setting exists to remove, with nothing logged to say the slug did not take.

slugs are now lowercased and trimmed, so all of those forms resolve to the same vendor. a slug that is not one of Grype's distros is also logged, since it fails in exactly the same quiet way. it is kept in the set rather than dropped: it can never match anyway, and dropping it would replace one silent behaviour with another.

## Additional Information

whitespace mattered on the config file path in particular. #593 trims the env form of the value, but the file form goes through `GetStringSlice` untouched, so `"trustedVendors": ["wolfi "]` arrived with the space attached.

the warning is safe against the defaults: `distro.All` holds all 24 types and `echo`, `chainguard`, `wolfi` and `minimos` are all among them, so the out-of-the-box configuration logs nothing.

## How to Test

`go test ./adapters/v1/ -run TestBuildTrustedVendorSet -count=1`

- `TestBuildTrustedVendorSet_NormalizesSlugs` resolves each spelling of a vendor against a wolfi image and checks whether it comes out trusted, including a different vendor and a slug that is not a distro, so it pins what must not match as well.
- `TestBuildTrustedVendorSet_SkipsEmpty` covers an empty entry, which would otherwise become a key matching a distro with no type.

four of the seven cases fail before this: capitalised, upper case, leading space and trailing space.

## Related issues/PRs:

* Resolved #650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trusted vendor settings now consistently handle capitalization and surrounding whitespace.
  * Empty vendor entries are ignored.
  * Unrecognized vendor values generate a warning while preserving non-empty entries for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->