### PR TITLE
fix: support storing CVE summary for workloads with empty WLID (#697)

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -729,17 +729,21 @@ func enrichSummaryManifestObjectLabels(ctx context.Context, labels map[string]st
 	}
 
 	workloadKind := wlid.GetKindFromWlid(workload.Wlid)
-	groupVersionScheme, err := k8sinterface.GetGroupVersionResource(workloadKind)
-	if err != nil {
-		return nil, err
-	}
+	if workloadKind != "" {
+		groupVersionScheme, err := k8sinterface.GetGroupVersionResource(workloadKind)
+		if err != nil {
+			return nil, err
+		}
 
-	enrichedLabels[helpersv1.ApiGroupMetadataKey] = groupVersionScheme.Group
-	enrichedLabels[helpersv1.ApiVersionMetadataKey] = groupVersionScheme.Version
-	enrichedLabels[helpersv1.RelatedKindMetadataKey] = strings.ToLower(workloadKind)
-	enrichedLabels[helpersv1.RelatedNameMetadataKey] = wlid.GetNameFromWlid(workload.Wlid)
-	enrichedLabels[helpersv1.RelatedNamespaceMetadataKey] = wlid.GetNamespaceFromWlid(workload.Wlid)
-	enrichedLabels[helpersv1.ContainerNameMetadataKey] = workload.ContainerName
+		enrichedLabels[helpersv1.ApiGroupMetadataKey] = groupVersionScheme.Group
+		enrichedLabels[helpersv1.ApiVersionMetadataKey] = groupVersionScheme.Version
+		enrichedLabels[helpersv1.RelatedKindMetadataKey] = strings.ToLower(workloadKind)
+		enrichedLabels[helpersv1.RelatedNameMetadataKey] = wlid.GetNameFromWlid(workload.Wlid)
+		enrichedLabels[helpersv1.RelatedNamespaceMetadataKey] = wlid.GetNamespaceFromWlid(workload.Wlid)
+	}
+	if workload.ContainerName != "" {
+		enrichedLabels[helpersv1.ContainerNameMetadataKey] = workload.ContainerName
+	}
 
 	return enrichedLabels, nil
 }
