### PR TITLE
fix: report actual SecurityException integration state in Diagnostics, not raw config flag

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -104,7 +104,8 @@ func main() {
 	// SecurityException CRD integration requires storage and riskAcceptance RBAC
 	var seRepo ports.SecurityExceptionRepository
 	var eventRecorder record.EventRecorder
-	if storage != nil && c.RiskAcceptance {
+	riskAcceptanceActive := isRiskAcceptanceActive(storage, c.RiskAcceptance)
+	if riskAcceptanceActive {
 		seRepo = storage
 		logger.L().Info("SecurityException CRD integration enabled")
 
@@ -166,7 +167,7 @@ func main() {
 			ScanTimeout:             c.ScanTimeout.String(),
 			ScannerReadinessTimeout: c.ScannerReadinessTimeout.String(),
 			StorageEnabled:          c.Storage,
-			RiskAcceptanceEnabled:   c.RiskAcceptance,
+			RiskAcceptanceEnabled:   riskAcceptanceActive,
 		}
 	})
 
@@ -256,4 +257,12 @@ func main() {
 	}
 
 	logger.L().Info("kubevuln exiting")
+}
+
+// isRiskAcceptanceActive reports whether SecurityException/ClusterSecurityException
+// CRD integration is actually wired up, as opposed to the raw --risk-acceptance
+// config flag: integration also requires storage to be configured, since without
+// it seRepo falls back to NoOpSecurityExceptionRepository regardless of the flag.
+func isRiskAcceptanceActive(storage *repositories.APIServerStore, riskAcceptance bool) bool {
+	return storage != nil && riskAcceptance
 }

--- a/cmd/http/main_test.go
+++ b/cmd/http/main_test.go
@@ -17,6 +17,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsRiskAcceptanceActive(t *testing.T) {
+	storage := repositories.NewFakeAPIServerStorage("kubescape")
+
+	tests := []struct {
+		name           string
+		storage        *repositories.APIServerStore
+		riskAcceptance bool
+		want           bool
+	}{
+		{
+			name:           "storage configured and flag enabled",
+			storage:        storage,
+			riskAcceptance: true,
+			want:           true,
+		},
+		{
+			name:           "storage configured but flag disabled",
+			storage:        storage,
+			riskAcceptance: false,
+			want:           false,
+		},
+		{
+			name:           "flag enabled but storage not configured",
+			storage:        nil,
+			riskAcceptance: true,
+			want:           false,
+		},
+		{
+			name:           "neither storage nor flag configured",
+			storage:        nil,
+			riskAcceptance: false,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRiskAcceptanceActive(tt.storage, tt.riskAcceptance))
+		})
+	}
+}
+
 func TestScan(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary
`Diagnostics.RiskAcceptanceEnabled` reported the raw `c.RiskAcceptance`
config flag instead of whether SecurityException integration was actually
active. SecurityException integration is only active when both
`RiskAcceptance` is enabled and `storage` is available.
When `storage == nil`, `seRepo` silently falls back to
`NoOpSecurityExceptionRepository`, which never suppresses anything.
So with `RiskAcceptance=true` and `storage == nil`, `/diagnostics` reported
`riskAcceptanceEnabled: true` while no suppression was actually happening.
This matters because, per its own doc comment, this endpoint exists
specifically so operators can check the running configuration "instead of
inferring it from logs"  it is intended to provide the effective runtime
state.
#562 identified the same misconfiguration (storage set,
`RiskAcceptance` unset), and #564 fixed it by adding a warning log. That
fix covered the logs; this PR covers the same gap on the diagnostics
endpoint, which was still reporting the wrong state.
## Changes
- Extracted the activation condition into a small, independently testable
  function: `isRiskAcceptanceActive(storage, riskAcceptance)`
- Reused the same function for both the `seRepo` branch (behavior
  unchanged) and `Diagnostics.RiskAcceptanceEnabled` (the fix), providing
  a single source of truth
## Testing
- Added `TestIsRiskAcceptanceActive`, covering all four combinations of
  storage/flag, including the regression case:
  `RiskAcceptance=true`, `storage=nil` → `false`
- Ran `go build ./...`
- Ran `go test ./cmd/http/... -run TestIsRiskAcceptanceActive -v` 
  all 4 subtests pass
- Ran `go test ./cmd/http/... -v`  existing `TestScan` suite still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SecurityException integration is now considered active only when both storage and risk-acceptance settings are enabled.
  - Diagnostics now accurately reflect the effective integration status instead of reporting the configured flag alone.

- **Tests**
  - Added coverage for enabled and disabled risk-acceptance settings with configured and unconfigured storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->