### PR TITLE
fix: bound the sbom-scanner sidecar's image pull by the request timeout

### DIFF
--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -146,11 +146,24 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		Credentials:           credentials,
 	}
 
-	// Download image from registry
+	// timeout bounds both the pull below and SBOM generation further down, as two independent
+	// windows (not one budget split across both) - matching adapters/v1/syft.go's scanTimeout,
+	// which bounds its own pull and cataloging phases the same way.
+	timeout := time.Duration(req.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+
+	// Download image from registry, bounded by timeout: a registry that accepts a connection
+	// but then stalls (no error, just no timely response) used to hang this call - and the
+	// caller's scanConcurrency slot with it - indefinitely, since neither the request ctx nor
+	// any deadline reached this pull; the only deadline in this method wrapped generation,
+	// which starts after the pull already returned. See #742.
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))
-	src, err := resolveSource(ctx, func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
-		// Pulls intentionally run on a detached context (see #421); the request ctx is used only for the registry auth provider inside resolveSource.
-		return tools.RetryWithBackoff(context.Background(), "source_resolution", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (source.Source, error) {
+	ctxWithTimeout, cancelPull := context.WithTimeout(ctx, timeout)
+	defer cancelPull()
+	src, err := resolveSource(ctxWithTimeout, func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
+		return tools.RetryWithBackoff(ctxWithTimeout, "source_resolution", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (source.Source, error) {
 			ctxWithSize := context.WithValue(retryCtx, image.MaxImageSize, req.MaxImageSize) //nolint:staticcheck // stereoscope requires string context key
 			return syft.GetSource(ctxWithSize, ref,
 				syft.DefaultGetSourceConfig().WithRegistryOptions(opts).WithPlatform(imgPlatform).WithSources("registry"))
@@ -158,6 +171,15 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	}, imageID, imageTag, registryOptions)
 
 	switch {
+	// stereoscope/oci-registry wraps deadline errors in a custom error type that does not
+	// implement Unwrap(), so the strings.Contains check is required alongside errors.Is (same
+	// as adapters/v1/syft.go's identical check on its own pull timeout).
+	case err != nil && (errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "context deadline exceeded")):
+		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
+		logger.L().Warning("image pull timed out", helpers.String("imageID", imageID))
+		return &pb.CreateSBOMResponse{
+			Status: helpersv1.Incomplete,
+		}, nil
 	case err != nil && (errors.Is(err, image.ErrImageTooLarge) || strings.Contains(err.Error(), image.ErrImageTooLarge.Error())):
 		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyImageTooLarge, metrics.FallbackOutcomeClassified)
 		logger.L().Warning("Image exceeds size limit",
@@ -212,12 +234,9 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		resolvedPlatform = formatResolvedPlatform(meta.OS, meta.Architecture, meta.Variant)
 	}
 
-	// Generate SBOM with timeout
+	// Generate SBOM with timeout (reuses the same timeout duration computed above for the
+	// pull, as its own independent window).
 	var syftSBOM *sbom.SBOM
-	timeout := time.Duration(req.TimeoutSeconds) * time.Second
-	if timeout <= 0 {
-		timeout = 5 * time.Minute
-	}
 	dl := deadline.New(timeout)
 	// Buffered so the abandoned goroutine below can always publish and exit, even when
 	// nobody is left to receive.

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -693,6 +693,64 @@ func TestCreateSBOM_PlatformMismatch_LocalRegistry(t *testing.T) {
 	assert.Empty(t, resp.Status)
 }
 
+// TestCreateSBOM_PullTimeout_ReturnsIncompleteInsteadOfHanging is a regression test for #742: a
+// registry that accepts the connection but never responds to the manifest request used to hang
+// the pull - and the RPC with it - indefinitely, since neither the request context nor any
+// deadline bounded resolveSource's call chain. The mock registry below blocks on the manifest
+// request until the test explicitly releases it, simulating exactly that stalling registry.
+// CreateSBOM must still return, bounded by TimeoutSeconds, well before that release happens.
+func TestCreateSBOM_PullTimeout_ReturnsIncompleteInsteadOfHanging(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Never respond to the manifest request until the test releases it - a connection
+		// that accepts the request but stalls, not one that errors or refuses outright.
+		<-release
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	// close(release) must run before server.Close(), which blocks until the handler above
+	// returns - deferred in this order so it does, since defers run LIFO.
+	defer server.Close()
+	defer close(release)
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	type result struct {
+		resp *pb.CreateSBOMResponse
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
+			ImageId:         u.Host + "/test-image",
+			ImageTag:        u.Host + "/test-image:latest",
+			Platform:        "linux/amd64",
+			MaxImageSize:    1 << 30,
+			MaxSbomSize:     1 << 30,
+			TimeoutSeconds:  1,
+			InsecureUseHttp: true,
+		})
+		done <- result{resp, err}
+	}()
+
+	select {
+	case r := <-done:
+		require.NoError(t, r.err)
+		require.NotNil(t, r.resp)
+		assert.Equal(t, helpersv1.Incomplete, r.resp.Status, "a stalled pull must surface as Incomplete, the same status a cataloguing timeout already uses")
+		assert.Empty(t, r.resp.ErrorMessage)
+	case <-time.After(10 * time.Second):
+		t.Fatal("CreateSBOM never returned after the pull's TimeoutSeconds elapsed - the pull is not bounded by any deadline")
+	}
+}
+
 // TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft covers the deadline path: deadline.Run
 // does not (and documents that it cannot) stop the work function, and Syft's cataloguers do
 // not observe cancellation, so on timeout the Syft goroutine keeps running and finishes after

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -727,6 +727,7 @@ func TestCreateSBOM_PullTimeout_ReturnsIncompleteInsteadOfHanging(t *testing.T) 
 		err  error
 	}
 	done := make(chan result, 1)
