### PR TITLE
fix: remove dead code and ineffectual assignment

### DIFF
--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -38,26 +38,8 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
-)
-
-// securityExceptionGVR and clusterSecurityExceptionGVR mirror the unexported GVRs of the same
-// names in package repositories (repositories/apiserver.go) — duplicated here because they're
-// not exported across the package boundary, only used to register the fake dynamic client's
-// list kinds for this test.
-var (
-	securityExceptionGVR = schema.GroupVersionResource{
-		Group:    "kubescape.io",
-		Version:  "v1beta1",
-		Resource: "securityexceptions",
-	}
-	clusterSecurityExceptionGVR = schema.GroupVersionResource{
-		Group:    "kubescape.io",
-		Version:  "v1beta1",
-		Resource: "clustersecurityexceptions",
-	}
 )
 
 type testSecurityExceptionRepo struct {

--- a/adapters/v1/domain_to_syft.go
+++ b/adapters/v1/domain_to_syft.go
@@ -75,18 +75,6 @@ func warnConversionErrors[T any](converted []T, errors []error) []T {
 	return converted
 }
 
-func deduplicateErrors(errors []error) []string {
-	errorCounts := make(map[string]int)
-	var errorMessages []string
-	for _, e := range errors {
-		errorCounts[e.Error()] = errorCounts[e.Error()] + 1
-	}
-	for msg, count := range errorCounts {
-		errorMessages = append(errorMessages, fmt.Sprintf("%q occurred %d time(s)", msg, count))
-	}
-	return errorMessages
-}
-
 func toSyftFiles(files []model.File) sbom.Artifacts {
 	ret := sbom.Artifacts{
 		FileMetadata: make(map[file.Coordinates]file.Metadata),

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -298,7 +298,7 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			}
 		}
 
-		filteredCve := domain.CVEManifest{}
+		var filteredCve domain.CVEManifest
 		var cveExceptionsComplete bool
 		// if CVE manifest is not available, create it
 		if cve.Content == nil {


### PR DESCRIPTION
## Overview
Removes dead code flagged by golangci-lint: an unused helper function, two unused test fixture variables, and an ineffectual assignment.

## Additional Information
`golangci-lint run ./...` was reporting these four findings:
- `adapters/v1/domain_to_syft.go:78` - `deduplicateErrors` had no callers (its only call site was commented out)
- `adapters/v1/backend_test.go:51,56` - `securityExceptionGVR` and `clusterSecurityExceptionGVR` were declared but never referenced anywhere. Checked git history and they were never wired into any test since they were added, so removing them does not drop any coverage.
- `core/services/scan.go:301` - `filteredCve := domain.CVEManifest{}` was always overwritten before being read, so it's now declared with `var filteredCve domain.CVEManifest` instead.

## How to Test
- `go build ./...`
- `go vet ./adapters/... ./core/...`
- `golangci-lint run --enable-only unused,ineffassign ./...` (0 issues, confirms all four findings are resolved)
- `go test ./adapters/... ./core/services/...`

## Related issues/PRs:
Resolved #707

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan processing so cached vulnerability information remains available for subsequent VEX handling.
* **Refactor**
  * Removed unused test declarations, imports, and obsolete internal error-handling code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->