### PR TITLE
fix: match VEX statements across all products/subcomponents, not just the first 

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -953,6 +953,29 @@ func createProductStructForImageAndPackage(imagePullable string, packagePURL str
 	return &product, nil
 }
 
+// anyPURLMatches reports whether fn returns true for any subcomponent PURL across any
+// product in products. This is the shared traversal used by both statementHasPURL and
+// the ignored-vulnerability lookup in updateVEX, so both stay correct together if the
+// traversal logic ever needs to change.
+func anyPURLMatches(products []v1beta1.Product, fn func(purl string) bool) bool {
+	for _, p := range products {
+		for _, sc := range p.Subcomponents {
+			if fn(sc.ID) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// statementHasPURL reports whether any subcomponent across any product in products
+// matches purl. External VEX statements (Red Hat CSAF, Chainguard OpenVEX) can list
+// multiple products/subcomponents per statement, so callers must not assume the match
+// is always at Products[0].Subcomponents[0].
+func statementHasPURL(products []v1beta1.Product, purl string) bool {
+	return anyPURLMatches(products, func(p string) bool { return p == purl })
+}
+
 // defaultActionStatement is used when a match does not carry enough fix data to build a
 // more specific remediation string.
 const defaultActionStatement = "Upgrade the vulnerable component to a version that is not affected"
@@ -1197,10 +1220,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 				if s.Vulnerability.Name != v.Vulnerability.ID {
 					continue
 				}
-				if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
-					continue
-				}
-				if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
+				if statementHasPURL(s.Products, v.Artifact.PURL) {
 					found = true
 					break
 				}
@@ -1251,10 +1271,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 				if s.Vulnerability.Name != v.Vulnerability.ID {
 					continue
 				}
-				if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
-					continue
-				}
-				if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {
+				if statementHasPURL(s.Products, v.Artifact.PURL) {
 					found = true
 					break
 				}
@@ -1313,12 +1330,9 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		vexDoc.Statements[i].Justification = v1beta1.Justification(vex.VulnerableCodeNotPresent)
 		vexDoc.Statements[i].ActionStatement = ""
 
-		isIgnored := false
-		if len(vexDoc.Statements[i].Products) > 0 && len(vexDoc.Statements[i].Products[0].Subcomponents) > 0 {
-			if ignoredMap[vexDoc.Statements[i].Vulnerability.Name+vexDoc.Statements[i].Products[0].Subcomponents[0].ID] {
-				isIgnored = true
-			}
-		}
+		isIgnored := anyPURLMatches(vexDoc.Statements[i].Products, func(purl string) bool {
+			return ignoredMap[vexDoc.Statements[i].Vulnerability.Name+purl]
+		})
 
 		if isIgnored {
 			vexDoc.Statements[i].ImpactStatement = "Vulnerability was ignored by a SecurityException"

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2586,6 +2586,240 @@ func TestAPIServerStore_storeVEX_ignoredMatches(t *testing.T) {
 	assert.True(t, foundTransitioned, "Transitioned match should be updated to not_affected with SecurityException impact statement")
 }
 
+// TestStatementHasPURL_MatchesAcrossMultipleProducts is a regression test for #665:
+// the dedup/ignore matching in createVEX/updateVEX used to only check
+// Products[0].Subcomponents[0], silently missing a match if the target package
+// was listed under any other product. Local statements never trigger this today
+// (createProductStructForImageAndPackage always builds exactly one product/
+// subcomponent), but external VEX statements (Red Hat CSAF, Chainguard OpenVEX)
+// can legitimately list several. This constructs a statement with the target
+// package as the second subcomponent of the second product, proving the match
+// is found regardless of position.
+func TestStatementHasPURL_MatchesAcrossMultipleProducts(t *testing.T) {
+	products := []v1beta1.Product{
+		{
+			Component: v1beta1.Component{ID: "pkg:oci/image-one"},
+			Subcomponents: []v1beta1.Subcomponent{
+				{Component: v1beta1.Component{ID: "pkg:deb/debian/openssl@1.0"}},
+			},
+		},
+		{
+			Component: v1beta1.Component{ID: "pkg:oci/image-two"},
+			Subcomponents: []v1beta1.Subcomponent{
+				{Component: v1beta1.Component{ID: "pkg:deb/debian/nginx@1.0"}},
+				{Component: v1beta1.Component{ID: "pkg:deb/debian/curl@7.68"}},
+			},
+		},
+	}
+
+	assert.True(t, statementHasPURL(products, "pkg:deb/debian/curl@7.68"),
+		"should find a package even when it is not the first subcomponent of the first product")
+	assert.True(t, statementHasPURL(products, "pkg:deb/debian/openssl@1.0"),
+		"should still find the first product package")
+	assert.False(t, statementHasPURL(products, "pkg:deb/debian/not-present@1.0"),
+		"should not match a package that is not present anywhere")
+	assert.False(t, statementHasPURL(nil, "pkg:deb/debian/curl@7.68"),
+		"should not panic or match on nil products")
+}
+
+// TestAPIServerStore_storeVEX_ignoredMatches_multiProductStatement is a regression
+// test for #665: the ignored-vulnerability lookup in updateVEX used to only check
+// Products[0].Subcomponents[0], so a statement whose target package sits under a
+// later product/subcomponent would never be recognized as ignored. This manually
+// expands an existing statement to carry an extra leading product before the real
+// one, then runs it through the real StoreVEX/updateVEX path (not just the isolated
+// helper) and asserts the ignore transition still happens correctly.
+func TestAPIServerStore_storeVEX_ignoredMatches_multiProductStatement(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	testMatch := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+				ID:         "CVE-MULTI-PRODUCT-TEST",
+				DataSource: "GHSA-MULTI-PRODUCT-TEST",
+			},
+			Fix: v1beta1.Fix{
+				State:    "fixed",
+				Versions: []string{"2.0"},
+			},
+		},
+		Artifact: v1beta1.GrypePackage{
+			Name:    "multi-product-package",
+			Version: "1.0",
+			PURL:    "pkg:deb/debian/multi-product-package@1.0",
+		},
+	}
+
+	cveManifest.Content.Matches = append(cveManifest.Content.Matches, testMatch)
+	cveManifestFiltered.Content.Matches = append(cveManifestFiltered.Content.Matches, testMatch)
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	// First StoreVEX call creates the statement as affected, single-product
+	// (this is how production code always creates it today).
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Manually expand the statement to carry an extra leading product before the
+	// real one, simulating what a multi-product external-style statement looks like.
+	// This proves the fix works through the real storage round-trip, not just
+	// against a hand-built struct in memory.
+	for i := range vexContainer.Spec.Statements {
+		if vexContainer.Spec.Statements[i].Vulnerability.Name == "CVE-MULTI-PRODUCT-TEST" {
+			realProduct := vexContainer.Spec.Statements[i].Products[0]
+			decoyProduct := v1beta1.Product{
+				Component: v1beta1.Component{ID: "pkg:oci/decoy-image"},
+				Subcomponents: []v1beta1.Subcomponent{
+					{Component: v1beta1.Component{ID: "pkg:deb/debian/decoy-package@1.0"}},
+				},
+			}
+			vexContainer.Spec.Statements[i].Products = []v1beta1.Product{decoyProduct, realProduct}
+		}
+	}
+	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(context.Background(), vexContainer, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Now move testMatch to IgnoredMatches, simulating a SecurityException rule applied.
+	var filteredMatches []v1beta1.Match
+	for _, m := range cveManifestFiltered.Content.Matches {
+		if m.Vulnerability.ID != "CVE-MULTI-PRODUCT-TEST" {
+			filteredMatches = append(filteredMatches, m)
+		}
+	}
+	cveManifestFiltered.Content.Matches = filteredMatches
+	cveManifestFiltered.Content.IgnoredMatches = append(cveManifestFiltered.Content.IgnoredMatches, v1beta1.IgnoredMatch{Match: testMatch})
+	cveManifest.Content.IgnoredMatches = append(cveManifest.Content.IgnoredMatches, v1beta1.IgnoredMatch{Match: testMatch})
+
+	// Second StoreVEX call: the real updateVEX ignored-lookup must find the real
+	// product even though it now sits second, not first.
+	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+
+	vexContainerUpdated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	var foundTransitioned bool
+	for _, stmt := range vexContainerUpdated.Spec.Statements {
+		if stmt.Vulnerability.Name == "CVE-MULTI-PRODUCT-TEST" {
+			foundTransitioned = true
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status,
+				"statement should transition to not_affected even though its real product is second, not first")
+			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement,
+				"ignore lookup should find the package regardless of product position")
+		}
+	}
+	assert.True(t, foundTransitioned, "multi-product statement should still be found and transitioned")
+}
+
+// TestAPIServerStore_storeVEX_dedup_multiProductStatement is a regression test for
+// #665: the dedup check in updateVEX (deciding whether a vulnerability is already
+// recorded) used to only check Products[0].Subcomponents[0]. This manually expands
+// an existing statement to carry an extra leading product before the real one, then
+// runs the same match through StoreVEX again and asserts no duplicate statement is
+// appended - proving the dedup check finds the existing entry through the real
+// updateVEX path, not just the isolated helper.
+func TestAPIServerStore_storeVEX_dedup_multiProductStatement(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	testMatch := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+				ID:         "CVE-DEDUP-MULTI-PRODUCT-TEST",
+				DataSource: "GHSA-DEDUP-MULTI-PRODUCT-TEST",
+			},
+			Fix: v1beta1.Fix{
+				State:    "fixed",
+				Versions: []string{"2.0"},
+			},
+		},
+		Artifact: v1beta1.GrypePackage{
+			Name:    "dedup-multi-product-package",
+			Version: "1.0",
+			PURL:    "pkg:deb/debian/dedup-multi-product-package@1.0",
+		},
+	}
+
+	cveManifest.Content.Matches = append(cveManifest.Content.Matches, testMatch)
+	cveManifestFiltered.Content.Matches = append(cveManifestFiltered.Content.Matches, testMatch)
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	// First StoreVEX call creates the statement, single-product (as production code
+	// always does today).
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Manually expand the statement to carry an extra leading decoy product before
+	// the real one, simulating a genuine multi-product external-style statement.
+	for i := range vexContainer.Spec.Statements {
+		if vexContainer.Spec.Statements[i].Vulnerability.Name == "CVE-DEDUP-MULTI-PRODUCT-TEST" {
+			realProduct := vexContainer.Spec.Statements[i].Products[0]
+			decoyProduct := v1beta1.Product{
+				Component: v1beta1.Component{ID: "pkg:oci/dedup-decoy-image"},
+				Subcomponents: []v1beta1.Subcomponent{
+					{Component: v1beta1.Component{ID: "pkg:deb/debian/dedup-decoy-package@1.0"}},
+				},
+			}
+			vexContainer.Spec.Statements[i].Products = []v1beta1.Product{decoyProduct, realProduct}
+		}
+	}
+	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(context.Background(), vexContainer, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	countBefore := 0
+	for _, s := range vexContainer.Spec.Statements {
+		if s.Vulnerability.Name == "CVE-DEDUP-MULTI-PRODUCT-TEST" {
+			countBefore++
+		}
+	}
+	require.Equal(t, 1, countBefore, "sanity check: exactly one statement before the second StoreVEX call")
+
+	// Second StoreVEX call: same match, still present (not ignored). The dedup check
+	// must recognize the real product even though it now sits second, not first, and
+	// must NOT append a duplicate statement.
+	err = a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+
+	vexContainerUpdated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	countAfter := 0
+	for _, s := range vexContainerUpdated.Spec.Statements {
+		if s.Vulnerability.Name == "CVE-DEDUP-MULTI-PRODUCT-TEST" {
+			countAfter++
+		}
+	}
+	assert.Equal(t, 1, countAfter, "dedup check should recognize the existing multi-product statement and not append a duplicate")
+}
+
 // TestAPIServerStore_StoreVEX_NilContentDoesNotPanic is a regression test for #518:
 // createVEX, updateVEX, and markRelevantVulnerabilitiesAsAffectedInVex used to guard
 // CVEManifest.Content inconsistently - some reads were nil-checked, others weren't, within


