### PR TITLE
fix(repositories): report the summary's own name when storing it fails

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -572,47 +572,14 @@ func (a *APIServerStore) StoreCVE(ctx context.Context, cve domain.CVEManifest, w
 	if cve.Content != nil {
 		manifest.Spec.Payload = *cve.Content
 	}
-	_, err := a.StorageClient.VulnerabilityManifests(a.Namespace).Create(ctx, &manifest, metav1.CreateOptions{})
-	switch {
-	case errors.IsAlreadyExists(err):
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			// retrieve the latest version before attempting update
-			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-			result, getErr := a.StorageClient.VulnerabilityManifests(a.Namespace).Get(ctx, cve.Name, metav1.GetOptions{ResourceVersion: "metadata"})
-			if getErr != nil {
-				return getErr
-			}
-			// update the vulnerability manifest
-			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
-			result.Labels = mergeMaps(result.Labels, manifest.Labels)
-			result.Spec = manifest.Spec
-			// try to send the updated vulnerability manifest
-			_, updateErr := a.StorageClient.VulnerabilityManifests(a.Namespace).Update(ctx, result, metav1.UpdateOptions{})
-			return updateErr
-		})
-		if retryErr != nil {
-			logger.L().Debug("failed to update CVE manifest in storage", helpers.Error(retryErr),
-				helpers.String("name", cve.Name),
-				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-			return fmt.Errorf("failed to update CVE manifest in storage: %w", retryErr)
-		}
-		logger.L().Debug("updated CVE manifest in storage",
-			helpers.String("name", cve.Name),
-			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-	case err != nil:
-		logger.L().Debug("failed to store CVE manifest in storage", helpers.Error(err),
-			helpers.String("name", cve.Name),
-			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-		return fmt.Errorf("failed to store CVE manifest in storage: %w", err)
-	default:
-		logger.L().Debug("stored CVE manifest in storage",
-			helpers.String("name", cve.Name),
-			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-	}
-	return nil
+	return createOrUpdate(ctx, a.StorageClient.VulnerabilityManifests(a.Namespace),
+		"CVE manifest", cve.Name, &manifest,
+		func(existing *v1beta1.VulnerabilityManifest) {
+			existing.Annotations = mergeMaps(existing.Annotations, manifest.Annotations)
+			existing.Labels = mergeMaps(existing.Labels, manifest.Labels)
+			existing.Spec = manifest.Spec
+		},
+		helpers.String("relevant", strconv.FormatBool(withRelevancy)))
 }
 
 func parseVulnerabilitiesComponents(cve domain.CVEManifest, cvep domain.CVEManifest, namespace string, withRelevancy bool) v1beta1.VulnerabilitiesComponents {
@@ -815,47 +782,14 @@ func (a *APIServerStore) StoreCVESummary(ctx context.Context, cve domain.CVEMani
 			Vulnerabilities: parseVulnerabilitiesComponents(cve, cvep, workloadNamespace, withRelevancy),
 		},
 	}
-	_, err = a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Create(ctx, &manifest, metav1.CreateOptions{})
-	switch {
-	case errors.IsAlreadyExists(err):
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			// retrieve the latest version before attempting update
-			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-			result, getErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Get(ctx, manifest.Name, metav1.GetOptions{ResourceVersion: "metadata"})
-			if getErr != nil {
-				return getErr
-			}
-			// update the vulnerability manifest
-			result.Annotations = mergeMaps(result.Annotations, manifest.Annotations)
-			result.Labels = mergeMaps(result.Labels, manifest.Labels)
-			result.Spec = manifest.Spec
-			// try to send the updated vulnerability manifest
-			_, updateErr := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Update(ctx, result, metav1.UpdateOptions{})
-			return updateErr
-		})
-		if retryErr != nil {
-			logger.L().Debug("failed to update CVE summary manifest in storage", helpers.Error(retryErr),
-				helpers.String("name", cve.Name),
-				helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-			return fmt.Errorf("failed to update CVE summary manifest in storage: %w", retryErr)
-		}
-		logger.L().Debug("updated CVE summary manifest in storage",
-			helpers.String("name", cve.Name),
-			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-	case err != nil:
-		logger.L().Debug("failed to store CVE summary manifest in storage", helpers.Error(err),
-			helpers.String("name", cve.Name),
-			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-		return fmt.Errorf("failed to store CVE summary manifest in storage: %w", err)
-	default:
-		logger.L().Debug("stored CVE summary manifest in storage",
-			helpers.String("name", manifest.Name),
-			helpers.String("relevant", strconv.FormatBool(withRelevancy)))
-	}
-	return nil
+	return createOrUpdate(ctx, a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace),
+		"CVE summary manifest", manifest.Name, &manifest,
+		func(existing *v1beta1.VulnerabilityManifestSummary) {
+			existing.Annotations = mergeMaps(existing.Annotations, manifest.Annotations)
+			existing.Labels = mergeMaps(existing.Labels, manifest.Labels)
+			existing.Spec = manifest.Spec
+		},
+		helpers.String("relevant", strconv.FormatBool(withRelevancy)))
 }
 
 // summaryHasVulnerabilityData reports whether a summary already holds real scan results
@@ -1870,7 +1804,10 @@ type objectStore[T any] interface {
 // wrote in between and the merge has to happen again on top of that.
 //
 // kind names the object in the logs and errors ("SBOM", "filtered SBOM").
-func createOrUpdate[T any](ctx context.Context, store objectStore[T], kind, name string, obj T, merge func(existing T)) error {
+// extra are appended to every log line this emits, for callers that carry an additional
+// field on them. name is the object's own name and is what the Get inside the retry uses,
+// so it is the one thing every line here reports about which object is meant.
+func createOrUpdate[T any](ctx context.Context, store objectStore[T], kind, name string, obj T, merge func(existing T), extra ...helpers.IDetails) error {
 	_, err := store.Create(ctx, obj, metav1.CreateOptions{})
 	switch {
 	case errors.IsAlreadyExists(err):
@@ -1889,19 +1826,15 @@ func createOrUpdate[T any](ctx context.Context, store objectStore[T], kind, name
 			return updateErr
 		})
 		if retryErr != nil {
-			logger.L().Debug("failed to update "+kind+" in storage", helpers.Error(retryErr),
-				helpers.String("name", name))
+			logger.L().Debug("failed to update "+kind+" in storage", append([]helpers.IDetails{helpers.Error(retryErr), helpers.String("name", name)}, extra...)...)
 			return fmt.Errorf("failed to update %s in storage: %w", kind, retryErr)
 		}
-		logger.L().Debug("updated "+kind+" in storage",
-			helpers.String("name", name))
+		logger.L().Debug("updated "+kind+" in storage", append([]helpers.IDetails{helpers.String("name", name)}, extra...)...)
 	case err != nil:
-		logger.L().Debug("failed to store "+kind+" in storage", helpers.Error(err),
-			helpers.String("name", name))
+		logger.L().Debug("failed to store "+kind+" in storage", append([]helpers.IDetails{helpers.Error(err), helpers.String("name", name)}, extra...)...)
 		return fmt.Errorf("failed to store %s in storage: %w", kind, err)
 	default:
-		logger.L().Debug("stored "+kind+" in storage",
-			helpers.String("name", name))
+		logger.L().Debug("stored "+kind+" in storage", append([]helpers.IDetails{helpers.String("name", name)}, extra...)...)
 	}
 	return nil
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -3380,3 +3380,39 @@ func TestCreateProductStructForImageAndPackage(t *testing.T) {
 		})
 	}
 }
