### PR TITLE
refactor(services): store the filtered CVE in one place

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -479,29 +479,7 @@ func (s *ScanService) ScanCVE(ctx context.Context) error {
 			return &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: fmt.Errorf("scanning SBOM: %w", err)}
 		}
 
-		// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
-
-		// store filtered CVE
-		if s.storage {
-			domain.UpdateScanPhase(ctx, "result_storage")
-			err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-			if err != nil {
-				logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
-					helpers.String("imageSlug", workload.ImageSlug))
-			}
-			err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-			if err != nil {
-				logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
-					helpers.String("imageSlug", workload.ImageSlug))
-			}
-			// Only publish VEX built from a known-complete exception set, matching how
-			// ScanCP gates its own call: a degraded fetch would otherwise emit a document
-			// asserting fewer suppressions than the user actually configured.
-			if exceptionsComplete {
-				s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
-			}
-		}
+		s.storeFilteredCVE(ctx, cve, workload.ImageSlug)
 	} else {
 		cve, _, _ = s.reconcileCachedCVE(ctx, cve, workload.ImageSlug, true)
 	}
@@ -599,29 +577,7 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 			return &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: err}
 		}
 
-		// apply security exceptions for storage (copy — original stays intact for SubmitCVE)
-		filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
-
-		// store filtered CVE
-		if s.storage {
-			domain.UpdateScanPhase(ctx, "result_storage")
-			err = s.cveRepository.StoreCVE(ctx, filteredCve, false)
-			if err != nil {
-				logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
-					helpers.String("imageSlug", workload.ImageSlug))
-			}
-			err = s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false)
-			if err != nil {
-				logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
-					helpers.String("imageSlug", workload.ImageSlug))
-			}
-			// Only publish VEX built from a known-complete exception set, matching how
-			// ScanCVE and ScanCP gate their own calls: a degraded fetch would otherwise
-			// emit a document asserting fewer suppressions than the user configured.
-			if exceptionsComplete {
-				s.storeVEX(ctx, filteredCve, filteredCve, false, workload.ImageSlug)
-			}
-		}
+		s.storeFilteredCVE(ctx, cve, workload.ImageSlug)
 	} else {
 		cve, _, _ = s.reconcileCachedCVE(ctx, cve, workload.ImageSlug, true)
 	}
@@ -651,6 +607,40 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 		helpers.String("imageSlug", workload.ImageSlug),
 		helpers.String("jobID", workload.JobID))
 	return nil
+}
+
+// storeFilteredCVE applies the current exception set to cve and stores what comes out: the
+// filtered manifest, its summary, and, when that exception set was complete, the VEX document
+// built from it. ScanCVE and ScanRegistry both do exactly this once matching is done. ScanCP
+// has its own variant, which carries the relevancy manifest alongside the full one.
+//
+// The exceptions are applied whether or not storage is on, since that call is also what
+// reports the degraded, expired and active exception counts for the scan.
+//
+// Storing is best effort: a failure is logged and the scan carries on, the report sent to the
+// backend not depending on any of it.
+func (s *ScanService) storeFilteredCVE(ctx context.Context, cve domain.CVEManifest, imageSlug string) {
+	// copy — original stays intact for SubmitCVE
+	filteredCve, exceptionsComplete := s.applyExceptionsToManifest(ctx, cve)
+	if !s.storage {
+		return
+	}
+
+	domain.UpdateScanPhase(ctx, "result_storage")
+	if err := s.cveRepository.StoreCVE(ctx, filteredCve, false); err != nil {
+		logger.L().Ctx(ctx).Warning("storing CVE", helpers.Error(err),
+			helpers.String("imageSlug", imageSlug))
+	}
+	if err := s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false); err != nil {
+		logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
+			helpers.String("imageSlug", imageSlug))
+	}
+	// Only publish VEX built from a known-complete exception set, matching how ScanCP gates
+	// its own call: a degraded fetch would otherwise emit a document asserting fewer
+	// suppressions than the user actually configured.
+	if exceptionsComplete {
+		s.storeVEX(ctx, filteredCve, filteredCve, false, imageSlug)
+	}
 }
 
 // storeVEX writes the VEX document for a scanned image when VEX generation is enabled,


### PR DESCRIPTION
## Overview

ScanCVE and ScanRegistry both finished matching with the same twenty-two lines: apply the current exception set, store the filtered manifest, store its summary, and publish the VEX if that exception set was complete. the two were identical apart from one comment's wording.

`storeFilteredCVE` is now that sequence, once. ScanCP keeps its own, which carries the relevancy manifest alongside the full one and is a different call in each of the three places it stores.

these flows drifting apart is where #469, #501, #557, #608, #609 and #623 came from, and #638 pulled `reconcileCachedCVE` out for exactly that reason. this is the same shape one step further along the same function.

## Additional Information

`applyExceptionsToManifest` stays outside the storage guard. It is also what reports the degraded, expired and active exception counts for the scan, so moving it inside would stop those being recorded on a deployment running without storage. The helper applies first and returns early after.

the store calls assigned to the enclosing `err` before, and nothing read it: both flows assign to `err` again at their next use, `SubmitCVE` in one and `SendStatus` in the other. so scoping those errors to the helper changes nothing and takes away a variable that looked like it carried a result out of the block and did not.

the gating comment used to name the other two flows from inside each copy, one saying "matching how ScanCP gates its own call" and the other "matching how ScanCVE and ScanCP gate their own calls". there is one copy of it now.

## How to Test

`go test ./core/... ./repositories/ -count=1`

no test changes. the existing ScanCVE and ScanRegistry tests cover both call sites, including `Test_ScanCVE`, `Test_ScanRegistry` and the exception-completeness cases that assert VEX is only published for a complete exception set, so them passing unchanged is what says the sequence is the same one.

## Related issues/PRs:

* Resolved #722


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CVE scanning so configured exceptions are consistently applied across scans.
  - Preserved the original scan manifest when submitting results.
  - Ensured summaries and VEX output reflect filtered findings when applicable.
  - Prevented CVE storage issues from interrupting scan workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->