### PR TITLE
test(adapters): cover deduplicateErrors so it does not read as dead code again

### DIFF
--- a/adapters/v1/domain_to_syft_test.go
+++ b/adapters/v1/domain_to_syft_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -135,4 +136,55 @@ func Test_domainJSONToSyft_DropsErrors(t *testing.T) {
 
 	// The unknown relationship is silently dropped
 	assert.Equal(t, 0, len(got.Relationships), "expected relationship to be dropped silently")
+}
+
+func Test_deduplicateErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []error
+		want []string
+	}{
+		{
+			name: "no errors",
+			errs: nil,
+			want: nil,
+		},
+		{
+			name: "one error is reported once",
+			errs: []error{errors.New("bad cpe")},
+			want: []string{`"bad cpe" occurred 1 time(s)`},
+		},
+		{
+			name: "repeats collapse into a count",
+			errs: []error{errors.New("bad cpe"), errors.New("bad cpe"), errors.New("bad cpe")},
+			want: []string{`"bad cpe" occurred 3 time(s)`},
+		},
+		{
+			name: "distinct errors each keep their own count",
+			errs: []error{
+				errors.New("bad cpe"),
+				errors.New("unknown relationship"),
+				errors.New("bad cpe"),
+			},
+			want: []string{
+				`"bad cpe" occurred 2 time(s)`,
+				`"unknown relationship" occurred 1 time(s)`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// order comes from a map range, so compare as a set
+			assert.ElementsMatch(t, tt.want, deduplicateErrors(tt.errs))
+		})
+	}
+}
+
+// warnConversionErrors returns its input untouched whatever the errors say, so
+// the only thing that reaches deduplicateErrors on a real conversion is the log
+// line. This keeps that call covered.
+func Test_warnConversionErrors_PassesConvertedThrough(t *testing.T) {
+	converted := []string{"a", "b"}
+	got := warnConversionErrors(converted, []error{errors.New("x"), errors.New("x")})
+	assert.Equal(t, converted, got)
 }


### PR DESCRIPTION
## Overview

#739 restored `deduplicateErrors`, so this is now just the tests for it. rebased onto that, the function half of this PR dropped out as already applied and what is left is `adapters/v1/domain_to_syft_test.go`.

## Additional Information

the function was deleted once already. #717 removed it as dead code, correctly at the time, because its only reference was a commented-out line inside `warnConversionErrors`. #703 then uncommented that line and the merge stopped building.

what made it look dead is that nothing except one commented-out caller mentioned it. a test is what keeps that from reading the same way next time.

## How to Test

`go test ./adapters/v1/ -run 'Test_deduplicateErrors|Test_warnConversionErrors' -count=1`

`Test_deduplicateErrors` covers nothing, one error, the same error three times, and two distinct errors keeping separate counts. it compares as a set, since the order comes from a map range.

it holds the counting rather than just calling the function: dropping the accumulation to `errorCounts[e.Error()] = 1` fails the third and fourth cases.

`Test_warnConversionErrors_PassesConvertedThrough` pins the part that must not change, that `warnConversionErrors` returns its input untouched whatever the errors say.

## Related issues/PRs:

* Resolved #729
