### PR TITLE
refactor(repositories): build the local VEX statement in one place

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1149,6 +1149,39 @@ func ignoredMatchStatusNotes(rule v1beta1.IgnoreRule) string {
 	return strings.Join(parts, "; ")
 }
 
+// newLocalStatement builds the VEX statement kubevuln writes for a match, in the baseline
+// not_affected shape. createVEX and updateVEX each build one for a match and one for an
+// ignored match, and all four spelled it out; this is the one place that shape is defined,
+// so a field added to it cannot reach three sites and miss the fourth.
+//
+// A caller recording a suppression overwrites the baseline with applyIgnoredMatchAssessment,
+// which sets every one of the five fields it touches.
+func newLocalStatement(m v1beta1.Match, imagePullable string) (v1beta1.Statement, error) {
+	product, err := createProductStructForImageAndPackage(imagePullable, m.Artifact.PURL)
+	if err != nil {
+		return v1beta1.Statement{}, err
+	}
+
+	var aliases []string
+	for _, alias := range m.RelatedVulnerabilities {
+		aliases = append(aliases, alias.ID)
+	}
+
+	return v1beta1.Statement{
+		ID: fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(m.Vulnerability.ID), url.PathEscape(m.Artifact.PURL)),
+		Vulnerability: v1beta1.VexVulnerability{
+			ID:          m.Vulnerability.DataSource,
+			Name:        m.Vulnerability.ID,
+			Description: m.Vulnerability.Description,
+			Aliases:     aliases,
+		},
+		Products:        []v1beta1.Product{*product},
+		Status:          v1beta1.Status(vex.StatusNotAffected),
+		Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
+		ImpactStatement: defaultLocalImpactStatement,
+	}, nil
+}
+
 func applyIgnoredMatchAssessment(stmt *v1beta1.Statement, assessment ignoredVEXAssessment) {
 	stmt.Status = assessment.status
 	stmt.Justification = assessment.justification
@@ -1234,60 +1267,17 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 	// Both loops read cve.Content, so both are guarded by the same nil check.
 	if cve.Content != nil {
 		for _, v := range cve.Content.Matches {
-			var aliases []string
-			for _, alias := range v.RelatedVulnerabilities {
-				aliases = append(aliases, alias.ID)
-			}
-
-			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
-
+			stmt, err := newLocalStatement(v, imagePullable)
 			if err != nil {
 				return err
 			}
-
-			vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
-				ID: fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(v.Vulnerability.ID), url.PathEscape(v.Artifact.PURL)),
-				Vulnerability: v1beta1.VexVulnerability{
-					ID:          v.Vulnerability.DataSource,
-					Name:        v.Vulnerability.ID,
-					Description: v.Vulnerability.Description,
-					Aliases:     aliases,
-				},
-
-				Products: []v1beta1.Product{
-					*product,
-				},
-
-				Status:          v1beta1.Status(vex.StatusNotAffected),
-				Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-				ImpactStatement: defaultLocalImpactStatement,
-			})
+			vexDoc.Statements = append(vexDoc.Statements, stmt)
 		}
 
 		for _, v := range cve.Content.IgnoredMatches {
-			var aliases []string
-			for _, alias := range v.RelatedVulnerabilities {
-				aliases = append(aliases, alias.ID)
-			}
-
-			product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
-
+			stmt, err := newLocalStatement(v.Match, imagePullable)
 			if err != nil {
 				return err
-			}
-
-			stmt := v1beta1.Statement{
-				ID: fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(v.Vulnerability.ID), url.PathEscape(v.Artifact.PURL)),
-				Vulnerability: v1beta1.VexVulnerability{
-					ID:          v.Vulnerability.DataSource,
-					Name:        v.Vulnerability.ID,
-					Description: v.Vulnerability.Description,
-					Aliases:     aliases,
-				},
-
-				Products: []v1beta1.Product{
-					*product,
-				},
 			}
 			applyIgnoredMatchAssessment(&stmt, ignoredMatchAssessment(v))
 			vexDoc.Statements = append(vexDoc.Statements, stmt)
@@ -1401,33 +1391,11 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 			}
 			if !found {
 				// Add the vulnerability to the VEX document
-				var aliases []string
-				for _, alias := range v.RelatedVulnerabilities {
-					aliases = append(aliases, alias.ID)
-				}
-
-				product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
+				stmt, err := newLocalStatement(v, imagePullable)
 				if err != nil {
 					return err
 				}
-
-				vexDoc.Statements = append(vexDoc.Statements, v1beta1.Statement{
-					ID: fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(v.Vulnerability.ID), url.PathEscape(v.Artifact.PURL)),
-					Vulnerability: v1beta1.VexVulnerability{
-						ID:          v.Vulnerability.DataSource,
-						Name:        v.Vulnerability.ID,
-						Description: v.Vulnerability.Description,
-						Aliases:     aliases,
-					},
-
-					Products: []v1beta1.Product{
-						*product,
-					},
-
-					Status:          v1beta1.Status(vex.StatusNotAffected),
-					Justification:   v1beta1.Justification(vex.VulnerableCodeNotPresent),
-					ImpactStatement: defaultLocalImpactStatement,
-				})
+				vexDoc.Statements = append(vexDoc.Statements, stmt)
 			}
 		}
 
