### PR TITLE
fix(controllers): fix copylocks violation on HTTPController method receivers (#720)

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -96,7 +96,7 @@ func (h *HTTPController) claimTrackedJob(jobID string) bool {
 // domain.ErrPartialContainerProfile result is a warning-level expected outcome, not a failure.
 // err is the error returned by the scan (nil for success/partial) and is only consulted to
 // resolve the bounded reason label on a failed outcome; see scanFailureReason.
-func (h HTTPController) recordScan(ctx context.Context, endpoint string, start time.Time, outcome string, err error) {
+func (h *HTTPController) recordScan(ctx context.Context, endpoint string, start time.Time, outcome string, err error) {
 	if h.metrics == nil {
 		return
 	}
@@ -130,7 +130,7 @@ func scanFailureReason(outcome string, err error) string {
 // "too_many_requests" for registry back-pressure (ErrTooManyRequests) and "invalid_request"
 // for every other validation error, keeping the rejection-rate signal distinct from
 // malformed-payload noise while staying low cardinality.
-func (h HTTPController) recordRejection(ctx context.Context, endpoint string, err error) {
+func (h *HTTPController) recordRejection(ctx context.Context, endpoint string, err error) {
 	if h.metrics == nil {
 		return
 	}
@@ -203,12 +203,12 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 }
 
 // Alive returns 200 OK
-func (h HTTPController) Alive(c *gin.Context) {
+func (h *HTTPController) Alive(c *gin.Context) {
 	_, _ = problem.Of(http.StatusOK).WriteTo(c.Writer)
 }
 
 // Ready calls scanService.Ready
-func (h HTTPController) Ready(c *gin.Context) {
+func (h *HTTPController) Ready(c *gin.Context) {
 	if !h.scanService.Ready(c.Request.Context()) {
 		_, _ = problem.Of(http.StatusServiceUnavailable).WriteTo(c.Writer)
 		return


### PR DESCRIPTION

## Overview
Fixes `copylocks` analyzer violations reported by `go vet ./controllers/...`:

```text
controllers/http.go:99:9: recordScan passes lock by value: github.com/kubescape/kubevuln/controllers.HTTPController contains sync.Once contains sync.noCopy
controllers/http.go:133:9: recordRejection passes lock by value: github.com/kubescape/kubevuln/controllers.HTTPController contains sync.Once contains sync.noCopy
controllers/http.go:206:9: Alive passes lock by value: github.com/kubescape/kubevuln/controllers.HTTPController contains sync.Once contains sync.noCopy
controllers/http.go:211:9: Ready passes lock by value: github.com/kubescape/kubevuln/controllers.HTTPController contains sync.Once contains sync.noCopy
```

### Changes
`HTTPController` contains `statusesOnce sync.Once` (which embeds `sync.noCopy` for mutex synchronization safety). While constructors and route handlers use pointer receivers `func (h *HTTPController)`, four helper/probe methods were defined with value receivers `func (h HTTPController)`. 

Updated `recordScan`, `recordRejection`, `Alive`, and `Ready` to use pointer receivers `(h *HTTPController)` consistently.

## How to Test
Run `go vet ./controllers/...` and ensure it exits with code 0:
```bash
go vet ./controllers/...
go test -v -race -cover ./controllers/...
```

## Related issues/PRs:
* Resolved #720

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal request handling and health-check methods without changing their behavior or end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->