### PR TITLE
test(domain): add unit tests for ScanError

### DIFF
--- a/core/domain/scan_test.go
+++ b/core/domain/scan_test.go
@@ -1,0 +1,55 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanError_Error(t *testing.T) {
+	inner := errors.New("boom")
+	scanErr := &ScanError{Reason: "some-reason", Err: inner}
+
+	assert.Equal(t, "boom", scanErr.Error())
+}
+
+func TestScanError_Unwrap(t *testing.T) {
+	inner := errors.New("boom")
+	scanErr := &ScanError{Reason: "some-reason", Err: inner}
+
+	assert.Equal(t, inner, scanErr.Unwrap())
+}
+
+func TestScanError_ErrorsIs(t *testing.T) {
+	// ScanError's own doc comment promises that wrapping a sentinel error keeps
+	// existing errors.Is-based checks working exactly as before wrapping.
+	var err error = &ScanError{Reason: "too-many-requests", Err: ErrTooManyRequests}
+
+	assert.True(t, errors.Is(err, ErrTooManyRequests))
+	assert.False(t, errors.Is(err, ErrMissingSBOM))
+}
+
+func TestScanError_ErrorsAs(t *testing.T) {
+	// Callers up the stack recover the Reason via errors.As without re-deriving
+	// it from the error string, per ScanError's doc comment.
+	var err error = &ScanError{Reason: "outdated-sbom", Err: ErrOutdatedSBOM}
+
+	var scanErr *ScanError
+	ok := errors.As(err, &scanErr)
+
+	assert.True(t, ok)
+	assert.Equal(t, "outdated-sbom", scanErr.Reason)
+}
+
+func TestScanError_WrappedInFmtErrorf(t *testing.T) {
+	// A ScanError wrapped further (e.g. via fmt.Errorf("%w", ...) somewhere up
+	// the call chain) must still be recoverable via errors.As/errors.Is.
+	scanErr := &ScanError{Reason: "incomplete-sbom", Err: ErrIncompleteSBOM}
+	wrapped := errors.Join(errors.New("context"), scanErr)
+
+	var got *ScanError
+	assert.True(t, errors.As(wrapped, &got))
+	assert.Equal(t, "incomplete-sbom", got.Reason)
+	assert.True(t, errors.Is(wrapped, ErrIncompleteSBOM))
+}


### PR DESCRIPTION
## Summary

`core/domain/scan.go` has no test file, yet it exports `ScanError`   a
type whose own doc comment makes a specific contract promise: wrapping a
sentinel error in `ScanError` must keep existing `errors.Is` checks
working unchanged, and callers up the stack must be able to recover the
`Reason` field via `errors.As` without re-parsing the error string. That
contract was only exercised indirectly, through one case in
`controllers/http_test.go`.

## Changes

- `TestScanError_Error` / `TestScanError_Unwrap`  : basic interface behavior
- `TestScanError_ErrorsIs`  :confirms wrapping a sentinel error (e.g.
  `ErrTooManyRequests`) doesn't break `errors.Is` checks against it
- `TestScanError_ErrorsAs`  :  confirms the `Reason` field is recoverable via
  `errors.As`
- `TestScanError_WrappedInFmtErrorf`  : confirms both properties still hold
  when `ScanError` is wrapped one level further (e.g. via `errors.Join`)

## Testing

- Ran `go build ./...`
- Ran `go test ./core/domain/... -run TestScanError -v`   all 5 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for scan error messages and unwrapping behavior.
  - Verified compatibility with standard error inspection, including wrapped and combined errors.
  - Confirmed scan errors can be identified and retrieved correctly through contextual error chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->