### PR TITLE
fix(repositories): invalidate SecurityException cache on CRD changes

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -29,14 +29,17 @@ import (
 	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
+	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -77,6 +80,8 @@ type APIServerStore struct {
 	// nil is safe (falls back to always listing, e.g. in tests that construct APIServerStore
 	// literals directly instead of through the constructors below).
 	securityExceptionListCache *cache.Cache
+
+	securityExceptionInformerStop context.CancelFunc
 }
 
 var (
@@ -128,12 +133,14 @@ func NewAPIServerStorage(namespace string) (*APIServerStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &APIServerStore{
+	store := &APIServerStore{
 		StorageClient:              clientset.SpdxV1beta1(),
 		DynamicClient:              dynClient,
 		Namespace:                  namespace,
 		securityExceptionListCache: cache.New(securityExceptionListCacheCleaningInterval),
-	}, nil
+	}
+	store.enableSecurityExceptionCacheInvalidation(context.Background())
+	return store, nil
 }
 
 type fakeStorageClientset struct {
@@ -202,6 +209,90 @@ func newFakeAPIServerStore(namespace string, storageClient spdxv1beta1.SpdxV1bet
 
 func NewFakeAPIServerStorage(namespace string, objects ...runtime.Object) *APIServerStore {
 	return newFakeAPIServerStore(namespace, newFakeStorageClientset(objects...).SpdxV1beta1())
+}
+
+func (a *APIServerStore) enableSecurityExceptionCacheInvalidation(ctx context.Context) {
+	if a == nil || a.DynamicClient == nil || a.securityExceptionListCache == nil || a.securityExceptionInformerStop != nil {
+		return
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(a.DynamicClient, 0, metav1.NamespaceAll, nil)
+
+	if _, err := factory.ForResource(securityExceptionGVR).Informer().AddEventHandler(k8scache.ResourceEventHandlerFuncs{
+		AddFunc:    a.invalidateSecurityExceptionCacheForObject,
+		UpdateFunc: func(_, newObj interface{}) { a.invalidateSecurityExceptionCacheForObject(newObj) },
+		DeleteFunc: a.invalidateSecurityExceptionCacheForObject,
+	}); err != nil {
+		cancel()
+		logger.L().Warning("failed to register SecurityException cache invalidation handler", helpers.Error(err))
+		return
+	}
+
+	if _, err := factory.ForResource(clusterSecurityExceptionGVR).Informer().AddEventHandler(k8scache.ResourceEventHandlerFuncs{
+		AddFunc:    func(interface{}) { a.invalidateClusterSecurityExceptionCache() },
+		UpdateFunc: func(interface{}, interface{}) { a.invalidateClusterSecurityExceptionCache() },
+		DeleteFunc: func(interface{}) { a.invalidateClusterSecurityExceptionCache() },
+	}); err != nil {
+		cancel()
+		logger.L().Warning("failed to register ClusterSecurityException cache invalidation handler", helpers.Error(err))
+		return
+	}
+
+	a.securityExceptionInformerStop = cancel
+	go factory.Start(watchCtx.Done())
+}
+
+func (a *APIServerStore) invalidateSecurityExceptionCacheForObject(obj interface{}) {
+	if a == nil || a.securityExceptionListCache == nil {
+		return
+	}
+
+	u := unstructuredFromEvent(obj)
+	if u == nil {
+		a.invalidateAllSecurityExceptionCaches()
+		return
+	}
+	if namespace := u.GetNamespace(); namespace != "" {
+		a.securityExceptionListCache.Delete("se/" + namespace)
+		return
+	}
+	a.invalidateAllSecurityExceptionCaches()
+}
+
+func (a *APIServerStore) invalidateClusterSecurityExceptionCache() {
+	if a == nil || a.securityExceptionListCache == nil {
+		return
+	}
+	a.securityExceptionListCache.Delete(clusterSecurityExceptionListCacheKey)
+}
+
+func (a *APIServerStore) invalidateAllSecurityExceptionCaches() {
+	if a == nil || a.securityExceptionListCache == nil {
+		return
+	}
+	a.securityExceptionListCache.Range(func(key, _ interface{}) bool {
+		if cacheKey, ok := key.(string); ok && strings.HasPrefix(cacheKey, "se/") {
+			a.securityExceptionListCache.Delete(cacheKey)
+		}
+		return true
+	})
+}
+
+func unstructuredFromEvent(obj interface{}) *unstructured.Unstructured {
+	switch typed := obj.(type) {
+	case *unstructured.Unstructured:
+		return typed
+	case k8scache.DeletedFinalStateUnknown:
+		if u, ok := typed.Obj.(*unstructured.Unstructured); ok {
+			return u
+		}
+	case *k8scache.DeletedFinalStateUnknown:
+		if u, ok := typed.Obj.(*unstructured.Unstructured); ok {
+			return u
+		}
+	}
+	return nil
 }
 
 // GetSecurityExceptions lists both namespaced SecurityExceptions and cluster-scoped

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/tools"
+	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	spdxv1beta1 "github.com/kubescape/storage/pkg/generated/clientset/versioned/typed/softwarecomposition/v1beta1"
 	"github.com/openvex/go-vex/pkg/vex"
@@ -2050,6 +2051,39 @@ func TestAPIServerStore_GetSecurityExceptions_DoesNotCacheListFailures(t *testin
 	_, _, err = a.GetSecurityExceptions(context.TODO(), "")
 	require.NoError(t, err, "a failed List() must not be cached, so the next call retries instead of replaying the failure")
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestAPIServerStore_InvalidateSecurityExceptionCacheForObject(t *testing.T) {
+	a := &APIServerStore{securityExceptionListCache: cache.New(time.Minute)}
+	a.securityExceptionListCache.Set("se/ns-a", []sev1beta1.SecurityException{{}}, time.Minute)
+	a.securityExceptionListCache.Set("se/ns-b", []sev1beta1.SecurityException{{}}, time.Minute)
+	a.securityExceptionListCache.Set(clusterSecurityExceptionListCacheKey, []sev1beta1.ClusterSecurityException{{}}, time.Minute)
+
+	a.invalidateSecurityExceptionCacheForObject(&unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "ns-a",
+		},
+	}})
+
+	_, ok := a.securityExceptionListCache.Get("se/ns-a")
+	assert.False(t, ok, "the changed namespace must be evicted immediately")
+	_, ok = a.securityExceptionListCache.Get("se/ns-b")
+	assert.True(t, ok, "other namespaces must stay cached")
+	_, ok = a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey)
+	assert.True(t, ok, "cluster-scoped exceptions must not be evicted by a namespaced change")
+}
+
+func TestAPIServerStore_InvalidateClusterSecurityExceptionCache(t *testing.T) {
+	a := &APIServerStore{securityExceptionListCache: cache.New(time.Minute)}
+	a.securityExceptionListCache.Set("se/ns-a", []sev1beta1.SecurityException{{}}, time.Minute)
+	a.securityExceptionListCache.Set(clusterSecurityExceptionListCacheKey, []sev1beta1.ClusterSecurityException{{}}, time.Minute)
+
+	a.invalidateClusterSecurityExceptionCache()
+
+	_, ok := a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey)
+	assert.False(t, ok, "cluster-scoped cache must be evicted immediately")
+	_, ok = a.securityExceptionListCache.Get("se/ns-a")
+	assert.True(t, ok, "namespaced exceptions must stay cached")
 }
 
 // ctxCapturingResource wraps a dynamic.ResourceInterface, invoking a hook synchronously with


### PR DESCRIPTION
## Overview
This wires a best effort informer based invalidation path into `APIServerStore` so the existing shared `SecurityException` list cache is evicted as soon as the backing CRDs change instead of waiting for the 30 second TTL to expire.

The fetch path is unchanged. Repeated scans still reuse the existing cached `List()` results between change events, but namespaced cache keys are now evicted on `SecurityException` add, update, and delete events, and the cluster wide cache key is evicted on `ClusterSecurityException` add, update, and delete events.

## Additional Information
This stays scoped to the exception fetch cache in `repositories/apiserver.go` and adds focused regression coverage in `repositories/apiserver_test.go` for namespaced and cluster scoped invalidation. No unrelated files were changed.

## How to Test
1. `go test ./repositories/...`
2. `make verify`

## Related issues/PRs:
Resolved #652

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security exception data now refreshes automatically when relevant Kubernetes resources are created, updated, or deleted.
  * Changes to namespaced resources refresh only the affected namespace, while cluster-wide changes refresh the appropriate cluster-level data.
  * Unexpected resource events now trigger a broader cache refresh to prevent stale results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->