### PR TITLE
fix: close TOCTOU race between SecurityException cache invalidation and in-flight List()

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/akyoto/cache"
@@ -83,7 +84,76 @@ type APIServerStore struct {
 	// literals directly instead of through the constructors below).
 	securityExceptionListCache *cache.Cache
 
+	// securityExceptionCacheEntries backs the compare-and-swap that keeps a List() in flight
+	// when a CRD change invalidates its cache key from silently re-populating the cache with
+	// its now-stale result afterward — see securityExceptionCacheEntry's doc comment and #733.
+	// Zero value (empty sync.Map) is ready to use, so this needs no constructor initialization.
+	securityExceptionCacheEntries sync.Map // cacheKey (string) -> *securityExceptionCacheEntry
+
 	securityExceptionInformerStop context.CancelFunc
+}
+
+// securityExceptionCacheEntry pairs a cache key's invalidation generation with the mutex that
+// makes reading/bumping it, and conditionally writing securityExceptionListCache for that key,
+// atomic with respect to each other. See securityExceptionCacheEntry (the method) for why this
+// exists: a plain generation counter alone still leaves a check-then-act gap between reading it
+// and calling Set().
+type securityExceptionCacheEntry struct {
+	mu         sync.Mutex
+	generation uint64
+}
+
+// securityExceptionCacheEntry returns the entry for cacheKey, creating it on first use. Entries
+// are never removed: the number of distinct keys is bounded by the number of namespaces that
+// have ever had SecurityExceptions listed, plus one for the cluster-scoped key, which is small
+// and stable for the life of the process.
+func (a *APIServerStore) securityExceptionCacheEntry(cacheKey string) *securityExceptionCacheEntry {
+	v, _ := a.securityExceptionCacheEntries.LoadOrStore(cacheKey, &securityExceptionCacheEntry{})
+	return v.(*securityExceptionCacheEntry)
+}
+
+// invalidateSecurityExceptionCacheKey evicts cacheKey from securityExceptionListCache and bumps
+// its generation, atomically with respect to beginSecurityExceptionCacheRefresh/
+// trySetSecurityExceptionCache below: whichever of an invalidation and a racing List()'s
+// conditional Set() acquires the entry's mutex last determines the outcome, and in either order
+// the result is correct (see trySetSecurityExceptionCache's doc comment for why).
+func (a *APIServerStore) invalidateSecurityExceptionCacheKey(cacheKey string) {
+	entry := a.securityExceptionCacheEntry(cacheKey)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	entry.generation++
+	a.securityExceptionListCache.Delete(cacheKey)
+}
+
+// beginSecurityExceptionCacheRefresh snapshots cacheKey's current generation before a caller
+// starts a List() call for it, to later pass to trySetSecurityExceptionCache.
+func (a *APIServerStore) beginSecurityExceptionCacheRefresh(cacheKey string) (seenGeneration uint64) {
+	entry := a.securityExceptionCacheEntry(cacheKey)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	return entry.generation
+}
+
+// trySetSecurityExceptionCache writes value to securityExceptionListCache under cacheKey only if
+// cacheKey's generation is still seenGeneration, i.e. no invalidation has happened for it since
+// the caller's beginSecurityExceptionCacheRefresh snapshot. This closes the race #733 describes:
+// without it, a List() started before a CRD change could still write its now-stale result to the
+// cache after the informer's invalidation for that change already ran, silently undoing it. The
+// check and the write happen under the same per-key mutex invalidateSecurityExceptionCacheKey
+// uses, so there is no gap between "check the generation" and "write the cache" for a concurrent
+// invalidation to land in — unlike a bare atomic counter compared just before an unguarded Set().
+// The List() call itself is deliberately not covered by this lock: holding it across a network
+// call would let a slow List() delay an unrelated invalidation for the same key, and informers
+// typically deliver events to a handler serially, so that delay could stall processing of other,
+// unrelated CRD events too.
+func (a *APIServerStore) trySetSecurityExceptionCache(cacheKey string, seenGeneration uint64, value interface{}) {
+	entry := a.securityExceptionCacheEntry(cacheKey)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.generation != seenGeneration {
+		return
+	}
+	a.securityExceptionListCache.Set(cacheKey, value, securityExceptionListCacheTTL)
 }
 
 var (
@@ -256,7 +326,7 @@ func (a *APIServerStore) invalidateSecurityExceptionCacheForObject(obj interface
 		return
 	}
 	if namespace := u.GetNamespace(); namespace != "" {
-		a.securityExceptionListCache.Delete("se/" + namespace)
+		a.invalidateSecurityExceptionCacheKey("se/" + namespace)
 		return
 	}
 	a.invalidateAllSecurityExceptionCaches()
@@ -266,16 +336,23 @@ func (a *APIServerStore) invalidateClusterSecurityExceptionCache() {
 	if a == nil || a.securityExceptionListCache == nil {
 		return
 	}
-	a.securityExceptionListCache.Delete(clusterSecurityExceptionListCacheKey)
+	a.invalidateSecurityExceptionCacheKey(clusterSecurityExceptionListCacheKey)
 }
 
+// invalidateAllSecurityExceptionCaches invalidates every namespaced SecurityException cache key
+// this process has ever seen, for events unstructuredFromEvent could not resolve to a specific
+// namespace (a defensive fallback, not the normal add/update/delete path). It ranges over
+// securityExceptionCacheEntries rather than securityExceptionListCache so it also covers a key
+// with a List() currently in flight but no cached value yet (see beginSecurityExceptionCacheRefresh):
+// that entry already exists by the time its List() call started, even though it may not exist in
+// securityExceptionListCache until that List() returns.
 func (a *APIServerStore) invalidateAllSecurityExceptionCaches() {
 	if a == nil || a.securityExceptionListCache == nil {
 		return
 	}
-	a.securityExceptionListCache.Range(func(key, _ interface{}) bool {
+	a.securityExceptionCacheEntries.Range(func(key, _ interface{}) bool {
 		if cacheKey, ok := key.(string); ok && strings.HasPrefix(cacheKey, "se/") {
-			a.securityExceptionListCache.Delete(cacheKey)
+			a.invalidateSecurityExceptionCacheKey(cacheKey)
 		}
 		return true
 	})
@@ -336,7 +413,11 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 }
 
 // listSecurityExceptions returns the namespaced SecurityExceptions for namespace, from
-// securityExceptionListCache when a fresh entry exists.
+// securityExceptionListCache when a fresh entry exists. The write back to the cache after a
+// List() is conditional on no invalidation having raced it (see trySetSecurityExceptionCache) -
+// without that, a List() started just before a SecurityException change in namespace would
+// silently re-populate the cache with the pre-change result after the informer had already
+// evicted it — see #733.
 func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, namespace string) ([]sev1beta1.SecurityException, error) {
 	cacheKey := "se/" + namespace
 	if a.securityExceptionListCache != nil {
@@ -344,6 +425,7 @@ func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, na
 			return cached.([]sev1beta1.SecurityException), nil
 		}
 	}
+	seenGeneration := a.beginSecurityExceptionCacheRefresh(cacheKey)
 
 	seList, err := a.DynamicClient.Resource(securityExceptionGVR).Namespace(namespace).List(listCtx, metav1.ListOptions{})
 	if err != nil {
@@ -362,7 +444,7 @@ func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, na
 	}
 
 	if a.securityExceptionListCache != nil {
-		a.securityExceptionListCache.Set(cacheKey, exceptions, securityExceptionListCacheTTL)
+		a.trySetSecurityExceptionCache(cacheKey, seenGeneration, exceptions)
 	}
 	return exceptions, nil
 }
@@ -370,12 +452,15 @@ func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, na
 // listClusterSecurityExceptions returns every ClusterSecurityException in the cluster, from
 // securityExceptionListCache when a fresh entry exists. The result is the same regardless of
 // which workload/namespace triggered the call, so it is cached under a single cluster-wide key.
+// The write back to the cache after a List() is conditional on no invalidation having raced it -
+// see listSecurityExceptions' and trySetSecurityExceptionCache's doc comments, and #733.
 func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Context) ([]sev1beta1.ClusterSecurityException, error) {
 	if a.securityExceptionListCache != nil {
 		if cached, ok := a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey); ok {
 			return cached.([]sev1beta1.ClusterSecurityException), nil
 		}
 	}
