### PR TITLE
fix(repositories): stop calling cloud exception suppressions external VEX

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1079,8 +1079,18 @@ func statementHasPURL(products []v1beta1.Product, purl string) bool {
 const defaultActionStatement = "Upgrade the vulnerable component to a version that is not affected"
 
 const (
-	defaultLocalImpactStatement         = "Vulnerable component is not loaded into the memory"
-	securityExceptionImpactStatement    = "Vulnerability was ignored by a SecurityException"
+	defaultLocalImpactStatement      = "Vulnerable component is not loaded into the memory"
+	securityExceptionImpactStatement = "Vulnerability was ignored by a SecurityException"
+	// cloudExceptionImpactStatement covers a suppression from an exception policy that did
+	// not come from a CRD, which today means one delivered by the backend. Those reach
+	// ApplySecurityExceptions like any other policy but never go through buildPolicy, so
+	// they carry no sourceKind and their ignore rule carries no SourceKind either.
+	cloudExceptionImpactStatement = "Vulnerability was ignored by an exception policy"
+	// externalIgnoreImpactStatement covers an ignore that did not come from our exception
+	// machinery at all. Nothing produces one today, ApplySecurityExceptions being the only
+	// writer of IgnoredMatches and Grype being given no VEX documents or ignore rules, but
+	// consuming external VEX feeds (#387) is what would.
+	externalIgnoreImpactStatement       = "Vulnerability was ignored by an external VEX document or scanner configuration"
 	securityExceptionAcceptedRiskAction = "A SecurityException accepted this vulnerability as an affected finding"
 )
 
@@ -1100,7 +1110,14 @@ func ignoredMatchAssessment(m v1beta1.IgnoredMatch) ignoredVEXAssessment {
 
 	rule, ok := securityExceptionIgnoreRule(m)
 	if !ok {
-		assessment.impactStatement = "Vulnerability was ignored by an external VEX document or scanner configuration"
+		// No CRD provenance does not make it someone else's. A backend-delivered exception
+		// policy suppresses through the same path and leaves a rule with only the
+		// vulnerability id on it, so calling that an external VEX document would describe
+		// most suppressions wrongly on any cluster using cloud exceptions.
+		assessment.impactStatement = externalIgnoreImpactStatement
+		if isOwnIgnoreRule(m) {
+			assessment.impactStatement = cloudExceptionImpactStatement
+		}
 		return assessment
 	}
 
@@ -1136,6 +1153,17 @@ func ignoredMatchAssessment(m v1beta1.IgnoredMatch) ignoredVEXAssessment {
 // This is distinct from the adapter's isExceptionSourcedIgnore because it strictly
 // matches the SourceKind rather than inferring provenance from rule shape, ensuring
 // that only explicit CRD-driven rules receive the SecurityException impact statement.
+// isOwnIgnoreRule reports whether an ignored match was suppressed by our own exception
+// machinery. buildIgnoreRule writes exactly one rule per suppression and never sets Package,
+// while Grype expresses its own ignore rules in terms of a package, so one carrying a package
+// did not come from us.
+func isOwnIgnoreRule(m v1beta1.IgnoredMatch) bool {
+	if len(m.AppliedIgnoreRules) != 1 {
+		return false
+	}
+	return m.AppliedIgnoreRules[0].Package == nil
+}
+
 func securityExceptionIgnoreRule(m v1beta1.IgnoredMatch) (v1beta1.IgnoreRule, bool) {
 	for _, rule := range m.AppliedIgnoreRules {
 		switch rule.SourceKind {

--- a/repositories/apiserver_external_test.go
+++ b/repositories/apiserver_external_test.go
@@ -503,3 +503,56 @@ func TestIsOwnActionStatement(t *testing.T) {
 	assert.True(t, isOwnActionStatement(defaultActionStatement, ""))
 	assert.False(t, isOwnActionStatement(upgradeActionStatementPrefix(purl)+"1.30", ""))
 }
+
+// Every ignored match in a manifest came from ApplySecurityExceptions, that being the only
+// thing that writes IgnoredMatches, and Grype is given no VEX documents or ignore rules of
+// its own. A backend-delivered exception policy never goes through buildPolicy, so it
+// carries no sourceKind and its rule carries no SourceKind, which is not grounds for calling
+// the suppression external.
+func TestIgnoredMatchAssessment_AttributesBySource(t *testing.T) {
+	match := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		rules []v1beta1.IgnoreRule
+		want  string
+	}{
+		{
+			name:  "CRD SecurityException",
+			rules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-2021-44228", SourceKind: "SecurityException", SourceName: "se/ns/name"}},
+			want:  securityExceptionImpactStatement,
+		},
+		{
+			name:  "cluster-scoped CRD",
+			rules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-2021-44228", SourceKind: "ClusterSecurityException", SourceName: "cse/name"}},
+			want:  securityExceptionImpactStatement,
+		},
+		{
+			// What buildIgnoreRule leaves behind for a backend-delivered policy: the
+			// vulnerability id and nothing else.
+			name:  "backend-delivered exception policy",
+			rules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-2021-44228"}},
+			want:  cloudExceptionImpactStatement,
+		},
+		{
+			// Grype states its own ignore rules against a package, which buildIgnoreRule
+			// never sets. Nothing produces this today; #387 is what would.
+			name:  "not ours",
+			rules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-2021-44228", Package: &v1beta1.IgnoreRulePackage{Name: "tar"}}},
+			want:  externalIgnoreImpactStatement,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ignoredMatchAssessment(v1beta1.IgnoredMatch{Match: match, AppliedIgnoreRules: tt.rules})
+			assert.Equal(t, tt.want, got.impactStatement)
+			assert.Equal(t, v1beta1.Status(vex.StatusNotAffected), got.status,
+				"all of these are suppressions, so the status is unchanged")
+		})
+	}
+}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -3277,7 +3277,10 @@ func TestStoreVEX_ExternalVEXMasking(t *testing.T) {
 	store := NewFakeAPIServerStorage(namespace)
 
 	// Simulate a CVE manifest with two ignored matches:
-	// 1. Grype suppressed a finding natively (no SecurityException)
+	// 1. Suppressed by a backend-delivered exception policy. Those never go through
+	//    buildPolicy, so they carry no sourceKind and the rule buildIgnoreRule writes for
+	//    them holds the vulnerability id and nothing else. It is not a Grype-native ignore:
+	//    Grype states those against a package, which buildIgnoreRule never sets.
 	// 2. Suppressed by a genuine SecurityException
 	cveManifest := domain.CVEManifest{
 		Name: "deployment-my-app",
@@ -3315,17 +3318,21 @@ func TestStoreVEX_ExternalVEXMasking(t *testing.T) {
 	vexContainer, err := store.StorageClient.OpenVulnerabilityExchangeContainers(namespace).Get(ctx, cveManifest.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
-	var foundExternal, foundCRD bool
+	var foundPolicy, foundCRD bool
 	for _, stmt := range vexContainer.Spec.Statements {
 		if stmt.Vulnerability.Name == "CVE-2023-1234" {
-			foundExternal = true
-			assert.Equal(t, "Vulnerability was ignored by an external VEX document or scanner configuration", stmt.ImpactStatement)
+			foundPolicy = true
+			// Still the point of this test: a suppression with no CRD provenance must not
+			// be attributed to a SecurityException. It is attributed to the policy that
+			// actually made it rather than to an external document.
+			assert.Equal(t, cloudExceptionImpactStatement, stmt.ImpactStatement)
+			assert.NotEqual(t, securityExceptionImpactStatement, stmt.ImpactStatement)
 		} else if stmt.Vulnerability.Name == "CVE-2023-5678" {
 			foundCRD = true
-			assert.Equal(t, "Vulnerability was ignored by a SecurityException", stmt.ImpactStatement)
+			assert.Equal(t, securityExceptionImpactStatement, stmt.ImpactStatement)
 		}
 	}
-	assert.True(t, foundExternal, "Should have found external VEX statement")
+	assert.True(t, foundPolicy, "Should have found the exception-policy statement")
 	assert.True(t, foundCRD, "Should have found CRD SecurityException statement")
 }
 


### PR DESCRIPTION
## Overview

#671 was right that a suppression without CRD provenance must not be attributed to a `SecurityException`. this keeps that. what it added in its place says something else that is wrong for most suppressions:

> Vulnerability was ignored by an external VEX document or scanner configuration

only CRD-sourced policies ever carry a `SourceKind`, since `buildIgnoreRule` reads it from the attributes `buildSuppressionAttributes` sets and that runs from `buildPolicy`, which only the CRD path calls. a policy delivered by the backend suppresses through the same code and comes out with a rule holding the vulnerability id and nothing else, so it takes the `!ok` branch and the document says it came from an external VEX document. it did not, it came from an exception policy, and cloud exceptions being the older of the two mechanisms that is every suppressed finding on a cluster using them.

so the branch now distinguishes the two, and the external wording is kept for a rule that really did not come from us.

## Additional Information

the shapes are separable: Grype states an ignore rule against a package and `buildIgnoreRule` never sets one, so a rule carrying a package did not come from us. `isOwnIgnoreRule` is that check.

nothing produces the external case today. `ApplySecurityExceptions` is the only writer of `IgnoredMatches`, and Grype is given no VEX documents and no ignore rules, so it contributes none. the wording is kept rather than dropped because #387 is what makes it reachable, and it is a named constant now like the other two instead of a literal in the branch.

`TestStoreVEX_ExternalVEXMasking` from #671 changes here. its fixture is commented as a Grype-native suppression but is `{{Vulnerability: "CVE-2023-1234"}}`, which is the shape our own code writes for a cloud policy, so it was asserting the misattribution. it now expects the exception-policy wording and still asserts the thing that test exists for, that the statement is not attributed to a `SecurityException`.

## How to Test

`go test ./repositories/ -count=1`

`TestIgnoredMatchAssessment_AttributesBySource` covers the four shapes: a namespaced CRD, a cluster-scoped CRD, a backend-delivered policy, and a rule carrying a package. before this the backend-delivered case fails with

```
expected: "Vulnerability was ignored by an exception policy"
actual  : "Vulnerability was ignored by an external VEX document or scanner configuration"
```

and all four assert the status is untouched, since every one of them is a suppression.

## Related issues/PRs:

* Resolved #713
* Follow-up to #671
