### PR TITLE
perf(sbom): index the Syft metadata reattachment instead of scanning

### DIFF
--- a/adapters/v1/syft_to_domain.go
+++ b/adapters/v1/syft_to_domain.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/anchore/syft/syft/format/syftjson"
 	"github.com/anchore/syft/syft/sbom"
-	"github.com/kubescape/go-logger"
-	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubevuln/internal/syftmeta"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
 
@@ -25,19 +24,7 @@ func (s *SyftAdapter) syftToDomain(sbomSBOM sbom.SBOM) (*v1beta1.SyftDocument, e
 	if err := json.Unmarshal(b, &syftSBOM); err != nil {
 		return nil, err
 	}
-	for i := range syftSBOM.Artifacts {
-		for j := range doc.Artifacts {
-			if syftSBOM.Artifacts[i].ID == doc.Artifacts[j].ID {
-				syftSBOM.Artifacts[i].MetadataType = doc.Artifacts[j].MetadataType
-				if b, err := json.Marshal(doc.Artifacts[j].Metadata); err == nil {
-					syftSBOM.Artifacts[i].Metadata = b
-				} else {
-					logger.L().Warning("failed to marshal Artifacts[j].Metadata", helpers.Error(err))
-				}
-				break
-			}
-		}
-	}
+	syftmeta.Reattach(syftSBOM.Artifacts, doc.Artifacts)
 
 	return syftSBOM, nil
 }

--- a/internal/syftmeta/reattach.go
+++ b/internal/syftmeta/reattach.go
@@ -1,0 +1,52 @@
+// Package syftmeta carries the one step that has to happen after a Syft SBOM is round-tripped
+// through JSON into the storage types: putting each package's metadata back.
+package syftmeta
+
+import (
+	"encoding/json"
+
+	"github.com/anchore/syft/syft/format/syftjson/model"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+)
+
+// Reattach copies MetadataType and Metadata from the Syft document onto the matching stored
+// packages, which the JSON round-trip that produced them drops: v1beta1.SyftPackage holds
+// Metadata as a json.RawMessage, so it does not survive being decoded into a typed field.
+//
+// Both SBOM paths need it, the in-process SyftAdapter and the sidecar scanner's gRPC server,
+// and they had a copy each. Keeping one copy is worth a shared package here: three separate
+// bugs (#585, #587, #601) have come from those two paths drifting apart.
+//
+// Indexed by ID rather than scanned: an SBOM has a package per artifact, so pairing them by
+// searching the whole document for each one is quadratic, and at a few thousand packages,
+// ordinary for a Java or Node image, that is most of the time this conversion takes. On a
+// duplicate ID the first Syft package wins, matching the search this replaces.
+func Reattach(stored []v1beta1.SyftPackage, doc []model.Package) {
+	if len(stored) == 0 || len(doc) == 0 {
+		return
+	}
+
+	byID := make(map[string]*model.Package, len(doc))
+	for i := range doc {
+		if _, seen := byID[doc[i].ID]; !seen {
+			byID[doc[i].ID] = &doc[i]
+		}
+	}
+
+	for i := range stored {
+		p, ok := byID[stored[i].ID]
+		if !ok {
+			continue
+		}
+		stored[i].MetadataType = p.MetadataType
+		b, err := json.Marshal(p.Metadata)
+		if err != nil {
+			logger.L().Warning("failed to marshal Syft package metadata",
+				helpers.Error(err), helpers.String("packageID", p.ID))
+			continue
+		}
+		stored[i].Metadata = b
+	}
+}

