### PR TITLE
fix: preserve SecurityException VEX semantics

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -227,6 +227,9 @@ func buildSuppressionAttributes(spec sev1beta1.SecurityExceptionSpec, vuln sev1b
 		"sourceKind": src.kind,
 		"ruleId":     suppressionRuleID(src),
 	}
+	if status := strings.TrimSpace(string(vuln.Status)); status != "" {
+		attrs["status"] = status
+	}
 	if src.namespace != "" {
 		attrs["sourceNamespace"] = src.namespace
 	}
@@ -378,6 +381,9 @@ func buildIgnoreRule(m v1beta1.Match, matched []armotypes.VulnerabilityException
 	if ns, ok := p.Attributes["sourceNamespace"].(string); ok {
 		rule.SourceNamespace = ns
 	}
+	if status, ok := p.Attributes["status"].(string); ok {
+		rule.FixState = status
+	}
 	if just, ok := p.Attributes["justification"].(string); ok {
 		rule.Justification = just
 	}
@@ -513,7 +519,13 @@ func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 		return false
 	}
 	r := im.AppliedIgnoreRules[0]
-	return r.FixState == "" && r.Package == nil
+	if r.Package != nil {
+		return false
+	}
+	if r.SourceKind != "" || r.SourceName != "" || r.SourceNamespace != "" || r.Justification != "" || r.ImpactStatement != "" {
+		return true
+	}
+	return r.FixState == ""
 }
 
 // IgnoredMatchKeys returns the set of match-identity keys for a manifest's ignored matches.

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -382,6 +382,11 @@ func buildIgnoreRule(m v1beta1.Match, matched []armotypes.VulnerabilityException
 		rule.SourceNamespace = ns
 	}
 	if status, ok := p.Attributes["status"].(string); ok {
+		// FixState is repurposed here to carry the SecurityException's status vocabulary
+		// (not_affected/fixed/affected) rather than Grype's native fix-state vocabulary.
+		// This is safe because every reader of FixState gates on SourceKind being a
+		// SecurityException/ClusterSecurityException first — native Grype ignore rules
+		// never set SourceKind, so they're unaffected.
 		rule.FixState = status
 	}
 	if just, ok := p.Attributes["justification"].(string); ok {
@@ -512,8 +517,8 @@ func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument
 }
 
 // isExceptionSourcedIgnore reports whether an ignored match carries the AppliedIgnoreRules