@@ -757,8 +761,16 @@ func GetCVESummaryK8sResourceNameWithCVEName(ctx context.Context, cveName string
 	name := strings.ToLower(wlid.GetNameFromWlid(workload.Wlid))
 	contName := strings.ToLower(workload.ContainerName)
 
-	if kind == "" && name == "" && contName == "" && cveName != "" {
-		return cveName, nil
+	if kind == "" && name == "" {
+		if cveName != "" {
+			return cveName, nil
+		}
+		if workload.ImageSlug != "" {
+			return workload.ImageSlug, nil
+		}
+		if contName != "" {
+			return contName, nil
+		}
 	}
 
 	return fmt.Sprintf(vulnSummaryContNameFormat, kind, name, contName), nil

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1111,38 +1111,116 @@ func TestAPIServerStore_enrichSummaryManifestObjectLabels(t *testing.T) {
 				ContainerName: "anyJobContName",
 			},
 		},
+		{
+			k8sResourceType:      "",
+			k8sResourceGroup:     "",
+			k8sResourceVersion:   "",
+			k8sResourceName:      "",
+			k8sResourceNamespace: "",
+			labels:               make(map[string]string),
+			workload: domain.ScanCommand{
+				ImageHash:          "sha256:ead0a4a53df89fd173874b46093b6e62d8c72967bbf606d672c9e8c9b601a4fc",
+				ImageTag:           "registry.k8s.io/coredns/coredns:v1.10.1",
+				ImageTagNormalized: "registry.k8s.io/coredns/coredns:v1.10.1",
+				ImageSlug:          "registry-k8s-io-coredns-coredns-v1-10-1",
+				Wlid:               "",
+				ContainerName:      "contNameRegistryScan",
+			},
+		},
 	}
 
 	for i := range tests {
 		ctx = context.WithValue(ctx, domain.WorkloadKey{}, tests[i].workload)
 		enrichedLabels, err := enrichSummaryManifestObjectLabels(ctx, tests[i].labels, true)
-		assert.Equal(t, err, nil)
+		assert.NoError(t, err)
 
-		val, exist := enrichedLabels[helpersv1.ApiGroupMetadataKey]
-		assert.Equal(t, exist, true)
-		assert.Equal(t, val, tests[i].k8sResourceGroup)
+		if tests[i].workload.Wlid != "" {
+			val, exist := enrichedLabels[helpersv1.ApiGroupMetadataKey]
+			assert.True(t, exist)
+			assert.Equal(t, tests[i].k8sResourceGroup, val)
 
-		val, exist = enrichedLabels[helpersv1.ApiVersionMetadataKey]
-		assert.Equal(t, exist, true)
-		assert.Equal(t, val, tests[i].k8sResourceVersion)
+			val, exist = enrichedLabels[helpersv1.ApiVersionMetadataKey]
+			assert.True(t, exist)
+			assert.Equal(t, tests[i].k8sResourceVersion, val)
 
-		val, exist = enrichedLabels[helpersv1.RelatedKindMetadataKey]
-		assert.Equal(t, exist, true)
-		assert.Equal(t, val, tests[i].k8sResourceType)
+			val, exist = enrichedLabels[helpersv1.RelatedKindMetadataKey]
+			assert.True(t, exist)
+			assert.Equal(t, tests[i].k8sResourceType, val)
 
-		val, exist = enrichedLabels[helpersv1.RelatedNameMetadataKey]
-		assert.Equal(t, exist, true)
-		assert.Equal(t, val, tests[i].k8sResourceName)
+			val, exist = enrichedLabels[helpersv1.RelatedNameMetadataKey]
+			assert.True(t, exist)
+			assert.Equal(t, tests[i].k8sResourceName, val)
 
-		val, exist = enrichedLabels[helpersv1.RelatedNamespaceMetadataKey]
-		assert.Equal(t, exist, true)
-		assert.Equal(t, val, tests[i].k8sResourceNamespace)
+			val, exist = enrichedLabels[helpersv1.RelatedNamespaceMetadataKey]
+			assert.True(t, exist)
+			assert.Equal(t, tests[i].k8sResourceNamespace, val)
+		} else {
+			_, exist := enrichedLabels[helpersv1.ApiGroupMetadataKey]
+			assert.False(t, exist)
+			_, exist = enrichedLabels[helpersv1.ApiVersionMetadataKey]
+			assert.False(t, exist)
+			_, exist = enrichedLabels[helpersv1.RelatedKindMetadataKey]
+			assert.False(t, exist)
+			_, exist = enrichedLabels[helpersv1.RelatedNameMetadataKey]
+			assert.False(t, exist)
+			_, exist = enrichedLabels[helpersv1.RelatedNamespaceMetadataKey]
+			assert.False(t, exist)
+		}
 
-		val, exist = enrichedLabels[helpersv1.ContainerNameMetadataKey]
-		assert.Equal(t, exist, true)
-		assert.Equal(t, val, tests[i].workload.ContainerName)
+		val, exist := enrichedLabels[helpersv1.ContainerNameMetadataKey]
+		assert.True(t, exist)
+		assert.Equal(t, tests[i].workload.ContainerName, val)
 	}
 
