### PR TITLE
chore(tools): drop RemoveContainerFromSlug, which nothing calls

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -198,11 +198,3 @@ func appendUnique(forms []string, form string) []string {
 	}
 	return append(forms, form)
 }
-
-func RemoveContainerFromSlug(slug, container string) string {
-	i := strings.LastIndex(slug, container)
-	if i == -1 {
-		return slug
-	}
-	return slug[:i-1]
-}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -157,39 +157,6 @@ func TestNormalizeReference(t *testing.T) {
 	}
 }
 
-func TestRemoveContainerFromSlug(t *testing.T) {
-	tests := []struct {
-		name      string
-		slug      string
-		container string
-		want      string
-	}{
-		{
-			name:      "naked pod",
-			slug:      "pod-nn-nn-7c1c-a197",
-			container: "nn",
-			want:      "pod-nn",
-		},
-		{
-			name:      "replicaset",
-			slug:      "replicaset-nginx-bf5d5cf98-nginx-b532-f893",
-			container: "nginx",
-			want:      "replicaset-nginx-bf5d5cf98",
-		},
-		{
-			name:      "tricky",
-			slug:      "replicaset-local-path-provisioner-988d74bc-local-path-provisioner-4b6b-20c0",
-			container: "local-path-provisioner",
-			want:      "replicaset-local-path-provisioner-988d74bc",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, RemoveContainerFromSlug(tt.slug, tt.container))
-		})
-	}
-}
-
 func TestReferenceMatchForms(t *testing.T) {
 	const digest = "sha256:aaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999"
 	tests := []struct {


### PR DESCRIPTION
## Overview

`internal/tools.RemoveContainerFromSlug` has no callers. it arrived in d109fe7 (2024-06-04) with its test and nothing else, and that is still the only commit `git log -S RemoveContainerFromSlug --all` reports, so it has never been wired to anything.

this deletes it and its test.

## Additional Information

being unused is not on its own a reason to delete something. the reason here is that it is wrong in two ways and reads like a helper someone would reach for:

```go
return slug[:i-1]
```

assumes a separator sits before the match, so a slug that starts with the container name gives `i == 0` and panics with `slice bounds out of range [:-1]`.

`strings.LastIndex(slug, "")` returns `len(slug)` rather than -1, so an empty container walks past the `i == -1` guard and the function quietly returns the slug minus its last character.

the three existing test cases all put the container in the middle of the slug with a separator in front, so neither shape is covered and both would survive a refactor.

nothing else in `tools.go` used it, and `strings` is still needed by the rest of the file.

## How to Test

`go build ./... && go vet ./... && go test ./internal/tools/ -count=1`

`grep -rn "RemoveContainerFromSlug" --include=*.go .` returns nothing afterwards.

the behaviour claimed above is two lines to reproduce against the deleted function:

```
RemoveContainerFromSlug("nginx", "nginx")     panic: slice bounds out of range [:-1]
RemoveContainerFromSlug("nginx-abc", "")      "nginx-ab"
```

note the tree does not build on main right now for an unrelated reason (#729), so the build check above needs #730 or a base that has it.

## Related issues/PRs:

* Resolved #735


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an obsolete slug-processing utility that is no longer used.
  * Deleted its associated automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->