-// signature ApplySecurityExceptions writes: exactly one rule whose only field is the
-// vulnerability ID.
+// signature ApplySecurityExceptions writes: exactly one rule with no package set, and either
+// exception provenance (source/justification/impact) or an empty FixState.
 func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 	if len(im.AppliedIgnoreRules) != 1 {
 		return false

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -107,6 +107,7 @@ func TestConvertVulnerabilityExceptions_SuppressionProvenance(t *testing.T) {
 	assert.Equal(t, "allow-log4shell", nsPolicy.Name)
 	assert.Equal(t, "SecurityException", nsPolicy.Attributes["sourceKind"])
 	assert.Equal(t, "SecurityException/prod/allow-log4shell", nsPolicy.Attributes["ruleId"])
+	assert.Equal(t, "not_affected", nsPolicy.Attributes["status"])
 	assert.Equal(t, "prod", nsPolicy.Attributes["sourceNamespace"])
 	assert.Equal(t, "vulnerable code path is unreachable", nsPolicy.Attributes["justification"])
 	assert.Equal(t, "no network exposure", nsPolicy.Attributes["impactStatement"])
@@ -298,6 +299,7 @@ func TestApplySecurityExceptions_PopulatesIgnoreRuleProvenance(t *testing.T) {
 					"sourceKind":      "SecurityException",
 					"ruleId":          "SecurityException/production/allow-log4shell",
 					"sourceNamespace": "production",
+					"status":          "not_affected",
 					"justification":   "vulnerable_code_not_present",
 					"impactStatement": "Vulnerable component is not loaded into the memory",
 				},
@@ -319,6 +321,7 @@ func TestApplySecurityExceptions_PopulatesIgnoreRuleProvenance(t *testing.T) {
 	assert.Equal(t, "SecurityException/production/allow-log4shell", rule.SourceName,
 		"SourceName carries the structured ruleId form, not the bare object name, so it stays unambiguous for cluster-scoped exceptions too")
 	assert.Equal(t, "production", rule.SourceNamespace)
+	assert.Equal(t, "not_affected", rule.FixState)
 	assert.Equal(t, "vulnerable_code_not_present", rule.Justification)
 	assert.Equal(t, "Vulnerable component is not loaded into the memory", rule.ImpactStatement)
 }

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1071,6 +1071,95 @@ func statementHasPURL(products []v1beta1.Product, purl string) bool {
 // more specific remediation string.
 const defaultActionStatement = "Upgrade the vulnerable component to a version that is not affected"
 
+const (
+	defaultLocalImpactStatement         = "Vulnerable component is not loaded into the memory"
+	securityExceptionImpactStatement    = "Vulnerability was ignored by a SecurityException"
+	securityExceptionAcceptedRiskAction = "A SecurityException accepted this vulnerability as an affected finding"
+)
+
+type ignoredVEXAssessment struct {
+	status          v1beta1.Status
+	justification   v1beta1.Justification
+	impactStatement string
+	actionStatement string
+	statusNotes     string
+}
+
+func defaultIgnoredVEXAssessment() ignoredVEXAssessment {
+	return ignoredVEXAssessment{
+		status:          v1beta1.Status(vex.StatusNotAffected),
+		justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
+		impactStatement: securityExceptionImpactStatement,
+	}
+}
+
+func ignoredMatchAssessment(m v1beta1.IgnoredMatch) ignoredVEXAssessment {
+	assessment := defaultIgnoredVEXAssessment()
+	rule, ok := securityExceptionIgnoreRule(m)
+	if !ok {
+		return assessment
+	}
+
+	switch strings.TrimSpace(rule.FixState) {
+	case string(sev1beta1.VulnerabilityStatusFixed):
+		assessment.status = v1beta1.Status(sev1beta1.VulnerabilityStatusFixed)
+		assessment.justification = ""
+		assessment.impactStatement = ""
+		assessment.statusNotes = ignoredMatchStatusNotes(rule)
+	case string(sev1beta1.VulnerabilityStatusAffected):
+		assessment.status = v1beta1.Status(vex.StatusAffected)
+		assessment.justification = ""
+		assessment.impactStatement = ""
+		assessment.actionStatement = securityExceptionAcceptedRiskAction
+		assessment.statusNotes = ignoredMatchStatusNotes(rule)
+	case "", string(sev1beta1.VulnerabilityStatusNotAffected):
+		if j := strings.TrimSpace(rule.Justification); j != "" {
+			assessment.justification = v1beta1.Justification(j)
+		}
+		if impact := strings.TrimSpace(rule.ImpactStatement); impact != "" {
+			assessment.impactStatement = impact
+		}
+	default:
+		if j := strings.TrimSpace(rule.Justification); j != "" {
+			assessment.justification = v1beta1.Justification(j)
+		}
+		if impact := strings.TrimSpace(rule.ImpactStatement); impact != "" {
+			assessment.impactStatement = impact
+		}
+	}
+
+	return assessment
+}
+
+func securityExceptionIgnoreRule(m v1beta1.IgnoredMatch) (v1beta1.IgnoreRule, bool) {
+	for _, rule := range m.AppliedIgnoreRules {
+		switch rule.SourceKind {
+		case "SecurityException", "ClusterSecurityException":
+			return rule, true
+		}
+	}
+	return v1beta1.IgnoreRule{}, false
+}
+
+func ignoredMatchStatusNotes(rule v1beta1.IgnoreRule) string {
+	parts := make([]string, 0, 2)
+	if j := strings.TrimSpace(rule.Justification); j != "" {
+		parts = append(parts, "justification: "+j)
+	}
+	if impact := strings.TrimSpace(rule.ImpactStatement); impact != "" {
+		parts = append(parts, "impact: "+impact)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func applyIgnoredMatchAssessment(stmt *v1beta1.Statement, assessment ignoredVEXAssessment) {
+	stmt.Status = assessment.status
+	stmt.Justification = assessment.justification
+	stmt.ImpactStatement = assessment.impactStatement
+	stmt.ActionStatement = assessment.actionStatement
+	stmt.StatusNotes = assessment.statusNotes
+}
+
 // buildActionStatement returns a remediation string for an affected VEX statement. When the
 // match reports a fixed state with known fix versions, it names them; otherwise it falls back
 // to defaultActionStatement.
@@ -1104,6 +1193,7 @@ func markRelevantVulnerabilitiesAsAffectedInVex(vexDoc *v1beta1.VEX, cvep *domai
 							vexDoc.Statements[i].Justification = ""
 							vexDoc.Statements[i].ImpactStatement = ""
 							vexDoc.Statements[i].ActionStatement = buildActionStatement(v)
+							vexDoc.Statements[i].StatusNotes = ""
 							foundProduct = true
 						}
 						if foundProduct {
@@ -1173,7 +1263,7 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 
 				Status:          v1beta1.Status(vex.StatusNotAffected),
 				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-				ImpactStatement: "Vulnerable component is not loaded into the memory",
+				ImpactStatement: defaultLocalImpactStatement,
 			})
 		}
 
@@ -1189,7 +1279,7 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 				return err
 			}
 
-			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
+			stmt := v1beta1.Statement{
 				ID: fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(v.Vulnerability.ID), url.PathEscape(v.Artifact.PURL)),
 				Vulnerability: v1beta1.VexVulnerability{
 					ID:          v.Vulnerability.DataSource,
@@ -1201,11 +1291,9 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 				Products: []v1beta1.Product{
 					*product,
 				},
-
-				Status:          v1beta1.Status(vex.StatusNotAffected),
-				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-				ImpactStatement: "Vulnerability was ignored by a SecurityException",
-			})
+			}
+			applyIgnoredMatchAssessment(&stmt, ignoredMatchAssessment(v))
+			vexDoc.Statements = append(vexDoc.Statements, stmt)
 		}
 	}
 
