### PR TITLE
refactor(controllers): share the tracked-scan submit sequence

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -177,28 +177,39 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
+	h.runTrackedScan(bgCtx, newScan.JobID, "generateSBOM", h.scanService.GenerateSBOM,
+		"service error - GenerateSBOM",
+		helpers.String("imageSlug", newScan.ImageSlug),
+		helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
+		helpers.String("imageHash", newScan.ImageHash))
+}
+
+// runTrackedScan submits scan to the worker pool and reports its result to both the scan
+// metrics and the status store. GenerateSBOM, ScanCVE and ScanRegistry all report the same
+// way, differing only in the endpoint label, the service call and the fields on the error
+// log line, which is what errMsg and errDetails carry.
+//
+// ScanCP keeps its own copy: ErrPartialContainerProfile is a third outcome there, recorded
+// as "partial" for the metric while still marking the job succeeded, and it has no
+// equivalent in the other three.
+func (h *HTTPController) runTrackedScan(bgCtx context.Context, jobID, endpoint string, scan func(context.Context) error, errMsg string, errDetails ...helpers.IDetails) {
 	h.workerPool.Submit(func() {
-		if !h.claimTrackedJob(newScan.JobID) {
+		if !h.claimTrackedJob(jobID) {
 			return
 		}
 		start := time.Now()
-		err = h.scanService.GenerateSBOM(bgCtx)
+		err := scan(bgCtx)
 		outcome := "success"
 		if err != nil {
 			outcome = "error"
 		}
-		h.recordScan(bgCtx, "generateSBOM", start, outcome, err)
+		h.recordScan(bgCtx, endpoint, start, outcome, err)
 		if err != nil {
-			h.ensureStatuses().markFailed(newScan.JobID, scanFailureReason(outcome, err))
-		} else {
-			h.ensureStatuses().markSucceeded(newScan.JobID)
+			h.ensureStatuses().markFailed(jobID, scanFailureReason(outcome, err))
+			logger.L().Ctx(bgCtx).Error(errMsg, append([]helpers.IDetails{helpers.Error(err)}, errDetails...)...)
+			return
 		}
-		if err != nil {
-			logger.L().Ctx(bgCtx).Error("service error - GenerateSBOM", helpers.Error(err),
-				helpers.String("imageSlug", newScan.ImageSlug),
-				helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
-				helpers.String("imageHash", newScan.ImageHash))
-		}
+		h.ensureStatuses().markSucceeded(jobID)
 	})
 }
 
@@ -335,30 +346,12 @@ func (h *HTTPController) ScanCVE(c *gin.Context) {
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
-	h.workerPool.Submit(func() {
-		if !h.claimTrackedJob(newScan.JobID) {
-			return
-		}
-		start := time.Now()
-		err = h.scanService.ScanCVE(bgCtx)
-		outcome := "success"
-		if err != nil {
-			outcome = "error"
-		}
-		h.recordScan(bgCtx, "scanCVE", start, outcome, err)
-		if err != nil {
-			h.ensureStatuses().markFailed(newScan.JobID, scanFailureReason(outcome, err))
-		} else {
-			h.ensureStatuses().markSucceeded(newScan.JobID)
-		}
-		if err != nil {
-			logger.L().Ctx(bgCtx).Error("service error - ScanCVE", helpers.Error(err),
-				helpers.String("wlid", newScan.Wlid),
-				helpers.String("imageSlug", newScan.ImageSlug),
-				helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
-				helpers.String("imageHash", newScan.ImageHash))
-		}
-	})
+	h.runTrackedScan(bgCtx, newScan.JobID, "scanCVE", h.scanService.ScanCVE,
+		"service error - ScanCVE",
+		helpers.String("wlid", newScan.Wlid),
+		helpers.String("imageSlug", newScan.ImageSlug),
+		helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
+		helpers.String("imageHash", newScan.ImageHash))
 }
 
 // validationStatusCode maps a validation error to the HTTP status code that best
@@ -433,29 +426,11 @@ func (h *HTTPController) ScanRegistry(c *gin.Context) {
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
-	h.workerPool.Submit(func() {
-		if !h.claimTrackedJob(newScan.JobID) {
-			return
-		}
-		start := time.Now()
-		err = h.scanService.ScanRegistry(bgCtx)
-		outcome := "success"
-		if err != nil {
-			outcome = "error"
-		}
-		h.recordScan(bgCtx, "scanRegistry", start, outcome, err)
-		if err != nil {
-			h.ensureStatuses().markFailed(newScan.JobID, scanFailureReason(outcome, err))
-		} else {
-			h.ensureStatuses().markSucceeded(newScan.JobID)
-		}
-		if err != nil {
-			logger.L().Ctx(bgCtx).Error("service error - ScanRegistry", helpers.Error(err),
-				helpers.String("imageSlug", newScan.ImageSlug),
-				helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
-				helpers.String("imageHash", newScan.ImageHash))
-		}
-	})
+	h.runTrackedScan(bgCtx, newScan.JobID, "scanRegistry", h.scanService.ScanRegistry,
+		"service error - ScanRegistry",
+		helpers.String("imageSlug", newScan.ImageSlug),
+		helpers.String("imageTagNormalized", newScan.ImageTagNormalized),
+		helpers.String("imageHash", newScan.ImageHash))
 }
 
 // registryScanCommandToScanCommand converts a RegistryScanCommand into a domain.ScanCommand, populating normalized image reference, image hash, and image slug.


### PR DESCRIPTION
## Overview

`GenerateSBOM`, `ScanCVE` and `ScanRegistry` each submitted the same twenty-two lines to the worker pool: claim the job, time the call, derive the outcome, record the metric, mark the status, log on error. The three differed only in the endpoint label, which service method they called, and the fields on the error log line.

`runTrackedScan` is that sequence once. The three call sites are five lines each now.

## Additional Information

`ScanCP` keeps its own copy. `ErrPartialContainerProfile` is a third outcome there, recorded as `partial` for the metric while the job is still marked succeeded, and there is nothing equivalent in the other three, so folding it in would mean a parameter only one caller ever sets.

the error is scoped to the closure now. all three used `err =` against the handler's own `err`, which the worker goroutine writes after the handler has already returned. nothing reads it after `Submit` today, so this is not a live race, only one that would appear the moment a line is added below the submit.

the log call goes from a fixed argument list to `append([]helpers.IDetails{helpers.Error(err)}, errDetails...)`, so the error stays the first field and the per-endpoint fields follow in the order they did before. same message strings, same endpoint labels, same fields.

`markSucceeded` moved into an early-return shape rather than an `else`, which is the only structural change to the sequence itself.

## How to Test

`go build ./... && go vet ./controllers/... && go test ./controllers/ -race -count=1`

no test changes. the paths this touches are already covered end to end:

```
TestHTTPController_GenerateSBOM / ScanCVE / ScanRegistry
TestHTTPController_ScanStatus_Succeeded / _Failed / _AbandonedOnShutdown
TestHTTPController_GenerateSBOM_EmptyJobIDStillRuns
TestHTTPController_MetricsEndpoint_RecordsScanFailureReason
```

they pass unchanged, and all three endpoints now run the same code, so what was three sets of assertions about three copies is three sets about one.

that they actually constrain the helper rather than just compiling against it: replacing the recorded outcome inside `runTrackedScan` with a hardcoded success fails `TestHTTPController_MetricsEndpoint_RecordsScanFailureReason` on all three endpoints, generateSBOM, scanCVE and scanRegistryImage, plus its unclassified-error case.

`TestHTTPController_GenerateSBOM_EmptyJobIDStillRuns` is the one that pins `claimTrackedJob("")` returning true, so an untracked job still runs.

note main does not build right now for an unrelated reason (#729), so the commands above need #730 or a base that has it.

## Related issues/PRs:

* Resolved #737
