### PR TITLE
perf(adapters): index CVE exceptions once per scan instead of per match

### DIFF
--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -363,3 +363,62 @@ func getCVEExceptionMatchCVENameFromList(srcCVEList []armotypes.VulnerabilityExc
 	}
 	return nil
 }
+
+// cveExceptionIndex maps a lower-cased CVE/alias name to the indices, into the exception
+// list it was built from, of every exception that declares a VulnerabilityPolicy with that
+// name. It lets a scan with many matches look up candidate exceptions in roughly constant
+// time per match instead of re-walking every exception (and every policy within it) for
+// each one, which is what getCVEExceptionMatchCVENameFromList does on its own.
+type cveExceptionIndex struct {
+	srcCVEList []armotypes.VulnerabilityExceptionPolicy
+	byName     map[string][]int
+}
+
+// buildCVEExceptionIndex builds a cveExceptionIndex over srcCVEList in a single pass. Build
+// it once per scan (the exception list does not change across matches within a scan) and
+// reuse it via lookup for every match.
+func buildCVEExceptionIndex(srcCVEList []armotypes.VulnerabilityExceptionPolicy) *cveExceptionIndex {
+	idx := &cveExceptionIndex{
+		srcCVEList: srcCVEList,
+		byName:     make(map[string][]int, len(srcCVEList)),
+	}
+	for i := range srcCVEList {
+		seen := make(map[string]struct{})
+		for j := range srcCVEList[i].VulnerabilityPolicies {
+			name := strings.ToLower(srcCVEList[i].VulnerabilityPolicies[j].Name)
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			idx.byName[name] = append(idx.byName[name], i)
+		}
+	}
+	return idx
+}
+
+// lookup returns the same result getCVEExceptionMatchCVENameFromList(idx.srcCVEList, CVEName,
+// filterFixed) would return, but only inspects the exceptions that actually declare a policy
+// named CVEName rather than the full exception list.
+func (idx *cveExceptionIndex) lookup(CVEName string, filterFixed bool) []armotypes.VulnerabilityExceptionPolicy {
+	if idx == nil {
+		return nil
+	}
+	indices := idx.byName[strings.ToLower(CVEName)]
+	if len(indices) == 0 {
+		return nil
+	}
+
+	var l []armotypes.VulnerabilityExceptionPolicy
+	for _, i := range indices {
+		exc := idx.srcCVEList[i]
+		if filterFixed && exc.ExpiredOnFix != nil && *exc.ExpiredOnFix {
+			continue
+		}
+		l = append(l, exc)
+	}
+
+	if len(l) > 0 {
+		return l
+	}
+	return nil
+}

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -207,8 +208,79 @@ func TestGetCVEExceptionMatchCVENameFromList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := getCVEExceptionMatchCVENameFromList(tc.srcCVEList, tc.CVEName, tc.isFixed)
 			assert.Equal(t, tc.expected, actual)
+
+			indexed := buildCVEExceptionIndex(tc.srcCVEList).lookup(tc.CVEName, tc.isFixed)
+			assert.Equal(t, tc.expected, indexed)
 		})
 	}
+}
+
+// buildCVEExceptionIndex+lookup must return exactly what getCVEExceptionMatchCVENameFromList
+// returns for the same inputs, since callers switched from the linear scan to the index to
+// avoid re-walking the full exception list per match.
+func TestCVEExceptionIndex_MatchesLinearScan(t *testing.T) {
+	expiredOnFix := true
+	srcCVEList := []armotypes.VulnerabilityExceptionPolicy{
+		{
+			PortalBase:            armotypes.PortalBase{Name: "exc-1"},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-1234"}},
+		},
+		{
+			PortalBase:            armotypes.PortalBase{Name: "exc-2"},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-5678"}, {Name: "CVE-2021-1234"}},
+		},
+		{
+			PortalBase:            armotypes.PortalBase{Name: "exc-3"},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-1234"}},
+			ExpiredOnFix:          &expiredOnFix,
+		},
+	}
+	index := buildCVEExceptionIndex(srcCVEList)
+
+	for _, cve := range []string{"CVE-2021-1234", "cve-2021-1234", "CVE-2021-5678", "CVE-9999-0000"} {
+		for _, filterFixed := range []bool{false, true} {
+			want := getCVEExceptionMatchCVENameFromList(srcCVEList, cve, filterFixed)
+			got := index.lookup(cve, filterFixed)
+			assert.Equal(t, want, got, "cve=%s filterFixed=%v", cve, filterFixed)
+		}
+	}
+}
+
+func BenchmarkGetCVEExceptionMatch(b *testing.B) {
+	const numExceptions = 200
+	const policiesPerException = 5
+	const numMatches = 5000
+
+	srcCVEList := make([]armotypes.VulnerabilityExceptionPolicy, numExceptions)
+	for i := range srcCVEList {
+		policies := make([]armotypes.VulnerabilityPolicy, policiesPerException)
+		for j := range policies {
+			policies[j] = armotypes.VulnerabilityPolicy{Name: fmt.Sprintf("CVE-2024-%05d", i*policiesPerException+j)}
+		}
+		srcCVEList[i] = armotypes.VulnerabilityExceptionPolicy{VulnerabilityPolicies: policies}
+	}
+
+	cveNames := make([]string, numMatches)
+	for i := range cveNames {
+		cveNames[i] = fmt.Sprintf("CVE-2024-%05d", i%(numExceptions*policiesPerException))
+	}
+
+	b.Run("LinearScanPerMatch", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, cve := range cveNames {
+				getCVEExceptionMatchCVENameFromList(srcCVEList, cve, false)
+			}
+		}
+	})
+
+	b.Run("IndexBuiltOncePerScan", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			index := buildCVEExceptionIndex(srcCVEList)
+			for _, cve := range cveNames {
+				index.lookup(cve, false)
+			}
+		}
+	})
 }
 
 //go:embed testdata/nginx-image-manifest.json

