### PR TITLE
fix: record all matching exception policies in AppliedIgnoreRules (#715)

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -523,7 +523,8 @@ func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument
 
 // isExceptionSourcedIgnore reports whether an ignored match carries the AppliedIgnoreRules
 // signature ApplySecurityExceptions writes: non-empty AppliedIgnoreRules where every rule has no
-// package set, and either exception provenance (source/justification/impact) or an empty FixState.
+// package set and its SourceKind is a known exception source ("SecurityException" or
+// "ClusterSecurityException"), or matches the empty legacy-rule fallback.
 func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 	if len(im.AppliedIgnoreRules) == 0 {
 		return false
@@ -532,12 +533,13 @@ func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 		if r.Package != nil {
 			return false
 		}
-		if r.SourceKind != "" || r.SourceName != "" || r.SourceNamespace != "" || r.Justification != "" || r.ImpactStatement != "" {
+		if r.SourceKind == "SecurityException" || r.SourceKind == "ClusterSecurityException" {
 			continue
 		}
-		if r.FixState != "" {
-			return false
+		if r.SourceKind == "" && r.SourceName == "" && r.SourceNamespace == "" && r.Justification == "" && r.ImpactStatement == "" && r.FixState == "" {
+			continue
 		}
+		return false
 	}
 	return true
 }

--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -338,10 +338,8 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 		matched = scopedToSubcomponent(matched, m.Artifact.PURL)
 		if len(matched) > 0 && hasIgnoreAction(matched) {
 			doc.IgnoredMatches = append(doc.IgnoredMatches, v1beta1.IgnoredMatch{
-				Match: m,
-				AppliedIgnoreRules: []v1beta1.IgnoreRule{
-					buildIgnoreRule(m, matched),
-				},
+				Match:              m,
+				AppliedIgnoreRules: buildIgnoreRules(m, matched),
 			})
 			logSuppression(m, matched, recorder)
 			matchedKinds := map[string]struct{}{}
@@ -361,45 +359,48 @@ func ApplySecurityExceptions(doc *v1beta1.GrypeDocument, exceptions domain.CVEEx
 	return matchedBySource
 }
 
-// buildIgnoreRule constructs the IgnoreRule recorded on the manifest for m, populating
-// provenance fields from the first suppressing policy's Attributes (the same values
-// buildSuppressionAttributes calculates and logSuppression already logs), so this
-// information is durably stored on the manifest itself, not only logged. SourceName here
-// carries suppressionRuleID's structured kind/namespace/name form rather than the bare
-// object name, so it stays unambiguous for both namespaced and cluster-scoped exceptions.
-func buildIgnoreRule(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionPolicy) v1beta1.IgnoreRule {
-	rule := v1beta1.IgnoreRule{Vulnerability: m.Vulnerability.ID}
-
+// buildIgnoreRules constructs the slice of IgnoreRule entries recorded on the manifest for m,
+// populating provenance fields from EVERY suppressing policy's Attributes (the same values
+// buildSuppressionAttributes calculates and logSuppression already logs), so complete provenance
+// is durably stored on the manifest itself when multiple policies match. SourceName here carries
+// suppressionRuleID's structured kind/namespace/name form rather than the bare object name, so it
+// stays unambiguous for both namespaced and cluster-scoped exceptions.
+func buildIgnoreRules(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionPolicy) []v1beta1.IgnoreRule {
 	suppressing := suppressingPolicies(matched)
 	if len(suppressing) == 0 {
-		return rule
+		return []v1beta1.IgnoreRule{{Vulnerability: m.Vulnerability.ID}}
 	}
-	p := suppressing[0]
 
-	if kind, ok := p.Attributes["sourceKind"].(string); ok {
-		rule.SourceKind = kind
+	rules := make([]v1beta1.IgnoreRule, 0, len(suppressing))
+	for _, p := range suppressing {
+		rule := v1beta1.IgnoreRule{Vulnerability: m.Vulnerability.ID}
+
+		if kind, ok := p.Attributes["sourceKind"].(string); ok {
+			rule.SourceKind = kind
+		}
+		if ruleID, ok := p.Attributes["ruleId"].(string); ok {
+			rule.SourceName = ruleID
+		}
+		if ns, ok := p.Attributes["sourceNamespace"].(string); ok {
+			rule.SourceNamespace = ns
+		}
+		if status, ok := p.Attributes["status"].(string); ok {
+			// FixState is repurposed here to carry the SecurityException's status vocabulary
+			// (not_affected/fixed/affected) rather than Grype's native fix-state vocabulary.
+			// This is safe because every reader of FixState gates on SourceKind being a
+			// SecurityException/ClusterSecurityException first — native Grype ignore rules
+			// never set SourceKind, so they're unaffected.
+			rule.FixState = status
+		}
+		if just, ok := p.Attributes["justification"].(string); ok {
+			rule.Justification = just
+		}
+		if impact, ok := p.Attributes["impactStatement"].(string); ok {
+			rule.ImpactStatement = impact
+		}
+		rules = append(rules, rule)
 	}
-	if ruleID, ok := p.Attributes["ruleId"].(string); ok {
-		rule.SourceName = ruleID
-	}
-	if ns, ok := p.Attributes["sourceNamespace"].(string); ok {
-		rule.SourceNamespace = ns
-	}
-	if status, ok := p.Attributes["status"].(string); ok {
-		// FixState is repurposed here to carry the SecurityException's status vocabulary
-		// (not_affected/fixed/affected) rather than Grype's native fix-state vocabulary.
-		// This is safe because every reader of FixState gates on SourceKind being a
-		// SecurityException/ClusterSecurityException first — native Grype ignore rules
-		// never set SourceKind, so they're unaffected.
-		rule.FixState = status
-	}
-	if just, ok := p.Attributes["justification"].(string); ok {
-		rule.Justification = just
-	}
-	if impact, ok := p.Attributes["impactStatement"].(string); ok {
-		rule.ImpactStatement = impact
-	}
-	return rule
+	return rules
 }
 
 // suppressingPolicies filters matched down to the policies that actually cause suppression,
@@ -521,20 +522,24 @@ func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument
 }
 
 // isExceptionSourcedIgnore reports whether an ignored match carries the AppliedIgnoreRules
-// signature ApplySecurityExceptions writes: exactly one rule with no package set, and either
-// exception provenance (source/justification/impact) or an empty FixState.
+// signature ApplySecurityExceptions writes: non-empty AppliedIgnoreRules where every rule has no
+// package set, and either exception provenance (source/justification/impact) or an empty FixState.
 func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
-	if len(im.AppliedIgnoreRules) != 1 {
+	if len(im.AppliedIgnoreRules) == 0 {
 		return false
 	}
-	r := im.AppliedIgnoreRules[0]
-	if r.Package != nil {
-		return false
+	for _, r := range im.AppliedIgnoreRules {
+		if r.Package != nil {
+			return false
+		}
+		if r.SourceKind != "" || r.SourceName != "" || r.SourceNamespace != "" || r.Justification != "" || r.ImpactStatement != "" {
+			continue
+		}
+		if r.FixState != "" {
+			return false
+		}
 	}
-	if r.SourceKind != "" || r.SourceName != "" || r.SourceNamespace != "" || r.Justification != "" || r.ImpactStatement != "" {
-		return true
-	}
-	return r.FixState == ""
+	return true
 }
 
 // IgnoredMatchKeys returns the set of match-identity keys for a manifest's ignored matches.

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -834,17 +834,25 @@ func TestRestoreSuppressedMatches(t *testing.T) {
 					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-NATIVE"}}},
 					AppliedIgnoreRules: []v1beta1.IgnoreRule{{Vulnerability: "CVE-NATIVE", FixState: "not-fixed"}},
 				},
+				{
+					Match: v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-CUSTOM"}}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{
+						{Vulnerability: "CVE-CUSTOM", SourceKind: "CustomIgnore"},
+						{Vulnerability: "CVE-CUSTOM", SourceKind: "CustomIgnore"},
+					},
+				},
 			},
 		}
 
 		restored := RestoreSuppressedMatches(doc)
 
 		require.NotNil(t, restored)
-		// only the exception-shaped entry is restored; the other is preserved
+		// only the exception-shaped entry is restored; non-exception rules (including multi-rule CustomIgnore) are preserved
 		assert.Len(t, restored.Matches, 1)
 		assert.Equal(t, "CVE-A", restored.Matches[0].Vulnerability.ID)
-		require.Len(t, restored.IgnoredMatches, 1)
+		require.Len(t, restored.IgnoredMatches, 2)
 		assert.Equal(t, "CVE-NATIVE", restored.IgnoredMatches[0].Match.Vulnerability.ID)
+		assert.Equal(t, "CVE-CUSTOM", restored.IgnoredMatches[1].Match.Vulnerability.ID)
 	})
 }
 

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -356,6 +356,77 @@ func TestApplySecurityExceptions_MatchedCountDedupesPerFinding(t *testing.T) {
 	require.Len(t, doc.IgnoredMatches, 1, "one finding should be ignored")
 	assert.Equal(t, map[string]int{"SecurityException": 1}, matchedBySource,
 		"two policies suppressing the same finding must count as a single match")
+	assert.Len(t, doc.IgnoredMatches[0].AppliedIgnoreRules, 2, "both policies must be recorded in AppliedIgnoreRules")
+}
+
+func TestApplySecurityExceptions_MultipleMatchingPolicies_PopulatesAllIgnoreRules(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2023-1234"}}},
+		},
+	}
+	exceptions := domain.CVEExceptions{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "cluster-policy",
+				Attributes: map[string]interface{}{
+					"sourceKind":      "ClusterSecurityException",
+					"ruleId":          "ClusterSecurityException/cluster-policy",
+					"status":          "will_not_fix",
+					"justification":   "code_not_reachable",
+					"impactStatement": "Vendor will not supply fix",
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2023-1234"}},
+		},
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "namespaced-policy",
+				Attributes: map[string]interface{}{
+					"sourceKind":      "SecurityException",
+					"ruleId":          "SecurityException/default/namespaced-policy",
+					"sourceNamespace": "default",
+					"status":          "not_affected",
+					"justification":   "inline_mitigation",
+					"impactStatement": "Mitigated by firewall rule",
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2023-1234"}},
+		},
+	}
+
+	matchedBySource := ApplySecurityExceptions(doc, exceptions, nil)
+
+	require.Len(t, doc.IgnoredMatches, 1)
+	require.Len(t, doc.IgnoredMatches[0].AppliedIgnoreRules, 2, "both matching policies must be recorded on the IgnoredMatch")
+
+	rule1 := doc.IgnoredMatches[0].AppliedIgnoreRules[0]
+	assert.Equal(t, "CVE-2023-1234", rule1.Vulnerability)
+	assert.Equal(t, "ClusterSecurityException", rule1.SourceKind)
+	assert.Equal(t, "ClusterSecurityException/cluster-policy", rule1.SourceName)
+	assert.Equal(t, "will_not_fix", rule1.FixState)
+
+	rule2 := doc.IgnoredMatches[0].AppliedIgnoreRules[1]
+	assert.Equal(t, "CVE-2023-1234", rule2.Vulnerability)
+	assert.Equal(t, "SecurityException", rule2.SourceKind)
+	assert.Equal(t, "SecurityException/default/namespaced-policy", rule2.SourceName)
+	assert.Equal(t, "default", rule2.SourceNamespace)
+	assert.Equal(t, "not_affected", rule2.FixState)
+
+	assert.Equal(t, map[string]int{
+		"ClusterSecurityException": 1,
+		"SecurityException":        1,
+	}, matchedBySource)
+
+	// Test cache reconciliation restoration
+	restored := RestoreSuppressedMatches(doc)
+	assert.Len(t, restored.Matches, 1, "match with multiple AppliedIgnoreRules must be restored")
+	assert.Equal(t, "CVE-2023-1234", restored.Matches[0].Vulnerability.ID)
+	assert.Empty(t, restored.IgnoredMatches)
 }
 
 func TestApplySecurityExceptions_ExpiredOnFix(t *testing.T) {


### PR DESCRIPTION
## Overview
When a vulnerability finding matches multiple active `SecurityException` or `ClusterSecurityException` policies, `buildIgnoreRule` previously constructed an `IgnoreRule` for only the first policy (`suppressing[0]`). As a result, secondary matching policies were silently omitted from `v1beta1.IgnoredMatch.AppliedIgnoreRules` on the stored `VulnerabilityManifest` and `VulnerabilityManifestSummary` CRDs, causing loss of provenance on persisted Kubernetes resources.

Additionally, `isExceptionSourcedIgnore` enforced `len(im.AppliedIgnoreRules) == 1`, which meant that any ignored match carrying multiple ignore rules would fail identification and prevent `RestoreSuppressedMatches` from restoring the match on cache hits during reconciliation.

### Root Cause
- `buildIgnoreRule` accepted `matched []armotypes.VulnerabilityExceptionPolicy` but returned a single `v1beta1.IgnoreRule` built solely from `suppressing[0]`.
- `ApplySecurityExceptions` wrapped that single `IgnoreRule` in a literal 1-element slice `[]v1beta1.IgnoreRule{...}`.
- `isExceptionSourcedIgnore` hardcoded the condition `len(im.AppliedIgnoreRules) != 1`.

### Solution
1. **Refactored `buildIgnoreRule` to `buildIgnoreRules`**: Returns a `[]v1beta1.IgnoreRule` slice containing an `IgnoreRule` entry for every policy in `suppressingPolicies(matched)`.
2. **Updated `ApplySecurityExceptions`**: Populates `AppliedIgnoreRules` directly with `buildIgnoreRules(m, matched)`.
3. **Updated `isExceptionSourcedIgnore`**: Relaxed the length check to `len(im.AppliedIgnoreRules) > 0` and verified that all rules in `AppliedIgnoreRules` conform to the exception-sourced signature, allowing `RestoreSuppressedMatches` to function correctly for multi-policy suppressions.

## Additional Information
This fix ensures durably stored `VulnerabilityManifest` CRDs carry complete audit provenance when multiple policies match a single vulnerability.

## How to Test
Run the updated unit test suite:
```bash
go test -v ./adapters/v1 -run "TestApplySecurityExceptions|TestRestoreSuppressedMatches"
```

## Related issues/PRs:
* Fixes #715

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Findings suppressed by multiple matching policies now retain all applicable suppression rules.
  * Suppression provenance is preserved for both cluster-scoped and namespaced policies.
  * Restoring suppressed findings now correctly handles multiple exception-based rules while rejecting incompatible rules.
  * Match counts remain deduplicated by source when multiple policies apply.

* **Tests**
  * Added regression coverage for multi-policy suppression and restoration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->