### PR TITLE
fix(adapters): document and test isExpired's now-equality boundary

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -102,6 +102,9 @@ func ConvertToVulnerabilityExceptionPolicies(exceptions []sev1beta1.SecurityExce
 	return policies, stats
 }
 
+// isExpired reports whether expiresAt has passed relative to now. The boundary is
+// exclusive: an expiresAt exactly equal to now is not yet expired, so the suppression
+// it governs remains active through that exact instant and only expires strictly after it.
 func isExpired(expiresAt *metav1.Time, now time.Time) bool {
 	return expiresAt != nil && expiresAt.Time.Before(now)
 }

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -216,6 +216,16 @@ func TestConvertSkipsExpired(t *testing.T) {
 		"one expired namespaced and one expired cluster-scoped exception should each be counted once")
 }
 
+func TestIsExpiredBoundary(t *testing.T) {
+	now := time.Now()
+	exact := metav1.NewTime(now)
+
+	assert.False(t, isExpired(&exact, now), "expiresAt equal to now must not be treated as expired")
+	assert.True(t, isExpired(&metav1.Time{Time: now.Add(time.Nanosecond)}, now.Add(2*time.Nanosecond)),
+		"expiresAt strictly before now must be treated as expired")
+	assert.False(t, isExpired(nil, now), "a nil expiresAt must never be treated as expired")
+}
+
 func TestConvertMatchResources(t *testing.T) {
 	exceptions := []sev1beta1.SecurityException{
 		{


### PR DESCRIPTION
## Overview
`isExpired` in `adapters/v1/securityexception.go` decides whether a SecurityException/ClusterSecurityException vulnerability suppression has expired, but it had no doc comment stating which way the boundary resolves when `expiresAt` is exactly equal to `now`, and no test exercised that exact instant. This PR documents the intended behavior (the boundary is exclusive, so an exception still suppresses through the instant it expires) and adds a test that locks it in.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test
Run `go test ./adapters/v1/... -run TestIsExpiredBoundary -v` to see the new boundary test pass, or `go test ./...` for the full suite.

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

## Related issues/PRs:

Resolved #709

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that an expiration time equal to the current time remains active.

* **Tests**
  * Added coverage for expiration boundary conditions, including equal, earlier, and unspecified expiration times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->