### PR TITLE
refactor(registryauth): share the registry auth fallback ladder

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -201,57 +201,16 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 
 	//nolint:staticcheck // stereoscope expects string key image.MaxImageSize
 	ctxWithSize := context.WithValue(ctxWithTimeout, image.MaxImageSize, s.maxImageSize)
-	pullRef := rewriteImageRef(imageID, s.proxyRegistryMap)
-	usedFallback := false
-	src, err := syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
-
-	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
-		usedFallback = true
-		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
-			helpers.String("imageTag", imageTag),
-			helpers.String("imageID", imageID))
-		pullRef = rewriteImageRef(imageTag, s.proxyRegistryMap)
-		src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
-	}
-
-	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
-		usedFallback = true
-		unauthorizedErr := err
-		if provider, ok := registryauth.For(pullRef); ok {
-			if creds, credErr := provider.Credentials(ctxWithTimeout, pullRef); credErr != nil || creds == nil {
-				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), metrics.FallbackOutcomeFailed)
-				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
-					helpers.Error(credErr),
-					helpers.String("imageID", imageID))
-			} else {
-				registryOptions.Credentials = []image.RegistryCredentials{*creds}
-				src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
-				outcome := metrics.FallbackOutcomeFailed
-				if err == nil {
-					outcome = metrics.FallbackOutcomeSucceeded
-				}
-				metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), outcome)
-			}
-		}
-		// If no provider matched, its credentials were unavailable, or it succeeded in auth
-		// but still got 401, fall back to anonymous access. err/src retain the last attempt.
-		if err != nil {
-			logger.L().Debug("retrying without credentials",
-				helpers.String("imageID", imageID))
-			registryOptions.Credentials = nil
-			src, err = syft.GetSource(ctxWithSize, pullRef, syftGetSourceConfig(&registryOptions, imgPlatform))
-			outcome := metrics.FallbackOutcomeFailed
-			if err == nil {
-				outcome = metrics.FallbackOutcomeSucceeded
-			}
-			metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyAnonymous, outcome)
-			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
-				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
-			}
-		}
-	}
-
-	metrics.RecordSourceResolution(ctx, metrics.ComponentInProcess, usedFallback, err == nil)
+	// The MANIFEST_UNKNOWN and 401 fallback ladder lives in internal/registryauth, shared
+	// with the sidecar scanner, which ran a copy of it. The pull keeps its own context,
+	// carrying the size limit; ctxWithTimeout is what bounds the credential lookup.
+	src, err := registryauth.ResolveSource(ctxWithTimeout, metrics.ComponentInProcess,
+		func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+			return syft.GetSource(ctxWithSize, ref, syftGetSourceConfig(opts, imgPlatform))
+		},
+		rewriteImageRef(imageID, s.proxyRegistryMap),
+		rewriteImageRef(imageTag, s.proxyRegistryMap),
+		registryOptions)
 
 	switch {
 	// Note: stereoscope/oci-registry wraps deadline errors in a custom error type that does not implement Unwrap(),

--- a/internal/registryauth/resolve.go
+++ b/internal/registryauth/resolve.go
@@ -1,0 +1,89 @@
+package registryauth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/kubevuln/internal/metrics"
+)
+
+// Getter pulls an image source for a reference. It is generic over the source type so this
+// package stays free of Syft: the fallback ladder below cares about which reference and
+// which credentials to try, not about what comes back.
+type Getter[T any] func(ctx context.Context, ref string, opts *image.RegistryOptions) (T, error)
+
+// ResolveSource pulls imageID, falling back in order when the pull fails:
+//
+//   - MANIFEST_UNKNOWN, which a registry returns for a digest it does not hold, is retried
+//     against imageTag.
+//   - 401 Unauthorized is retried with credentials from the provider matching the reference
+//     (ECR, GCP), and then, if that provider has none or its credentials are refused too,
+//     without credentials at all. A registry that rejects our credentials may still serve
+//     the image anonymously.
+//
+// component is the metrics label for the caller (in_process or sidecar), and ctx is used for
+// the credential lookup and the metrics, not for the pull: both callers hand the pull a
+// context of their own choosing.
+//
+// Both SBOM paths need this ladder and had a copy each. One copy is worth keeping here:
+// those two drifting apart is where #585, #587, #601 and #675 came from, and the sidecar's
+// copy had already reimplemented For inline rather than calling it.
+func ResolveSource[T any](ctx context.Context, component string, get Getter[T], imageID, imageTag string, opts image.RegistryOptions) (T, error) {
+	pullRef := imageID
+	usedFallback := false
+
+	src, err := get(ctx, pullRef, &opts)
+
+	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+		usedFallback = true
+		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
+			helpers.String("imageTag", imageTag),
+			helpers.String("imageID", imageID))
+		pullRef = imageTag
+		src, err = get(ctx, pullRef, &opts)
+	}
+
+	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
+		usedFallback = true
+		unauthorizedErr := err
+		if provider, ok := For(pullRef); ok {
+			if creds, credErr := provider.Credentials(ctx, pullRef); credErr != nil || creds == nil {
+				metrics.RecordScanFallback(ctx, component, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), metrics.FallbackOutcomeFailed)
+				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
+					helpers.Error(credErr),
+					helpers.String("imageID", imageID))
+			} else {
+				opts.Credentials = []image.RegistryCredentials{*creds}
+				src, err = get(ctx, pullRef, &opts)
+				outcome := metrics.FallbackOutcomeFailed
+				if err == nil {
+					outcome = metrics.FallbackOutcomeSucceeded
+				}
+				metrics.RecordScanFallback(ctx, component, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), outcome)
+			}
+		}
+		// If no provider matched, its credentials were unavailable, or it succeeded in auth
+		// but still got 401, fall back to anonymous access. err/src retain the last attempt.
+		if err != nil {
+			logger.L().Debug("retrying without credentials",
+				helpers.String("imageID", imageID))
+			opts.Credentials = nil
+			src, err = get(ctx, pullRef, &opts)
+			outcome := metrics.FallbackOutcomeFailed
+			if err == nil {
+				outcome = metrics.FallbackOutcomeSucceeded
+			}
+			metrics.RecordScanFallback(ctx, component, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyAnonymous, outcome)
+			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
+				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
+			}
+		}
+	}
+
+	metrics.RecordSourceResolution(ctx, component, usedFallback, err == nil)
+	return src, err
+}

--- a/internal/registryauth/resolve_test.go
+++ b/internal/registryauth/resolve_test.go
@@ -1,0 +1,84 @@
+package registryauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ResolveSource is generic over what a pull returns, so the ladder can be exercised without
+// Syft. The sidecar and the in-process adapter both reach it with their own source type.
+type fakeSource struct{ ref string }
+
+func TestResolveSource_RetriesTagOnManifestUnknown(t *testing.T) {
+	var tried []string
+	get := func(_ context.Context, ref string, _ *image.RegistryOptions) (fakeSource, error) {
+		tried = append(tried, ref)
+		if ref == "repo@sha256:deadbeef" {
+			return fakeSource{}, errors.New("MANIFEST_UNKNOWN: manifest unknown")
+		}
+		return fakeSource{ref: ref}, nil
+	}
+
+	src, err := ResolveSource(context.Background(), "in_process", get,
+		"repo@sha256:deadbeef", "repo:latest", image.RegistryOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "repo:latest", src.ref)
+	assert.Equal(t, []string{"repo@sha256:deadbeef", "repo:latest"}, tried)
+}
+
+// A registry that refuses our credentials may still serve the image anonymously, so a 401
+// falls back to a pull with none. No provider matches a plain docker.io reference, so this
+// goes straight to the anonymous attempt.
+func TestResolveSource_FallsBackToAnonymousOn401(t *testing.T) {
+	var credentialsSeen []int
+	get := func(_ context.Context, ref string, opts *image.RegistryOptions) (fakeSource, error) {
+		credentialsSeen = append(credentialsSeen, len(opts.Credentials))
+		if len(opts.Credentials) > 0 {
+			return fakeSource{}, errors.New("401 Unauthorized")
+		}
+		return fakeSource{ref: ref}, nil
+	}
+
+	opts := image.RegistryOptions{Credentials: []image.RegistryCredentials{{Username: "u", Password: "p"}}}
+	src, err := ResolveSource(context.Background(), "in_process", get, "docker.io/library/nginx:1.25", "docker.io/library/nginx:1.25", opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, "docker.io/library/nginx:1.25", src.ref)
+	assert.Equal(t, []int{1, 0}, credentialsSeen, "the retry must drop the credentials that were refused")
+}
+
+// The caller's options must not be modified: the ladder swaps credentials as it retries, and
+// a caller reusing its RegistryOptions for a later pull would otherwise inherit that.
+func TestResolveSource_DoesNotMutateCallerOptions(t *testing.T) {
+	get := func(_ context.Context, _ string, _ *image.RegistryOptions) (fakeSource, error) {
+		return fakeSource{}, errors.New("401 Unauthorized")
+	}
+
+	opts := image.RegistryOptions{Credentials: []image.RegistryCredentials{{Username: "u", Password: "p"}}}
+	_, err := ResolveSource(context.Background(), "in_process", get, "docker.io/library/nginx:1.25", "docker.io/library/nginx:1.25", opts)
+
+	require.Error(t, err)
+	require.Len(t, opts.Credentials, 1, "the caller's credentials must survive the anonymous retry")
+	assert.Equal(t, "u", opts.Credentials[0].Username)
+}
+
+// An error that is neither MANIFEST_UNKNOWN nor a 401 is returned as it is, with one attempt.
+func TestResolveSource_PassesOtherErrorsStraightBack(t *testing.T) {
+	attempts := 0
+	boom := errors.New("no route to host")
+	get := func(_ context.Context, _ string, _ *image.RegistryOptions) (fakeSource, error) {
+		attempts++
+		return fakeSource{}, boom
+	}
+
+	_, err := ResolveSource(context.Background(), "in_process", get, "repo:tag", "repo:tag", image.RegistryOptions{})
+
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, 1, attempts)
+}

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -72,59 +72,8 @@ type sourceGetter func(ctx context.Context, ref string, opts *image.RegistryOpti
 // 401/provider/anonymous fallbacks in order. It mirrors the retry chain in
 // adapters/v1/syft.go so the sidecar and in-process adapters behave the same.
 func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag string, opts image.RegistryOptions) (source.Source, error) {
-	pullRef := imageID
-	usedFallback := false
-	src, err := get(ctx, pullRef, &opts)
-	if err != nil && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
-		usedFallback = true
-		logger.L().Debug("got MANIFEST_UNKNOWN, retrying with imageTag",
-			helpers.String("imageTag", imageTag),
-			helpers.String("imageID", imageID))
-		pullRef = imageTag
-		src, err = get(ctx, pullRef, &opts)
-	}
-	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
-		usedFallback = true
-		unauthorizedErr := err
-		for _, provider := range registryauth.Providers {
-			if !provider.Matches(pullRef) {
-				continue
-			}
-			if creds, credErr := provider.Credentials(ctx, pullRef); credErr != nil || creds == nil {
-				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), metrics.FallbackOutcomeFailed)
-				logger.L().Debug("registry auth provider credentials unavailable, falling back to anonymous",
-					helpers.Error(credErr),
-					helpers.String("imageID", imageID))
-			} else {
-				opts.Credentials = []image.RegistryCredentials{*creds}
-				src, err = get(ctx, pullRef, &opts)
-				outcome := metrics.FallbackOutcomeFailed
-				if err == nil {
-					outcome = metrics.FallbackOutcomeSucceeded
-				}
-				metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, provider.Strategy(), outcome)
-			}
-			break
-		}
-		// If no provider matched, its credentials were unavailable, or it succeeded
-		// in auth but still got 401, fall back to anonymous access.
-		if err != nil {
-			logger.L().Debug("retrying without credentials",
-				helpers.String("imageID", imageID))
-			opts.Credentials = nil
-			src, err = get(ctx, pullRef, &opts)
-			outcome := metrics.FallbackOutcomeFailed
-			if err == nil {
-				outcome = metrics.FallbackOutcomeSucceeded
-			}
-			metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryRegistryAuth, metrics.FallbackStrategyAnonymous, outcome)
-			if err != nil && !strings.Contains(err.Error(), "401 Unauthorized") {
-				err = fmt.Errorf("%w (anonymous fallback failed: %v)", unauthorizedErr, err)
-			}
-		}
-	}
-	metrics.RecordSourceResolution(ctx, metrics.ComponentSidecar, usedFallback, err == nil)
-	return src, err
+	return registryauth.ResolveSource(ctx, metrics.ComponentSidecar,
+		registryauth.Getter[source.Source](get), imageID, imageTag, opts)
 }
 
 type scannerServer struct {


### PR DESCRIPTION
## Overview

the registry auth fallback ladder existed twice, about fifty lines each and the same fifty: retry MANIFEST_UNKNOWN against the tag, then walk a 401 through the matching provider and on to anonymous, wrapping the anonymous failure back into the original 401. one copy in the in-process `SyftAdapter`, one in the sidecar scanner's `resolveSource`.

this puts it in `internal/registryauth.ResolveSource` and has both call it. that removes 51 lines from `adapters/v1/syft.go` and 51 from `pkg/sbomscanner/v1/server.go`.

that pair drifting apart is where #585, #587, #601 and #675 came from, and this copy had already started: the sidecar walked `registryauth.Providers` by hand rather than calling `registryauth.For`, which is that loop exactly, and which the in-process copy does call.

## Additional Information

`internal/` is where it has to go. `adapters/v1` imports `pkg/sbomscanner/v1`, so the shared code cannot live in either, and both already depend on `internal/registryauth` and `internal/metrics`.

`ResolveSource` is generic over what a pull returns, so `internal/registryauth` does not have to import Syft. The ladder is about which reference and which credentials to try next, not about what comes back, and the sidecar's `sourceGetter` had already made the pull itself a parameter, so the shape was mostly there.

behaviour is unchanged on both sides. the pull keeps its own context on both, the in-process one carrying the size limit and the sidecar detaching for #421; the context handed to `ResolveSource` is the one used for the credential lookup and the metrics, which is `ctxWithTimeout` in-process and the request context on the sidecar, exactly as before. the metrics component label is a parameter.

## How to Test

`go test ./internal/registryauth/ ./adapters/... ./pkg/... -count=1`

the sidecar's five existing tests (`TestResolveSource`, `..._RecordsFallbackMetrics`, `..._CustomProvider`, `..._ProviderNilCredentialsFallsBackAnonymous`, `..._ProviderMatchesUsesPullRef`) are untouched and pass against the shared implementation, which is what says the extraction did not change it.

four new tests in `internal/registryauth` cover the ladder directly: the MANIFEST_UNKNOWN retry against the tag, the anonymous retry dropping refused credentials, an unrelated error going straight back after one attempt, and the caller's `RegistryOptions` surviving unmodified, since the ladder swaps credentials as it retries and a caller reusing its options for a later pull would otherwise inherit that.

the in-process ladder had no tests at all before this, nothing in `adapters/v1` exercises a 401, so it is covered now by the same tests as the sidecar rather than by nothing.

## Related issues/PRs:

* Resolved #685