+	seenGeneration := a.beginSecurityExceptionCacheRefresh(clusterSecurityExceptionListCacheKey)
 
 	cseList, err := a.DynamicClient.Resource(clusterSecurityExceptionGVR).List(listCtx, metav1.ListOptions{})
 	if err != nil {
@@ -394,7 +479,7 @@ func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Cont
 	}
 
 	if a.securityExceptionListCache != nil {
-		a.securityExceptionListCache.Set(clusterSecurityExceptionListCacheKey, clusterExceptions, securityExceptionListCacheTTL)
+		a.trySetSecurityExceptionCache(clusterSecurityExceptionListCacheKey, seenGeneration, clusterExceptions)
 	}
 	return clusterExceptions, nil
 }

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -71,6 +71,7 @@ const (
 	securityExceptionListCacheCleaningInterval = 30 * time.Second
 	securityExceptionListCacheTTL              = 30 * time.Second
 	clusterSecurityExceptionListCacheKey       = "cse"
+	securityExceptionListCacheKeyPrefix        = "se/"
 )
 
 // APIServerStore implements both CVERepository and SBOMRepository with in-cluster storage (apiserver) to be used for production
@@ -104,9 +105,10 @@ type securityExceptionCacheEntry struct {
 }
 
 // securityExceptionCacheEntry returns the entry for cacheKey, creating it on first use. Entries