+
+// StoreCVESummary writes a VulnerabilityManifestSummary named for the workload, not for the
+// CVE manifest it was built from, so cve.Name and the stored object's name are two different
+// strings on any real scan. Three of that function's four log lines used to report cve.Name,
+// which named nothing that exists in storage; only the success line reported the object.
+// Passing the name once to createOrUpdate is what keeps those from disagreeing.
+func TestAPIServerStore_StoreCVESummary_reportsTheSummaryName(t *testing.T) {
+	workload := domain.ScanCommand{
+		Wlid:          "wlid://cluster-kind/namespace-local-path-storage/deployment-local-path-provisioner",
+		ContainerName: "local-path-provisioner",
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	cve := domain.CVEManifest{Name: "some-image-slug-cve-manifest"}
+
+	summaryName, err := GetCVESummaryK8sResourceNameWithCVEName(ctx, cve.Name)
+	require.NoError(t, err)
+	// the premise: the two names are not the same string
+	require.NotEqual(t, cve.Name, summaryName)
+
+	a := NewFakeAPIServerStorage("kubescape")
+	require.NoError(t, a.StoreCVESummary(ctx, cve, domain.CVEManifest{}, false))
+
+	ns, err := GetCVESummaryK8sResourceNamespace(ctx)
+	require.NoError(t, err)
+
+	// the object exists under the summary name
+	stored, err := a.StorageClient.VulnerabilityManifestSummaries(ns).Get(ctx, summaryName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, summaryName, stored.Name)
+
+	// and nothing was written under the CVE manifest's name
+	_, err = a.StorageClient.VulnerabilityManifestSummaries(ns).Get(ctx, cve.Name, metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "expected no summary stored under the CVE manifest name, got %v", err)
+}


### PR DESCRIPTION
## Overview

`StoreCVESummary` writes a `VulnerabilityManifestSummary` named for the workload, `kind-name-container`, not for the CVE manifest it was built from. Those are different strings on any scan that has a workload. Three of its four log lines reported `cve.Name`, which names nothing in storage, and only the success line reported the object that was actually written.

This folds `StoreCVE` and `StoreCVESummary` into `createOrUpdate`, the follow-up #725 left open. The name is passed once there, and is what both the `Get` inside the retry and every log line use, so the two cannot drift apart again.

## Additional Information

storage was never wrong. the `Get` inside the retry already used `manifest.Name`, so the right object was read and written the whole time. what was wrong was the reporting, on the three lines where it matters: a failed summary store logged a name that resolves to nothing, and the only line that named the object correctly was the success one.

`createOrUpdate` gains a variadic `extra ...helpers.IDetails` appended to each of its four log lines. that is the "couple more parameters" #725 said these callers needed, and it turned out to be one: both carry `relevant=`.

`StoreCVESummaryStub` and `StoreVEX` are still not folded in and this does not touch them. the stub reads the full object rather than metadata only, because it needs the spec to check `summaryHasVulnerabilityData` before declining to overwrite a real summary with a stub, and `StoreVEX` reads before creating and re-reads with full options inside its own retry. both want more than an extra log field.

## How to Test

`go build ./... && go vet ./... && go test ./repositories/ -count=1`

the existing tests cover both folded callers and pass unchanged, including the create path, the read-modify-write behind `AlreadyExists`, a failing read inside the retry, the retry giving up, and context propagation:

```
TestAPIServerStore_StoreCVESummary_transientError
TestAPIServerStore_StoreCVESummary_updateGetFailure_transientError
TestAPIServerStore_StoreCVESummary_retryExhausted_transientError
TestAPIServerStore_StoreCVESummary_ctxPropagated
TestAPIServerStore_StoreCVESummary_RetryConflict_ctxPropagated
```

they hold the name too, rather than just the sequence: passing `cve.Name` to `createOrUpdate` in place of `manifest.Name` fails `..._retryExhausted_transientError`, `..._RetryConflict_ctxPropagated` and `..._NilContentDoesNotPanic`.

`TestAPIServerStore_StoreCVESummary_reportsTheSummaryName` is new and states the premise directly: for a real wlid it asserts `cve.Name` and the derived summary name differ, that the stored object exists under the summary name, and that nothing was written under the CVE manifest name.

the log text itself is not asserted, since that would mean capturing the logger's output. the change that keeps those lines right is structural, one name reaching all four of them.

## Related issues/PRs:

* Resolved #744


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CVE summary storage to use the workload-derived summary name.
  * Prevented duplicate or incorrectly named summary resources from being created.

* **Tests**
  * Added regression coverage to verify correct summary naming and storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->