@@ -1451,28 +1419,9 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 				}
 			}
 			if !found {
-				var aliases []string
-				for _, alias := range v.RelatedVulnerabilities {
-					aliases = append(aliases, alias.ID)
-				}
-
-				product, err := createProductStructForImageAndPackage(imagePullable, v.Artifact.PURL)
+				stmt, err := newLocalStatement(v.Match, imagePullable)
 				if err != nil {
 					return err
-				}
-
-				stmt := v1beta1.Statement{
-					ID: fmt.Sprintf("https://kubescape.io/vex/statement/%s/%s", url.PathEscape(v.Vulnerability.ID), url.PathEscape(v.Artifact.PURL)),
-					Vulnerability: v1beta1.VexVulnerability{
-						ID:          v.Vulnerability.DataSource,
-						Name:        v.Vulnerability.ID,
-						Description: v.Vulnerability.Description,
-						Aliases:     aliases,
-					},
-
-					Products: []v1beta1.Product{
-						*product,
-					},
 				}
 				applyIgnoredMatchAssessment(&stmt, ignoredMatchAssessment(v))
 				vexDoc.Statements = append(vexDoc.Statements, stmt)

--- a/repositories/apiserver_external_test.go
+++ b/repositories/apiserver_external_test.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -216,4 +217,46 @@ func TestAPIServerStore_updateVEX_externalStatementDoesNotSuppressLocalOne(t *te
 	}
 	assert.True(t, foundExternal, "the external statement must survive")
 	assert.True(t, foundLocal, "kubescape must still record its own assessment alongside the external one")
+}
+
+// newLocalStatement is the one place the shape of a statement kubevuln writes is defined,
+// so it is worth pinning: createVEX and updateVEX each build one for a match and one for an
+// ignored match, and all four used to spell it out.
+func TestNewLocalStatement(t *testing.T) {
+	m := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+				ID:          "CVE-2024-0001",
+				DataSource:  "https://security-tracker.debian.org/tracker/CVE-2024-0001",
+				Description: "a description",
+			},
+		},
+		RelatedVulnerabilities: []v1beta1.VulnerabilityMetadata{{ID: "GHSA-aaaa"}, {ID: "EUVD-1"}},
+		Artifact:               v1beta1.GrypePackage{PURL: "pkg:deb/debian/tar@1.29"},
+	}
+
+	stmt, err := newLocalStatement(m, "docker.io/library/nginx@sha256:abc")
+	require.NoError(t, err)
+
+	assert.True(t, isLocalStatement(stmt.ID), "the statement must be recognised as ours: %s", stmt.ID)
+	assert.Contains(t, stmt.ID, url.PathEscape("CVE-2024-0001"))
+	assert.Contains(t, stmt.ID, url.PathEscape("pkg:deb/debian/tar@1.29"))
+
+	// The CVE goes in Name and the data source in ID, which is the mapping updateVEX's
+	// normalization exists to repair on documents written the other way round.
+	assert.Equal(t, "CVE-2024-0001", stmt.Vulnerability.Name)
+	assert.Equal(t, "https://security-tracker.debian.org/tracker/CVE-2024-0001", stmt.Vulnerability.ID)
+	assert.Equal(t, "a description", stmt.Vulnerability.Description)
+	assert.Equal(t, []string{"GHSA-aaaa", "EUVD-1"}, stmt.Vulnerability.Aliases)
+
+	require.Len(t, stmt.Products, 1)
+	require.Len(t, stmt.Products[0].Subcomponents, 1)
+	assert.Equal(t, "pkg:deb/debian/tar@1.29", stmt.Products[0].Subcomponents[0].ID)
+
+	// The baseline every caller starts from; a suppression overwrites it wholesale.
+	assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), stmt.Status)
+	assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), stmt.Justification)
+	assert.Equal(t, defaultLocalImpactStatement, stmt.ImpactStatement)
+	assert.Empty(t, stmt.ActionStatement)
+	assert.Empty(t, stmt.StatusNotes)
 }


### PR DESCRIPTION
## Overview

the statement kubevuln writes into a VEX document was built in four places: `createVEX` and `updateVEX` each build one over `Matches` and one over `IgnoredMatches`. the two match sites were byte for byte identical, as were the two ignored ones, and each of the four also repeated collecting the aliases and calling `createProductStructForImageAndPackage` in front of it.

`newLocalStatement` is now the one place that shape is defined. 90 lines out, 39 in.

the ignored loops pass `v.Match`, the `Match` embedded in an `IgnoredMatch` being the same type, and keep their `applyIgnoredMatchAssessment` call afterwards. that call sets all five of the fields it touches, so the baseline the builder returns is fully replaced for a suppression and nothing about those statements changes.

## Additional Information

this overlaps #682 by a few lines. that one adopts statements stored before #595 and had to stamp the same `https://kubescape.io/vex/statement/%s/%s` format a fifth time to produce an ID the dedup recognises, which is what having four copies costs. whichever of the two lands first, the other's rebase is a small manual merge in the same region, and the end state is the format written once either way.

`newLocalStatement` returns an error because `createProductStructForImageAndPackage` does. worth knowing that it never actually returns one, its only return is `nil`, so the `if err != nil` at each site was already dead. I left the plumbing as it was rather than fold a signature change into a de-duplication, but dropping the error from both would take the four call sites down to a line each.

## How to Test

`go test ./repositories/ -count=1`

the existing VEX tests are untouched and cover this end to end: `Test_StoreVEX`, the external-statement tests from #595 and #664, and #633's. they exercise all four sites through `StoreVEX`, so them passing is what says the four literals really were the same.

`TestNewLocalStatement` pins the shape directly: that the ID is one `isLocalStatement` accepts and carries both escaped components, that the CVE goes in `Name` and the data source in `ID` (the mapping `updateVEX`'s normalization exists to repair on older documents), the aliases, the single product and subcomponent, and the baseline status, justification and impact statement with no action statement or status notes.

## Related issues/PRs:

* Resolved #688


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined generation of local vulnerability assessment statements.
  * Preserved existing assessment handling and error behavior for regular and ignored matches.

* **Tests**
  * Added coverage verifying statement identifiers, vulnerability metadata, package associations, baseline status, and optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->