+}
+
+func TestAPIServerStore_StoreCVESummary_EmptyWlid(t *testing.T) {
+	a := NewFakeAPIServerStorage("kubescape")
+	workload := domain.ScanCommand{
+		ImageTag:           "registry.k8s.io/coredns/coredns:v1.10.1",
+		ImageTagNormalized: "registry.k8s.io/coredns/coredns:v1.10.1",
+		ImageSlug:          "registry-k8s-io-coredns-coredns-v1-10-1",
+		Wlid:               "",
+		ContainerName:      "coredns",
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	cve := domain.CVEManifest{
+		Name: "registry-k8s-io-coredns-coredns-v1-10-1",
+	}
+
+	err := a.StoreCVESummary(ctx, cve, domain.CVEManifest{}, false)
+	require.NoError(t, err)
+
+	got, err := a.StorageClient.VulnerabilityManifestSummaries("kubescape").Get(context.Background(), cve.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, cve.Name, got.Name)
+	assert.Equal(t, helpersv1.ContextMetadataKeyNonFiltered, got.Labels[helpersv1.ContextMetadataKey])
+	assert.Equal(t, "coredns", got.Labels[helpersv1.ContainerNameMetadataKey])
+	assert.NotContains(t, got.Labels, helpersv1.ApiGroupMetadataKey)
+}
+
+func TestAPIServerStore_StoreCVESummaryStub_EmptyWlid(t *testing.T) {
+	a := NewFakeAPIServerStorage("kubescape")
+	workload := domain.ScanCommand{
+		ImageTag:           "registry.k8s.io/coredns/coredns:v1.10.1",
+		ImageTagNormalized: "registry.k8s.io/coredns/coredns:v1.10.1",
+		ImageSlug:          "registry-k8s-io-coredns-coredns-v1-10-1",
+		Wlid:               "",
+		ContainerName:      "coredns",
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	err := a.StoreCVESummaryStub(ctx, helpersv1.UnsupportedSchema)
+	require.NoError(t, err)
+
+	got, err := a.StorageClient.VulnerabilityManifestSummaries("kubescape").Get(context.Background(), "registry-k8s-io-coredns-coredns-v1-10-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, helpersv1.UnsupportedSchema, got.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, "coredns", got.Labels[helpersv1.ContainerNameMetadataKey])
+	assert.NotContains(t, got.Labels, helpersv1.ApiGroupMetadataKey)
 }
 
 func TestAPIServerStore_enrichSummaryManifestObjectAnnotations(t *testing.T) {


### PR DESCRIPTION
## Overview
Fixes an issue where `APIServerStore.StoreCVESummary` and `APIServerStore.StoreCVESummaryStub` fail to persist `VulnerabilityManifestSummary` objects for registry image scans (or any scan command where `workload.Wlid` is empty).

### Problem & Root Cause
In `repositories/apiserver.go`, `enrichSummaryManifestObjectLabels` extracts `workloadKind := wlid.GetKindFromWlid(workload.Wlid)`. For registry scans, `workload.Wlid` is empty (`""`), returning `workloadKind = ""`. `enrichSummaryManifestObjectLabels` then unconditionally called `k8sinterface.GetGroupVersionResource("")`, which failed with an unsupported resource error (`kind '' is not supported`) and returned `nil, err`. As a result, `StoreCVESummary` and `StoreCVESummaryStub` aborted immediately, leaving the API server without summary CRDs for registry-scanned images.

### Solution
1. **Label Enrichment**: Updated `enrichSummaryManifestObjectLabels` in `repositories/apiserver.go` to check `if workloadKind != ""` before calling `k8sinterface.GetGroupVersionResource`. When `workloadKind` is empty, label enrichment sets context metadata and container name (if present) without attempting to query GVR for empty workload kinds.
2. **Resource Naming**: Updated `GetCVESummaryK8sResourceNameWithCVEName` to fall back to `cveName`, `workload.ImageSlug`, or `contName` when `kind == "" && name == ""`, avoiding invalid resource names starting with hyphens.
3. **Tests**: Added comprehensive unit test coverage in `repositories/apiserver_test.go` verifying label enrichment, `StoreCVESummary`, and `StoreCVESummaryStub` for scan commands with empty `Wlid`.

## Related issues/PRs:
* Fixes #697

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CVE summary handling when workload identifiers are unavailable or incomplete.
  - Summaries now receive more reliable resource names using available CVE, image, or container details.
  - Prevented incomplete Kubernetes API and resource labels from being added when workload information cannot be resolved.
  - Preserved container metadata, including for registry-scan workloads with empty workload identifiers.
  - Improved storage reliability for CVE summaries and summary stubs in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->