### PR TITLE
fix(adapters): key relevancy on the package version too, not just its name

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -583,18 +583,35 @@ func httpPostDebug(httpClient httputils.IHttpClient, fullURL string, headers map
 	return httputils.HttpPostWithContext(context.Background(), httpClient, fullURL, headers, body, -1, func(resp *http.Response) bool { return true })
 }
 
+// relevancyIdentity is what makes two vulnerability records the same finding: the CVE, and
+// the package it was found on. The package needs its version as well as its name, because a
+// name is not unique within an image. Two versions of one library can sit side by side, which
+// is ordinary in Java and Node images, and DomainToArmo emits a record per (vulnerability,
+// artifact) pair, so both versions produce a record carrying the same name.
+type relevancyIdentity struct {
+	cve            string
+	packageName    string
+	packageVersion string
+}
+
+func identifyForRelevancy(v cs.CommonContainerVulnerabilityResult) relevancyIdentity {
+	return relevancyIdentity{cve: v.Name, packageName: v.RelatedPackageName, packageVersion: v.PackageVersion}
+}
+
 // markRelevantVulnerabilities annotates each vulnerability with IsRelevant=true iff the same
-// (CVE, package) pair also appeared in the relevancy (CVEp) scan. Keying by CVE id alone would
-// mark a CVE relevant on every package it affects even when only one of those packages was
-// executed; the pair is the record identity (see RelatedPackageName in DomainToArmo and the
-// uniqueness assertion in backend_test.go).
+// finding also appeared in the relevancy (CVEp) scan. Keying by CVE id alone would mark a CVE
+// relevant on every package it affects even when only one of those packages was executed, and
+// keying by CVE and package name alone does the same thing one level down, marking an
+// unloaded version of a library relevant because another version of it was loaded. Both
+// manifests are built from the same artifacts, the filtered one from a subset of the same
+// SBOM, so the versions on either side are the same strings.
 func markRelevantVulnerabilities(vulnerabilities, relevantVulnerabilities []cs.CommonContainerVulnerabilityResult) {
-	cvepIndices := make(map[string]struct{}, len(relevantVulnerabilities))
+	cvepIndices := make(map[relevancyIdentity]struct{}, len(relevantVulnerabilities))
 	for _, v := range relevantVulnerabilities {
-		cvepIndices[v.Name+"+"+v.RelatedPackageName] = struct{}{}
+		cvepIndices[identifyForRelevancy(v)] = struct{}{}
 	}
 	for i, v := range vulnerabilities {
-		_, isRelevant := cvepIndices[v.Name+"+"+v.RelatedPackageName]
+		_, isRelevant := cvepIndices[identifyForRelevancy(v)]
 		vulnerabilities[i].IsRelevant = &isRelevant
 	}
 }

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/kinbiko/jsonassert"
 	beClientV1 "github.com/kubescape/backend/pkg/client/v1"
-	"github.com/kubescape/go-logger"
 	sysreport "github.com/kubescape/backend/pkg/server/v1/systemreports"
+	"github.com/kubescape/go-logger"
 	"github.com/kubescape/kubevuln/core/domain"
 	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/kubevuln/repositories"
@@ -675,6 +675,48 @@ func TestMarkRelevantVulnerabilities(t *testing.T) {
 				assert.Equal(t, want, *v.IsRelevant, "IsRelevant mismatch for %s", id)
 			}
 		})
+	}
+}
+
+// A package name is not unique within an image: two versions of one library sitting side by
+// side is ordinary in Java and Node images, and each produces its own vulnerability record
+// under the same name. Keying relevancy on the CVE and the name alone marked the version that
+// was never loaded relevant because the other one was, which is the opposite of what the
+// relevancy scan is for.
+func TestMarkRelevantVulnerabilities_DistinguishesPackageVersions(t *testing.T) {
+	vuln := func(cve, pkg, version string) containerscan.CommonContainerVulnerabilityResult {
+		return containerscan.CommonContainerVulnerabilityResult{
+			Vulnerability: containerscan.Vulnerability{
+				Name:               cve,
+				RelatedPackageName: pkg,
+				PackageVersion:     version,
+			},
+		}
+	}
+
+	vulnerabilities := []containerscan.CommonContainerVulnerabilityResult{
+		vuln("CVE-2024-0001", "commons-collections", "3.2.1"),
+		vuln("CVE-2024-0001", "commons-collections", "4.4"),
+		vuln("CVE-2024-0002", "log4j-core", "2.14.1"),
+	}
+	// only the 4.4 copy is actually loaded
+	relevant := []containerscan.CommonContainerVulnerabilityResult{
+		vuln("CVE-2024-0001", "commons-collections", "4.4"),
+	}
+
+	markRelevantVulnerabilities(vulnerabilities, relevant)
+
+	want := map[string]bool{
+		"CVE-2024-0001+commons-collections@3.2.1": false,
+		"CVE-2024-0001+commons-collections@4.4":   true,
+		"CVE-2024-0002+log4j-core@2.14.1":         false,
+	}
+	for _, v := range vulnerabilities {
+		id := v.Name + "+" + v.RelatedPackageName + "@" + v.PackageVersion
+		expected, ok := want[id]
+		require.True(t, ok, "unexpected vulnerability %s", id)
+		require.NotNil(t, v.IsRelevant, "IsRelevant should be set for %s", id)
+		assert.Equal(t, expected, *v.IsRelevant, "IsRelevant mismatch for %s", id)
 	}
 }
 


### PR DESCRIPTION
## Overview

`markRelevantVulnerabilities` keyed relevancy on the CVE and the package name. a package name is not unique within an image: two versions of one library sitting side by side is ordinary, particularly in Java and Node images, and `DomainToArmo` emits a record per (vulnerability, artifact) pair, so both versions produce a record under the same name.

one loaded version then marked every version relevant, which is the opposite of what the CVEp scan is for. a finding on a version that was never loaded got promoted because a different version of it was, and `RelevantCount` in the summary was inflated to match.

the version is already on the record as `PackageVersion`, and both manifests come from the same artifacts (the filtered one from a subset of the same SBOM), so the two sides carry the same strings.

## Additional Information

the key is a small struct rather than a longer concatenated string, so no separator has to be chosen that cannot occur in a package name. npm scoped names contain `@`, which is the obvious separator to reach for.

the function's comment cited the uniqueness assertion in `backend_test.go` as grounds for the old key. that assertion checks the nginx fixture contains no duplicate (CVE, package name) pairs, which holds for that fixture rather than in general, so the comment now says what actually makes two records the same finding.

## How to Test

`go test ./adapters/v1/ -run TestMarkRelevantVulnerabilities -count=1`

`TestMarkRelevantVulnerabilities_DistinguishesPackageVersions` puts two versions of one library in the full manifest, marks only one of them loaded, and asserts the other stays irrelevant.

before this it fails on the unloaded copy:

```
IsRelevant mismatch for CVE-2024-0001+commons-collections@3.2.1
expected: false
actual  : true
```

`TestMarkRelevantVulnerabilities` is unchanged and still passes: its cases use one version per package, which is the case that already worked.

## Related issues/PRs:

* Resolved #658


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability relevance matching by distinguishing package versions.
  * Prevented vulnerabilities affecting different versions of the same package from being incorrectly treated as identical.

* **Tests**
  * Added regression coverage for package-version-specific relevance matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->