--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -92,6 +92,10 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 		return vulnerabilityResults, domain.ErrCastingWorkload
 	}
 
+	// Built once per scan and reused for every match below, instead of re-walking the full
+	// exception list per match.
+	exceptionIndex := buildCVEExceptionIndex(vulnerabilityExceptionPolicyList)
+
 	if grypeDocument.Source != nil {
 		// generate a map of child to parent
 		parentLayerHash := ""
@@ -158,7 +162,7 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 						},
 					},
 					PackageType:      string(m.Artifact.Type),
-					ExceptionApplied: scopedToSubcomponent(getCVEExceptionMatchCVENameFromList(vulnerabilityExceptionPolicyList, m.Vulnerability.ID, isFixed == 1), m.Artifact.PURL),
+					ExceptionApplied: scopedToSubcomponent(exceptionIndex.lookup(m.Vulnerability.ID, isFixed == 1), m.Artifact.PURL),
 					IsRelevant:       nil, // TODO add relevancy here?
 					Coordinates:      syftCoordinatesToCoordinates(m.Artifact.Locations),
 				},

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -327,10 +327,14 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 		return matchedBySource
 	}
 
+	// Built once per scan and reused for every match below, instead of re-walking the full
+	// exception list per match.
+	exceptionIndex := buildCVEExceptionIndex(exceptions)
+
 	var remaining []v1beta1.Match
 	for _, m := range doc.Matches {
 		isFixed, _ := hasKnownFix(m)
-		matched := getCVEExceptionMatchCVENameFromList(exceptions, m.Vulnerability.ID, isFixed)
+		matched := exceptionIndex.lookup(m.Vulnerability.ID, isFixed)
 		matched = scopedToSubcomponent(matched, m.Artifact.PURL)
 		if len(matched) > 0 && hasIgnoreAction(matched) {
 			doc.IgnoredMatches = append(doc.IgnoredMatches, v1beta1.IgnoredMatch{


### PR DESCRIPTION
## Overview
getCVEExceptionMatchCVENameFromList rescanned the full exception list, and every VulnerabilityPolicies entry within it, once per vulnerability match. Both DomainToArmo and ApplySecurityExceptions call it inside their match loops, so a scan with N matches against an exception list of M entries did O(N*M) work even though the exception list does not change between matches within a scan. This PR builds a name indexed lookup once per scan and reuses it for every match instead.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

* Resolved #692

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->

## What changed
- Added `cveExceptionIndex`/`buildCVEExceptionIndex`/`lookup` in `adapters/v1/backend_utils.go`, which builds a lower cased CVE name to exception index map in one pass and returns exactly what the old linear scan returned for a given CVE name and `filterFixed` value.
- `DomainToArmo` (`adapters/v1/domain_to_armo.go`) and `ApplySecurityExceptions` (`adapters/v1/securityexception.go`) now build the index once before their match loops and call `lookup` per match instead of `getCVEExceptionMatchCVENameFromList`.
- Kept `getCVEExceptionMatchCVENameFromList` in place since it is still directly covered by existing tests, and added `TestCVEExceptionIndex_MatchesLinearScan` plus an assertion in the existing table test to confirm the index produces identical results to the linear scan for every case.
- Added `BenchmarkGetCVEExceptionMatch` in `adapters/v1/backend_utils_test.go` comparing the two approaches with 200 exceptions (5 policies each) against 5000 matches. On my machine this showed the indexed version at roughly 1/57th the time of the linear scan (55.6ms vs 0.97ms per iteration).

## Verification
- `go build ./...` passed
- `go test ./...` passed (all packages)
- `make lint` passed with 0 new issues
- `go vet ./...` shows 4 pre existing findings in controllers/http.go unrelated to this change, confirmed present on main before this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved vulnerability exception matching efficiency, especially for scans with many vulnerabilities or exception policies.
  * Reused indexed exception lookups while preserving existing CVE, alias, case-insensitive, expiration, and subcomponent matching behavior.

* **Bug Fixes**
  * Prevented duplicate exception policy results during matching.
  * Ensured exceptions expired by a vulnerability fix continue to be filtered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->