### PR TITLE
fix: omit empty repository_url query parameter in createProductStructForImageAndPackage

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1032,7 +1032,12 @@ func createProductStructForImageAndPackage(imagePullable string, packagePURL str
 	imageName := imageComponents[len(imageComponents)-1]
 	imageRepo := strings.Join(imageComponents[:len(imageComponents)-1], "/")
 	// pkg:oci/adservice@sha256%3A45fb8ed886902c0c49e044b1f8870fad61c1022fa23c4943098302a8f1c5b75f?repository_url=gcr.io/google-samples/microservices-demo
-	imageField := fmt.Sprintf("pkg:oci/%s?repository_url=%s", url.PathEscape(imageName), url.PathEscape(imageRepo))
+	var imageField string
+	if imageRepo != "" {
+		imageField = fmt.Sprintf("pkg:oci/%s?repository_url=%s", url.PathEscape(imageName), url.PathEscape(imageRepo))
+	} else {
+		imageField = fmt.Sprintf("pkg:oci/%s", url.PathEscape(imageName))
+	}
 	product := v1beta1.Product{
 		Component: v1beta1.Component{
 			ID: imageField,

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -3206,3 +3206,48 @@ func TestStoreVEX_ExternalVEXMasking(t *testing.T) {
 	assert.True(t, foundExternal, "Should have found external VEX statement")
 	assert.True(t, foundCRD, "Should have found CRD SecurityException statement")
 }
+
+func TestCreateProductStructForImageAndPackage(t *testing.T) {
+	tests := []struct {
+		name          string
+		imagePullable string
+		packagePURL   string
+		wantProductID string
+	}{
+		{
+			name:          "multi-segment image reference with repository",
+			imagePullable: "gcr.io/google-samples/microservices-demo/adservice@sha256:45fb8ed886902c0c49e044b1f8870fad61c1022fa23c4943098302a8f1c5b75f",
+			packagePURL:   "pkg:golang/github.com/foo/bar@v1.0.0",
+			wantProductID: "pkg:oci/adservice@sha256:45fb8ed886902c0c49e044b1f8870fad61c1022fa23c4943098302a8f1c5b75f?repository_url=gcr.io%2Fgoogle-samples%2Fmicroservices-demo",
+		},
+		{
+			name:          "docker:// prefix with repository",
+			imagePullable: "docker://docker.io/library/nginx:latest",
+			packagePURL:   "pkg:deb/debian/nginx@1.18.0",
+			wantProductID: "pkg:oci/nginx:latest?repository_url=docker.io%2Flibrary",
+		},
+		{
+			name:          "single-component image reference without repository",
+			imagePullable: "alpine:latest",
+			packagePURL:   "pkg:apk/alpine/musl@1.2.2",
+			wantProductID: "pkg:oci/alpine:latest",
+		},
+		{
+			name:          "single-component bare name without tag",
+			imagePullable: "redis",
+			packagePURL:   "pkg:generic/redis@7.0.0",
+			wantProductID: "pkg:oci/redis",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			product, err := createProductStructForImageAndPackage(tt.imagePullable, tt.packagePURL)
+			require.NoError(t, err)
+			require.NotNil(t, product)
+			assert.Equal(t, tt.wantProductID, product.Component.ID)
+			require.Len(t, product.Subcomponents, 1)
+			assert.Equal(t, tt.packagePURL, product.Subcomponents[0].Component.ID)
+		})
+	}
+}


### PR DESCRIPTION
## Overview
Fixes an issue in `createProductStructForImageAndPackage` where generated OpenVEX product component identifiers contain an empty `?repository_url=` query parameter (e.g. `pkg:oci/alpine%3Alatest?repository_url=`) when `imagePullable` is a single-component image reference without a repository path (e.g., `alpine:latest`, `nginx`).

## Additional Information
- Root Cause: `createProductStructForImageAndPackage` unconditionally appended `?repository_url=%s` even when `imageRepo` was empty (`""`).
- Fix: Updated `createProductStructForImageAndPackage` to check `if imageRepo != ""` before formatting `?repository_url=`. Single-component image references now produce valid OCI PURLs like `pkg:oci/alpine%3Alatest`.

## How to Test
Run the newly added unit tests in `repositories/apiserver_test.go`:
```bash
go test -v ./repositories -run "TestCreateProductStructForImageAndPackage"
```

## Related issues/PRs:
* Fixes #718

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed product links for images without a repository by omitting the empty repository parameter.
  * Preserved correct handling of repository paths, prefixes, and untagged image names.

* **Tests**
  * Added coverage for image references with multiple path segments, prefixes, missing repositories, and missing tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->