### PR TITLE
fix: prevent RestoreSuppressedMatches from undoing VEX suppressions

### DIFF
--- a/adapters/v1/domain_to_syft.go
+++ b/adapters/v1/domain_to_syft.go
@@ -77,6 +77,18 @@ func warnConversionErrors[T any](converted []T, errors []error) []T {
 	return converted
 }
 
+func deduplicateErrors(errors []error) []string {
+	errorCounts := make(map[string]int)
+	var errorMessages []string
+	for _, e := range errors {
+		errorCounts[e.Error()] = errorCounts[e.Error()] + 1
+	}
+	for msg, count := range errorCounts {
+		errorMessages = append(errorMessages, fmt.Sprintf("%q occurred %d time(s)", msg, count))
+	}
+	return errorMessages
+}
+
 func toSyftFiles(files []model.File) sbom.Artifacts {
 	ret := sbom.Artifacts{
 		FileMetadata: make(map[file.Coordinates]file.Metadata),

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -500,10 +500,10 @@ func emitSuppressionEvent(recorder record.EventRecorder, p armotypes.Vulnerabili
 // so the shared stored object is never modified.
 //
 // Only ignored matches carrying the signature ApplySecurityExceptions writes (a single ignore
-// rule with only the vulnerability ID set) are restored. Any other entry (e.g. one that would be
-// produced if GrypeAdapter ever wired up IgnoreRules/VexProcessor) is preserved, so the helper is
-// self-guarding instead of relying on an assumption. Reconstruction is lossless because
-// IgnoredMatch embeds the full Match.
+// rule with CRD provenance tags like SourceKind or Justification set) are restored. Any other
+// entry (e.g. one produced by GrypeAdapter wiring up IgnoreRules/VexProcessor, which drops CRD
+// tags) is preserved, so the helper is self-guarding instead of relying on an assumption.
+// Reconstruction is lossless because IgnoredMatch embeds the full Match.
 func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument {
 	if doc == nil {
 		return nil
@@ -526,8 +526,7 @@ func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument
 
 // isExceptionSourcedIgnore reports whether an ignored match carries the AppliedIgnoreRules
 // signature ApplySecurityExceptions writes: non-empty AppliedIgnoreRules where every rule has no
-// package set and its SourceKind is a known exception source ("SecurityException" or
-// "ClusterSecurityException"), or matches the empty legacy-rule fallback.
+// package set, and exception provenance (source/justification/impact).
 func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 	if len(im.AppliedIgnoreRules) == 0 {
 		return false
@@ -537,9 +536,6 @@ func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 			return false
 		}
 		if r.SourceKind == "SecurityException" || r.SourceKind == "ClusterSecurityException" {
-			continue
-		}
-		if r.SourceKind == "" && r.SourceName == "" && r.SourceNamespace == "" && r.Justification == "" && r.ImpactStatement == "" && r.FixState == "" {
 			continue
 		}
 		return false

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -790,11 +790,11 @@ func TestRestoreSuppressedMatches(t *testing.T) {
 			IgnoredMatches: []v1beta1.IgnoredMatch{
 				{
 					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-A"}}},
-					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-A"}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-A", SourceKind: "SecurityException"}},
 				},
 				{
 					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-B"}}},
-					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-B"}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-B", SourceKind: "SecurityException"}},
 				},
 			},
 		}
@@ -838,7 +838,7 @@ func TestRestoreSuppressedMatches(t *testing.T) {
 			IgnoredMatches: []v1beta1.IgnoredMatch{
 				{
 					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-A"}}},
-					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-A"}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-A", SourceKind: "SecurityException"}},
 				},
 				{
 					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-NATIVE"}}},
@@ -1249,3 +1249,54 @@ func TestConvertAffectedRecordsProvenance(t *testing.T) {
 	assert.Equal(t, "WAF mitigation in place, ticket SEC-1234", policies[0].Attributes["actionStatement"])
 	assert.Equal(t, []string{"will_not_fix"}, policies[0].Attributes["response"])
 }
+
+func TestRestoreSuppressedMatches_ExternalVEXFalsePositive(t *testing.T) {
+	// This simulates what happens when Grype processes a VEX file and 
+	// Kubevuln drops the tags during conversion. We are left with a single 
+	// rule that only has the Vulnerability ID.
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-KEEP"}}},
+		},
+		IgnoredMatches: []v1beta1.IgnoredMatch{
+			{
+				Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-VEX-SUPPRESSED"}}},
+				AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-VEX-SUPPRESSED"}},
+			},
+		},
+	}
+
+	restored := RestoreSuppressedMatches(doc)
+
+	require.NotNil(t, restored)
+	assert.Len(t, restored.Matches, 1, "VEX-suppressed match should NOT be restored")
+	assert.Len(t, restored.IgnoredMatches, 1, "VEX-suppressed match should stay ignored")
+}
+
+func TestRestoreSuppressedMatches_GenuineCRDException(t *testing.T) {
+	// This simulates a genuine CRD-sourced IgnoreRule which has provenance
+	// tags (like SourceKind) but an empty FixState. It proves we haven't 
+	// broken restoration for legitimate CRD exceptions.
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{},
+		IgnoredMatches: []v1beta1.IgnoredMatch{
+			{
+				Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-CRD-SUPPRESSED"}}},
+				AppliedIgnoreRules: []v1beta1.IgnoreRule{
+					{
+						Vulnerability: "CVE-CRD-SUPPRESSED",
+						SourceKind:    "SecurityException",
+						// FixState is deliberately left empty
+					},
+				},
+			},
+		},
+	}
+
+	restored := RestoreSuppressedMatches(doc)
+
+	require.NotNil(t, restored)
+	assert.Len(t, restored.Matches, 1, "Genuine CRD-suppressed match MUST be restored")
+	assert.Len(t, restored.IgnoredMatches, 0, "Genuine CRD-suppressed match should no longer be ignored")
+}
+

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1892,7 +1892,7 @@ func matchForTest(id string) v1beta1.Match {
 func ignoredMatchForTest(id string) v1beta1.IgnoredMatch {
 	return v1beta1.IgnoredMatch{
 		Match:              matchForTest(id),
-		AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: id}},
+		AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: id, SourceKind: "SecurityException"}},
 	}
 }
 