### PR DESCRIPTION
## Overview

`repositories/apiserver.go` has three sites that match a VEX statement's package by indexing only the first product and first subcomponent:

    if v.Artifact.PURL == s.Products[0].Subcomponents[0].ID {

This is dormant today: `createProductStructForImageAndPackage` always builds exactly one product with exactly one subcomponent, so every local statement is single-product by construction. But the External VEX Ingestion project (kubevuln#387) will introduce statements from Red Hat CSAF and Chainguard OpenVEX, which can legitimately list multiple products/subcomponents per statement. Once external statement matching is wired up, the `[0][0]` indexing would silently miss real matches, with no error.

## Changes

Add `anyPURLMatches`, a shared traversal over every product/subcomponent in a statement, used by:

- `statementHasPURL`  the dedup check when adding new vulnerabilities (2 call sites)
- the ignored-vulnerability lookup in the statement-reset loop (1 call site)

All three sites previously ran their own independent `[0][0]` index checks; they now share one tested traversal.

## Before / After

Before (a plain, unprotected client):

    BEFORE FIX -> found: false

A package genuinely present in a statement, just not at `Products[0].Subcomponents[0]`, was reported as not found.

After (`anyPURLMatches`):

    AFTER FIX -> found: true

The same package is now found correctly regardless of its position.

## Testing

3 tests, covering the fix at both the unit and integration level:

- `TestStatementHasPURL_MatchesAcrossMultipleProducts` - unit-level: a match in a non-first position, a match in the first position, a genuine non-match, and nil input.
- `TestAPIServerStore_storeVEX_ignoredMatches_multiProductStatement`  integration-level: injects a real multi-product statement, runs it through the actual `StoreVEX`/`updateVEX` path, and confirms the ignore transition still fires correctly.
- `TestAPIServerStore_storeVEX_dedup_multiProductStatement`  integration-level: confirms the dedup check recognizes an existing multi-product statement through the real `StoreVEX` path and does not append a duplicate.

Full `repositories` package build and `go test ./...` pass with no failures (85 PASS, 0 FAIL).

## Related issues/PRs:

* Resolved [VEX matching only checks the first product/package, ignoring the rest](https://github.com/kubescape/kubevuln/issues/665) #665

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vulnerability statement matching across all listed products and subcomponents.
  - Prevented duplicate vulnerability entries when a matching product is not listed first.
  - Correctly preserves and resets ignored status for statements containing multiple products or subcomponents.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->