### PR TITLE
fix(adapters): log when suppression event is skipped due to incomplet…

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -476,6 +476,12 @@ func emitSuppressionEvent(recorder record.EventRecorder, p armotypes.Vulnerabili
 	kind, _ := p.Attributes["sourceKind"].(string)
 	uid, _ := p.Attributes["sourceUID"].(string)
 	if kind == "" || p.Name == "" || uid == "" {
+		logger.L().Debug("skipping suppression event: incomplete provenance",
+			helpers.String("cve", m.Vulnerability.ID),
+			helpers.String("sourceKind", kind),
+			helpers.String("sourceName", p.Name),
+			helpers.String("sourceUID", uid),
+		)
 		return
 	}
 	namespace, _ := p.Attributes["sourceNamespace"].(string)

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -761,6 +761,53 @@ func TestApplySecurityExceptions_EmitsEventWhenRecorderConfigured(t *testing.T) 
 	}
 }
 
+func TestApplySecurityExceptions_RecorderConfiguredButUIDMissingSkipsEventSilentlyNoMore(t *testing.T) {
+	// Regression test for a source policy that carries kind/name but no UID (e.g. an
+	// object that reached ApplySecurityExceptions before its UID was populated, such as
+	// via a fake client in tests or an un-synced watch cache). emitSuppressionEvent must
+	// still skip emitting the Event in this case — an ObjectReference needs a UID — but
+	// the skip itself should now be observable via a debug log rather than silent. This
+	// test only asserts the resulting behavior (no event, no panic), since the repo has
+	// no log-capturing test infrastructure to assert on the log line's content directly.
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{
+				Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}},
+				Artifact:      v1beta1.GrypePackage{Name: "log4j-core"},
+			},
+		},
+	}
+
+	policies := domain.CVEExceptions{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "allow-log4shell",
+				Attributes: map[string]interface{}{
+					"sourceKind": "SecurityException",
+					// sourceUID intentionally omitted — this is the only missing field.
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-44228"}},
+		},
+	}
+
+	recorder := record.NewFakeRecorder(1)
+
+	assert.NotPanics(t, func() {
+		ApplySecurityExceptions(doc, policies, recorder)
+	})
+
+	require.Len(t, doc.IgnoredMatches, 1, "the CVE is still suppressed even though no event is emitted")
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("expected no suppression event to be recorded when source UID is missing, got: %q", event)
+	default:
+		// expected: no event was recorded.
+	}
+}
+
 func TestApplySecurityExceptions_NilRecorderIsNoOp(t *testing.T) {
 	doc := &v1beta1.GrypeDocument{
 		Matches: []v1beta1.Match{


### PR DESCRIPTION
## Context

Related to #708.

## What this does

`emitSuppressionEvent` in `adapters/v1/securityexception.go` silently
returned when a source SecurityException/ClusterSecurityException policy
was missing `kind`, `Name`, or `uid`, with no way to tell "suppressed +
event fired" apart from "suppressed + event skipped, provenance
incomplete."

Adds a debug-level log on that early return, matching the existing
`logger.L().Debug(...)` pattern used elsewhere in the codebase (e.g.
`repositories/apiserver.go`). No behavior change on the happy path.

## Note on the "asserts a debug log fires" acceptance criterion

The repo has no log-capturing test infrastructure (`go-logger` writes
directly to stdout/stderr with no injectable writer visible in this
codebase), so redirecting file descriptors in-test felt riskier than
useful here. The added test instead asserts the *behavior* the log
line is meant to make debuggable: no event recorded, no panic, on the
"recorder configured + missing UID" path. Happy to add proper log
capture if there's an existing pattern for it I've missed   let me know.

## Testing

Added `TestApplySecurityExceptions_RecorderConfiguredButUIDMissingSkipsEventSilentlyNoMore`,
covering "recorder configured + missing UID."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when suppression-event provenance is incomplete.
  * Suppressions now continue safely without emitting an event when required policy information is missing.
  * Added diagnostic logging to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->