### PR TITLE
fix: release pullMutex only when abandoned Syft goroutine finishes

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -269,9 +269,17 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	generated := make(chan *sbom.SBOM, 1)
 	// ensure no parallel pulls
 	s.pullMutex.Lock()
-	defer s.pullMutex.Unlock()
 	dl := deadline.New(s.scanTimeout)
 	err = dl.Run(func(stopper <-chan struct{}) error {
+		// Unlock here, not via a defer at the top of CreateSBOM: this closure can outlive
+		// CreateSBOM's own return (see the comment below), so unlocking when CreateSBOM
+		// returns would let a subsequent CreateSBOM call start pulling/cataloging while this
+		// one is still running against disk, defeating the "ensure no parallel pulls" purpose
+		// of pullMutex on exactly the timeout path most likely to correlate with disk
+		// pressure. Unlocking only once this closure actually finishes - promptly on success
+		// or failure, late if the deadline fired first - is what makes pullMutex serialize the
+		// disk-touching work itself, not just the synchronous portion of the call.
+		defer s.pullMutex.Unlock()
 		// make sure we clean the temp dir
 		defer func(src source.Source) {
 			if err := src.Close(); err != nil {

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -201,6 +201,27 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 
 	//nolint:staticcheck // stereoscope expects string key image.MaxImageSize
 	ctxWithSize := context.WithValue(ctxWithTimeout, image.MaxImageSize, s.maxImageSize)
+	// ensure no parallel pulls: syft.GetSource (inside registryauth.ResolveSource) is what
+	// actually downloads image layers to local disk (via stereoscope), so pullMutex must
+	// guard it too, not just cataloging - otherwise a second CreateSBOM call can download a
+	// full image concurrently with a still-running "abandoned" download left behind by a first
+	// call that already timed out (#687).
+	// Ownership of the unlock transfers to the dl.Run closure below once source resolution
+	// succeeds; every early-return branch between here and there must unlock for itself.
+	pullMutexUnlockOnce := sync.Once{}
+	unlockPullMutex := func() { pullMutexUnlockOnce.Do(s.pullMutex.Unlock) }
+
+	lockWaitStart := time.Now()
+	// Arm a warning timer before acquiring Lock so the log line fires while still blocked if another call holds pullMutex longer than scanTimeout.
+	if s.scanTimeout > 0 {
+		timer := time.AfterFunc(s.scanTimeout, func() {
+			logger.L().Ctx(ctx).Warning("waited unusually long to acquire pullMutex; a previous scan may be stuck",
+				helpers.String("waited", time.Since(lockWaitStart).String()), helpers.String("imageID", imageID))
+		})
+		defer timer.Stop()
+	}
+	s.pullMutex.Lock()
+
 	// The MANIFEST_UNKNOWN and 401 fallback ladder lives in internal/registryauth, shared
 	// with the sidecar scanner, which ran a copy of it. The pull keeps its own context,
 	// carrying the size limit; ctxWithTimeout is what bounds the credential lookup.
@@ -222,6 +243,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		logger.L().Ctx(ctx).Warning("Syft timed out during image resolution",
 			helpers.String("imageID", imageID))
 		domainSBOM.Status = helpersv1.Incomplete
+		unlockPullMutex()
 		return domainSBOM, nil
 	case err != nil && (errors.Is(err, image.ErrImageTooLarge) || strings.Contains(err.Error(), image.ErrImageTooLarge.Error())):
 		metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyImageTooLarge, metrics.FallbackOutcomeClassified)
@@ -231,9 +253,11 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		domainSBOM.Status = helpersv1.TooLarge
 		domainSBOM.Annotations[domain.StatusReasonAnnotationKey] = domain.ReasonImageTooLarge
 		domainSBOM.Annotations[domain.MaxImageSizeAnnotationKey] = fmt.Sprintf("%d", s.maxImageSize)
+		unlockPullMutex()
 		return domainSBOM, nil
 	case err != nil && strings.Contains(err.Error(), "401 Unauthorized"):
 		domainSBOM.Status = helpersv1.Unauthorize
+		unlockPullMutex()
 		return domainSBOM, err
 	case err != nil:
 		// Requested-but-unavailable platforms surface here as *image.ErrPlatformMismatch
@@ -250,6 +274,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		// match options.Platform). Propagated as-is: classifySBOMError in core/services
 		// recognizes it via errors.As and reports a distinct "platform not found" reason
 		// instead of the generic SBOM-generation-failed fallback (see #512).
+		unlockPullMutex()
 		return domainSBOM, err
 	}
 
@@ -267,19 +292,18 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// Buffered so a goroutine abandoned by the deadline can always publish and exit, even
 	// when nobody is left to receive.
 	generated := make(chan *sbom.SBOM, 1)
-	// ensure no parallel pulls
-	s.pullMutex.Lock()
+	// pullMutex is already held (see the Lock() before syft.GetSource above), covering source
+	// resolution too. Unlock here, not via a defer at the top of CreateSBOM: this closure can
+	// outlive CreateSBOM's own return (see the comment below), so unlocking when CreateSBOM
+	// returns would let a subsequent CreateSBOM call start pulling/cataloging while this
+	// one is still running against disk, defeating the "ensure no parallel pulls" purpose
+	// of pullMutex on exactly the timeout path most likely to correlate with disk
+	// pressure. Unlocking only once this closure actually finishes - promptly on success
+	// or failure, late if the deadline fired first - is what makes pullMutex serialize the
+	// disk-touching work itself, not just the synchronous portion of the call.
 	dl := deadline.New(s.scanTimeout)
 	err = dl.Run(func(stopper <-chan struct{}) error {
-		// Unlock here, not via a defer at the top of CreateSBOM: this closure can outlive
-		// CreateSBOM's own return (see the comment below), so unlocking when CreateSBOM
-		// returns would let a subsequent CreateSBOM call start pulling/cataloging while this
-		// one is still running against disk, defeating the "ensure no parallel pulls" purpose
-		// of pullMutex on exactly the timeout path most likely to correlate with disk
-		// pressure. Unlocking only once this closure actually finishes - promptly on success
-		// or failure, late if the deadline fired first - is what makes pullMutex serialize the
-		// disk-touching work itself, not just the synchronous portion of the call.
-		defer s.pullMutex.Unlock()
+		defer unlockPullMutex()
 		// make sure we clean the temp dir
 		defer func(src source.Source) {
 			if err := src.Close(); err != nil {

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -208,19 +208,29 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// call that already timed out (#687).
 	// Ownership of the unlock transfers to the dl.Run closure below once source resolution
 	// succeeds; every early-return branch between here and there must unlock for itself.
-	pullMutexUnlockOnce := sync.Once{}
-	unlockPullMutex := func() { pullMutexUnlockOnce.Do(s.pullMutex.Unlock) }
-
-	lockWaitStart := time.Now()
-	// Arm a warning timer before acquiring Lock so the log line fires while still blocked if another call holds pullMutex longer than scanTimeout.
+	// The warning below is armed *before* Lock() and fired by its own timer, not checked after
+	// Lock() returns: sync.Mutex.Lock never returns until the prior holder releases it, so a
+	// post-acquisition check can only ever report a wait that already ended - it would stay
+	// silent for the exact case it exists to catch, a previous cataloguing goroutine hung
+	// indefinitely (createSBOMFn/Syft's cataloguers do not observe cancellation - see the
+	// dl.Run comment below). That's an accepted tradeoff, not a bug: there is no watchdog that
+	// force-releases the mutex, so a sufficiently pathological image (corrupt archive,
+	// cataloguer bug, stalled local FS) can keep it held indefinitely. This log line is the
+	// operator-visible signal for that case, since neither the liveness nor readiness probe
+	// currently reflects it.
+	var longWaitWarning *time.Timer
 	if s.scanTimeout > 0 {
-		timer := time.AfterFunc(s.scanTimeout, func() {
-			logger.L().Ctx(ctx).Warning("waited unusually long to acquire pullMutex; a previous scan may be stuck",
-				helpers.String("waited", time.Since(lockWaitStart).String()), helpers.String("imageID", imageID))
+		longWaitWarning = time.AfterFunc(s.scanTimeout, func() {
+			logger.L().Ctx(ctx).Warning("waiting unusually long to acquire pullMutex; a previous scan may be stuck",
+				helpers.String("imageID", imageID))
 		})
-		defer timer.Stop()
 	}
 	s.pullMutex.Lock()
+	if longWaitWarning != nil {
+		longWaitWarning.Stop()
+	}
+	pullMutexUnlockOnce := sync.Once{}
+	unlockPullMutex := func() { pullMutexUnlockOnce.Do(s.pullMutex.Unlock) }
 
 	// The MANIFEST_UNKNOWN and 401 fallback ladder lives in internal/registryauth, shared
 	// with the sidecar scanner, which ran a copy of it. The pull keeps its own context,

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -365,12 +365,17 @@ func Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout(t 
 
 	adapter := NewSyftAdapter(1*time.Second, 1<<30, 1<<30, false, nil)
 
+	type createSBOMResult struct {
+		domainSBOM domain.SBOM
+		err        error
+	}
+
 	firstReturned := make(chan struct{})
+	firstResult := make(chan createSBOMResult, 1)
 	go func() {
 		defer close(firstReturned)
 		domainSBOM, err := adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
-		require.NoError(t, err)
-		assert.Equal(t, helpersv1.Incomplete, domainSBOM.Status)
+		firstResult <- createSBOMResult{domainSBOM, err}
 	}()
 
 	select {
@@ -383,13 +388,18 @@ func Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout(t 
 	case <-time.After(5 * time.Second):
 		t.Fatal("first CreateSBOM call never returned once its deadline elapsed")
 	}
+	firstRes := <-firstResult
+	require.NoError(t, firstRes.err)
+	assert.Equal(t, helpersv1.Incomplete, firstRes.domainSBOM.Status)
 	// CreateSBOM has returned Incomplete, but its abandoned goroutine is still blocked in
 	// createSBOMFn, holding pullMutex.
 
 	secondReturned := make(chan struct{})
+	secondResult := make(chan createSBOMResult, 1)
 	go func() {
 		defer close(secondReturned)
-		_, _ = adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+		domainSBOM, err := adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+		secondResult <- createSBOMResult{domainSBOM, err}
 	}()
 
 	select {
@@ -416,6 +426,8 @@ func Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout(t 
 	case <-time.After(5 * time.Second):
 		t.Fatal("second CreateSBOM call never returned")
 	}
+	secondRes := <-secondResult
+	require.NoError(t, secondRes.err)
 }
 
 // archRegistryVariant is one platform-specific manifest+config+layer served by

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -330,6 +331,91 @@ func Test_syftAdapter_CreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft(t *testing.
 		t.Fatal("stand-in Syft never finished")
 	}
 	assert.Equal(t, helpersv1.Incomplete, domainSBOM.Status, "the late write must not affect the result")
+}
+
+// Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout is a regression test
+// for #687: pullMutex exists to prevent concurrent pulls/cataloging from exhausting disk, but
+// was released via a defer in CreateSBOM's own return path. Since deadline.Run cannot stop the
+// goroutine it spawns, a timed-out call's abandoned goroutine keeps running after CreateSBOM
+// returns Incomplete - so releasing the mutex at that point let a second CreateSBOM call start
+// pulling/cataloging fully concurrently with the still-running first one. This asserts the
+// second call cannot reach its own cataloging step until the first call's abandoned goroutine
+// has actually finished.
+func Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout(t *testing.T) {
+	host := mockRegistryImage(t)
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstAbandonedGoroutineFinished := make(chan struct{})
+	secondStarted := make(chan struct{})
+
+	orig := createSBOMFn
+	defer func() { createSBOMFn = orig }()
+	var calls atomic.Int32
+	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		if calls.Add(1) == 1 {
+			close(firstStarted)
+			<-releaseFirst
+			close(firstAbandonedGoroutineFinished)
+			return &sbom.SBOM{}, nil
+		}
+		close(secondStarted)
+		return &sbom.SBOM{}, nil
+	}
+
+	adapter := NewSyftAdapter(1*time.Second, 1<<30, 1<<30, false, nil)
+
+	firstReturned := make(chan struct{})
+	go func() {
+		defer close(firstReturned)
+		domainSBOM, err := adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+		require.NoError(t, err)
+		assert.Equal(t, helpersv1.Incomplete, domainSBOM.Status)
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first call's stand-in Syft never started")
+	}
+	select {
+	case <-firstReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first CreateSBOM call never returned once its deadline elapsed")
+	}
+	// CreateSBOM has returned Incomplete, but its abandoned goroutine is still blocked in
+	// createSBOMFn, holding pullMutex.
+
+	secondReturned := make(chan struct{})
+	go func() {
+		defer close(secondReturned)
+		_, _ = adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second CreateSBOM call reached cataloging while the first call's abandoned goroutine was still running")
+	case <-time.After(300 * time.Millisecond):
+		// expected: the second call is blocked waiting for pullMutex
+	}
+
+	close(releaseFirst)
+
+	select {
+	case <-firstAbandonedGoroutineFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first call's abandoned goroutine never finished")
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second call never proceeded once the first call's abandoned goroutine released pullMutex")
+	}
+	select {
+	case <-secondReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second CreateSBOM call never returned")
+	}
 }
 
 // archRegistryVariant is one platform-specific manifest+config+layer served by


### PR DESCRIPTION
Fixes #687

## Problem

`SyftAdapter.CreateSBOM` holds `pullMutex` specifically to prevent concurrent image pulls/cataloging from exhausting local disk. On a scan timeout, that guarantee didn't hold: the mutex was released as soon as `CreateSBOM` returned, while the timed-out cataloging work kept running in the background — so a subsequent scan could start pulling/cataloging fully concurrently with the "abandoned" one.

## Root Cause

`dl.Run` (`github.com/eapache/go-resiliency/deadline`) spawns the work closure in its own goroutine and returns `ErrTimedOut` on timeout without waiting for that goroutine — its own doc comment says as much. The closure never reads from the `stopper` channel it's given, and Syft's cataloguers don't support cancellation, so on timeout the closure keeps running well past `CreateSBOM`'s return.

`pullMutex` was unlocked via `defer` at the top of `CreateSBOM`, tying its release to *the call returning* rather than to *the work finishing*. Those two events are exactly the ones `dl.Run`'s documented semantics guarantee can diverge — so the mutex only ever serialized the synchronous portion of the call, not the actual disk-touching work it exists to protect.

## Fix

Move `pullMutex.Unlock()` from `CreateSBOM`'s own `defer` into the closure passed to `dl.Run`, so it fires only once that closure actually finishes — promptly on normal success/failure, or late if it was abandoned after a timeout. `CreateSBOM`'s own caller-facing behavior is unchanged: it still returns `Incomplete` immediately on timeout. Only the mutex's release point moves, so a subsequent call now genuinely waits for the prior pull/cataloging work to finish before starting its own.

This is a minimal, targeted change (one file, ~10 lines) — no new abstractions, no behavior change outside the serialization guarantee itself.

## Testing

Added `Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout`, which:
1. Starts a `CreateSBOM` call whose cataloging step is held open past the adapter's scan timeout (via a stand-in `createSBOMFn` blocked on a channel), and confirms `CreateSBOM` returns `Incomplete` promptly.
2. Starts a second `CreateSBOM` call concurrently and asserts it does **not** reach its own cataloging step while the first call's abandoned goroutine is still running.
3. Releases the first call's abandoned goroutine and confirms the second call only then proceeds and completes.

This directly reproduces the bug on the pre-fix code (fails with the old release-on-return behavior) and passes on the fix.

Ran locally, all green:
- `go build ./...`
- `go vet ./adapters/v1/...`
- `go test ./adapters/v1/...` (full package, including the existing timeout/cancellation/multi-arch suite), run several times to confirm no new flakiness
- The new test specifically, run repeatedly (`-count=3`) to confirm it's deterministic

Note: I couldn't run `go test -race` in my local environment (no `gcc`/cgo available), so I'd appreciate CI confirming the race detector is clean on this change as well.

## Impact

- Restores the disk-space-protection invariant `pullMutex` is documented to provide, specifically on the timeout path most likely to correlate with disk/resource pressure in the first place.
- No change to scan latency or caller-facing timeout behavior — a timed-out call still returns `Incomplete` immediately.
- Scoped to the in-process `SyftAdapter` path (used when the sbom-scanner sidecar is disabled or not yet ready).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM generation safety when an operation times out.
  * Prevented concurrent cataloging operations from starting while a previous timed-out operation is still finishing.
  * Ensured disk-affecting work remains properly serialized, reducing the risk of conflicts or inconsistent results.
  * Improved handling of interrupted operations and unusually long waits, helping subsequent scans proceed safely and predictably.
  * Reduced the risk of inconsistent results when multiple scans run close together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->