@@ -1255,9 +1343,7 @@ func markIgnoredVulnerabilitiesInVex(vexDoc *v1beta1.VEX, cve *domain.CVEManifes
 					for _, sc := range p.Subcomponents {
 						if sc.ID == v.Artifact.PURL {
 							vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
-							vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
-							vexDoc.Statements[i].ImpactStatement = "Vulnerability was ignored by a SecurityException"
-							vexDoc.Statements[i].ActionStatement = ""
+							applyIgnoredMatchAssessment(&vexDoc.Statements[i], ignoredMatchAssessment(v))
 							foundProduct = true
 						}
 						if foundProduct {
@@ -1343,7 +1429,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 
 					Status:          v1beta1.Status(vex.StatusNotAffected),
 					Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-					ImpactStatement: "Vulnerable component is not loaded into the memory",
+					ImpactStatement: defaultLocalImpactStatement,
 				})
 			}
 		}
@@ -1378,7 +1464,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 					return err
 				}
 
-				vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
+				stmt := v1beta1.Statement{
 					ID: fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(v.Vulnerability.ID), url.PathEscape(v.Artifact.PURL)),
 					Vulnerability: v1beta1.VexVulnerability{
 						ID:          v.Vulnerability.DataSource,
@@ -1390,21 +1476,19 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 					Products: []v1beta1.Product{
 						*product,
 					},
-
-					Status:          v1beta1.Status(vex.StatusNotAffected),
-					Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-					ImpactStatement: "Vulnerability was ignored by a SecurityException",
-				})
+				}
+				applyIgnoredMatchAssessment(&stmt, ignoredMatchAssessment(v))
+				vexDoc.Statements = append(vexDoc.Statements, stmt)
 			}
 		}
 	}
 
 	// ignoredMap drives the "reset every statement" pass below; guarded the same way as the
 	// Matches/IgnoredMatches loops above, since it reads the same cve.Content.
-	ignoredMap := make(map[string]bool)
+	ignoredMap := make(map[string]ignoredVEXAssessment)
 	if cve.Content != nil {
 		for _, v := range cve.Content.IgnoredMatches {
-			ignoredMap[v.Vulnerability.ID+v.Artifact.PURL] = true
+			ignoredMap[v.Vulnerability.ID+v.Artifact.PURL] = ignoredMatchAssessment(v)
 		}
 	}
 
@@ -1419,16 +1503,21 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 
 		vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
 		vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
+		vexDoc.Statements[i].ImpactStatement = defaultLocalImpactStatement
 		vexDoc.Statements[i].ActionStatement = ""
+		vexDoc.Statements[i].StatusNotes = ""
 
