### PR TITLE
fix(controllers): stop copying HTTPController's sync.Once by value

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -96,7 +96,7 @@ func (h *HTTPController) claimTrackedJob(jobID string) bool {
 // domain.ErrPartialContainerProfile result is a warning-level expected outcome, not a failure.
 // err is the error returned by the scan (nil for success/partial) and is only consulted to
 // resolve the bounded reason label on a failed outcome; see scanFailureReason.
-func (h HTTPController) recordScan(ctx context.Context, endpoint string, start time.Time, outcome string, err error) {
+func (h *HTTPController) recordScan(ctx context.Context, endpoint string, start time.Time, outcome string, err error) {
 	if h.metrics == nil {
 		return
 	}
@@ -130,7 +130,7 @@ func scanFailureReason(outcome string, err error) string {
 // "too_many_requests" for registry back-pressure (ErrTooManyRequests) and "invalid_request"
 // for every other validation error, keeping the rejection-rate signal distinct from
 // malformed-payload noise while staying low cardinality.
-func (h HTTPController) recordRejection(ctx context.Context, endpoint string, err error) {
+func (h *HTTPController) recordRejection(ctx context.Context, endpoint string, err error) {
 	if h.metrics == nil {
 		return
 	}
@@ -203,12 +203,12 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 }
 
 // Alive returns 200 OK
-func (h HTTPController) Alive(c *gin.Context) {
+func (h *HTTPController) Alive(c *gin.Context) {
 	_, _ = problem.Of(http.StatusOK).WriteTo(c.Writer)
 }
 
 // Ready calls scanService.Ready
-func (h HTTPController) Ready(c *gin.Context) {
+func (h *HTTPController) Ready(c *gin.Context) {
 	if !h.scanService.Ready(c.Request.Context()) {
 		_, _ = problem.Of(http.StatusServiceUnavailable).WriteTo(c.Writer)
 		return

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1050,4 +1051,21 @@ func TestHTTPController_ScanStatus_AbandonedOnShutdown(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("shutdown did not finish in time")
 	}
+}
+
+// HTTPController carries a sync.Once, so a method on the value type copies that Once along
+// with the rest of the struct. Nothing goes wrong while none of them reach ensureStatuses,
+// but the copy's Once starts unfired, so one that did would build a second status store and
+// write into an object no request ever reads. go vet reports this as copylocks; the repo's
+// lint runs against the diff rather than the whole tree, so four of these sat on main
+// unnoticed from the commit that added the Once.
+//
+// reflect lists only exported methods, which is where the risk is: those are the gin handlers.
+func TestHTTPController_NoValueReceiverMethods(t *testing.T) {
+	valueType := reflect.TypeOf(HTTPController{})
+	var offenders []string
+	for i := 0; i < valueType.NumMethod(); i++ {
+		offenders = append(offenders, valueType.Method(i).Name)
+	}
+	assert.Empty(t, offenders, "these take a value receiver and so copy the sync.Once: %v", offenders)
 }


### PR DESCRIPTION
## Overview

`go vet ./controllers/` fails on main with four copylocks reports. `HTTPController` picked up a `sync.Once` when #636 added the scan status store, and `recordScan`, `recordRejection`, `Alive` and `Ready` still take a value receiver, so each call copies the struct and the `Once` in it.

this makes them pointer receivers. `go vet ./...` is clean afterwards.

## Additional Information

nothing is broken today: none of those four reach `ensureStatuses`, so no second store is built. it is what comes next that this is about. a copy's `Once` starts unfired, so a value-receiver method that called `ensureStatuses` would allocate its own `scanStatusStore` and record into an object no request reads, leaving `/v1/scanStatus/:jobID` answering 404 for a job it had just accepted. `Alive` and `Ready` are gin handlers, and putting a status or queue-depth line in one is an ordinary thing to want.

nothing changes at the call sites. production only ever holds a `*HTTPController`, `NewHTTPController` returning one, and the tests build addressable locals, so the method calls resolve the same way.

lint runs against the diff rather than the whole tree (#566/#567), which is why four of these sat on main from the commit that added the `Once` without turning anything red.

## How to Test

`go vet ./... && go test ./controllers/ -race -count=1`

`TestHTTPController_NoValueReceiverMethods` asks the value type for its method set, which is empty once every method takes a pointer, and names any that do not. putting the receiver back on `Alive` alone fails it with

```
Should be empty, but was [Alive]
these take a value receiver and so copy the sync.Once: [Alive]
```

reflect lists exported methods only, which is where the risk sits: those are the gin handlers. `recordScan` and `recordRejection` are unexported and stay covered by `go vet` rather than by this.

## Related issues/PRs:

* Resolved #726