@@ -2052,8 +2052,8 @@ func TestScanService_ScanCVE_CacheHit_ExpiredOnFixRestoresFixedMatch(t *testing.
 	// cached: both matches suppressed by the earlier, wider policy (no ExpiredOnFix)
 	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
 		IgnoredMatches: []v1beta1.IgnoredMatch{
-			{Match: fixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X"}}},
-			{Match: unfixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X"}}},
+			{Match: fixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X", SourceKind: "SecurityException"}}},
+			{Match: unfixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X", SourceKind: "SecurityException"}}},
 		},
 	})
 
@@ -2087,7 +2087,7 @@ func TestScanService_ScanCVE_CacheHit_ExpiredOnFixWideningPersistsSuppression(t 
 	seedCachedCVEManifest(t, repo, "imageSlug", sbomVer, cveVer, cveDBVer, ctx, &v1beta1.GrypeDocument{
 		Matches: []v1beta1.Match{fixedMatch},
 		IgnoredMatches: []v1beta1.IgnoredMatch{
-			{Match: unfixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X"}}},
+			{Match: unfixedMatch, AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-X", SourceKind: "SecurityException"}}},
 		},
 	})
 


### PR DESCRIPTION
## Overview

Right now, if an external VEX document ignores a vulnerability, it accidentally gets un-ignored the next time you scan the same image (when the cache is used). This happens because the code gets confused and thinks the blank VEX rule is a SecurityException, so it puts the vulnerability back into the active list.

This PR fixes that. It makes the check much stricter. Now, the code only thinks something is a SecurityException if it actually has the right tags (like `SourceKind`). This stops the VEX ignores from being undone.

## Additional Information

> Any additional information that may be useful for reviewers to know 

The real root cause is that VEX tags get dropped when converting data in `grype_to_domain.go`. We can't fully fix that here because we need to add fields to `v1beta1.IgnoreRule` in the `kubescape/storage` repo first. This PR is a necessary, quick fix to stop the bug for now. The other fix will come in a future PR.

I also fixed a wrong comment above the `RestoreSuppressedMatches` function.

## How to Test

> Please provide instructions on how to test the changes made in this pull request

I added two new unit tests:
- `TestRestoreSuppressedMatches_ExternalVEXFalsePositive`: Proves that a VEX rule with lost tags stays ignored.
- `TestRestoreSuppressedMatches_GenuineCRDException`: Proves that real CRD exceptions (which always have a `SourceKind` tag) still get restored properly.

**To test manually:**
1. Scan an image that has a VEX-ignored vulnerability.
2. Scan the exact same image again (this triggers the cache).
3. Check that the vulnerability stays ignored instead of coming back.

## Examples/Screenshots

> Here you add related screenshots 

*(No screenshots needed for this logic fix)*

## Related issues/PRs:

* Related to #387
* Resolved #699

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of suppressed vulnerability matches by recognizing their CRD provenance.
  * Prevented externally sourced VEX suppressions from being incorrectly restored as security exceptions.
  * Correctly identifies genuine security exception suppressions even when fix-state information is absent.
  * Consolidated repeated conversion warnings into clearer messages with occurrence counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->