+		var assessment ignoredVEXAssessment
 		isIgnored := anyPURLMatches(vexDoc.Statements[i].Products, func(purl string) bool {
-			return ignoredMap[vexDoc.Statements[i].Vulnerability.Name+purl]
+			if ignoredAssessment, ok := ignoredMap[vexDoc.Statements[i].Vulnerability.Name+purl]; ok {
+				assessment = ignoredAssessment
+				return true
+			}
+			return false
 		})
 
 		if isIgnored {
-			vexDoc.Statements[i].ImpactStatement = "Vulnerability was ignored by a SecurityException"
-		} else {
-			vexDoc.Statements[i].ImpactStatement = "Vulnerable component is not loaded into the memory"
+			applyIgnoredMatchAssessment(&vexDoc.Statements[i], assessment)
 		}
 	}
 

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1112,14 +1112,9 @@ func ignoredMatchAssessment(m v1beta1.IgnoredMatch) ignoredVEXAssessment {
 		assessment.impactStatement = ""
 		assessment.actionStatement = securityExceptionAcceptedRiskAction
 		assessment.statusNotes = ignoredMatchStatusNotes(rule)
-	case "", string(sev1beta1.VulnerabilityStatusNotAffected):
-		if j := strings.TrimSpace(rule.Justification); j != "" {
-			assessment.justification = v1beta1.Justification(j)
-		}
-		if impact := strings.TrimSpace(rule.ImpactStatement); impact != "" {
-			assessment.impactStatement = impact
-		}
 	default:
+		// Any unrecognized status (including "" and NotAffected) falls back to the safe
+		// not_affected-shaped assessment.
 		if j := strings.TrimSpace(rule.Justification); j != "" {
 			assessment.justification = v1beta1.Justification(j)
 		}
@@ -1342,7 +1337,6 @@ func markIgnoredVulnerabilitiesInVex(vexDoc *v1beta1.VEX, cve *domain.CVEManifes
 				for _, p := range s.Products {
 					for _, sc := range p.Subcomponents {
 						if sc.ID == v.Artifact.PURL {
-							vexDoc.Statements[i].Status = v1beta1.Status(vex.StatusNotAffected)
 							applyIgnoredMatchAssessment(&vexDoc.Statements[i], ignoredMatchAssessment(v))
 							foundProduct = true
 						}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -452,6 +452,122 @@ func TestAPIServerStore_storeVEX_ignoredMatches_append(t *testing.T) {
 	assert.True(t, foundIgnored2, "Second IgnoredMatch should be included in the VEX document during update")
 }
 
+func TestAPIServerStore_storeVEX_preservesSecurityExceptionSemantics(t *testing.T) {
+	ignoredMatches := []v1beta1.IgnoredMatch{
+		{
+			Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-NOT-AFFECTED", DataSource: "https://example.test/CVE-NOT-AFFECTED"},
+				},
+				Artifact: v1beta1.GrypePackage{PURL: "pkg:deb/debian/not-affected@1.0"},
+			},
+			AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+				Vulnerability:   "CVE-NOT-AFFECTED",
+				SourceKind:      "SecurityException",
+				SourceName:      "SecurityException/default/not-affected",
+				SourceNamespace: "default",
+				FixState:        string(sev1beta1.VulnerabilityStatusNotAffected),
+				Justification:   "component is compiled without the vulnerable feature",
+				ImpactStatement: "runtime path is unreachable in this deployment",
+			}},
+		},
+		{
+			Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-FIXED", DataSource: "https://example.test/CVE-FIXED"},
+				},
+				Artifact: v1beta1.GrypePackage{PURL: "pkg:deb/debian/fixed@2.0"},
+			},
+			AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+				Vulnerability:   "CVE-FIXED",
+				SourceKind:      "SecurityException",
+				SourceName:      "SecurityException/default/fixed",
+				SourceNamespace: "default",
+				FixState:        string(sev1beta1.VulnerabilityStatusFixed),
+				Justification:   "patch validated in downstream image build",
+				ImpactStatement: "rolled out via golden base image",
+			}},
+		},
+		{
+			Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-AFFECTED", DataSource: "https://example.test/CVE-AFFECTED"},
+				},
+				Artifact: v1beta1.GrypePackage{PURL: "pkg:deb/debian/affected@3.0"},
+			},
+			AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+				Vulnerability:   "CVE-AFFECTED",
+				SourceKind:      "SecurityException",
+				SourceName:      "SecurityException/default/affected",
+				SourceNamespace: "default",
+				FixState:        string(sev1beta1.VulnerabilityStatusAffected),
+				Justification:   "accepted risk",
+				ImpactStatement: "compensating controls limit exposure",
+			}},
+		},
+	}
+
+	cveManifest := domain.CVEManifest{
+		Name: name,
+		Annotations: map[string]string{
+			helpersv1.ImageIDMetadataKey: "registry.k8s.io/coredns/coredns:v1.10.1",
+		},
+		Content: &v1beta1.GrypeDocument{
+			IgnoredMatches: ignoredMatches,
+		},
+	}
+	cveManifestFiltered := cveManifest
+	cveManifestFiltered.Content = &v1beta1.GrypeDocument{
+		IgnoredMatches: append([]v1beta1.IgnoredMatch(nil), ignoredMatches...),
+	}
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err, "updateVEX should preserve the same SecurityException-derived semantics")
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	got := map[string]v1beta1.Statement{}
+	for _, stmt := range vexContainer.Spec.Statements {
+		got[stmt.Vulnerability.Name] = stmt
+	}
+
+	require.Contains(t, got, "CVE-NOT-AFFECTED")
+	assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), got["CVE-NOT-AFFECTED"].Status)
+	assert.Equal(t, v1beta1.Justification("component is compiled without the vulnerable feature"), got["CVE-NOT-AFFECTED"].Justification)
+	assert.Equal(t, "runtime path is unreachable in this deployment", got["CVE-NOT-AFFECTED"].ImpactStatement)
+	assert.Empty(t, got["CVE-NOT-AFFECTED"].ActionStatement)
+	assert.Empty(t, got["CVE-NOT-AFFECTED"].StatusNotes)
+
+	require.Contains(t, got, "CVE-FIXED")
+	assert.Equal(t, v1beta1.Status(sev1beta1.VulnerabilityStatusFixed), got["CVE-FIXED"].Status)
+	assert.Empty(t, got["CVE-FIXED"].Justification)
+	assert.Empty(t, got["CVE-FIXED"].ImpactStatement)
+	assert.Empty(t, got["CVE-FIXED"].ActionStatement)
+	assert.Equal(t, "justification: patch validated in downstream image build; impact: rolled out via golden base image", got["CVE-FIXED"].StatusNotes)
+
+	require.Contains(t, got, "CVE-AFFECTED")
+	assert.Equal(t, v1beta1.Status(vex.StatusAffected), got["CVE-AFFECTED"].Status)
+	assert.Empty(t, got["CVE-AFFECTED"].Justification)
+	assert.Empty(t, got["CVE-AFFECTED"].ImpactStatement)
+	assert.Equal(t, securityExceptionAcceptedRiskAction, got["CVE-AFFECTED"].ActionStatement)
+	assert.Equal(t, "justification: accepted risk; impact: compensating controls limit exposure", got["CVE-AFFECTED"].StatusNotes)
+}
+
 // TestAPIServerStore_storeVEX_updateRestoresNotAffected guards against a regression where
 // updateVEX only ever promoted statements to "affected" and never reset them back to
 // "not_affected" once the corresponding CVE/package pair stopped being relevant.


