### PR TITLE
refactor: remove dead isGlobal parameter from incrementCounter

### DIFF
--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -186,8 +186,8 @@ func (a *BackendAdapter) sendVulnerabilities(ctx context.Context, chunksChan <-c
 	}
 }
 
-func incrementCounter(counter *int64, isGlobal, isIgnored bool) {
-	if isGlobal && isIgnored {
+func incrementCounter(counter *int64, isIgnored bool) {
+	if isIgnored {
 		return
 	}
 
@@ -252,15 +252,15 @@ func Summarize(report v1.ScanResultReport, vulnerabilities []containerscan.Commo
 		isFixed := containerscan.CalculateFixed(vulnerabilities[i].Fixes) > 0
 		if isFixed {
 			vulnSeverityStats.FixAvailableOfTotalCount++
-			incrementCounter(&summary.FixAvailableOfTotalCount, true, isIgnored)
+			incrementCounter(&summary.FixAvailableOfTotalCount, isIgnored)
 		}
 		isRCE := vulnerabilities[i].IsRCE()
 		if isRCE {
 			vulnSeverityStats.RCECount++
-			incrementCounter(&summary.RCECount, true, isIgnored)
+			incrementCounter(&summary.RCECount, isIgnored)
 			if isFixed {
 				vulnSeverityStats.RCEFixCount++
-				incrementCounter(&summary.RCEFixCount, true, isIgnored)
+				incrementCounter(&summary.RCEFixCount, isIgnored)
 			}
 		}
 
@@ -270,10 +270,10 @@ func Summarize(report v1.ScanResultReport, vulnerabilities []containerscan.Commo
 				// vulnerability is relevant
 				vulnerabilities[i].SetRelevantLabel(containerscan.RelevantLabelYes)
 				vulnSeverityStats.RelevantCount++
-				incrementCounter(&summary.RelevantCount, true, isIgnored)
+				incrementCounter(&summary.RelevantCount, isIgnored)
 				if isFixed {
 					vulnSeverityStats.RelevantFixCount++
-					incrementCounter(&summary.RelevantFixCount, true, isIgnored)
+					incrementCounter(&summary.RelevantFixCount, isIgnored)
 				}
 			} else {
 				// vulnerability is not relevant


### PR DESCRIPTION
## Overview
This PR removes the dead `isGlobal` parameter from `incrementCounter` in `adapters/v1/backend_utils.go`. Across all call sites in `Summarize()`, this parameter was unconditionally passed as `true`, meaning the branching logic `if isGlobal && isIgnored` was effectively just `if isIgnored`. This change simplifies the function signature without altering any functional behavior.

## How to Test
 Run unit tests in `adapters/v1` to verify logic remains intact.
```bash
go test ./adapters/v1
```

## Related issues/PRs:
Closes #705

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes