### PR TITLE
test(adapters): cover mock failure-injection and limit-getter paths

### DIFF
--- a/adapters/mockplatform_test.go
+++ b/adapters/mockplatform_test.go
@@ -2,8 +2,10 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/armosec/armoapi-go/scanfailure"
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,5 +28,17 @@ func TestMockPlatform_SubmitCVE(t *testing.T) {
 	m := NewMockPlatform(true, nil)
 	ctx := context.TODO()
 	err := m.SubmitCVE(ctx, domain.CVEManifest{}, domain.CVEManifest{})
+	assert.NoError(t, err)
+}
+
+func TestMockPlatform_ReportError(t *testing.T) {
+	m := NewMockPlatform(true, nil)
+	err := m.ReportError(context.TODO(), errors.New("boom"))
+	assert.NoError(t, err)
+}
+
+func TestMockPlatform_ReportScanFailure(t *testing.T) {
+	m := NewMockPlatform(true, nil)
+	err := m.ReportScanFailure(context.TODO(), scanfailure.ScanFailureCVE, "wlid", errors.New("boom"))
 	assert.NoError(t, err)
 }

--- a/adapters/mockrelevancy_test.go
+++ b/adapters/mockrelevancy_test.go
@@ -1,0 +1,20 @@
+package adapters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMockRelevancyAdapter(t *testing.T) {
+	m := NewMockRelevancyAdapter()
+	assert.NotNil(t, m)
+}
+
+func TestMockRelevancyAdapter_GetContainerRelevancyScans(t *testing.T) {
+	m := NewMockRelevancyAdapter()
+	scans, err := m.GetContainerRelevancyScans(context.TODO(), "wlid", "container", false)
+	assert.NoError(t, err)
+	assert.Empty(t, scans)
+}

--- a/adapters/mocksbom_test.go
+++ b/adapters/mocksbom_test.go
@@ -32,3 +32,18 @@ func TestMockSBOMAdapter_Version(t *testing.T) {
 	m := NewMockSBOMAdapter(false, false, false)
 	assert.Equal(t, "Mock SBOM 1.0", m.Version())
 }
+
+func TestMockSBOMAdapter_GetMaxImageSize(t *testing.T) {
+	m := NewMockSBOMAdapter(false, false, false)
+	assert.Equal(t, int64(0), m.GetMaxImageSize())
+}
+
+func TestMockSBOMAdapter_GetMaxSBOMSize(t *testing.T) {
+	m := NewMockSBOMAdapter(false, false, false)
+	assert.Equal(t, 0, m.GetMaxSBOMSize())
+}
+
+func TestMockSBOMAdapter_GetMemoryLimit(t *testing.T) {
+	m := NewMockSBOMAdapter(false, false, false)
+	assert.Equal(t, "", m.GetMemoryLimit())
+}


### PR DESCRIPTION
## Overview
The `adapters` package sat at 50.7% coverage, well below `adapters/v1` (84.2%) and `core/services` (87.1%). Most of the gap was in the mock adapters that back the service layer tests, specifically the failure injection methods on `MockPlatform` and the limit getters on `MockSBOMAdapter`, plus the whole `MockRelevancyAdapter`. This PR adds direct unit tests for those methods so the mock behavior they exist to simulate is actually exercised somewhere.

After this change `go test ./adapters/... -cover` reports 67.2% for the `adapters` package, and every previously 0.0% function (`ReportError`, `ReportScanFailure`, `NewMockRelevancyAdapter`, `GetContainerRelevancyScans`, `GetMaxImageSize`, `GetMaxSBOMSize`, `GetMemoryLimit`) now shows 100%.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

`go test ./adapters/... -coverprofile=/tmp/cov.out && go tool cover -func=/tmp/cov.out`

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

Resolved #693

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