### PR DESCRIPTION
## Overview
This change preserves the suppression semantics that come from `SecurityException` CRDs when kubevuln writes local VEX statements.

Current behavior: any ignored finding is rewritten into the same local `not_affected` statement with a hard coded justification and impact string.
Future behavior: ignored findings keep the effective suppression outcome that caused them to be filtered. `not_affected` keeps its stored justification and impact text, `fixed` is emitted as `fixed`, and accepted risk `affected` suppressions are emitted as `affected` with explicit local policy context.

## Additional Information
The fix is split into two parts:
1. `adapters/v1/securityexception.go` now carries the originating `SecurityException` status into the stored ignore rule provenance.
2. `repositories/apiserver.go` now derives ignored statement semantics from that provenance during create, update, and reset flows, while preserving the previous generic fallback when no exception provenance is available.

Focused regression coverage was added for `not_affected`, `fixed`, and accepted risk `affected` suppressions, and the update path is exercised as well.

## How to Test
1. Run `go test ./adapters/v1/... ./repositories/...`
2. Run `make verify`
3. Optionally inspect a generated `OpenVulnerabilityExchangeContainer` after applying a `SecurityException` with `not_affected`, `fixed`, or accepted risk `affected` semantics and confirm the stored statement preserves that meaning.

## Related issues/PRs:
* Resolved #656

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
