### PR TITLE
fix: sweep stale stereoscope temp dirs periodically, not once at startup

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/DmitriyVTitov/size"
-	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging"
@@ -178,16 +177,6 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	if err != nil {
 		return domainSBOM, err
 	}
-
-	// prepare temporary directory for image download
-	t := file.NewTempDirGenerator("stereoscope")
-	defer func(t *file.TempDirGenerator) {
-		err := t.Cleanup()
-		if err != nil {
-			logger.L().Ctx(ctx).Warning("failed to cleanup temp dir", helpers.Error(err),
-				helpers.String("imageID", imageID))
-		}
-	}(t)
 
 	// download image
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -301,8 +301,13 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// or failure, late if the deadline fired first - is what makes pullMutex serialize the
 	// disk-touching work itself, not just the synchronous portion of the call.
 	dl := deadline.New(s.scanTimeout)
+	// Registered here, not deferred at CreateSBOM's own top level: this closure can outlive
+	// CreateSBOM's return (see the comment below), so the periodic temp-dir sweep must stay
+	// blind to this closure's completion, not to CreateSBOM's.
+	endActiveTempDirUse := tools.BeginActiveTempDirUse()
 	err = dl.Run(func(stopper <-chan struct{}) error {
 		defer unlockPullMutex()
+		defer endActiveTempDirUse()
 		// make sure we clean the temp dir
 		defer func(src source.Source) {
 			if err := src.Close(); err != nil {

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -304,7 +305,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// Registered here, not deferred at CreateSBOM's own top level: this closure can outlive
 	// CreateSBOM's return (see the comment below), so the periodic temp-dir sweep must stay
 	// blind to this closure's completion, not to CreateSBOM's.
-	endActiveTempDirUse := tools.BeginActiveTempDirUse()
+	endActiveTempDirUse := tools.BeginActiveTempDirUse(os.TempDir())
 	err = dl.Run(func(stopper <-chan struct{}) error {
 		defer unlockPullMutex()
 		defer endActiveTempDirUse()

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -181,20 +181,30 @@ func main() {
 		logger.L().Ctx(ctx).Fatal("metrics registration error", helpers.Error(err))
 	}
 
-	// Best-effort startup sweep: reclaim stereoscope temp dirs orphaned by previous process
-	// invocations killed by SIGKILL (OOM kill, or terminationGracePeriodSeconds exceeded)
-	// before their defer-based cleanup could run. The threshold is ScanTimeout: the main
-	// process and the SBOM-scanner sidecar run in the same Pod on the same machine (same
-	// kernel clock), so no clock-skew margin is needed, and a dir idle longer than
-	// ScanTimeout can only belong to a dead or already-timed-out scan.
-	if removed, err := tools.CleanupStaleTempDirs(os.TempDir(), "stereoscope-", c.ScanTimeout); err != nil {
-		logger.L().Ctx(ctx).Warning("startup temp dir sweep error",
-			helpers.Error(err),
-			helpers.Int("removed", removed))
-	} else if removed > 0 {
-		logger.L().Ctx(ctx).Info("startup temp dir sweep complete",
-			helpers.Int("removed", removed))
-	}
+	// Best-effort periodic sweep: reclaim stereoscope temp dirs left behind either by a
+	// previous process invocation killed by SIGKILL (OOM kill, or terminationGracePeriodSeconds
+	// exceeded) before its defer-based cleanup could run, or by an ordinary (non-crash) registry
+	// pull failure in *this* process — stereoscope creates the image temp dir before it has
+	// anything to Cleanup() it, so auth failures, transient registry errors, and platform
+	// mismatches can all leak one. This process runs for the life of a long-lived pod rather
+	// than restarting per scan, so a single startup-only sweep would never reclaim leaks from
+	// its own uptime; run it on a recurring interval instead. The threshold is ScanTimeout: the
+	// main process and the SBOM-scanner sidecar run in the same Pod on the same machine (same
+	// kernel clock), so no clock-skew margin is needed, and a dir idle longer than ScanTimeout
+	// can only belong to a dead or already-timed-out scan. ScanTimeout also doubles as the sweep
+	// interval, keeping worst-case accumulation bounded to roughly one ScanTimeout's worth of
+	// leaks at a time.
+	tools.StartPeriodicTempDirSweep(ctx.Done(), os.TempDir(), "stereoscope-", c.ScanTimeout, c.ScanTimeout, func(removed int, err error) {
+		if err != nil {
+			logger.L().Ctx(ctx).Warning("temp dir sweep error",
+				helpers.Error(err),
+				helpers.Int("removed", removed))
+		} else if removed > 0 {
+			logger.L().Ctx(ctx).Info("temp dir sweep complete",
+				helpers.Int("removed", removed))
+		}
+		metrics.RecordTempDirSweep(ctx, metrics.ComponentInProcess, removed)
+	})
 
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()

--- a/cmd/sbom-scanner/main.go
+++ b/cmd/sbom-scanner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net"
 	"os"
 	"os/signal"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubevuln/internal/metrics"
+	"github.com/kubescape/kubevuln/internal/tools"
 	sbomscanner "github.com/kubescape/kubevuln/pkg/sbomscanner/v1"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"google.golang.org/grpc"
@@ -29,6 +32,14 @@ import (
 // shutdownTimeout default so both processes give a comparable grace period before a
 // terminationGracePeriodSeconds-driven SIGKILL would otherwise cut them off mid-shutdown.
 const shutdownTimeout = 20 * time.Second
+
+// tempDirSweepInterval bounds how long a stereoscope temp dir leaked by this process (e.g. a
+// registry pull that fails after the image temp dir is created but before there's an
+// image.Image to Cleanup() it -- see internal/tools.StartPeriodicTempDirSweep) can sit on disk
+// before being reclaimed. This process has no config file of its own (unlike cmd/http, which
+// derives the same cadence from ScanTimeout), so it uses the same 5-minute value CreateSBOM
+// already falls back to when a request carries no TimeoutSeconds (pkg/sbomscanner/v1/server.go).
+const tempDirSweepInterval = 5 * time.Minute
 
 // gracefulStopWithTimeout waits up to timeout for srv's in-flight RPCs to finish via
 // GracefulStop, then force-closes the server with Stop if the timeout elapses first.
@@ -79,12 +90,26 @@ func main() {
 	)
 	pb.RegisterSBOMScannerServer(srv, sbomscanner.NewScannerServer())
 
+	// See tempDirSweepInterval: this process (unlike cmd/http) previously had no temp-dir
+	// sweep at all, startup or periodic, despite being the one that performs pod-less
+	// registry pulls (registry rescans, periodic CRD-based rescans).
+	stopSweep := make(chan struct{})
+	tools.StartPeriodicTempDirSweep(stopSweep, os.TempDir(), "stereoscope-", tempDirSweepInterval, tempDirSweepInterval, func(removed int, err error) {
+		if err != nil {
+			logger.L().Warning("temp dir sweep error", helpers.Error(err), helpers.Int("removed", removed))
+		} else if removed > 0 {
+			logger.L().Info("temp dir sweep complete", helpers.Int("removed", removed))
+		}
+		metrics.RecordTempDirSweep(context.Background(), metrics.ComponentSidecar, removed)
+	})
+
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
 	go func() {
 		sig := <-sigCh
 		logger.L().Info("received signal, shutting down", helpers.String("signal", sig.String()))
+		close(stopSweep)
 		gracefulStopWithTimeout(srv, shutdownTimeout)
 		if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) { // #nosec G703 -- SOCKET_PATH is operator-controlled deployment config; path is cleaned above
 			logger.L().Warning("failed to remove socket file on shutdown", helpers.Error(err), helpers.String("path", socketPath))

--- a/cmd/sbom-scanner/main.go
+++ b/cmd/sbom-scanner/main.go
@@ -44,8 +44,12 @@ const tempDirSweepInterval = 5 * time.Minute
 
 // defaultMetricsAddr is the listen address for the Prometheus /metrics endpoint, used when
 // METRICS_ADDR is unset. Overridable per-deployment via METRICS_ADDR, mirroring SOCKET_PATH
-// below.
-const defaultMetricsAddr = ":8080"
+// below. Deliberately not :8080: this process runs as a sidecar container in the same Pod as
+// cmd/http, which binds :8080 for its own server (also serving /metrics there). Containers in
+// a Pod share one network namespace, so both processes defaulting to :8080 would collide --
+// this one would fail to bind and its component="sidecar" metrics, including
+// kubevuln_temp_dir_sweep_removed_total, would silently never be served.
+const defaultMetricsAddr = ":8081"
 
 // gracefulStopWithTimeout waits up to timeout for srv's in-flight RPCs to finish via
 // GracefulStop, then force-closes the server with Stop if the timeout elapses first.

--- a/cmd/sbom-scanner/main.go
+++ b/cmd/sbom-scanner/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -40,6 +41,11 @@ const shutdownTimeout = 20 * time.Second
 // derives the same cadence from ScanTimeout), so it uses the same 5-minute value CreateSBOM
 // already falls back to when a request carries no TimeoutSeconds (pkg/sbomscanner/v1/server.go).
 const tempDirSweepInterval = 5 * time.Minute
+
+// defaultMetricsAddr is the listen address for the Prometheus /metrics endpoint, used when
+// METRICS_ADDR is unset. Overridable per-deployment via METRICS_ADDR, mirroring SOCKET_PATH
+// below.
+const defaultMetricsAddr = ":8080"
 
 // gracefulStopWithTimeout waits up to timeout for srv's in-flight RPCs to finish via
 // GracefulStop, then force-closes the server with Stop if the timeout elapses first.
@@ -84,6 +90,24 @@ func main() {
 		logger.L().Fatal("failed to listen on socket", helpers.Error(err), helpers.String("path", socketPath))
 	}
 
+	// Without this, RecordTempDirSweep below (and any other metrics.Record* called from the
+	// sidecar's own code paths, e.g. adapters that run in-process here) reads a nil counter and
+	// is a no-op: the component="sidecar" series would never be emitted, silently.
+	m, err := metrics.New()
+	if err != nil {
+		logger.L().Fatal("metrics initialization error", helpers.Error(err))
+	}
+	metricsAddr := os.Getenv("METRICS_ADDR")
+	if metricsAddr == "" {
+		metricsAddr = defaultMetricsAddr
+	}
+	metricsServer := &http.Server{Addr: metricsAddr, Handler: m.Handler()}
+	go func() {
+		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.L().Warning("metrics server stopped unexpectedly", helpers.Error(err))
+		}
+	}()
+
 	srv := grpc.NewServer(
 		grpc.MaxRecvMsgSize(sbomscanner.MaxgRPCMessageSize),
 		grpc.MaxSendMsgSize(sbomscanner.MaxgRPCMessageSize),
@@ -111,6 +135,11 @@ func main() {
 		logger.L().Info("received signal, shutting down", helpers.String("signal", sig.String()))
 		close(stopSweep)
 		gracefulStopWithTimeout(srv, shutdownTimeout)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := metricsServer.Shutdown(shutdownCtx); err != nil {
+			logger.L().Warning("metrics server shutdown error", helpers.Error(err))
+		}
 		if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) { // #nosec G703 -- SOCKET_PATH is operator-controlled deployment config; path is cleaned above
 			logger.L().Warning("failed to remove socket file on shutdown", helpers.Error(err), helpers.String("path", socketPath))
 		}

--- a/cmd/sbom-scanner/main.go
+++ b/cmd/sbom-scanner/main.go
@@ -105,7 +105,14 @@ func main() {
 	if metricsAddr == "" {
 		metricsAddr = defaultMetricsAddr
 	}
-	metricsServer := &http.Server{Addr: metricsAddr, Handler: m.Handler()}
+	metricsServer := &http.Server{
+		Addr:              metricsAddr,
+		Handler:           m.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 	go func() {
 		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logger.L().Warning("metrics server stopped unexpectedly", helpers.Error(err))

--- a/config/config.go
+++ b/config/config.go
@@ -152,6 +152,14 @@ func LoadConfig(path string) (Config, error) {
 		return Config{}, err
 	}
 
+	// cmd/http passes ScanTimeout straight through to
+	// tools.StartPeriodicTempDirSweep as both the sweep interval and staleness threshold,
+	// which hands it to time.NewTicker: NewTicker panics on a non-positive duration, which
+	// would crash the process at startup instead of failing config validation cleanly.
+	if config.ScanTimeout <= 0 {
+		return Config{}, fmt.Errorf("scanTimeout must be positive, got %s", config.ScanTimeout)
+	}
+
 	// Resolve the effective CVE matching mode. An explicit cveMatchingMode
 	// always wins. Backward compatibility: when cveMatchingMode is absent but
 	// the legacy useDefaultMatchers boolean is set, derive the mode from it

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,22 @@ func TestLoadConfigNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// A non-positive ScanTimeout reaches tools.StartPeriodicTempDirSweep as both the sweep
+// interval and staleness threshold, which hands it to time.NewTicker: NewTicker panics on a
+// non-positive duration. LoadConfig must reject this at startup instead of letting the panic
+// happen later.
+func TestLoadConfigRejectsNonPositiveScanTimeout(t *testing.T) {
+	for _, v := range []string{"0", "-1s"} {
+		t.Run(v, func(t *testing.T) {
+			viper.Reset()
+			t.Setenv("SCANTIMEOUT", v)
+			_, err := LoadConfig("testdata")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "scanTimeout")
+		})
+	}
+}
+
 func TestLoadBackendServicesConfig(t *testing.T) {
 	services, err := LoadBackendServicesConfig("testdata", "")
 	assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/eapache/go-resiliency v1.3.0
 	github.com/gammazero/workerpool v1.1.3
 	github.com/gin-gonic/gin v1.9.1
+	github.com/gofrs/flock v0.13.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,8 @@ github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/gocsaf/csaf/v3 v3.3.0 h1:zQwCgBJfMMM/Q5vuIuj8eo5fVLcCKpaBa3t5uw6ku1U=
 github.com/gocsaf/csaf/v3 v3.3.0/go.mod h1:cDvnE5tnrO37OcOGWJsOl3mgfZjA4/EuC7TlDVRLGos=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -65,6 +65,7 @@ var sourceResolutionCounter metric.Int64Counter
 var registryAuthCacheCounter metric.Int64Counter
 var singleflightHitsCounter metric.Int64Counter
 var retryAttemptsCounter metric.Int64Counter
+var tempDirSweepCounter metric.Int64Counter
 
 // Metrics wraps the OTel meter and Prometheus exporter used to expose kubevuln's
 // operational metrics (worker-pool backlog, scan outcomes, rejection counts) on
@@ -84,6 +85,7 @@ type Metrics struct {
 	SourceResolutionCounter   metric.Int64Counter
 	SingleflightHitsCounter   metric.Int64Counter
 	RetryAttemptsCounter      metric.Int64Counter
+	TempDirSweepCounter       metric.Int64Counter
 }
 
 // New builds a Metrics instance backed by a Prometheus exporter registered
@@ -209,12 +211,21 @@ func New() (*Metrics, error) {
 		return nil, err
 	}
 
+	tempDirSweepMetric, err := meter.Int64Counter(
+		"kubevuln_temp_dir_sweep_removed_total",
+		metric.WithDescription("Total number of stale stereoscope temp directories removed by the periodic sweep, by component"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	recorderMu.Lock()
 	fallbackCounter = scanFallbackCounter
 	sourceResolutionCounter = sourceResolutionMetric
 	registryAuthCacheCounter = registryAuthCacheMetric
 	singleflightHitsCounter = singleflightHitsMetric
 	retryAttemptsCounter = retryAttemptsMetric
+	tempDirSweepCounter = tempDirSweepMetric
 	recorderMu.Unlock()
 
 	return &Metrics{
@@ -231,6 +242,7 @@ func New() (*Metrics, error) {
 		SourceResolutionCounter:   sourceResolutionMetric,
 		SingleflightHitsCounter:   singleflightHitsMetric,
 		RetryAttemptsCounter:      retryAttemptsMetric,
+		TempDirSweepCounter:       tempDirSweepMetric,
 	}, nil
 }
 
@@ -326,5 +338,23 @@ func RecordRetryAttempt(ctx context.Context, operation, outcome string) {
 	counter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("operation", operation),
 		attribute.String("outcome", outcome),
+	))
+}
+
+// RecordTempDirSweep reports how many stale temp directories a periodic sweep removed for
+// component (ComponentInProcess/ComponentSidecar). A steady, non-zero count is itself a signal
+// worth alerting on: it means leaks are occurring at least as fast as the sweep interval.
+func RecordTempDirSweep(ctx context.Context, component string, removed int) {
+	if removed <= 0 {
+		return
+	}
+	recorderMu.RLock()
+	counter := tempDirSweepCounter
+	recorderMu.RUnlock()
+	if counter == nil {
+		return
+	}
+	counter.Add(ctx, int64(removed), metric.WithAttributes(
+		attribute.String("component", component),
 	))
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -23,6 +23,7 @@ func TestNewAndHandler(t *testing.T) {
 	RecordScanFallback(context.Background(), ComponentInProcess, FallbackCategoryRegistryAuth, FallbackStrategyAnonymous, FallbackOutcomeSucceeded)
 	RecordSourceResolution(context.Background(), ComponentInProcess, true, true)
 	RecordRegistryAuthCache(context.Background(), FallbackStrategyECR, RegistryAuthCacheHit)
+	RecordTempDirSweep(context.Background(), ComponentInProcess, 3)
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	w := httptest.NewRecorder()
@@ -37,6 +38,44 @@ func TestNewAndHandler(t *testing.T) {
 	assert.True(t, strings.Contains(body, `kubevuln_scan_fallbacks_total{category="registry_auth",component="in_process",outcome="succeeded",strategy="anonymous"} 1`), body)
 	assert.True(t, strings.Contains(body, `kubevuln_scan_source_resolution_total{component="in_process",outcome="fallback_assisted_success"} 1`), body)
 	assert.True(t, strings.Contains(body, `kubevuln_registry_auth_cache_total{result="hit",strategy="ecr"} 1`), body)
+	assert.True(t, strings.Contains(body, `kubevuln_temp_dir_sweep_removed_total{component="in_process"} 3`), body)
+}
+
+func TestRecordTempDirSweep_ZeroOrNegativeRemovedIsANoOp(t *testing.T) {
+	m, err := New()
+	require.NoError(t, err)
+
+	// A sweep that removed nothing is the steady-state, common case; asserting it emits no
+	// series keeps the metric's presence itself meaningful (any series at all means the sweep
+	// has reclaimed something at least once), and avoids emitting a zero-valued series on
+	// every tick, forever, from both cmd/http and cmd/sbom-scanner.
+	RecordTempDirSweep(context.Background(), ComponentInProcess, 0)
+	RecordTempDirSweep(context.Background(), ComponentInProcess, -1)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	m.Handler().ServeHTTP(w, req)
+
+	assert.False(t, strings.Contains(w.Body.String(), "kubevuln_temp_dir_sweep_removed_total"), w.Body.String())
+}
+
+func TestRecordTempDirSweep_BeforeNewIsANoOp(t *testing.T) {
+	// Mirrors the existing package-level-var pattern (RecordScanFallback et al.): the sidecar
+	// binary (cmd/sbom-scanner) never calls metrics.New(), so RecordTempDirSweep must not panic
+	// when called against a nil counter.
+	recorderMu.Lock()
+	previous := tempDirSweepCounter
+	tempDirSweepCounter = nil
+	recorderMu.Unlock()
+	defer func() {
+		recorderMu.Lock()
+		tempDirSweepCounter = previous
+		recorderMu.Unlock()
+	}()
+
+	assert.NotPanics(t, func() {
+		RecordTempDirSweep(context.Background(), ComponentSidecar, 5)
+	})
 }
 
 func TestMeterRegistersObservableGauge(t *testing.T) {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/aquilax/truncate"
 	"github.com/distribution/distribution/reference"
+	"github.com/gofrs/flock"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -126,27 +127,71 @@ func DeleteContents(dir string) error {
 	return nil
 }
 
-// activeTempDirUsers counts in-flight callers that are actively reading from or writing to a
-// stereoscope temp dir, so StartPeriodicTempDirSweep's periodic pass can tell a busy directory
-// from an abandoned one. Both cmd/http (in-process SyftAdapter) and cmd/sbom-scanner share a
-// single stereoscope temp-dir root process-wide (stereoscope's rootTempDirGenerator is a package
-// singleton), so this is deliberately a single process-wide counter rather than something keyed
-// per-directory: while any pull/catalog is in flight, none of the shared root's contents are
-// safe to remove.
+// activeTempDirUsers counts in-flight callers, within this process, that are actively reading
+// from or writing to a stereoscope temp dir, so StartPeriodicTempDirSweep's periodic pass can
+// tell a busy directory from an abandoned one. It is deliberately a single process-wide counter
+// rather than something keyed per-directory: while any pull/catalog is in flight, none of the
+// shared root's contents are safe to remove.
+//
+// cmd/http and cmd/sbom-scanner run as separate OS processes but mount the same /tmp volume in
+// the kubevuln Pod (see the Helm chart's "tmp-dir" volume on both containers), sharing the same
+// stereoscope temp-dir root on disk. activeTempDirUsers alone is invisible across that process
+// boundary, so without the cross-process lease below, cmd/http's sweep could delete a directory
+// an in-flight cmd/sbom-scanner cataloguing job is still reading from, or vice versa.
 var activeTempDirUsers atomic.Int64
 
+// activeScanLockFileName is the cross-process lease file BeginActiveTempDirUse and
+// StartPeriodicTempDirSweep use, under the same dir they're both called with, to coordinate
+// around the shared stereoscope temp-dir root across process boundaries (see activeTempDirUsers'
+// doc comment). A flock-based lease is used instead of a marker file so a crashed process's hold
+// is released automatically by the kernel/OS, with no orphaned-lock cleanup required.
+const activeScanLockFileName = ".kubevuln-active-scan.lock"
+
+func activeScanLockPath(dir string) string {
+	return filepath.Join(dir, activeScanLockFileName)
+}
+
 // BeginActiveTempDirUse records that the caller is about to read from or write to a stereoscope
-// temp dir. Call the returned func exactly once when finished, however that happens: normal
-// completion, error, or an abandoned goroutine that outlives its own caller's deadline (e.g.
-// Syft cataloguing after a scan timeout — see adapters/v1/syft.go and
-// pkg/sbomscanner/v1/server.go). While any caller is registered, StartPeriodicTempDirSweep skips
-// its sweep entirely rather than risk deleting a directory still in use.
-func BeginActiveTempDirUse() (end func()) {
+// temp dir under dir. Call the returned func exactly once when finished, however that happens:
+// normal completion, error, or an abandoned goroutine that outlives its own caller's deadline
+// (e.g. Syft cataloguing after a scan timeout — see adapters/v1/syft.go and
+// pkg/sbomscanner/v1/server.go). While any caller is registered - in this process via
+// activeTempDirUsers, or in another process sharing dir via the shared lock acquired here -
+// StartPeriodicTempDirSweep skips its sweep entirely rather than risk deleting a directory still
+// in use.
+func BeginActiveTempDirUse(dir string) (end func()) {
 	activeTempDirUsers.Add(1)
 	var once sync.Once
-	return func() {
-		once.Do(func() { activeTempDirUsers.Add(-1) })
+	endFn := func() { once.Do(func() { activeTempDirUsers.Add(-1) }) }
+
+	fl := flock.New(activeScanLockPath(dir))
+	locked, err := fl.TryRLock()
+	if err != nil || !locked {
+		// Best-effort: cross-process coordination degrades to in-process-only tracking here,
+		// which is exactly the pre-existing behavior rather than a regression.
+		return endFn
 	}
+	return func() {
+		endFn()
+		_ = fl.Unlock()
+	}
+}
+
+// crossProcessScanInProgress reports whether another process holds the shared lock on dir's
+// active-scan lease acquired by BeginActiveTempDirUse, i.e. is mid-use there. A failure to
+// determine this (e.g. dir does not exist yet) is treated as "no cross-process information," not
+// as "busy" - activeTempDirUsers already covers this process's own in-flight uses regardless.
+func crossProcessScanInProgress(dir string) bool {
+	fl := flock.New(activeScanLockPath(dir))
+	locked, err := fl.TryLock()
+	if err != nil {
+		return false
+	}
+	if !locked {
+		return true
+	}
+	_ = fl.Unlock()
+	return false
 }
 
 // CleanupStaleTempDirs removes directories under dir whose names start with prefix and whose
@@ -203,13 +248,20 @@ func CleanupStaleTempDirs(dir, prefix string, olderThan time.Duration) (int, err
 // cmd/sbom-scanner, which intentionally allows concurrent CreateSBOM RPCs, sustained concurrent
 // traffic can keep the counter above zero indefinitely, deferring sweeps beyond one interval.
 // This only widens the reclaim window under continuous load; it never leaves a leaked dir
-// unreclaimed forever, since the sweep still runs as soon as the process has an idle gap.
+// unreclaimed forever, since the sweep still runs as soon as the process has an idle gap. The
+// same applies across processes sharing dir, via crossProcessScanInProgress.
 func StartPeriodicTempDirSweep(stop <-chan struct{}, dir, prefix string, olderThan, interval time.Duration, onSweep func(removed int, err error)) {
 	sweep := func() {
 		if activeTempDirUsers.Load() > 0 {
 			// A pull or a cataloguing pass that outlived its own timeout is still using the
 			// shared temp dir root; removing anything now could delete files out from under it.
 			// Skip this pass entirely and let the next tick re-check.
+			return
+		}
+		if crossProcessScanInProgress(dir) {
+			// Another process sharing dir (see activeTempDirUsers' doc comment) is mid-use, per
+			// the lease acquired in its own BeginActiveTempDirUse call. Same reasoning as above,
+			// just visible across the process boundary rather than within this one.
 			return
 		}
 		removed, err := CleanupStaleTempDirs(dir, prefix, olderThan)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -160,6 +160,40 @@ func CleanupStaleTempDirs(dir, prefix string, olderThan time.Duration) (int, err
 	return removed, allErrs
 }
 
+// StartPeriodicTempDirSweep runs CleanupStaleTempDirs immediately and then again on every
+// tick of interval, until stop is closed (or the process's shutdown signal fires, for a
+// context.Context's Done() channel). A single sweep at process startup only reclaims dirs
+// orphaned by a *previous* process invocation (e.g. one killed by SIGKILL before its
+// defer-based cleanup could run); it does nothing for dirs leaked by the *current*, still-running
+// process, e.g. a registry pull that fails after stereoscope creates its image temp dir but
+// before an image.Image exists to Cleanup() it (auth failures, transient registry errors,
+// platform mismatches - none of which are crashes). Since kubevuln processes stay up for the
+// life of a long-running pod rather than restarting per scan, those leaks would otherwise
+// accumulate for the pod's entire uptime. onSweep, if non-nil, is invoked after every sweep
+// (including the immediate one) with its outcome, so callers can log/record metrics without
+// this function taking a dependency on either.
+func StartPeriodicTempDirSweep(stop <-chan struct{}, dir, prefix string, olderThan, interval time.Duration, onSweep func(removed int, err error)) {
+	sweep := func() {
+		removed, err := CleanupStaleTempDirs(dir, prefix, olderThan)
+		if onSweep != nil {
+			onSweep(removed, err)
+		}
+	}
+	sweep()
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				sweep()
+			}
+		}
+	}()
+}
+
 func NormalizeReference(ref string) string {
 	n, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
@@ -124,6 +126,29 @@ func DeleteContents(dir string) error {
 	return nil
 }
 
+// activeTempDirUsers counts in-flight callers that are actively reading from or writing to a
+// stereoscope temp dir, so StartPeriodicTempDirSweep's periodic pass can tell a busy directory
+// from an abandoned one. Both cmd/http (in-process SyftAdapter) and cmd/sbom-scanner share a
+// single stereoscope temp-dir root process-wide (stereoscope's rootTempDirGenerator is a package
+// singleton), so this is deliberately a single process-wide counter rather than something keyed
+// per-directory: while any pull/catalog is in flight, none of the shared root's contents are
+// safe to remove.
+var activeTempDirUsers atomic.Int64
+
+// BeginActiveTempDirUse records that the caller is about to read from or write to a stereoscope
+// temp dir. Call the returned func exactly once when finished, however that happens: normal
+// completion, error, or an abandoned goroutine that outlives its own caller's deadline (e.g.
+// Syft cataloguing after a scan timeout — see adapters/v1/syft.go and
+// pkg/sbomscanner/v1/server.go). While any caller is registered, StartPeriodicTempDirSweep skips
+// its sweep entirely rather than risk deleting a directory still in use.
+func BeginActiveTempDirUse() (end func()) {
+	activeTempDirUsers.Add(1)
+	var once sync.Once
+	return func() {
+		once.Do(func() { activeTempDirUsers.Add(-1) })
+	}
+}
+
 // CleanupStaleTempDirs removes directories under dir whose names start with prefix and whose
 // mtime is older than olderThan. It is a best-effort startup sweep to reclaim disk space left
 // by processes killed before their defer-based cleanup could run (e.g. SIGKILL from OOM or
@@ -174,6 +199,12 @@ func CleanupStaleTempDirs(dir, prefix string, olderThan time.Duration) (int, err
 // this function taking a dependency on either.
 func StartPeriodicTempDirSweep(stop <-chan struct{}, dir, prefix string, olderThan, interval time.Duration, onSweep func(removed int, err error)) {
 	sweep := func() {
+		if activeTempDirUsers.Load() > 0 {
+			// A pull or a cataloguing pass that outlived its own timeout is still using the
+			// shared temp dir root; removing anything now could delete files out from under it.
+			// Skip this pass entirely and let the next tick re-check.
+			return
+		}
 		removed, err := CleanupStaleTempDirs(dir, prefix, olderThan)
 		if onSweep != nil {
 			onSweep(removed, err)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -197,6 +197,13 @@ func CleanupStaleTempDirs(dir, prefix string, olderThan time.Duration) (int, err
 // accumulate for the pod's entire uptime. onSweep, if non-nil, is invoked after every sweep
 // (including the immediate one) with its outcome, so callers can log/record metrics without
 // this function taking a dependency on either.
+//
+// Because activeTempDirUsers is a single process-wide counter (see its doc comment), a sweep is
+// skipped in full whenever any pull or catalog is in flight anywhere in the process. On
+// cmd/sbom-scanner, which intentionally allows concurrent CreateSBOM RPCs, sustained concurrent
+// traffic can keep the counter above zero indefinitely, deferring sweeps beyond one interval.
+// This only widens the reclaim window under continuous load; it never leaves a leaked dir
+// unreclaimed forever, since the sweep still runs as soon as the process has an idle gap.
 func StartPeriodicTempDirSweep(stop <-chan struct{}, dir, prefix string, olderThan, interval time.Duration, onSweep func(removed int, err error)) {
 	sweep := func() {
 		if activeTempDirUsers.Load() > 0 {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -177,21 +177,22 @@ func BeginActiveTempDirUse(dir string) (end func()) {
 	}
 }
 
-// crossProcessScanInProgress reports whether another process holds the shared lock on dir's
-// active-scan lease acquired by BeginActiveTempDirUse, i.e. is mid-use there. A failure to
+// acquireSweepLease takes the exclusive side of dir's active-scan lease and returns a release
+// func. It reports false when another process holds the shared lease acquired by
+// BeginActiveTempDirUse, i.e. is mid-use there. The lease is held for the whole sweep pass, so a
+// concurrent BeginActiveTempDirUse cannot start between the check and the removal. A failure to
 // determine this (e.g. dir does not exist yet) is treated as "no cross-process information," not
 // as "busy" - activeTempDirUsers already covers this process's own in-flight uses regardless.
-func crossProcessScanInProgress(dir string) bool {
+func acquireSweepLease(dir string) (release func(), ok bool) {
 	fl := flock.New(activeScanLockPath(dir))
 	locked, err := fl.TryLock()
 	if err != nil {
-		return false
+		return func() {}, true
 	}
 	if !locked {
-		return true
+		return func() {}, false
 	}
-	_ = fl.Unlock()
-	return false
+	return func() { _ = fl.Unlock() }, true
 }
 
 // CleanupStaleTempDirs removes directories under dir whose names start with prefix and whose
@@ -249,7 +250,7 @@ func CleanupStaleTempDirs(dir, prefix string, olderThan time.Duration) (int, err
 // traffic can keep the counter above zero indefinitely, deferring sweeps beyond one interval.
 // This only widens the reclaim window under continuous load; it never leaves a leaked dir
 // unreclaimed forever, since the sweep still runs as soon as the process has an idle gap. The
-// same applies across processes sharing dir, via crossProcessScanInProgress.
+// same applies across processes sharing dir, via acquireSweepLease.
 func StartPeriodicTempDirSweep(stop <-chan struct{}, dir, prefix string, olderThan, interval time.Duration, onSweep func(removed int, err error)) {
 	sweep := func() {
 		if activeTempDirUsers.Load() > 0 {
@@ -258,12 +259,14 @@ func StartPeriodicTempDirSweep(stop <-chan struct{}, dir, prefix string, olderTh
 			// Skip this pass entirely and let the next tick re-check.
 			return
 		}
-		if crossProcessScanInProgress(dir) {
+		release, ok := acquireSweepLease(dir)
+		if !ok {
 			// Another process sharing dir (see activeTempDirUsers' doc comment) is mid-use, per
 			// the lease acquired in its own BeginActiveTempDirUse call. Same reasoning as above,
 			// just visible across the process boundary rather than within this one.
 			return
 		}
+		defer release()
 		removed, err := CleanupStaleTempDirs(dir, prefix, olderThan)
 		if onSweep != nil {
 			onSweep(removed, err)

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -412,7 +413,7 @@ func TestStartPeriodicTempDirSweep_SkipsWhileACallerIsActive(t *testing.T) {
 	require.NoError(t, os.Mkdir(stale, 0o755))
 	require.NoError(t, os.Chtimes(stale, old, old))
 
-	end := BeginActiveTempDirUse()
+	end := BeginActiveTempDirUse(dir)
 	defer end()
 
 	removedCh := make(chan int, 1)
@@ -435,11 +436,74 @@ func TestStartPeriodicTempDirSweep_SkipsWhileACallerIsActive(t *testing.T) {
 
 func TestBeginActiveTempDirUse_EndIsIdempotent(t *testing.T) {
 	before := activeTempDirUsers.Load()
-	end := BeginActiveTempDirUse()
+	end := BeginActiveTempDirUse(t.TempDir())
 	assert.Equal(t, before+1, activeTempDirUsers.Load())
 	end()
 	end()
 	assert.Equal(t, before, activeTempDirUsers.Load(), "calling end twice must not double-decrement")
+}
+
+// TestBeginActiveTempDirUse_CrossProcessLeaseVisibleToAnotherHandle is a regression test for the
+// cross-container race CodeRabbit flagged on #669: cmd/http and cmd/sbom-scanner run as separate
+// OS processes sharing the same /tmp volume, so activeTempDirUsers alone (process-local) can't
+// stop one process's sweep from deleting a directory the other is still using. BeginActiveTempDirUse
+// acquires a shared flock alongside its in-process counter; opening the same lock file via an
+// independent *flock.Flock (simulating a second process, since flock semantics are per open file
+// description, not per process) must see it as held for as long as end() hasn't been called.
+func TestBeginActiveTempDirUse_CrossProcessLeaseVisibleToAnotherHandle(t *testing.T) {
+	dir := t.TempDir()
+
+	end := BeginActiveTempDirUse(dir)
+
+	other := flock.New(activeScanLockPath(dir))
+	locked, err := other.TryLock()
+	require.NoError(t, err)
+	assert.False(t, locked, "an independent handle must not be able to take an exclusive lock while BeginActiveTempDirUse's lease is held")
+
+	end()
+
+	locked, err = other.TryLock()
+	require.NoError(t, err)
+	assert.True(t, locked, "an independent handle must be able to take the lock once end() releases the lease")
+	if locked {
+		_ = other.Unlock()
+	}
+}
+
+// TestStartPeriodicTempDirSweep_SkipsForCrossProcessLease is a regression test for the same race:
+// a sweep must be skipped when another process (simulated the same way as above) holds the
+// active-scan lease, even though activeTempDirUsers - this process's own counter - is zero.
+func TestStartPeriodicTempDirSweep_SkipsForCrossProcessLease(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().Add(-2 * time.Hour)
+	stale := path.Join(dir, "stereoscope-old")
+	require.NoError(t, os.Mkdir(stale, 0o755))
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	otherProcess := flock.New(activeScanLockPath(dir))
+	locked, err := otherProcess.TryRLock()
+	require.NoError(t, err)
+	require.True(t, locked)
+	defer func() { _ = otherProcess.Unlock() }()
+
+	require.Zero(t, activeTempDirUsers.Load(), "this process must have no active users of its own for the test to isolate the cross-process path")
+
+	removedCh := make(chan int, 1)
+	stop := make(chan struct{})
+	defer close(stop)
+	StartPeriodicTempDirSweep(stop, dir, "stereoscope-", time.Hour, time.Hour, func(removed int, err error) {
+		require.NoError(t, err)
+		removedCh <- removed
+	})
+
+	select {
+	case removed := <-removedCh:
+		t.Fatalf("expected the sweep to be skipped while another process holds the active-scan lease, but onSweep was called with removed=%d", removed)
+	case <-time.After(50 * time.Millisecond):
+		// no sweep happened, as expected
+	}
+	_, statErr := os.Stat(stale)
+	assert.NoError(t, statErr, "the stale dir should survive a sweep skipped due to a cross-process lease holder")
 }
 
 func TestStartPeriodicTempDirSweep_NilOnSweepDoesNotPanic(t *testing.T) {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -405,6 +405,43 @@ func TestStartPeriodicTempDirSweep_StopsTickingOnceStopIsClosed(t *testing.T) {
 	assert.Equal(t, observedAtStop, calls, "no sweep should run after stop is closed")
 }
 
+func TestStartPeriodicTempDirSweep_SkipsWhileACallerIsActive(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().Add(-2 * time.Hour)
+	stale := path.Join(dir, "stereoscope-old")
+	require.NoError(t, os.Mkdir(stale, 0o755))
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	end := BeginActiveTempDirUse()
+	defer end()
+
+	removedCh := make(chan int, 1)
+	stop := make(chan struct{})
+	defer close(stop)
+	StartPeriodicTempDirSweep(stop, dir, "stereoscope-", time.Hour, time.Hour, func(removed int, err error) {
+		require.NoError(t, err)
+		removedCh <- removed
+	})
+
+	select {
+	case removed := <-removedCh:
+		t.Fatalf("expected the sweep to be skipped while a caller is active, but onSweep was called with removed=%d", removed)
+	case <-time.After(50 * time.Millisecond):
+		// no sweep happened, as expected
+	}
+	_, statErr := os.Stat(stale)
+	assert.NoError(t, statErr, "the stale dir should survive a sweep skipped due to an active caller")
+}
+
+func TestBeginActiveTempDirUse_EndIsIdempotent(t *testing.T) {
+	before := activeTempDirUsers.Load()
+	end := BeginActiveTempDirUse()
+	assert.Equal(t, before+1, activeTempDirUsers.Load())
+	end()
+	end()
+	assert.Equal(t, before, activeTempDirUsers.Load(), "calling end twice must not double-decrement")
+}
+
 func TestStartPeriodicTempDirSweep_NilOnSweepDoesNotPanic(t *testing.T) {
 	dir := t.TempDir()
 	stop := make(chan struct{})

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -313,6 +314,105 @@ func TestCleanupStaleTempDirs(t *testing.T) {
 func TestCleanupStaleTempDirs_NonexistentDir(t *testing.T) {
 	_, err := CleanupStaleTempDirs(path.Join(t.TempDir(), "does-not-exist"), "stereoscope-", time.Hour)
 	require.Error(t, err)
+}
+
+func TestStartPeriodicTempDirSweep_RunsAnImmediateSweepSynchronously(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().Add(-2 * time.Hour)
+	stale := path.Join(dir, "stereoscope-old")
+	require.NoError(t, os.Mkdir(stale, 0o755))
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	var mu sync.Mutex
+	var calls []int
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// A long interval means only the immediate, synchronous-before-return sweep can have run
+	// by the time this call returns - if it hadn't, the assertions below would be racy.
+	StartPeriodicTempDirSweep(stop, dir, "stereoscope-", time.Hour, time.Hour, func(removed int, err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		require.NoError(t, err)
+		calls = append(calls, removed)
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []int{1}, calls)
+	_, statErr := os.Stat(stale)
+	assert.True(t, os.IsNotExist(statErr), "the stale dir present before startup should be reclaimed by the immediate sweep")
+}
+
+func TestStartPeriodicTempDirSweep_ReclaimsDirsLeakedAfterStartup(t *testing.T) {
+	dir := t.TempDir()
+	stop := make(chan struct{})
+	defer close(stop)
+
+	removedCh := make(chan int, 8)
+	StartPeriodicTempDirSweep(stop, dir, "stereoscope-", 10*time.Millisecond, 10*time.Millisecond, func(removed int, err error) {
+		require.NoError(t, err)
+		removedCh <- removed
+	})
+
+	// the immediate sweep runs against an empty dir
+	require.Equal(t, 0, <-removedCh)
+
+	// simulate a leak from an ordinary (non-crash) failure occurring while this process is
+	// already running - e.g. a registry pull whose temp dir is created before an error path
+	// returns with nothing left to clean it up. A one-time startup sweep would never reclaim
+	// this; it must be caught by a later periodic tick.
+	old := time.Now().Add(-time.Hour)
+	leaked := path.Join(dir, "stereoscope-leaked-midflight")
+	require.NoError(t, os.Mkdir(leaked, 0o755))
+	require.NoError(t, os.Chtimes(leaked, old, old))
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(leaked)
+		return os.IsNotExist(err)
+	}, time.Second, 5*time.Millisecond, "a dir leaked after startup should be reclaimed by a subsequent periodic sweep")
+}
+
+func TestStartPeriodicTempDirSweep_StopsTickingOnceStopIsClosed(t *testing.T) {
+	dir := t.TempDir()
+	stop := make(chan struct{})
+
+	var mu sync.Mutex
+	calls := 0
+	StartPeriodicTempDirSweep(stop, dir, "stereoscope-", 10*time.Millisecond, 10*time.Millisecond, func(int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+	})
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls >= 3
+	}, time.Second, 5*time.Millisecond, "expected several periodic sweeps before stopping")
+
+	close(stop)
+	mu.Lock()
+	observedAtStop := calls
+	mu.Unlock()
+
+	// long enough for several more ticks to have fired had the goroutine kept running
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, observedAtStop, calls, "no sweep should run after stop is closed")
+}
+
+func TestStartPeriodicTempDirSweep_NilOnSweepDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	stop := make(chan struct{})
+	defer close(stop)
+
+	assert.NotPanics(t, func() {
+		StartPeriodicTempDirSweep(stop, dir, "stereoscope-", time.Hour, time.Hour, nil)
+	})
 }
 
 // LabelsFromImageID drops any label that fails DNS1123 validation, so a value SanitizeLabel

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/DmitriyVTitov/size"
-	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
@@ -84,7 +83,7 @@ func NewScannerServer() pb.SBOMScannerServer {
 }
 
 // CreateSBOM handles one scan per call, with no state shared across concurrent calls: each
-// invocation downloads into its own temp dir (via its own file.NewTempDirGenerator) and builds
+// invocation downloads into its own temp dir (managed internally by stereoscope) and builds
 // its own SBOM from its own source. s.version is set once in NewScannerServer and never
 // mutated, so it's safe to read concurrently without a lock. Do not add a mutex/semaphore
 // around this method — a previous version serialized the whole RPC (pull + generation) behind
@@ -145,15 +144,6 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		InsecureUseHTTP:       req.InsecureUseHttp,
 		Credentials:           credentials,
 	}
-
-	// Prepare temp dir for stereoscope
-	t := file.NewTempDirGenerator("stereoscope")
-	defer func() {
-		if err := t.Cleanup(); err != nil {
-			logger.L().Warning("failed to cleanup temp dir", helpers.Error(err),
-				helpers.String("imageID", imageID))
-		}
-	}()
 
 	// Download image from registry
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -224,7 +225,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// Registered here rather than deferred at the handler's own top level: this closure can
 	// outlive the handler's return (see the comment below), so the periodic temp-dir sweep
 	// must stay blind to this closure's completion, not the handler's.
-	endActiveTempDirUse := tools.BeginActiveTempDirUse()
+	endActiveTempDirUse := tools.BeginActiveTempDirUse(os.TempDir())
 	err = dl.Run(func(stopper <-chan struct{}) error {
 		defer endActiveTempDirUse()
 		defer func(src source.Source) {

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -221,7 +221,12 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// Buffered so the abandoned goroutine below can always publish and exit, even when
 	// nobody is left to receive.
 	generated := make(chan *sbom.SBOM, 1)
+	// Registered here rather than deferred at the handler's own top level: this closure can
+	// outlive the handler's return (see the comment below), so the periodic temp-dir sweep
+	// must stay blind to this closure's completion, not the handler's.
+	endActiveTempDirUse := tools.BeginActiveTempDirUse()
 	err = dl.Run(func(stopper <-chan struct{}) error {
+		defer endActiveTempDirUse()
 		defer func(src source.Source) {
 			if err := src.Close(); err != nil {
 				logger.L().Warning("failed to close source", helpers.Error(err),


### PR DESCRIPTION
## Problem

`kubevuln` leaks stereoscope-managed image temp directories on disk over the lifetime of a long-running pod, with no in-process recovery.

## Root cause

Two gaps combine:

1. **The reclaim sweep only ever ran once.** `tools.CleanupStaleTempDirs` (added in #491) was called exactly once, at `cmd/http` startup, before the HTTP server starts listening. Its own comment frames it around dirs orphaned by a crashed *previous* process invocation — it does nothing for leaks that occur during ordinary operation of the *current*, still-running process. `cmd/sbom-scanner` never called it at all, despite being the process that performs pod-less registry pulls (registry rescans, periodic CRD-based rescans).
2. **Leaks happen during ordinary operation, not just crashes.** The vendored fork (`github.com/matthyx/stereoscope@v0.1.22-ks.1`) creates the per-scan temp directory in `registryImageProvider.Provide` *before* the point where cleanup becomes reachable — `remote.Get`, `descriptor.Image()`, `img.ConfigFile()`, and `validatePlatform` can all return an error with the temp dir already on disk and nothing left holding a reference to clean it up. `validatePlatform` failing (platform mismatch) is not an edge case here: `kubevuln` explicitly treats it as a routine, metric-tracked outcome on pod-less scan paths (`FallbackStrategyPlatformMismatch`).

Making it worse, both call sites (`adapters/v1/syft.go`, `pkg/sbomscanner/v1/server.go`) constructed a second, unrelated `file.NewTempDirGenerator("stereoscope")` purely to `defer` its `Cleanup()`, which looked like the missing safety net. It wasn't: `NewDirectory`/`NewGenerator` was never called on that generator, so its `rootLocation` stayed `""` and `Cleanup()` was a guaranteed no-op on every call — dead code that actively misled anyone reading it into thinking this was handled.

Since `kubevuln` pods run for days/weeks without restarting rather than being recycled per scan, every leak from (2) accumulated for the pod's entire uptime with zero reclamation until the next restart.

## Fix

- Added `tools.StartPeriodicTempDirSweep`: runs the existing `CleanupStaleTempDirs` immediately (covering the original startup case) and then again on every tick of a configurable interval, until the process shuts down.
- `cmd/http/main.go` now runs the sweep on a `ScanTimeout`-driven ticker instead of once at startup — same staleness threshold as before, so a dir idle longer than `ScanTimeout` still can only belong to a dead or already-timed-out scan.
- `cmd/sbom-scanner/main.go` gets a periodic sweep for the first time (it had none, startup or otherwise), on a 5-minute interval matching the same default `CreateSBOM` already falls back to when a request carries no `TimeoutSeconds`.
- Removed the dead, no-op `TempDirGenerator`/`Cleanup()` blocks and their misleading comments in `adapters/v1/syft.go` and `pkg/sbomscanner/v1/server.go`.
- Added `kubevuln_temp_dir_sweep_removed_total`, a counter (by `component`) so sweep activity is observable — a steady, non-zero rate is itself a signal that leaks are occurring at least as fast as the sweep interval.

## Testing

- New regression tests in `internal/tools/tools_test.go`: immediate sweep runs synchronously before `StartPeriodicTempDirSweep` returns, a dir leaked *after* startup is reclaimed by a later tick (the scenario a one-shot sweep can't cover), the sweep goroutine stops ticking once `stop` is closed, and a nil `onSweep` doesn't panic.
- New tests in `internal/metrics/metrics_test.go`: the new counter is exposed correctly, a zero/negative `removed` is a no-op (no zero-valued series emitted on every steady-state tick), and the exported `RecordTempDirSweep` doesn't panic before `metrics.New()` has run (the sidecar's actual production condition today).
- `go build ./...`, `go vet ./...`, and the full test suite for every touched package pass.
- `golangci-lint run --new-from-rev=<merge-base>` (matching this repo's diff-scoped `make lint`) reports 0 issues.

## Impact

Bounds worst-case leaked-disk accumulation to roughly one sweep interval's worth of failures, in both processes, for the life of the pod — instead of unbounded accumulation between restarts. No behavior change for callers; `CleanupStaleTempDirs` itself is untouched.

Fixes #667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale temporary files during and after scanning.
  * Prevented leaked temporary directories from accumulating between scans or after unexpected shutdowns.
  * Prevented cleanup from interfering with active scans.
  * Invalid non-positive scan timeout values are now rejected.

* **Monitoring**
  * Added metrics and logging for temporary-directory cleanup activity, errors, and removals.

* **Reliability**
  * Cleanup now runs periodically in supported services and stops cleanly during shutdown.
  * Improved protection against cleanup conflicts during active SBOM generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->