### PR TITLE
fix: key ID-less matches in IgnoredMatchKeys so cache-diff republish detects them

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -539,6 +539,10 @@ func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 // fix (hasKnownFix, via getCVEExceptionMatchCVENameFromList), so two matches of the same CVE can
 // have different suppression states. The manifest content is fixed across a cache hit, so these
 // keys are stable and detect both ID- and fix-state-driven changes to the ignored set.
+//
+// Matches with no known CVE ID still get a key, prefixed with \x01 to keep them out of the
+// ID-keyed namespace, so that a suppression-state change limited to ID-less matches is still
+// visible to callers (like reconcileCachedCVE) diffing this set across cache hits.
 func IgnoredMatchKeys(doc *v1beta1.GrypeDocument) map[string]struct{} {
 	keys := map[string]struct{}{}
 	if doc == nil {
@@ -548,6 +552,8 @@ func IgnoredMatchKeys(doc *v1beta1.GrypeDocument) map[string]struct{} {
 		m := im.Match
 		if m.Vulnerability.ID != "" {
 			keys[m.Vulnerability.ID+"\x00"+m.Artifact.Name+"\x00"+m.Artifact.Version] = struct{}{}
+		} else {
+			keys["\x01"+m.Artifact.Name+"\x00"+m.Artifact.Version] = struct{}{}
 		}
 	}
 	return keys

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -786,11 +786,52 @@ func TestIgnoredMatchKeys(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, map[string]struct{}{"CVE-A\x00\x00": {}}, IgnoredMatchKeys(doc))
+		assert.Equal(t, map[string]struct{}{
+			"CVE-A\x00\x00": {},
+			"\x01\x00":      {},
+		}, IgnoredMatchKeys(doc))
 	})
 
 	t.Run("nil document returns an empty set", func(t *testing.T) {
 		assert.Empty(t, IgnoredMatchKeys(nil))
+	})
+
+	t.Run("a suppression-state change limited to an ID-less match is still detected", func(t *testing.T) {
+		// Regression test for the cache-diff blind spot: reconcileCachedCVE (core/services/scan.go)
+		// diffs IgnoredMatchKeys across cache hits via maps.Equal to decide whether to republish
+		// VEX. A match with no known CVE ID must still change the key set when it starts/stops
+		// being suppressed, or that republish is silently skipped.
+		before := &v1beta1.GrypeDocument{}
+		after := &v1beta1.GrypeDocument{
+			IgnoredMatches: []v1beta1.IgnoredMatch{
+				{Match: v1beta1.Match{
+					Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: ""}},
+					Artifact:      v1beta1.GrypePackage{Name: "unknown-pkg", Version: "1.0.0"},
+				}},
+			},
+		}
+
+		assert.NotEqual(t, IgnoredMatchKeys(before), IgnoredMatchKeys(after))
+	})
+
+	t.Run("ID-less matches from distinct packages get distinct keys", func(t *testing.T) {
+		doc := &v1beta1.GrypeDocument{
+			IgnoredMatches: []v1beta1.IgnoredMatch{
+				{Match: v1beta1.Match{
+					Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: ""}},
+					Artifact:      v1beta1.GrypePackage{Name: "pkg-a", Version: "1.0.0"},
+				}},
+				{Match: v1beta1.Match{
+					Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: ""}},
+					Artifact:      v1beta1.GrypePackage{Name: "pkg-b", Version: "1.0.0"},
+				}},
+			},
+		}
+
+		assert.Equal(t, map[string]struct{}{
+			"\x01pkg-a\x001.0.0": {},
+			"\x01pkg-b\x001.0.0": {},
+		}, IgnoredMatchKeys(doc))
 	})
 }
 


### PR DESCRIPTION
## Overview
IgnoredMatchKeys keys suppressed matches by vulnerability ID plus artifact name and version, but it silently skipped any match whose Vulnerability.ID was empty. reconcileCachedCVE relies on comparing this key set between cache hits to decide whether to republish VEX and repersist the manifest, so a suppression change that only affects an ID less match was invisible to that diff. This PR gives ID less matches their own key, prefixed so they can never collide with the ID keyed namespace, so those suppression changes are detected again.

## Related issues/PRs:

Resolved #691

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of ignored security findings that do not include a vulnerability ID.
  * Changes to the suppression status of these findings are now detected reliably.
  * Findings are distinguished correctly when they involve different package names or versions.
* **Tests**
  * Expanded coverage for ignored findings and suppression-state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->