### PR TITLE
fix(repositories): adopt the VEX statements we wrote before #595

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1198,9 +1198,68 @@ func applyIgnoredMatchAssessment(stmt *v1beta1.Statement, assessment ignoredVEXA
 // to defaultActionStatement.
 func buildActionStatement(v v1beta1.Match) string {
 	if v.Vulnerability.Fix.State == "fixed" && len(v.Vulnerability.Fix.Versions) > 0 {
-		return fmt.Sprintf("Upgrade %s to version %s", v.Artifact.PURL, strings.Join(v.Vulnerability.Fix.Versions, " or "))
+		return upgradeActionStatementPrefix(v.Artifact.PURL) + strings.Join(v.Vulnerability.Fix.Versions, " or ")
 	}
 	return defaultActionStatement
+}
+
+// hasSwappedVulnerabilityFields reports whether a statement carries the CVE in
+// Vulnerability.ID and the data source URL in Name, the mapping used before it was corrected
+// to match createVEX. Both the adoption below and the normalization that follows it key off
+// this, so they cannot disagree about which statements are written the old way round.
+func hasSwappedVulnerabilityFields(v v1beta1.VexVulnerability) bool {
+	return !strings.Contains(v.ID, "://") && (v.Name == "" || strings.Contains(v.Name, "://"))
+}
+
+// vulnerabilityCVEName returns the CVE identifier a statement carries, from whichever field
+// holds it. Statements written before #595 can be affected by both legacy shapes at once, no
+// ID and the swapped mapping, and stamping an ID needs the CVE rather than whatever happens
+// to be in Name.
+func vulnerabilityCVEName(v v1beta1.VexVulnerability) string {
+	if hasSwappedVulnerabilityFields(v) {
+		return v.ID
+	}
+	return v.Name
+}
+
+// upgradeActionStatementPrefix is the fixed part of the action statement
+// buildActionStatement writes when the fix versions are known. It is shared with
+// isOwnActionStatement so the two cannot drift on what our own wording looks like.
+func upgradeActionStatementPrefix(purl string) string {
+	return fmt.Sprintf("Upgrade %s to version ", purl)
+}
+
+// isOwnActionStatement reports whether an action statement is one kubevuln writes itself.
+//
+// markRelevantVulnerabilitiesAsAffectedInVex blanks the impact statement on a statement it
+// marks affected and fills this in instead, so on those this is the only wording of ours
+// left to recognise. Action statements arrived in #404, ten days before the IDs in #595, so
+// a statement written in between has one of these and no ID.
+//
+// The parameterised form is matched against the statement's own subcomponent rather than as
+// a loose prefix, so a feed's text that happens to open the same way does not qualify.
+func isOwnActionStatement(actionStatement, purl string) bool {
+	if actionStatement == defaultActionStatement {
+		return true
+	}
+	return purl != "" && strings.HasPrefix(actionStatement, upgradeActionStatementPrefix(purl))
+}
+
+// localStatementID is the ID kubevuln stamps on statements it authors.
+func localStatementID(cveName, purl string) string {
+	return fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(cveName), url.PathEscape(purl))
+}
+
+// isOwnImpactStatement reports whether an impact statement is one kubevuln writes itself.
+// It is the only thing left on a statement we stored before #595 that marks it as ours,
+// those having been written without an ID, and the wording is our own rather than anything
+// a feed would produce.
+func isOwnImpactStatement(impactStatement string) bool {
+	switch impactStatement {
+	case defaultLocalImpactStatement, securityExceptionImpactStatement:
+		return true
+	}
+	return false
 }
 
 func isLocalStatement(id string) bool {
@@ -1359,6 +1418,31 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 	originalVEX := *vexContainer.Spec.DeepCopy()
 	vexDoc := *vexContainer.Spec.DeepCopy()
 
+	// Statements we stored before #595 have no ID, that being the change which started
+	// setting one. #664 stopped reading an empty ID as ours so that a feed's ID-less
+	// statement is not overwritten, which is right, but it also left every statement we
+	// wrote before #595 looking like another author's: passed over by the reset loop and by
+	// every marking step, and passed over by the dedup too, so a second statement gets
+	// appended beside it for the same finding. Stamp the ID we would write today onto the
+	// ones carrying wording of ours, which brings them back under management and leaves
+	// anything else alone. Both fields are checked: a statement last written while affected
+	// had its impact statement blanked and an action statement put in its place, so that is
+	// the only wording left on it.
+	for i := range vexDoc.Statements {
+		s := &vexDoc.Statements[i]
+		if s.ID != "" {
+			continue
+		}
+		if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 {
+			continue
+		}
+		purl := s.Products[0].Subcomponents[0].ID
+		if !isOwnImpactStatement(s.ImpactStatement) && !isOwnActionStatement(s.ActionStatement, purl) {
+			continue
+		}
+		s.ID = localStatementID(vulnerabilityCVEName(s.Vulnerability), purl)
+	}
+
 	// Statements written before the ID/Name mapping was corrected to match createVEX
 	// carry the CVE identifier in ID and the data source URL in Name. Normalize them in
 	// place so the dedup below (which now keys on Name) also finds these older entries,
@@ -1367,7 +1451,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 		if !isLocalStatement(s.ID) {
 			continue
 		}
-		if !strings.Contains(s.Vulnerability.ID, "://") && (s.Vulnerability.Name == "" || strings.Contains(s.Vulnerability.Name, "://")) {
+		if hasSwappedVulnerabilityFields(s.Vulnerability) {
 			vexDoc.Statements[i].Vulnerability.ID, vexDoc.Statements[i].Vulnerability.Name = s.Vulnerability.Name, s.Vulnerability.ID
 		}
 	}

--- a/repositories/apiserver_external_test.go
+++ b/repositories/apiserver_external_test.go
@@ -260,3 +260,246 @@ func TestNewLocalStatement(t *testing.T) {
 	assert.Empty(t, stmt.ActionStatement)
 	assert.Empty(t, stmt.StatusNotes)
 }
+
+// Statements kubevuln wrote before #595 carry no ID, because #595 is what started setting
+// one. #595 recognised them as ours via isLocalStatement's id == "" clause; #664 removed
+// that clause so an external feed's ID-less statement would not be overwritten, which left
+// every pre-#595 statement looking like another author's data: frozen by the reset loop and
+// duplicated by the dedup, which now skips anything non-local.
+func TestAPIServerStore_updateVEX_adoptsPre595StatementsWithoutIDs(t *testing.T) {
+	cveManifestFull := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	})
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	var target v1beta1.Statement
+	for _, s := range vexContainer.Spec.Statements {
+		if isLocalStatement(s.ID) && len(s.Products) > 0 && len(s.Products[0].Subcomponents) > 0 {
+			target = s
+			break
+		}
+	}
+	require.NotEmpty(t, target.Vulnerability.Name)
+	pkg := target.Products[0].Subcomponents[0].ID
+
+	// Reshape it the way kubevuln stored it before #595: no ID, and carrying kubevuln's own
+	// impact statement. A stale status stands in for one written by an earlier scan.
+	legacy := *target.DeepCopy()
+	legacy.ID = ""
+	legacy.Status = v1beta1.Status(vex.StatusAffected)
+	legacy.ImpactStatement = defaultLocalImpactStatement
+
+	kept := make([]v1beta1.Statement, 0, len(vexContainer.Spec.Statements))
+	for _, s := range vexContainer.Spec.Statements {
+		if s.ID != target.ID {
+			kept = append(kept, s)
+		}
+	}
+	vexContainer.Spec.Statements = append(kept, legacy)
+	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(ctx, vexContainer, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+	updated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	var forTarget []v1beta1.Statement
+	for _, s := range updated.Spec.Statements {
+		if s.Vulnerability.Name != target.Vulnerability.Name {
+			continue
+		}
+		if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 || s.Products[0].Subcomponents[0].ID != pkg {
+			continue
+		}
+		forTarget = append(forTarget, s)
+	}
+
+	require.Len(t, forTarget, 1, "our own older statement must be adopted, not left beside a fresh duplicate")
+	assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), forTarget[0].Status,
+		"an adopted statement must be managed again, so the reset loop returns it to baseline")
+}
+
+// A statement can carry both legacy shapes at once: no ID, and the CVE in Vulnerability.ID
+// with the data source in Name, from before that mapping was corrected. Adoption runs ahead
+// of the normalization that repairs the mapping (it has to, since normalization only touches
+// statements already recognised as ours), so it has to read the CVE from whichever field
+// holds it or the ID it stamps is built from a URL and is wrong for good.
+func TestAPIServerStore_updateVEX_adoptsStatementsWithBothLegacyShapes(t *testing.T) {
+	cveManifestFull := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	})
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	var target v1beta1.Statement
+	for _, s := range vexContainer.Spec.Statements {
+		if isLocalStatement(s.ID) && len(s.Products) > 0 && len(s.Products[0].Subcomponents) > 0 {
+			target = s
+			break
+		}
+	}
+	require.NotEmpty(t, target.Vulnerability.Name)
+	cve := target.Vulnerability.Name
+	dataSource := target.Vulnerability.ID
+	pkg := target.Products[0].Subcomponents[0].ID
+	require.Contains(t, dataSource, "://", "the fixture's data source should be a URL")
+
+	// No ID, and the CVE and data source the other way round.
+	legacy := *target.DeepCopy()
+	legacy.ID = ""
+	legacy.Vulnerability.ID = cve
+	legacy.Vulnerability.Name = dataSource
+	legacy.ImpactStatement = defaultLocalImpactStatement
+
+	kept := make([]v1beta1.Statement, 0, len(vexContainer.Spec.Statements))
+	for _, s := range vexContainer.Spec.Statements {
+		if s.ID != target.ID {
+			kept = append(kept, s)
+		}
+	}
+	vexContainer.Spec.Statements = append(kept, legacy)
+	_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(ctx, vexContainer, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+	updated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	var forTarget []v1beta1.Statement
+	for _, s := range updated.Spec.Statements {
+		if s.Vulnerability.Name != cve {
+			continue
+		}
+		if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 || s.Products[0].Subcomponents[0].ID != pkg {
+			continue
+		}
+		forTarget = append(forTarget, s)
+	}
+
+	require.Len(t, forTarget, 1, "the doubly-legacy statement must be adopted, not duplicated")
+	assert.Equal(t, localStatementID(cve, pkg), forTarget[0].ID,
+		"the stamped ID must be built from the CVE, not from whatever Name held before normalization")
+	assert.Equal(t, dataSource, forTarget[0].Vulnerability.ID, "normalization must still repair the mapping")
+}
+
+// A statement last written while affected has no impact statement: the marking step blanks
+// it and writes an action statement instead. That action statement is still wording of ours,
+// and it arrived in #404, ten days before the IDs in #595, so a statement from that window
+// carries one and no ID. Without recognising it, an affected statement stays unmanaged and
+// gets duplicated on every rescan, the same failure this adoption exists to stop.
+func TestAPIServerStore_updateVEX_adoptsAffectedStatementsByActionStatement(t *testing.T) {
+	cveManifestFull := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	tests := []struct {
+		name            string
+		actionStatement func(purl string) string
+	}{
+		{"fallback wording", func(string) string { return defaultActionStatement }},
+		{"named fix versions", func(purl string) string { return upgradeActionStatementPrefix(purl) + "1.2.3 or 1.3.0" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewFakeAPIServerStorage("kubescape")
+			ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
+				ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+				InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+				Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+				ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+				ContainerName: "anyJobContName",
+			})
+
+			require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+			vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			var target v1beta1.Statement
+			for _, s := range vexContainer.Spec.Statements {
+				if isLocalStatement(s.ID) && len(s.Products) > 0 && len(s.Products[0].Subcomponents) > 0 {
+					target = s
+					break
+				}
+			}
+			require.NotEmpty(t, target.Vulnerability.Name)
+			pkg := target.Products[0].Subcomponents[0].ID
+
+			// The shape markRelevantVulnerabilitiesAsAffectedInVex leaves behind, stored
+			// before IDs existed.
+			legacy := *target.DeepCopy()
+			legacy.ID = ""
+			legacy.Status = v1beta1.Status(vex.StatusAffected)
+			legacy.Justification = ""
+			legacy.ImpactStatement = ""
+			legacy.ActionStatement = tt.actionStatement(pkg)
+
+			kept := make([]v1beta1.Statement, 0, len(vexContainer.Spec.Statements))
+			for _, s := range vexContainer.Spec.Statements {
+				if s.ID != target.ID {
+					kept = append(kept, s)
+				}
+			}
+			vexContainer.Spec.Statements = append(kept, legacy)
+			_, err = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Update(ctx, vexContainer, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
+			require.NoError(t, a.StoreVEX(ctx, cveManifestFull, cveManifestFiltered, false))
+			updated, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cveManifestFull.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			var forTarget []v1beta1.Statement
+			for _, s := range updated.Spec.Statements {
+				if s.Vulnerability.Name != target.Vulnerability.Name {
+					continue
+				}
+				if len(s.Products) == 0 || len(s.Products[0].Subcomponents) == 0 || s.Products[0].Subcomponents[0].ID != pkg {
+					continue
+				}
+				forTarget = append(forTarget, s)
+			}
+
+			require.Len(t, forTarget, 1, "the affected statement must be adopted, not left beside a duplicate")
+			assert.Equal(t, localStatementID(target.Vulnerability.Name, pkg), forTarget[0].ID)
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), forTarget[0].Status,
+				"once adopted it is managed again, so the reset loop returns it to baseline")
+		})
+	}
+}
+
+// An action statement that opens like ours but names a different package is another author's.
+func TestIsOwnActionStatement(t *testing.T) {
+	const purl = "pkg:deb/debian/tar@1.29"
+
+	assert.True(t, isOwnActionStatement(defaultActionStatement, purl))
+	assert.True(t, isOwnActionStatement(upgradeActionStatementPrefix(purl)+"1.30", purl))
+	assert.False(t, isOwnActionStatement(upgradeActionStatementPrefix("pkg:deb/debian/other@1.0")+"2.0", purl))
+	assert.False(t, isOwnActionStatement("Upgrade something to version 9", purl))
+	assert.False(t, isOwnActionStatement("", purl))
+
+	// The constant is ours whatever the subcomponent says, but the parameterised form is
+	// only ours when it names this statement's own package, so an empty purl must not let
+	// it through.
+	assert.True(t, isOwnActionStatement(defaultActionStatement, ""))
+	assert.False(t, isOwnActionStatement(upgradeActionStatementPrefix(purl)+"1.30", ""))
+}


