### PR TITLE
fix: restore deduplicateErrors helper in adapters/v1

### DIFF
--- a/adapters/v1/domain_to_syft.go
+++ b/adapters/v1/domain_to_syft.go
@@ -77,6 +77,18 @@ func warnConversionErrors[T any](converted []T, errors []error) []T {
 	return converted
 }
 
+func deduplicateErrors(errors []error) []string {
+	errorCounts := make(map[string]int)
+	var errorMessages []string
+	for _, e := range errors {
+		errorCounts[e.Error()] = errorCounts[e.Error()] + 1
+	}
+	for msg, count := range errorCounts {
+		errorMessages = append(errorMessages, fmt.Sprintf("%q occurred %d time(s)", msg, count))
+	}
+	return errorMessages
+}
+
 func toSyftFiles(files []model.File) sbom.Artifacts {
 	ret := sbom.Artifacts{
 		FileMetadata: make(map[file.Coordinates]file.Metadata),


### PR DESCRIPTION
## Overview
Restores `deduplicateErrors` helper function in `adapters/v1/domain_to_syft.go` which was erroneously removed in #717, fixing the compilation failure on `main` (`adapters/v1/domain_to_syft.go:73:19: undefined: deduplicateErrors`).

## How to Test
- `go build ./...`
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversion warnings are now grouped by message, reducing repeated notices and making error output easier to review.
  * Warning summaries include the number of occurrences for each distinct conversion issue, helping identify recurring problems more quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->