--- a/internal/syftmeta/reattach_test.go
+++ b/internal/syftmeta/reattach_test.go
@@ -1,0 +1,131 @@
+package syftmeta
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/anchore/syft/syft/format/syftjson/model"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func storedPackages(ids ...string) []v1beta1.SyftPackage {
+	out := make([]v1beta1.SyftPackage, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, v1beta1.SyftPackage{PackageBasicData: v1beta1.PackageBasicData{ID: id}})
+	}
+	return out
+}
+
+func docPackage(id, metadataType string, metadata any) model.Package {
+	return model.Package{
+		PackageBasicData:  model.PackageBasicData{ID: id},
+		PackageCustomData: model.PackageCustomData{MetadataType: metadataType, Metadata: metadata},
+	}
+}
+
+func TestReattach(t *testing.T) {
+	stored := storedPackages("a", "b", "c")
+	doc := []model.Package{
+		docPackage("a", "JavaMetadata", map[string]string{"virtualPath": "/a.jar"}),
+		docPackage("b", "ApkMetadata", map[string]string{"package": "b"}),
+		docPackage("c", "", nil),
+	}
+
+	Reattach(stored, doc)
+
+	assert.Equal(t, "JavaMetadata", stored[0].MetadataType)
+	assert.JSONEq(t, `{"virtualPath":"/a.jar"}`, string(stored[0].Metadata))
+	assert.Equal(t, "ApkMetadata", stored[1].MetadataType)
+	assert.JSONEq(t, `{"package":"b"}`, string(stored[1].Metadata))
+	assert.Equal(t, "", stored[2].MetadataType)
+	assert.JSONEq(t, `null`, string(stored[2].Metadata))
+}
+
+// The stored list comes from marshalling the same document, so the two are normally aligned,
+// but the pairing is by ID rather than by position and must stay that way: nothing in the
+// round-trip promises an order.
+func TestReattach_PairsByIDNotPosition(t *testing.T) {
+	stored := storedPackages("c", "a", "b")
+	doc := []model.Package{
+		docPackage("a", "JavaMetadata", nil),
+		docPackage("b", "ApkMetadata", nil),
+		docPackage("c", "RpmMetadata", nil),
+	}
+
+	Reattach(stored, doc)
+
+	assert.Equal(t, "RpmMetadata", stored[0].MetadataType)
+	assert.Equal(t, "JavaMetadata", stored[1].MetadataType)
+	assert.Equal(t, "ApkMetadata", stored[2].MetadataType)
+}
+
+// A stored package with no counterpart keeps what it already had rather than being cleared.
+func TestReattach_LeavesUnmatchedAlone(t *testing.T) {
+	stored := storedPackages("a", "orphan")
+	stored[1].MetadataType = "existing"
+	stored[1].Metadata = []byte(`{"kept":true}`)
+
+	Reattach(stored, []model.Package{docPackage("a", "JavaMetadata", nil)})
+
+	assert.Equal(t, "JavaMetadata", stored[0].MetadataType)
+	assert.Equal(t, "existing", stored[1].MetadataType)
+	assert.JSONEq(t, `{"kept":true}`, string(stored[1].Metadata))
+}
+
+// Syft keys its package collection by ID so duplicates should not occur, but the search this
+// replaced stopped at the first match and this keeps that resolution rather than the last.
+func TestReattach_FirstWinsOnDuplicateID(t *testing.T) {
+	stored := storedPackages("dup")
+	doc := []model.Package{
+		docPackage("dup", "first", nil),
+		docPackage("dup", "second", nil),
+	}
+
+	Reattach(stored, doc)
+
+	assert.Equal(t, "first", stored[0].MetadataType)
+}
+
+func TestReattach_EmptyInputs(t *testing.T) {
+	require.NotPanics(t, func() {
+		Reattach(nil, nil)
+		Reattach(storedPackages("a"), nil)
+		Reattach(nil, []model.Package{docPackage("a", "t", nil)})
+	})
+}
+
+// Metadata that cannot be marshalled leaves the package's existing value alone instead of
+// replacing it with a broken one.
+func TestReattach_UnmarshalableMetadataIsSkipped(t *testing.T) {
+	stored := storedPackages("a")
+	stored[0].Metadata = []byte(`{"kept":true}`)
+
+	Reattach(stored, []model.Package{docPackage("a", "JavaMetadata", make(chan int))})
+
+	assert.Equal(t, "JavaMetadata", stored[0].MetadataType)
+	assert.JSONEq(t, `{"kept":true}`, string(stored[0].Metadata))
+}
+
+func benchmarkInputs(n int) ([]v1beta1.SyftPackage, []model.Package) {
+	ids := make([]string, n)
+	doc := make([]model.Package, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("%016x-package-id", i)
+		ids[i] = id
+		doc[i] = docPackage(id, "JavaMetadata", map[string]string{"virtualPath": id})
+	}
+	return storedPackages(ids...), doc
+}
+
+func BenchmarkReattach(b *testing.B) {
+	for _, n := range []int{500, 2000, 8000} {
+		stored, doc := benchmarkInputs(n)
+		b.Run(fmt.Sprintf("packages-%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Reattach(stored, doc)
+			}
+		})
+	}
+}

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/metrics"
 	"github.com/kubescape/kubevuln/internal/registryauth"
