### PR TITLE
refactor(adapters): convert a grype match in one place

### DIFF
--- a/adapters/v1/grype_to_domain.go
+++ b/adapters/v1/grype_to_domain.go
@@ -44,41 +44,48 @@ func toRawMessage(v interface{}) json.RawMessage {
 func grypeToDomainMatches(matches []models.Match) []v1beta1.Match {
 	var result []v1beta1.Match
 	for _, m := range matches {
-		result = append(result, v1beta1.Match{
-			Vulnerability: v1beta1.Vulnerability{
-				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
-					ID:          m.Vulnerability.VulnerabilityMetadata.ID,
-					DataSource:  m.Vulnerability.VulnerabilityMetadata.DataSource,
-					Namespace:   m.Vulnerability.VulnerabilityMetadata.Namespace,
-					Severity:    m.Vulnerability.VulnerabilityMetadata.Severity,
-					URLs:        m.Vulnerability.VulnerabilityMetadata.URLs,
-					Description: m.Vulnerability.VulnerabilityMetadata.Description,
-					Cvss:        grypeToDomainMatchesCvss(m.Vulnerability.VulnerabilityMetadata.Cvss),
-				},
-				Fix: v1beta1.Fix{
-					Versions: m.Vulnerability.Fix.Versions,
-					State:    m.Vulnerability.Fix.State,
-				},
-				Advisories: grypeToDomainMatchesAdvisories(m.Vulnerability.Advisories),
-			},
-			RelatedVulnerabilities: grypeToDomainMatchesRelatedVulnerabilities(m.RelatedVulnerabilities),
-			MatchDetails:           grypeToDomainMatchesMatchDetails(m.MatchDetails),
-			Artifact: v1beta1.GrypePackage{
-				Name:         m.Artifact.Name,
-				Version:      m.Artifact.Version,
-				Type:         v1beta1.SyftType(m.Artifact.Type),
-				Locations:    grypeToDomainMatchesLocations(m.Artifact.Locations),
-				Language:     v1beta1.SyftLanguage(m.Artifact.Language),
-				Licenses:     m.Artifact.Licenses,
-				CPEs:         m.Artifact.CPEs,
-				PURL:         m.Artifact.PURL,
-				Upstreams:    grypeToDomainMatchesUpstreams(m.Artifact.Upstreams),
-				MetadataType: v1beta1.MetadataType(m.Artifact.MetadataType),
-				Metadata:     toRawMessage(m.Artifact.Metadata),
-			},
-		})
+		result = append(result, grypeToDomainMatch(m))
 	}
 	return result
+}
+
+// grypeToDomainMatch converts one match. models.IgnoredMatch embeds models.Match, so both
+// grypeToDomainMatches and grypeToDomainIgnoredMatches convert the same thing and a field
+// added here would otherwise have to be added to each of them separately.
+func grypeToDomainMatch(m models.Match) v1beta1.Match {
+	return v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+				ID:          m.Vulnerability.VulnerabilityMetadata.ID,
+				DataSource:  m.Vulnerability.VulnerabilityMetadata.DataSource,
+				Namespace:   m.Vulnerability.VulnerabilityMetadata.Namespace,
+				Severity:    m.Vulnerability.VulnerabilityMetadata.Severity,
+				URLs:        m.Vulnerability.VulnerabilityMetadata.URLs,
+				Description: m.Vulnerability.VulnerabilityMetadata.Description,
+				Cvss:        grypeToDomainMatchesCvss(m.Vulnerability.VulnerabilityMetadata.Cvss),
+			},
+			Fix: v1beta1.Fix{
+				Versions: m.Vulnerability.Fix.Versions,
+				State:    m.Vulnerability.Fix.State,
+			},
+			Advisories: grypeToDomainMatchesAdvisories(m.Vulnerability.Advisories),
+		},
+		RelatedVulnerabilities: grypeToDomainMatchesRelatedVulnerabilities(m.RelatedVulnerabilities),
+		MatchDetails:           grypeToDomainMatchesMatchDetails(m.MatchDetails),
+		Artifact: v1beta1.GrypePackage{
+			Name:         m.Artifact.Name,
+			Version:      m.Artifact.Version,
+			Type:         v1beta1.SyftType(m.Artifact.Type),
+			Locations:    grypeToDomainMatchesLocations(m.Artifact.Locations),
+			Language:     v1beta1.SyftLanguage(m.Artifact.Language),
+			Licenses:     m.Artifact.Licenses,
+			CPEs:         m.Artifact.CPEs,
+			PURL:         m.Artifact.PURL,
+			Upstreams:    grypeToDomainMatchesUpstreams(m.Artifact.Upstreams),
+			MetadataType: v1beta1.MetadataType(m.Artifact.MetadataType),
+			Metadata:     toRawMessage(m.Artifact.Metadata),
+		},
+	}
 }
 
 func grypeToDomainMatchesCvss(cvss []models.Cvss) []v1beta1.Cvss {
@@ -164,39 +171,7 @@ func grypeToDomainIgnoredMatches(ignoredMatches []models.IgnoredMatch) []v1beta1
 	var result []v1beta1.IgnoredMatch
 	for _, m := range ignoredMatches {
 		result = append(result, v1beta1.IgnoredMatch{
-			Match: v1beta1.Match{
-				Vulnerability: v1beta1.Vulnerability{
-					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
-						ID:          m.Vulnerability.VulnerabilityMetadata.ID,
-						DataSource:  m.Vulnerability.VulnerabilityMetadata.DataSource,
-						Namespace:   m.Vulnerability.VulnerabilityMetadata.Namespace,
-						Severity:    m.Vulnerability.VulnerabilityMetadata.Severity,
-						URLs:        m.Vulnerability.VulnerabilityMetadata.URLs,
-						Description: m.Vulnerability.VulnerabilityMetadata.Description,
-						Cvss:        grypeToDomainMatchesCvss(m.Vulnerability.VulnerabilityMetadata.Cvss),
-					},
-					Fix: v1beta1.Fix{
-						Versions: m.Vulnerability.Fix.Versions,
-						State:    m.Vulnerability.Fix.State,
-					},
-					Advisories: grypeToDomainMatchesAdvisories(m.Vulnerability.Advisories),
-				},
-				RelatedVulnerabilities: grypeToDomainMatchesRelatedVulnerabilities(m.RelatedVulnerabilities),
-				MatchDetails:           grypeToDomainMatchesMatchDetails(m.MatchDetails),
-				Artifact: v1beta1.GrypePackage{
-					Name:         m.Artifact.Name,
-					Version:      m.Artifact.Version,
-					Type:         v1beta1.SyftType(m.Artifact.Type),
-					Locations:    grypeToDomainMatchesLocations(m.Artifact.Locations),
-					Language:     v1beta1.SyftLanguage(m.Artifact.Language),
-					Licenses:     m.Artifact.Licenses,
-					CPEs:         m.Artifact.CPEs,
-					PURL:         m.Artifact.PURL,
-					Upstreams:    grypeToDomainMatchesUpstreams(m.Artifact.Upstreams),
-					MetadataType: v1beta1.MetadataType(m.Artifact.MetadataType),
-					Metadata:     toRawMessage(m.Artifact.Metadata),
-				},
-			},
+			Match:              grypeToDomainMatch(m.Match),
 			AppliedIgnoreRules: grypeToDomainIgnoredMatchesAppliedIgnoreRules(m.AppliedIgnoreRules),
 		})
 	}

