### PR TITLE
test(adapters): point the exception lookup tests at the live implementation

### DIFF
--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -234,7 +234,7 @@ func Summarize(report v1.ScanResultReport, vulnerabilities []containerscan.Commo
 	for i := range vulnerabilities {
 		// Same predicate ApplySecurityExceptions uses to decide suppression for the stored
 		// manifest. Reading only ExceptionApplied[0].Actions[0] would answer a narrower
-		// question: getCVEExceptionMatchCVENameFromList appends every policy matching the
+		// question: the exception lookup appends every policy matching the
 		// CVE name without filtering on actions, so the first one is not necessarily the
 		// one carrying Ignore, and the two surfaces would then disagree about whether the
 		// finding is suppressed.
@@ -338,37 +338,11 @@ func sortBySeverity(stats []containerscan.SeverityStats) {
 	})
 }
 
-func getCVEExceptionMatchCVENameFromList(srcCVEList []armotypes.VulnerabilityExceptionPolicy, CVEName string, filterFixed bool) []armotypes.VulnerabilityExceptionPolicy {
-	var l []armotypes.VulnerabilityExceptionPolicy
-
-	for i := range srcCVEList {
-		if filterFixed && srcCVEList[i].ExpiredOnFix != nil && *srcCVEList[i].ExpiredOnFix {
-			continue
-		}
-		for j := range srcCVEList[i].VulnerabilityPolicies {
-			if strings.EqualFold(srcCVEList[i].VulnerabilityPolicies[j].Name, CVEName) {
-				// A policy contributes at most once. buildPolicy expands a vulnerability
-				// entry into one VulnerabilityPolicy per id and alias, so an exception
-				// listing an alias equal to its id, or the same alias twice, would
-				// otherwise return the same policy several times, and every consumer
-				// counts it that many times.
-				l = append(l, srcCVEList[i])
-				break
-			}
-		}
-	}
-
-	if len(l) > 0 {
-		return l
-	}
-	return nil
-}
-
 // cveExceptionIndex maps a lower-cased CVE/alias name to the indices, into the exception
 // list it was built from, of every exception that declares a VulnerabilityPolicy with that
 // name. It lets a scan with many matches look up candidate exceptions in roughly constant
 // time per match instead of re-walking every exception (and every policy within it) for
-// each one, which is what getCVEExceptionMatchCVENameFromList does on its own.
+// each one, which is what a linear scan of the list would do per match.
 type cveExceptionIndex struct {
 	srcCVEList []armotypes.VulnerabilityExceptionPolicy
 	byName     map[string][]int
@@ -396,9 +370,12 @@ func buildCVEExceptionIndex(srcCVEList []armotypes.VulnerabilityExceptionPolicy)
 	return idx
 }
 