+	start := time.Now()
 	go func() {
 		resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
 			ImageId:         u.Host + "/test-image",
@@ -742,11 +743,17 @@ func TestCreateSBOM_PullTimeout_ReturnsIncompleteInsteadOfHanging(t *testing.T) 
 
 	select {
 	case r := <-done:
+		// Bounds the response to the configured 1s pull timeout plus CI scheduling
+		// tolerance, not just "eventually" - a regression that returns after several
+		// seconds instead of hanging forever would otherwise still pass.
+		assert.Less(t, time.Since(start), 4*time.Second, "CreateSBOM should return shortly after the pull's TimeoutSeconds, not after an unrelated delay")
 		require.NoError(t, r.err)
 		require.NotNil(t, r.resp)
 		assert.Equal(t, helpersv1.Incomplete, r.resp.Status, "a stalled pull must surface as Incomplete, the same status a cataloguing timeout already uses")
 		assert.Empty(t, r.resp.ErrorMessage)
 	case <-time.After(10 * time.Second):
+		// Deadlock fallback only, well above the 4s bound asserted above: if the pull
+		// truly never returns, fail with a clear message instead of hanging the suite.
 		t.Fatal("CreateSBOM never returned after the pull's TimeoutSeconds elapsed - the pull is not bounded by any deadline")
 	}
 }


### PR DESCRIPTION
## Problem

`pkg/sbomscanner/v1/server.go`'s `CreateSBOM` gRPC handler resolves the image source (registry pull) on `context.Background()` - fully detached, with no deadline at any layer (client, gRPC transport, or server). A registry that accepts a connection but stalls on the manifest/blob response (not an outright error - a slow or half-open connection) hangs the pull, and the RPC, indefinitely. The only timeout the handler establishes (`deadline.New(timeout)`) wraps SBOM *generation*, which starts strictly after the pull already returned, so it gives the pull no protection at all.

## Root cause

`adapters/v1/syft.go` (the in-process adapter) already bounds its own pull by `scanTimeout` via a `context.WithTimeout(ctx, s.scanTimeout)`. `CreateSBOM`'s doc comment claims `resolveSource` "mirrors the retry chain in `adapters/v1/syft.go` so the sidecar and in-process adapters behave the same" - but on this dimension it didn't.

The `// Pulls intentionally run on a detached context (see #421)` comment is stale: it traces to PR #424, whose description says the file's `context.Background()` calls were "tracked separately in #421" - #421 was fixed by PR #422, which touched only `repositories/apiserver.go` and never this file. The comment reads like a settled design decision; it isn't one that was ever acted on here.

## Fix

Compute the request's timeout once (same fallback-to-5-minutes logic as before), derive a `context.WithTimeout(ctx, timeout)` from it, and thread that through `resolveSource` and its `RetryWithBackoff` call in place of `context.Background()`. This mirrors `adapters/v1/syft.go`'s pattern of independent timeout-bounded windows for the pull and generation phases (not one budget split across both).

A pull that times out now surfaces as `Status: Incomplete` - the same status a cataloguing timeout already uses - instead of hanging the RPC. The `errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "context deadline exceeded")` check mirrors the identical one in `adapters/v1/syft.go`, needed because stereoscope/oci-registry wraps deadline errors in a type that doesn't implement `Unwrap()`.

## Testing

- New regression test `TestCreateSBOM_PullTimeout_ReturnsIncompleteInsteadOfHanging`: a local mock registry accepts the connection but never responds to the manifest request (the exact "stalling registry" scenario), and the test asserts `CreateSBOM` returns `Status: Incomplete` within the configured timeout rather than hanging.
- **Verified to fail against the pre-fix code**: reverted the production change locally, reran the new test, and confirmed it fails after 10s with "the pull is not bounded by any deadline"; restored the fix and reran to confirm it passes in ~1s.
- `go build ./...` - clean.
- `go vet ./pkg/sbomscanner/...` - clean.
- `go test ./pkg/sbomscanner/... -count=1` - all tests pass, including the existing `TestResolveSource*`, `TestCreateSBOM_*`, and `TestHealth` suites, unchanged.
- Could not run `go test -race` locally (no cgo/gcc in this environment, same limitation noted in prior PRs in this repo).

## Impact

Any deployment running the sidecar scanner is exposed today: a single slow or partially-unresponsive registry can wedge one `scanConcurrency` slot per affected image indefinitely, with no timeout, no error, and no automatic recovery. Enough stuck pulls from one registry can starve scanning cluster-wide, including workloads pulling from unrelated, healthy registries. This fix gives the pull phase the same timeout ceiling the generation phase already has.

Fixes #742

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan timeout handling during image retrieval and SBOM generation.
  * Scans that exceed the configured timeout now complete promptly with an **Incomplete** status instead of hanging or returning an error.
  * Registry retries and source resolution now respect the scan timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->