-// are never removed: the number of distinct keys is bounded by the number of namespaces that
-// have ever had SecurityExceptions listed, plus one for the cluster-scoped key, which is small
-// and stable for the life of the process.
+// are never removed, so the key count grows with every distinct namespace that has ever had
+// SecurityExceptions listed, plus one for the cluster-scoped key. Each entry is small, so this
+// is slow growth rather than an urgent leak, but it is not bounded in clusters where namespaces
+// are created and deleted continuously.
 func (a *APIServerStore) securityExceptionCacheEntry(cacheKey string) *securityExceptionCacheEntry {
 	v, _ := a.securityExceptionCacheEntries.LoadOrStore(cacheKey, &securityExceptionCacheEntry{})
 	return v.(*securityExceptionCacheEntry)
@@ -326,7 +328,7 @@ func (a *APIServerStore) invalidateSecurityExceptionCacheForObject(obj interface
 		return
 	}
 	if namespace := u.GetNamespace(); namespace != "" {
-		a.invalidateSecurityExceptionCacheKey("se/" + namespace)
+		a.invalidateSecurityExceptionCacheKey(securityExceptionListCacheKeyPrefix + namespace)
 		return
 	}
 	a.invalidateAllSecurityExceptionCaches()
@@ -351,7 +353,7 @@ func (a *APIServerStore) invalidateAllSecurityExceptionCaches() {
 		return
 	}
 	a.securityExceptionCacheEntries.Range(func(key, _ interface{}) bool {
-		if cacheKey, ok := key.(string); ok && strings.HasPrefix(cacheKey, "se/") {
+		if cacheKey, ok := key.(string); ok && strings.HasPrefix(cacheKey, securityExceptionListCacheKeyPrefix) {
 			a.invalidateSecurityExceptionCacheKey(cacheKey)
 		}
 		return true
@@ -419,13 +421,14 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 // silently re-populate the cache with the pre-change result after the informer had already
 // evicted it — see #733.
 func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, namespace string) ([]sev1beta1.SecurityException, error) {
-	cacheKey := "se/" + namespace
+	cacheKey := securityExceptionListCacheKeyPrefix + namespace
+	var seenGeneration uint64
 	if a.securityExceptionListCache != nil {
 		if cached, ok := a.securityExceptionListCache.Get(cacheKey); ok {
 			return cached.([]sev1beta1.SecurityException), nil
 		}
+		seenGeneration = a.beginSecurityExceptionCacheRefresh(cacheKey)
 	}
-	seenGeneration := a.beginSecurityExceptionCacheRefresh(cacheKey)
 
 	seList, err := a.DynamicClient.Resource(securityExceptionGVR).Namespace(namespace).List(listCtx, metav1.ListOptions{})
 	if err != nil {
@@ -455,12 +458,13 @@ func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, na
 // The write back to the cache after a List() is conditional on no invalidation having raced it -
 // see listSecurityExceptions' and trySetSecurityExceptionCache's doc comments, and #733.
 func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Context) ([]sev1beta1.ClusterSecurityException, error) {
+	var seenGeneration uint64
 	if a.securityExceptionListCache != nil {
 		if cached, ok := a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey); ok {
 			return cached.([]sev1beta1.ClusterSecurityException), nil
 		}
+		seenGeneration = a.beginSecurityExceptionCacheRefresh(clusterSecurityExceptionListCacheKey)
 	}
-	seenGeneration := a.beginSecurityExceptionCacheRefresh(clusterSecurityExceptionListCacheKey)
 
 	cseList, err := a.DynamicClient.Resource(clusterSecurityExceptionGVR).List(listCtx, metav1.ListOptions{})
 	if err != nil {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2326,10 +2326,10 @@ func TestAPIServerStore_ListSecurityExceptions_DoesNotRepopulateAfterRacingInval
 	}
 
 	done := make(chan struct{})
+	var listErr error
 	go func() {
 		defer close(done)
-		_, _, err := a.GetSecurityExceptions(context.Background(), "ns-a")
-		assert.NoError(t, err)
+		_, _, listErr = a.GetSecurityExceptions(context.Background(), "ns-a")
 	}()
 
 	select {
@@ -2347,6 +2347,7 @@ func TestAPIServerStore_ListSecurityExceptions_DoesNotRepopulateAfterRacingInval
 	close(releaseList)
 	select {
 	case <-done:
+		assert.NoError(t, listErr)
 	case <-time.After(5 * time.Second):
 		t.Fatal("GetSecurityExceptions never returned")
 	}
@@ -2383,10 +2384,10 @@ func TestAPIServerStore_ListClusterSecurityExceptions_DoesNotRepopulateAfterRaci
 	}
 
 	done := make(chan struct{})
+	var listErr error
 	go func() {
 		defer close(done)
-		_, _, err := a.GetSecurityExceptions(context.Background(), "")
-		assert.NoError(t, err)
+		_, _, listErr = a.GetSecurityExceptions(context.Background(), "")
 	}()
 
 	select {
@@ -2400,6 +2401,7 @@ func TestAPIServerStore_ListClusterSecurityExceptions_DoesNotRepopulateAfterRaci
 	close(releaseList)
 	select {
 	case <-done:
+		assert.NoError(t, listErr)
 	case <-time.After(5 * time.Second):
 		t.Fatal("GetSecurityExceptions never returned")
 	}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2293,6 +2293,170 @@ func TestAPIServerStore_GetSecurityExceptions_DoesNotCacheListFailures(t *testin
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
 }
 
+// TestAPIServerStore_ListSecurityExceptions_DoesNotRepopulateAfterRacingInvalidation is a
+// regression test for #733: enableSecurityExceptionCacheInvalidation evicts a cache key as soon
+// as its CRD changes, but a List() already in flight for that key when the change lands used to
+// still write its now-stale result back to the cache once it returned, silently undoing the
+// invalidation. The hook blocks the fake client's List() call exactly where the real one would
+// be in flight against a real apiserver, letting the test fire the informer's invalidation
+// handler while List() hasn't returned yet - the same interleaving the issue describes.
+func TestAPIServerStore_ListSecurityExceptions_DoesNotRepopulateAfterRacingInvalidation(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+	wrapped := &ctxCapturingDynamicClient{Interface: dynClient}
+
+	listInFlight := make(chan struct{})
+	releaseList := make(chan struct{})
+	wrapped.resources = map[schema.GroupVersionResource]*ctxCapturingResource{
+		securityExceptionGVR: {
+			ResourceInterface: dynClient.Resource(securityExceptionGVR),
+			hook: func(context.Context) {
+				close(listInFlight)
+				<-releaseList
+			},
+		},
+	}
+
+	a := &APIServerStore{
+		DynamicClient:              wrapped,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _, err := a.GetSecurityExceptions(context.Background(), "ns-a")
+		assert.NoError(t, err)
+	}()
+
+	select {
+	case <-listInFlight:
+	case <-time.After(5 * time.Second):
+		t.Fatal("List() never reached the point where it should be in flight")
+	}
+
+	// Simulate a SecurityException change in ns-a landing while the List() above is still in
+	// flight, the same way the informer's event handler would invoke this on a real change.
+	a.invalidateSecurityExceptionCacheForObject(&unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"namespace": "ns-a"},
+	}})
+
+	close(releaseList)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetSecurityExceptions never returned")
+	}
+
+	_, ok := a.securityExceptionListCache.Get("se/ns-a")
+	assert.False(t, ok, "a List() that raced an invalidation must not repopulate the cache with its now-stale result")
+}
+
+// TestAPIServerStore_ListClusterSecurityExceptions_DoesNotRepopulateAfterRacingInvalidation is
+// the cluster-scoped counterpart of the test above, for invalidateClusterSecurityExceptionCache.
+func TestAPIServerStore_ListClusterSecurityExceptions_DoesNotRepopulateAfterRacingInvalidation(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+	wrapped := &ctxCapturingDynamicClient{Interface: dynClient}
+
+	listInFlight := make(chan struct{})
+	releaseList := make(chan struct{})
+	wrapped.resources = map[schema.GroupVersionResource]*ctxCapturingResource{
+		clusterSecurityExceptionGVR: {
+			ResourceInterface: dynClient.Resource(clusterSecurityExceptionGVR),
+			hook: func(context.Context) {
+				close(listInFlight)
+				<-releaseList
+			},
+		},
+	}
+
+	a := &APIServerStore{
+		DynamicClient:              wrapped,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _, err := a.GetSecurityExceptions(context.Background(), "")
+		assert.NoError(t, err)
+	}()
+
+	select {
+	case <-listInFlight:
+	case <-time.After(5 * time.Second):
+		t.Fatal("List() never reached the point where it should be in flight")
+	}
+
+	a.invalidateClusterSecurityExceptionCache()
+
+	close(releaseList)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetSecurityExceptions never returned")
+	}
+
+	_, ok := a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey)
+	assert.False(t, ok, "a List() that raced an invalidation must not repopulate the cache with its now-stale result")
+}
+
+
+
+
+// TestAPIServerStore_TrySetSecurityExceptionCache_GenerationMismatchSkipsWrite unit-tests the
+// compare-and-swap primitive directly, without goroutines: the write must be skipped whenever an
+// invalidation bumped the generation after the snapshot the caller took before its List() call.
+func TestAPIServerStore_TrySetSecurityExceptionCache_GenerationMismatchSkipsWrite(t *testing.T) {
+	a := &APIServerStore{securityExceptionListCache: cache.New(time.Minute)}
+
+	seenGeneration := a.beginSecurityExceptionCacheRefresh("se/ns-a")
+	a.invalidateSecurityExceptionCacheKey("se/ns-a") // simulates a CRD change landing mid-List()
+	a.trySetSecurityExceptionCache("se/ns-a", seenGeneration, []sev1beta1.SecurityException{{}})
+
+	_, ok := a.securityExceptionListCache.Get("se/ns-a")
+	assert.False(t, ok, "a stale generation must prevent the write")
+}
+
+// TestAPIServerStore_TrySetSecurityExceptionCache_GenerationMatchWrites is the non-racing
+// counterpart: with no invalidation in between, the write must still succeed exactly as before
+// this fix, so #733's fix does not change GetSecurityExceptions' behavior on the common path.
+func TestAPIServerStore_TrySetSecurityExceptionCache_GenerationMatchWrites(t *testing.T) {
+	a := &APIServerStore{securityExceptionListCache: cache.New(time.Minute)}
+
+	seenGeneration := a.beginSecurityExceptionCacheRefresh("se/ns-a")
+	a.trySetSecurityExceptionCache("se/ns-a", seenGeneration, []sev1beta1.SecurityException{{}})
+
+	cached, ok := a.securityExceptionListCache.Get("se/ns-a")
+	require.True(t, ok, "an unraced write must still populate the cache")
+	assert.Len(t, cached.([]sev1beta1.SecurityException), 1)
+}
+
+// TestAPIServerStore_InvalidateAllSecurityExceptionCaches_CoversInFlightKey is a regression test
+// for the "unrecognized object" fallback path in invalidateSecurityExceptionCacheForObject: it
+// must invalidate a namespace whose List() is in flight (and so has no value in
+// securityExceptionListCache yet, only an entry in securityExceptionCacheEntries), not just
+// namespaces that already have a cached value to range over.
+func TestAPIServerStore_InvalidateAllSecurityExceptionCaches_CoversInFlightKey(t *testing.T) {
+	a := &APIServerStore{securityExceptionListCache: cache.New(time.Minute)}
+
+	seenGeneration := a.beginSecurityExceptionCacheRefresh("se/ns-a") // List() "in flight", no Set() yet
+
+	a.invalidateSecurityExceptionCacheForObject(&unstructured.Unstructured{}) // unresolvable -> invalidate all
+
+	a.trySetSecurityExceptionCache("se/ns-a", seenGeneration, []sev1beta1.SecurityException{{}})
+
+	_, ok := a.securityExceptionListCache.Get("se/ns-a")
+	assert.False(t, ok, "an in-flight key must be covered by the invalidate-all fallback, not just already-cached keys")
+}
+
 func TestAPIServerStore_InvalidateSecurityExceptionCacheForObject(t *testing.T) {
 	a := &APIServerStore{securityExceptionListCache: cache.New(time.Minute)}
 	a.securityExceptionListCache.Set("se/ns-a", []sev1beta1.SecurityException{{}}, time.Minute)


### PR DESCRIPTION
## Problem

`GetSecurityExceptions` caches `SecurityException`/`ClusterSecurityException` `List()` results in `securityExceptionListCache`, invalidated by a dynamic informer as soon as the backing CRDs change (#653). But the evict-then-repopulate sequence has no synchronization between the informer's invalidation and an in-flight `List()`'s cache write: a `List()` started *before* a CRD change can still write its now-stale result back to the cache *after* the informer's invalidation for that key already ran, silently undoing the invalidation.

## Root Cause

`listSecurityExceptions`/`listClusterSecurityExceptions` called `securityExceptionListCache.Set()` unconditionally after `List()` returned, with no way to know whether an invalidation had happened for that key while `List()` was in flight. `github.com/akyoto/cache` backs `Set`/`Delete` with a plain `sync.Map` — no compare-and-swap or versioning available to build that check on top of directly.

## Fix

Each cache key now gets a small `securityExceptionCacheEntry{mu sync.Mutex, generation uint64}`, created lazily. Invalidation bumps the generation under the key's mutex; a list call snapshots the generation before calling `List()` and only writes the result back — under that same mutex — if the generation is unchanged. Whichever of an invalidation and a racing write acquires the mutex last determines the outcome, and the result is correct either way:

- If invalidation runs last: cache ends up evicted (correct — the change is real and later).
- If the write runs last but the generation moved: the write is skipped, leaving the cache in the invalidated state.

The `List()` call itself stays outside the lock: holding it across a network call would let a slow `List()` delay an unrelated invalidation for the same key, and `client-go` informers deliver events to a handler serially, so that could stall processing of *other* CRD events too.

`invalidateAllSecurityExceptionCaches` (the fallback for CRD events `unstructuredFromEvent` can't resolve to a specific namespace) now ranges over the generation-entry map instead of the value cache, so it also covers a key whose `List()` is in flight but has no cached value yet.

## Testing

- Two new regression tests reproduce the exact race from the issue using a hook that blocks the fake dynamic client's `List()` call mid-flight, fires the real invalidation handler, then unblocks it — one for the namespaced path, one for cluster-scoped. **Verified both fail against the pre-fix code** (reverted the fix locally, confirmed both tests fail with the stale value present in the cache, then restored the fix).
- Direct unit tests of the generation compare-and-swap (`trySetSecurityExceptionCache`) for both the racing and non-racing paths, and of `invalidateAllSecurityExceptionCaches` covering an in-flight key.
- All pre-existing `repositories` tests still pass unchanged, confirming no behavior change on the non-racing path.
- `go build ./repositories/...`, `go vet ./repositories/...`, `go test ./repositories/...` all pass.
- `go test ./...`: every package that builds passes, including `repositories`. `adapters/v1` and its dependents (`cmd/http`, `controllers`, `core/services`) currently fail to build on `main` independent of this change — `adapters/v1/domain_to_syft.go:73` calls an undefined `deduplicateErrors`, introduced by #703. This PR does not touch that path; confirmed by checking out a clean `main` and reproducing the same build failure there.
- Could not run `go test -race` locally (no cgo/gcc in this environment); the new tests are goroutine-based and channel-synchronized (no sleeps), so they should be race-detector-clean, but I'd appreciate CI confirming it.

## Impact

Closes the residual staleness window from #733: a revoked/narrowed `SecurityException` or `ClusterSecurityException` now reliably takes effect as soon as the informer processes the change, instead of possibly being silently re-cached by a racing `List()` for up to the full cache TTL (30s).

Fixes #733


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated SecurityException list results from repopulating the cache after invalidation.
  * Improved cache invalidation for both namespaced and cluster-scoped results, including requests already in progress.

* **Tests**
  * Added coverage for cache invalidation races, generation mismatches, successful updates, and invalidate-all behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->