-// lookup returns the same result getCVEExceptionMatchCVENameFromList(idx.srcCVEList, CVEName,
-// filterFixed) would return, but only inspects the exceptions that actually declare a policy
-// named CVEName rather than the full exception list.
+// lookup returns every exception declaring a policy named CVEName, in the order they appear
+// in the list it was built from, skipping those marked ExpiredOnFix when filterFixed is set.
+// An exception contributes at most once, however many of its policies carry that name:
+// buildPolicy expands a vulnerability entry into one VulnerabilityPolicy per id and alias, so
+// an exception listing an alias equal to its id would otherwise be returned several times and
+// every consumer would count it that many times.
 func (idx *cveExceptionIndex) lookup(CVEName string, filterFixed bool) []armotypes.VulnerabilityExceptionPolicy {
 	if idx == nil {
 		return nil

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,30 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/pointer"
 )
+
+// linearExceptionLookup is the straightforward scan the index replaced, kept here so the
+// equivalence test below has something independent to compare against. Production has one
+// implementation now, and an index checked against itself asserts nothing.
+func linearExceptionLookup(srcCVEList []armotypes.VulnerabilityExceptionPolicy, CVEName string, filterFixed bool) []armotypes.VulnerabilityExceptionPolicy {
+	var l []armotypes.VulnerabilityExceptionPolicy
+	for i := range srcCVEList {
+		if filterFixed && srcCVEList[i].ExpiredOnFix != nil && *srcCVEList[i].ExpiredOnFix {
+			continue
+		}
+		for j := range srcCVEList[i].VulnerabilityPolicies {
+			if strings.EqualFold(srcCVEList[i].VulnerabilityPolicies[j].Name, CVEName) {
+				// an exception contributes at most once however many of its policies carry
+				// the name, matching what the index does with its per-exception seen set
+				l = append(l, srcCVEList[i])
+				break
+			}
+		}
+	}
+	if len(l) > 0 {
+		return l
+	}
+	return nil
+}
 
 func TestGetCVEExceptionMatchCVENameFromList(t *testing.T) {
 	testCases := []struct {
@@ -206,16 +231,13 @@ func TestGetCVEExceptionMatchCVENameFromList(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := getCVEExceptionMatchCVENameFromList(tc.srcCVEList, tc.CVEName, tc.isFixed)
+			actual := buildCVEExceptionIndex(tc.srcCVEList).lookup(tc.CVEName, tc.isFixed)
 			assert.Equal(t, tc.expected, actual)
-
-			indexed := buildCVEExceptionIndex(tc.srcCVEList).lookup(tc.CVEName, tc.isFixed)
-			assert.Equal(t, tc.expected, indexed)
 		})
 	}
 }
 
-// buildCVEExceptionIndex+lookup must return exactly what getCVEExceptionMatchCVENameFromList
+// buildCVEExceptionIndex+lookup must return exactly what a linear scan of the exception list
 // returns for the same inputs, since callers switched from the linear scan to the index to
 // avoid re-walking the full exception list per match.
 func TestCVEExceptionIndex_MatchesLinearScan(t *testing.T) {
@@ -239,7 +261,7 @@ func TestCVEExceptionIndex_MatchesLinearScan(t *testing.T) {
 
 	for _, cve := range []string{"CVE-2021-1234", "cve-2021-1234", "CVE-2021-5678", "CVE-9999-0000"} {
 		for _, filterFixed := range []bool{false, true} {
-			want := getCVEExceptionMatchCVENameFromList(srcCVEList, cve, filterFixed)
+			want := linearExceptionLookup(srcCVEList, cve, filterFixed)
 			got := index.lookup(cve, filterFixed)
 			assert.Equal(t, want, got, "cve=%s filterFixed=%v", cve, filterFixed)
 		}
@@ -268,7 +290,7 @@ func BenchmarkGetCVEExceptionMatch(b *testing.B) {
 	b.Run("LinearScanPerMatch", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for _, cve := range cveNames {
-				getCVEExceptionMatchCVENameFromList(srcCVEList, cve, false)
+				linearExceptionLookup(srcCVEList, cve, false)
 			}
 		}
 	})
@@ -778,7 +800,7 @@ func Test_sendSummaryAndVulnerabilities(t *testing.T) {
 }
 
 // Summarize and ApplySecurityExceptions must answer "is this CVE suppressed?" the same way.
-// getCVEExceptionMatchCVENameFromList appends every policy whose VulnerabilityPolicies name
+// the exception lookup appends every policy whose VulnerabilityPolicies name
 // the CVE, without filtering on actions, so ExceptionApplied[0] is not necessarily the policy
 // carrying Ignore. Reading only the first policy's first action made the stored manifest hide
 // a finding the backend summary still counted as active.
@@ -909,7 +931,7 @@ func TestGetCVEExceptionMatch_PolicyMatchesAtMostOnce(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getCVEExceptionMatchCVENameFromList(tt.list, tt.cve, false)
+			got := buildCVEExceptionIndex(tt.list).lookup(tt.cve, false)
 			assert.Len(t, got, tt.wantLen)
 		})
 	}
@@ -926,9 +948,9 @@ func TestGetCVEExceptionMatch_ExpiredOnFixSkipsWholePolicy(t *testing.T) {
 		ExpiredOnFix:          &expiredOnFix,
 	}
 
