### PR TITLE
fix(tools): bound a Retry-After so a registry cannot park a scan

### DIFF
--- a/internal/tools/retry.go
+++ b/internal/tools/retry.go
@@ -21,15 +21,32 @@ type RetryConfig struct {
 	InitialWait time.Duration
 	MaxWait     time.Duration
 	Backoff     float64
+	// MaxRetryAfter bounds a delay taken from a registry's Retry-After. That number is
+	// chosen by the registry rather than by us, and nothing else on this path stops the
+	// clock: the scan context is built with context.WithoutCancel, so it carries no
+	// deadline, and the sidecar's own scanTimeout only wraps SBOM generation, which comes
+	// after this. A ceiling well under the scan timeout keeps the header useful without
+	// letting one response decide how long a worker is held. Non-positive falls back to
+	// MaxWait.
+	MaxRetryAfter time.Duration
 }
 
 func Default429RetryConfig() RetryConfig {
 	return RetryConfig{
-		MaxAttempts: 3,
-		InitialWait: 500 * time.Millisecond,
-		MaxWait:     2 * time.Second,
-		Backoff:     2.0,
+		MaxAttempts:   3,
+		InitialWait:   500 * time.Millisecond,
+		MaxWait:       2 * time.Second,
+		Backoff:       2.0,
+		MaxRetryAfter: 30 * time.Second,
 	}
+}
+
+// retryAfterCeiling is the largest delay a Retry-After is allowed to ask for.
+func (c RetryConfig) retryAfterCeiling() time.Duration {
+	if c.MaxRetryAfter > 0 {
+		return c.MaxRetryAfter
+	}
+	return c.MaxWait
 }
 
 func IsRateLimitError(err error) bool {
@@ -108,6 +125,12 @@ func RetryWithBackoff[T any](ctx context.Context, operation string, config Retry
 		delay := wait
 		if retryAfter, ok := ParseRetryAfter(err); ok {
 			delay = retryAfter
+			if ceiling := config.retryAfterCeiling(); delay > ceiling {
+				logger.L().Ctx(ctx).Debug("capping Retry-After to the configured ceiling",
+					helpers.String("requested", retryAfter.String()),
+					helpers.String("ceiling", ceiling.String()))
+				delay = ceiling
+			}
 		} else {
 			if delay > 0 {
 				jitter := time.Duration(rand.Float64() * 0.25 * float64(delay))

--- a/internal/tools/retry_test.go
+++ b/internal/tools/retry_test.go
@@ -206,3 +206,76 @@ func TestRetryWithBackoff_MetricsRecordingExhausted(t *testing.T) {
 	assert.True(t, strings.Contains(body, `kubevuln_retry_attempts_total{operation="test_exhausted_op",outcome="attempt"} 1`), body)
 	assert.True(t, strings.Contains(body, `kubevuln_retry_attempts_total{operation="test_exhausted_op",outcome="exhausted"} 1`), body)
 }
+
+// A Retry-After is chosen by the registry, and nothing else on this path bounds the wait:
+// the scan context is built with context.WithoutCancel so it has no deadline, and the
+// sidecar's scanTimeout only wraps SBOM generation, which happens after source resolution.
+// Left uncapped, one 429 response decides how long a worker is held.
+func TestRetryWithBackoff_CapsRetryAfter(t *testing.T) {
+	cfg := RetryConfig{
+		MaxAttempts:   3,
+		InitialWait:   time.Millisecond,
+		MaxWait:       2 * time.Millisecond,
+		Backoff:       2.0,
+		MaxRetryAfter: 20 * time.Millisecond,
+	}
+	// Two orders of magnitude above the ceiling, standing in for a registry asking for hours.
+	rateLimited := errors.New("429 Too Many Requests, Retry-After: 2")
+
+	attempts := 0
+	start := time.Now()
+	_, err := RetryWithBackoff(context.Background(), "source_resolution", cfg, IsRateLimitError,
+		func(context.Context) (int, error) {
+			attempts++
+			return 0, rateLimited
+		})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Equal(t, cfg.MaxAttempts, attempts)
+	// Two waits at the 20ms ceiling, not two at the 2s the header asked for.
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"Retry-After must be capped at MaxRetryAfter, took %s", elapsed)
+}
+
+// The cap must not turn the header off: a Retry-After under the ceiling is still waited out,
+// which is the whole point of reading it.
+func TestRetryWithBackoff_HonoursRetryAfterUnderTheCeiling(t *testing.T) {
+	cfg := RetryConfig{
+		MaxAttempts:   2,
+		InitialWait:   time.Microsecond,
+		MaxWait:       time.Microsecond,
+		Backoff:       2.0,
+		MaxRetryAfter: time.Minute,
+	}
+	// Well above the backoff this config would otherwise produce, so the wait can only have
+	// come from the header.
+	rateLimited := errors.New("429 Too Many Requests, Retry-After: 1")
+
+	start := time.Now()
+	_, err := RetryWithBackoff(context.Background(), "source_resolution", cfg, IsRateLimitError,
+		func(context.Context) (int, error) { return 0, rateLimited })
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.GreaterOrEqual(t, elapsed, time.Second, "a Retry-After below the ceiling must still be honoured")
+}
+
+// A config that never sets MaxRetryAfter still gets a bound rather than an open-ended wait.
+func TestRetryWithBackoff_UnsetCeilingFallsBackToMaxWait(t *testing.T) {
+	cfg := RetryConfig{
+		MaxAttempts: 2,
+		InitialWait: time.Millisecond,
+		MaxWait:     10 * time.Millisecond,
+		Backoff:     2.0,
+	}
+	rateLimited := errors.New("429 Too Many Requests, Retry-After: 2")
+
+	start := time.Now()
+	_, err := RetryWithBackoff(context.Background(), "source_resolution", cfg, IsRateLimitError,
+		func(context.Context) (int, error) { return 0, rateLimited })
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 500*time.Millisecond, "took %s", elapsed)
+}


### PR DESCRIPTION
## Overview

`RetryWithBackoff` clamped the backoff it calculates to `MaxWait`, but the clamp sat inside the `else`, so a delay taken from a `Retry-After` went to `time.After` verbatim. that number comes from the registry's 429 response.

nothing else on the path bounds it. the scan context is `context.WithoutCancel(...)`, which in go carries no deadline; `adapters/v1/sidecar.go` calls the RPC on it with no `WithTimeout` and the client hands it to gRPC unchanged; and the sidecar's `scanTimeout` wraps SBOM generation further down `CreateSBOM`, while this retry is source resolution and runs before it. so `case <-ctx.Done()` never fires, the sleep runs to completion, and the worker-pool slot behind it is held for the duration. `scanConcurrency` defaults to 1.

with the default config, `MaxWait: 2s` and 3 attempts, an error carrying `Retry-After: 3` took 6s. `Retry-After: 86400` takes 48 hours the same way.

this adds `MaxRetryAfter` to `RetryConfig`, defaulted to 30s, and caps the header at it.

## Additional Information

capping at `MaxWait` instead would have been a smaller change, but at 2s it makes reading the header close to pointless, and honouring a registry's backoff is the reason #655 read it in the first place. 30s keeps it useful, and two waits at that ceiling is a small fraction of the 5 minute default scan timeout. it is one constant to change if you want it longer or shorter.

a config that never sets `MaxRetryAfter` falls back to `MaxWait` rather than to no bound, so a zero value cannot reintroduce the same thing, and there is a test for that.

the cap is logged at debug when it bites, so a registry asking for much longer than we are willing to wait is visible rather than silent.

## How to Test

`go test ./internal/tools/ -count=1`

- `TestRetryWithBackoff_CapsRetryAfter` asks for `Retry-After: 2` against a 20ms ceiling and asserts the whole run stays under 500ms. before this it takes 4s.
- `TestRetryWithBackoff_UnsetCeilingFallsBackToMaxWait` does the same with `MaxRetryAfter` unset. before this it takes 2s.
- `TestRetryWithBackoff_HonoursRetryAfterUnderTheCeiling` asks for `Retry-After: 1` under a 1 minute ceiling and asserts it is still waited out, so the cap does not quietly disable the header.

the existing retry tests, including the two metric ones from #655, are untouched and still pass.

## Related issues/PRs:

* Resolved #677
* Follow-up to #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a configurable maximum wait time for server-provided retry delays.
  * Retry delays exceeding the configured limit are now capped, preventing unexpectedly long waits.
  * Existing behavior remains unchanged when the new limit is not configured.

* **Tests**
  * Added coverage for capped, honored, and default retry-delay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->