+	"github.com/kubescape/kubevuln/internal/syftmeta"
 	"github.com/kubescape/kubevuln/internal/tools"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
@@ -409,17 +410,7 @@ func syftToDomain(sbomSBOM sbom.SBOM) *v1beta1.SyftDocument {
 	if err := json.Unmarshal(b, &syftDoc); err != nil {
 		return nil
 	}
-	for i := range syftDoc.Artifacts {
-		for j := range doc.Artifacts {
-			if syftDoc.Artifacts[i].ID == doc.Artifacts[j].ID {
-				syftDoc.Artifacts[i].MetadataType = doc.Artifacts[j].MetadataType
-				if b, err := json.Marshal(doc.Artifacts[j].Metadata); err == nil {
-					syftDoc.Artifacts[i].Metadata = b
-				}
-				break
-			}
-		}
-	}
+	syftmeta.Reattach(syftDoc.Artifacts, doc.Artifacts)
 
 	return syftDoc
 }


### PR DESCRIPTION
## Overview

putting each package's metadata back after the JSON round-trip into the storage types paired the two lists by scanning the whole Syft document for every stored package. that is quadratic in the package count and runs on every SBOM created.

against the same input, indexed by ID instead:

```
packages   scan        indexed
500        0.55 ms     0.19 ms
2000       4.50 ms     0.49 ms
8000     281.40 ms    12.90 ms
```

500 packages costs nothing either way. a Java or Node image in the low thousands is ordinary, and at 8000 the pairing alone was 281 ms per SBOM. the 12.9 ms left is the `json.Marshal` of each package's metadata, which is the actual work.

the loop itself is needed: `v1beta1.SyftPackage` holds `Metadata` as a `json.RawMessage`, so it does not survive being decoded and has to be reattached. only the search is replaced.

## Additional Information

there were two copies, one per SBOM path (`adapters/v1/syft_to_domain.go` for the in-process adapter, `pkg/sbomscanner/v1/server.go` for the sidecar), identical apart from the sidecar's dropping the warning when metadata will not marshal. this puts one copy in `internal/syftmeta` and has both call it. `adapters/v1` imports `pkg/sbomscanner/v1`, so the shared code cannot live in either of them, but `internal/` is already imported by both.

that de-duplication is the reason for a new package rather than the same fix written twice: those two paths drifting apart has caused three bugs on its own (#585, #587, #601).

pairing stays by ID rather than by position. the two lists are aligned in practice, since one is marshalled from the other, but nothing in the round-trip promises an order and a positional pairing would attach the wrong metadata if that ever stopped holding. on a duplicate ID the first Syft package wins, which is what the search did.

behaviour is otherwise unchanged, including leaving a stored package alone when the document has no counterpart, and keeping its existing metadata when marshalling fails. the sidecar gains the warning it was missing on that last case.

## How to Test

`go test ./internal/syftmeta/ ./adapters/v1/ ./pkg/sbomscanner/... -count=1`

six tests in the new package cover the pairing, ID-not-position pairing, unmatched packages, duplicate IDs, empty inputs, and unmarshalable metadata.

for the numbers above:

```
go test ./internal/syftmeta/ -run XXX -bench BenchmarkReattach -benchtime 30x
```

the existing adapter and sidecar tests are untouched and still pass.

## Related issues/PRs:

* Resolved #674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restoration of package metadata when converting scan results.
  - Ensured metadata remains correctly associated by package ID, even when package ordering differs or duplicate IDs exist.
  - Preserved existing metadata for unmatched packages or invalid metadata values.

- **Tests**
  - Added coverage for matching, duplicates, empty inputs, unmatched packages, and invalid metadata.
  - Added benchmarks for processing scans containing hundreds to thousands of packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->