### PR TITLE
fix(adapters): restore cloud-sourced suppressions again

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -500,7 +500,7 @@ func emitSuppressionEvent(recorder record.EventRecorder, p armotypes.Vulnerabili
 // so the shared stored object is never modified.
 //
 // Only ignored matches carrying the signature ApplySecurityExceptions writes (a single ignore
-// rule with CRD provenance tags like SourceKind or Justification set) are restored. Any other
+// rule carrying CRD or backend exception provenance) are restored. Any other
 // entry (e.g. one produced by GrypeAdapter wiring up IgnoreRules/VexProcessor, which drops CRD
 // tags) is preserved, so the helper is self-guarding instead of relying on an assumption.
 // Reconstruction is lossless because IgnoredMatch embeds the full Match.
@@ -526,7 +526,8 @@ func RestoreSuppressedMatches(doc *v1beta1.GrypeDocument) *v1beta1.GrypeDocument
 
 // isExceptionSourcedIgnore reports whether an ignored match carries the AppliedIgnoreRules
 // signature ApplySecurityExceptions writes: non-empty AppliedIgnoreRules where every rule has no
-// package set, and exception provenance (source/justification/impact).
+// package set, and either a known CRD sourceKind or some other exception provenance, which is
+// what a backend-delivered policy leaves behind.
 func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 	if len(im.AppliedIgnoreRules) == 0 {
 		return false
@@ -536,6 +537,17 @@ func isExceptionSourcedIgnore(im v1beta1.IgnoredMatch) bool {
 			return false
 		}
 		if r.SourceKind == "SecurityException" || r.SourceKind == "ClusterSecurityException" {
+			continue
+		}
+		// A policy that never went through buildPolicy carries no sourceKind, which today means
+		// one delivered by the backend rather than a CRD. buildIgnoreRules still stamps whatever
+		// provenance that policy did carry onto the rule, so a rule holding any of it is ours.
+		//
+		// These four are safe to key on because grypeToDomainIgnoredMatchesAppliedIgnoreRules
+		// copies only Vulnerability, FixState and Package off a Grype rule, so nothing Grype
+		// produces can set them. FixState is deliberately not among them: Grype does set it, in
+		// its own fix-state vocabulary, so a rule carrying only that is not evidence of us.
+		if r.SourceName != "" || r.SourceNamespace != "" || r.Justification != "" || r.ImpactStatement != "" {
 			continue
 		}
 		return false

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -1251,8 +1251,8 @@ func TestConvertAffectedRecordsProvenance(t *testing.T) {
 }
 
 func TestRestoreSuppressedMatches_ExternalVEXFalsePositive(t *testing.T) {
-	// This simulates what happens when Grype processes a VEX file and 
-	// Kubevuln drops the tags during conversion. We are left with a single 
+	// This simulates what happens when Grype processes a VEX file and
+	// Kubevuln drops the tags during conversion. We are left with a single
 	// rule that only has the Vulnerability ID.
 	doc := &v1beta1.GrypeDocument{
 		Matches: []v1beta1.Match{
@@ -1275,7 +1275,7 @@ func TestRestoreSuppressedMatches_ExternalVEXFalsePositive(t *testing.T) {
 
 func TestRestoreSuppressedMatches_GenuineCRDException(t *testing.T) {
 	// This simulates a genuine CRD-sourced IgnoreRule which has provenance
-	// tags (like SourceKind) but an empty FixState. It proves we haven't 
+	// tags (like SourceKind) but an empty FixState. It proves we haven't
 	// broken restoration for legitimate CRD exceptions.
 	doc := &v1beta1.GrypeDocument{
 		Matches: []v1beta1.Match{},
@@ -1300,3 +1300,72 @@ func TestRestoreSuppressedMatches_GenuineCRDException(t *testing.T) {
 	assert.Len(t, restored.IgnoredMatches, 0, "Genuine CRD-suppressed match should no longer be ignored")
 }
 
+// A backend-delivered exception policy never goes through buildPolicy, so it carries no
+// sourceKind and buildIgnoreRules leaves SourceKind empty on the rule it writes. #701 narrowed
+// isExceptionSourcedIgnore to a known CRD sourceKind, which took those with it: a cloud-sourced
+// suppression stopped being restored, so once it had suppressed a finding, removing the policy
+// could never bring the finding back on the cached path.
+func TestRestoreSuppressedMatches_RestoresCloudSourcedSuppressions(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}},
+		},
+	}
+	exceptions := domain.CVEExceptions{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "cloud-allow",
+				Attributes: map[string]interface{}{
+					"ruleId":        "some-cloud-rule-id",
+					"justification": "vulnerable_code_not_present",
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-44228"}},
+		},
+	}
+
+	ApplySecurityExceptions(doc, exceptions, nil)
+	require.Len(t, doc.IgnoredMatches, 1)
+	require.Empty(t, doc.IgnoredMatches[0].AppliedIgnoreRules[0].SourceKind,
+		"a cloud-sourced policy carries no sourceKind, which is the premise here")
+
+	// the policy is gone from the backend now, so the cached path restores before re-applying
+	restored := RestoreSuppressedMatches(doc)
+	assert.Len(t, restored.Matches, 1, "a cloud-suppressed match must come back for re-evaluation")
+	assert.Empty(t, restored.IgnoredMatches)
+}
+
+// The counterpart: a rule Grype itself produced must stay suppressed. #701's case.
+// grypeToDomainIgnoredMatchesAppliedIgnoreRules copies only Vulnerability, FixState and
+// Package off a Grype rule, so neither shape below can carry our provenance.
+func TestRestoreSuppressedMatches_LeavesGrypeSourcedIgnoresAlone(t *testing.T) {
+	tests := []struct {
+		name string
+		rule v1beta1.IgnoreRule
+	}{
+		{
+			name: "bare rule, as a VEX-suppressed match arrives",
+			rule: v1beta1.IgnoreRule{Vulnerability: "CVE-VEX"},
+		},
+		{
+			name: "fix-state only, Grype's own vocabulary",
+			rule: v1beta1.IgnoreRule{Vulnerability: "CVE-VEX", FixState: "wont-fix"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &v1beta1.GrypeDocument{
+				IgnoredMatches: []v1beta1.IgnoredMatch{{
+					Match:              v1beta1.Match{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-VEX"}}},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{tt.rule},
+				}},
+			}
+
+			restored := RestoreSuppressedMatches(doc)
+			assert.Empty(t, restored.Matches, "must not undo a suppression we did not make")
+			assert.Len(t, restored.IgnoredMatches, 1)
+		})
+	}
+}


### PR DESCRIPTION
## Overview

A finding suppressed by a backend-delivered exception policy could never be un-suppressed on the cached path: once the policy had hidden it, deleting the policy left it hidden.

#701 narrowed `isExceptionSourcedIgnore` to a known CRD `sourceKind`, correctly, so a VEX-suppressed match Grype produced would stop being restored. Backend-delivered policies went with it. They never go through `buildPolicy`, so they carry no `sourceKind` and `buildIgnoreRules` leaves `SourceKind` empty on the rule it writes.

A rule with no `SourceKind` but some other exception provenance is ours again.

## Additional Information

the cached path is where it mattered. `reconcileCachedCVE` restores before it re-applies the current exception set, so the set decides the outcome. a match that is not restored is not in `Matches` for the re-apply to look at, and stays ignored whatever the set now says.

the four fields keyed on are `SourceName`, `SourceNamespace`, `Justification` and `ImpactStatement`. that is safe rather than arbitrary: `grypeToDomainIgnoredMatchesAppliedIgnoreRules` copies only `Vulnerability`, `FixState` and `Package` off a Grype rule, so nothing Grype produces can set any of the four, while `buildIgnoreRules` stamps whichever the policy carried.

`FixState` is deliberately not one of them. Grype does set it, in its own fix-state vocabulary, so a rule carrying only that is not evidence of us. It stays preserved.

#701's case is untouched. a bare rule, which is the shape a VEX-suppressed match arrives in, carries none of the four and is still preserved.

a policy whose only attribute is `status` would produce a rule with just `Vulnerability` and `FixState`, which this cannot tell apart from a native Grype rule. it is preserved, i.e. it errs the way #701 wanted.

## How to Test

`go build ./... && go vet ./... && go test ./adapters/... ./core/... -count=1`

`TestRestoreSuppressedMatches_ExternalVEXFalsePositive` and `TestRestoreSuppressedMatches_GenuineCRDException`, both from #701, pass unchanged. That is the main thing: this widens what counts as ours without giving back the VEX false positive.

`TestRestoreSuppressedMatches_RestoresCloudSourcedSuppressions` is new and goes through the real path rather than hand-building a rule: it applies a policy with no `sourceKind`, asserts the stored rule's `SourceKind` is empty so the premise is on the record, then restores and expects the match back in `Matches`. Reverting the fix fails it.

`TestRestoreSuppressedMatches_LeavesGrypeSourcedIgnoresAlone` holds the other side, for both shapes Grype can produce: a bare rule, and one carrying only `FixState`.

## Related issues/PRs:

* Resolved #746


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud-sourced security suppressions are now correctly restored even when their source type is unavailable.
  * Grype and VEX-sourced ignores continue to remain suppressed as expected.

* **Tests**
  * Added regression coverage for restoring cloud suppressions and preserving Grype/VEX ignores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->