### PR TITLE
fix(services): count a singleflight waiter even when the creation failed

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -1382,6 +1382,13 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 
 	select {
 	case res := <-ch:
+		if !ran {
+			// Counted before the error is handled: a caller that waited on a shared creation
+			// was spared the work whether or not that creation succeeded, and a failing
+			// image is the one a burst of scans keeps arriving for, so leaving those out
+			// hides the deduplication where there is most of it.
+			metrics.RecordSingleflightHit(ctx, "sbom_generation")
+		}
 		if res.Err != nil {
 			// The leader already reported this failure with its own workload identity
 			// from inside the closure. Every other caller sharing the same result would
@@ -1392,9 +1399,6 @@ func (s *ScanService) getOrCreateSBOM(ctx context.Context, workload domain.ScanC
 				s.reportWaiterSBOMFailure(workerCtx, res.Err)
 			}
 			return domain.SBOM{}, nil, res.Err
-		}
-		if !ran {
-			metrics.RecordSingleflightHit(ctx, "sbom_generation")
 		}
 		created := res.Val.(sbomCreation)
 		return created.sbom, created.storeErr, nil

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2836,6 +2836,62 @@ func TestScanService_SingleflightHitsCountOnlyDeduplicatedCallers(t *testing.T) 
 		"the caller that did the work is not one of the callers it spared")
 }
 
+// A caller that waited on a shared SBOM creation was spared the work whether or not that
+// creation succeeded, so it is deduplicated either way. The error path returned before the
+// hit was recorded, so every waiter on a failing image went uncounted, and a failing image
+// is exactly the one a burst of scans keeps retrying.
+func TestScanService_SingleflightHitsCountedWhenCreationFails(t *testing.T) {
+	m, err := metrics.New()
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	creator := &blockingSBOMCreator{
+		SBOMCreator: adapters.NewMockSBOMAdapter(true, false, false), // CreateSBOM fails
+		onStart: func() {
+			once.Do(func() { close(started) })
+			<-release
+		},
+	}
+
+	store := repositories.NewMemoryStorage(false, false)
+	s := NewScanService(creator, store, adapters.NewMockCVEAdapter(), store, adapters.NewMockPlatform(false, nil), adapters.NewMockRelevancyAdapter(), false, false, true, false, false)
+
+	workload := domain.ScanCommand{
+		ImageSlug:          "library-alpine-latest-1234567890ab",
+		ImageTagNormalized: "library/alpine:latest",
+		ImageHash:          "sha256:1234567890ab",
+	}
+
+	const callers = 5
+	var startWg, wg sync.WaitGroup
+	startWg.Add(callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startWg.Done()
+			_, _, err := s.getOrCreateSBOM(context.TODO(), workload)
+			assert.Error(t, err, "every caller must see the shared failure")
+		}()
+	}
+	startWg.Wait()
+	<-started
+	close(release)
+	wg.Wait()
+
+	creator.mu.Lock()
+	ranTheWork := creator.calls
+	creator.mu.Unlock()
+
+	w := httptest.NewRecorder()
+	m.Handler().ServeHTTP(w, httptest.NewRequest("GET", "/metrics", nil))
+	assert.Contains(t, w.Body.String(),
+		fmt.Sprintf(`kubevuln_singleflight_hits_total{target="sbom_generation"} %d`, callers-ranTheWork),
+		"a waiter is deduplicated whether the shared creation succeeded or failed")
+}
+
 func TestScanService_SingleflightSBOMDeduplication(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})


### PR DESCRIPTION
## Overview

`kubevuln_singleflight_hits_total` recorded nothing when the shared SBOM creation failed, because the error was handled and returned before the hit was recorded.

a caller that waited on that creation was spared it either way: it pulled no image and built no SBOM, it was handed someone else's result. #642 and #649 already treat those same callers as real enough to each get their own `ReportScanFailure`, two lines above where the counter was being skipped.

the gap is not evenly spread. a burst of concurrent scans for one image is most likely while that image keeps failing, a registry outage or an auth problem or an image over the size limit, so the deduplication went uncounted in the window that has most of it and the counter read as though singleflight were doing nothing.

the hit is now recorded before the error is handled.

## Additional Information

the early return came in with #610. #631 left it where it was: that change was about `res.Shared` counting the leader as one of the callers it spared, and only swapped the condition on the line without moving it. I wrote #631 and did not notice the ordering at the time.

no change to what counts as a hit, only to when it is recorded, so the leader is still excluded via `ran`.

## How to Test

`go test ./core/services/ -run Singleflight -count=1`

`TestScanService_SingleflightHitsCountedWhenCreationFails` runs five callers against one image whose `CreateSBOM` fails, on the blocking creator #610 already uses, and asserts the hits equal the callers that did not run the work. it asserts `callers - CreateSBOM calls` rather than a fixed four, so a caller arriving late enough to start its own round does not make it flap.

before this the counter is absent from the scrape entirely:

```
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="kubevuln"} 1
does not contain kubevuln_singleflight_hits_total{target="sbom_generation"} 4
```

`TestScanService_SingleflightHitsCountOnlyDeduplicatedCallers` from #631 and `TestScanService_SingleflightSBOMDeduplication` from #610 are untouched and still pass.

## Related issues/PRs:

* Resolved #683