### PR DESCRIPTION
## Overview

#664 stopped `isLocalStatement` reading an empty ID as ours, so that a feed's ID-less statement is not overwritten. that is right, and this keeps it.

statements kubevuln wrote before #595 also have no ID though, #595 being the change that started setting one. so on any cluster that ran kubevuln before then, everything already in storage now reads as another author's data: skipped by the reset loop, by both marking steps, by the ID/Name normalization, and by the dedup, which appends a fresh statement beside it for the same finding. the document ends up with a stale copy of every finding it had, each frozen at whatever status it was written with.

the two cases are separable by what is on the statement. one of ours carries an impact statement we wrote, `"Vulnerable component is not loaded into the memory"` or `"Vulnerability was ignored by a SecurityException"`, and both are still the constants used today. this stamps the ID we would write now onto ID-less statements carrying one of them, before the local/external split, so they come back under management. every other ID-less statement is left exactly as #664 leaves it.

## Additional Information

adoption is deliberately narrow. it needs an empty ID, one of our two impact statements, and a product with a subcomponent to build the ID from. a feed would have to reproduce our own wording word for word to be picked up, and #664's test case, whose impact statement is `"External feed assessed this one (no ID)"`, is untouched and still passes.

the ID format was written out at four call sites, so it is now `localStatementID`, which the adoption also uses. that keeps the stamped ID identical to the one `createVEX` writes rather than a second copy of the format string that could drift from it.

this is only reachable through `updateVEX`, so a fresh document is unaffected, and adoption is a no-op once a statement has an ID.

## How to Test

`go test ./repositories/ -count=1`

`TestAPIServerStore_updateVEX_adoptsPre595StatementsWithoutIDs` takes a statement from a stored document, reshapes it the way it would have been stored before #595 (no ID, our impact statement, a stale status), and runs `StoreVEX` again. it asserts one statement for that vulnerability and package rather than two, and that it has been reset to baseline.

before this it fails with the duplicate:

```
{                                    ... CVE-2005-2541 ... tar@1.29b-1.1 ... affected     ...}
{https://kubescape.io/vex/statement/CVE-2005-2541/... tar@1.29b-1.1 ... not_affected ...}
should have 1 item(s), but has 2
```

`TestAPIServerStore_updateVEX_preservesExternalStatements` from #664 and `TestAPIServerStore_updateVEX_externalStatementDoesNotSuppressLocalOne` from #633 are both untouched and still pass.

## Related issues/PRs:

* Resolved #681
* Follow-up to #664


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of previously created VEX statements that do not have IDs.
  - Existing locally authored vulnerability statements are now recognized and reused instead of duplicated.
  - Statement identifiers are assigned consistently during creation and updates.
  - Legacy vulnerability field mappings are recognized and normalized automatically.
  - Adopted legacy statements are reset to the current baseline status during subsequent updates, ensuring displayed vulnerability information remains accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->