--- a/adapters/v1/grype_to_domain_test.go
+++ b/adapters/v1/grype_to_domain_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/anchore/syft/syft/file"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_grypeToDomain(t *testing.T) {
@@ -68,4 +69,61 @@ func Test_grypeToDomain(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// models.IgnoredMatch embeds models.Match, so an ignored match goes through the same
+// conversion as a regular one. The case above leaves that embedded Match zero, which would
+// let the two paths disagree without failing anything.
+func Test_grypeToDomain_ignoredMatchConvertsLikeAMatch(t *testing.T) {
+	m := models.Match{
+		Vulnerability: models.Vulnerability{
+			VulnerabilityMetadata: models.VulnerabilityMetadata{
+				ID:          "CVE-2021-44228",
+				DataSource:  "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+				Namespace:   "nvd:cpe",
+				Severity:    "Critical",
+				URLs:        []string{"https://logging.apache.org/log4j/2.x/security.html"},
+				Description: "Apache Log4j2 JNDI features do not protect against attacker controlled LDAP",
+				Cvss: []models.Cvss{{
+					Version: "3.1",
+					Vector:  "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+					Metrics: models.CvssMetrics{BaseScore: 10.0},
+				}},
+			},
+			Fix:        models.Fix{Versions: []string{"2.15.0"}, State: "fixed"},
+			Advisories: []models.Advisory{{ID: "GHSA-jfh8-c2jp-5v3q", Link: "https://github.com/advisories"}},
+		},
+		RelatedVulnerabilities: []models.VulnerabilityMetadata{{ID: "GHSA-jfh8-c2jp-5v3q", Namespace: "github:language:java"}},
+		MatchDetails:           []models.MatchDetails{{Type: "exact-indirect-match", Matcher: "java-matcher"}},
+		Artifact: models.Package{
+			Name:      "log4j-core",
+			Version:   "2.14.1",
+			Type:      "java-archive",
+			Language:  "java",
+			Licenses:  []string{"Apache-2.0"},
+			CPEs:      []string{"cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*"},
+			PURL:      "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+			Upstreams: []models.UpstreamPackage{{Name: "log4j"}},
+		},
+	}
+
+	got, err := grypeToDomain(models.Document{
+		Matches: []models.Match{m},
+		IgnoredMatches: []models.IgnoredMatch{{
+			Match:              m,
+			AppliedIgnoreRules: []models.IgnoreRule{{Vulnerability: "CVE-2021-44228"}},
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got.Matches, 1)
+	require.Len(t, got.IgnoredMatches, 1)
+
+	assert.Equal(t, got.Matches[0], got.IgnoredMatches[0].Match)
+
+	// so the comparison above is not two zero values agreeing with each other
+	assert.Equal(t, "CVE-2021-44228", got.IgnoredMatches[0].Vulnerability.ID)
+	assert.Equal(t, "log4j-core", got.IgnoredMatches[0].Artifact.Name)
+	assert.Equal(t, []string{"2.15.0"}, got.IgnoredMatches[0].Vulnerability.Fix.Versions)
+	assert.Len(t, got.IgnoredMatches[0].Vulnerability.VulnerabilityMetadata.Cvss, 1)
+	assert.Len(t, got.IgnoredMatches[0].AppliedIgnoreRules, 1)
 }


### PR DESCRIPTION
## Overview

`grypeToDomainMatches` and `grypeToDomainIgnoredMatches` each built the same `v1beta1.Match`, thirty-two identical lines twice. `models.IgnoredMatch` embeds `models.Match`, so the two are converting the same thing and a field added to one had to be added to the other by hand.

`grypeToDomainMatch` is that conversion once. The ignored path calls it with `m.Match`.

## Additional Information

the ignored copy was the untested one. the existing case sets only `AppliedIgnoreRules` and leaves the embedded `Match` zero, so those thirty-two lines converted nothing under test and a difference between the two paths failed nothing.

that copy is the one feeding suppression data. ignored matches are what `ApplySecurityExceptions` writes, and what the VEX statements and the exception attribution in `repositories/apiserver.go` read, so a field going missing there reads as wrong suppression rather than as an obviously absent field.

three grype fields are dropped by this conversion and stay dropped: `models.Package.ID`, `models.MatchDetails.Fix` and `models.Fix.Available`. `v1beta1.GrypePackage`, `v1beta1.MatchDetails` and `v1beta1.Fix` have no field for any of them, so that is a storage-side limit and not something this can fix.

no behaviour change otherwise. same fields, same order, same helpers.

## How to Test

`go build ./... && go vet ./adapters/... && go test ./adapters/... -count=1`

`Test_grypeToDomain` passes unchanged.

`Test_grypeToDomain_ignoredMatchConvertsLikeAMatch` is new. it converts one populated match through both paths in a single document and asserts `got.Matches[0]` equals `got.IgnoredMatches[0].Match`, then checks the ID, package name, fix versions and cvss are actually set, so the equality is not two zero values agreeing.

it catches what it is for. making the ignored path drop `Fix.Versions` while the regular path keeps it fails the new test and leaves `Test_grypeToDomain` passing, which is the gap this closes.

## Related issues/PRs:

* Resolved #740