-	assert.Empty(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "CVE-2021-44228", true))
-	assert.Empty(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "GHSA-jfh8", true))
-	assert.Len(t, getCVEExceptionMatchCVENameFromList([]armotypes.VulnerabilityExceptionPolicy{p}, "CVE-2021-44228", false), 1)
+	assert.Empty(t, buildCVEExceptionIndex([]armotypes.VulnerabilityExceptionPolicy{p}).lookup("CVE-2021-44228", true))
+	assert.Empty(t, buildCVEExceptionIndex([]armotypes.VulnerabilityExceptionPolicy{p}).lookup("GHSA-jfh8", true))
+	assert.Len(t, buildCVEExceptionIndex([]armotypes.VulnerabilityExceptionPolicy{p}).lookup("CVE-2021-44228", false), 1)
 }
 
 // Summarize collected its severity stats in a map and emitted them in iteration order, which

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -550,7 +550,7 @@ func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 // IgnoredMatchKeys returns the set of match-identity keys for a manifest's ignored matches.
 // Keyed by vulnerability ID + artifact name + version (via \x00 separators) rather than CVE ID
 // alone, because an ExpiredOnFix policy suppresses only the matches of a CVE that have no known
-// fix (hasKnownFix, via getCVEExceptionMatchCVENameFromList), so two matches of the same CVE can
+// fix (hasKnownFix, via the exception lookup), so two matches of the same CVE can
 // have different suppression states. The manifest content is fixed across a cache hit, so these
 // keys are stable and detect both ID- and fix-state-driven changes to the ignored set.
 //


### PR DESCRIPTION
## Overview

#694 moved both callers of `getCVEExceptionMatchCVENameFromList` onto `cveExceptionIndex.lookup` and left the old function behind. it has no callers outside tests now, but seven test call sites still point at it, so the tests for how a `SecurityException` decides to suppress a finding cover a function no scan reaches: the at-most-once behaviour from #579, the `ExpiredOnFix` filtering, the alias matching and the case handling.

they pass whatever `lookup` does, which matters more than the dead lines. if the two ever disagree the tests keep saying it is fine, and what they cover is which vulnerabilities get hidden.

this points the seven at `buildCVEExceptionIndex(list).lookup(...)` and deletes the old function.

## Additional Information

all seven pass against the index unchanged, which is the evidence that the two are equivalent today and that nothing is lost by dropping the linear one. I checked the two against each other before touching anything:

- ordering: the index appends exception positions in ascending order while walking the list once, and `lookup` walks that ascending, so both return matches in list order.
- at most once per exception: the linear one `break`s out of the policy loop, the index keeps a per-exception `seen` set while building, so an exception listing an alias equal to its id contributes once either way.
- `ExpiredOnFix`: skipped before the policies in one, at lookup in the other, same set either way.
- case: `strings.EqualFold` against `strings.ToLower` on both sides. these part company on some non-ASCII input, `EqualFold` doing full case folding, but a CVE id or alias is ASCII.

the comments that named the old function are updated rather than left pointing at something that is gone, including the one on `lookup` itself, which described its result as "the same result getCVEExceptionMatchCVENameFromList would return" and now states the behaviour directly.

## How to Test

`go test ./adapters/v1/ -count=1`

no test is added or removed, seven change which function they call. `TestBuildCVEExceptionIndex_MatchesLinearLookup` from #694, `Test_getCVEExceptionMatchCVENameFromList`, the #579 at-most-once case and the `ExpiredOnFix` and alias cases all pass unchanged against the index.

## Related issues/PRs:

* Resolved #711
* Follow-up to #694


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability exception matching for consistent suppression across multiple policies and actions.
  * Added case-insensitive matching, prevented duplicate policy matches, and excluded exceptions that expired after a fix.
  * Preserved exception ordering and existing suppression behavior.
* **Performance**
  * Accelerated vulnerability exception lookups, particularly for larger policy sets.
* **Documentation**
  * Clarified terminology in security exception documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->