### PR TITLE
fix: bound the HTTP controller's scan queue with admission control

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -158,6 +158,7 @@ func main() {
 		service.SetEventRecorder(eventRecorder)
 	}
 	controller := controllers.NewHTTPController(service, c.ScanConcurrency)
+	controller = controller.WithMaxQueueDepth(c.MaxQueueDepth)
 	controller = controller.WithDiagnostics(func(diagCtx context.Context) domain.Diagnostics {
 		return domain.Diagnostics{
 			ScanMode:                scanMode,

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	KeepLocal               bool              `mapstructure:"keepLocal"`
 	ListingURL              string            `mapstructure:"listingURL"`
 	MaxImageSize            int64             `mapstructure:"maxImageSize"`
+	MaxQueueDepth           int               `mapstructure:"maxQueueDepth"`
 	MaxSBOMSize             int               `mapstructure:"maxSBOMSize"`
 	Namespace               string            `mapstructure:"namespace"`
 	NodeSbomGeneration      bool              `mapstructure:"nodeSbomGeneration"`
@@ -97,6 +98,12 @@ func LoadConfig(path string) (Config, error) {
 	v.SetDefault("maxImageSize", 512*1024*1024)
 	v.SetDefault("maxSBOMSize", 20*1024*1024)
 	v.SetDefault("scanConcurrency", 1)
+	// maxQueueDepth bounds how many scans HTTPController will accept but not yet finish
+	// (queued or running) before rejecting new requests instead of queuing them (see #748:
+	// the underlying workerpool.Submit never blocks and its queue is otherwise unbounded).
+	// 0 preserves the pre-existing unbounded behavior, so this ships without changing
+	// anyone's runtime behavior until they opt in.
+	v.SetDefault("maxQueueDepth", 0)
 	v.SetDefault("scanTimeout", 5*time.Minute)
 	v.SetDefault("scannerReadinessTimeout", 60*time.Second)
 	// cmd/http/main.go spends up to 5s on the HTTP server's own Shutdown before this

--- a/config/config.go
+++ b/config/config.go
@@ -101,8 +101,8 @@ func LoadConfig(path string) (Config, error) {
 	// maxQueueDepth bounds how many scans HTTPController will accept but not yet finish
 	// (queued or running) before rejecting new requests instead of queuing them (see #748:
 	// the underlying workerpool.Submit never blocks and its queue is otherwise unbounded).
-	// 0 preserves the pre-existing unbounded behavior, so this ships without changing
-	// anyone's runtime behavior until they opt in.
+	// 0 (or less) preserves the pre-existing unbounded behavior, so this ships without
+	// changing anyone's runtime behavior until they opt in.
 	v.SetDefault("maxQueueDepth", 0)
 	v.SetDefault("scanTimeout", 5*time.Minute)
 	v.SetDefault("scannerReadinessTimeout", 60*time.Second)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,16 @@ func TestLoadConfigShutdownTimeoutDefault(t *testing.T) {
 	assert.Equal(t, 20*time.Second, c.ShutdownTimeout)
 }
 
+// TestLoadConfigMaxQueueDepthDefault is a regression test for #748: maxQueueDepth must
+// default to 0 (unbounded), preserving the pre-existing behavior for anyone who doesn't
+// explicitly opt in to bounding the HTTP controller's admission queue.
+func TestLoadConfigMaxQueueDepthDefault(t *testing.T) {
+	viper.Reset()
+	c, err := LoadConfig("testdata")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, c.MaxQueueDepth)
+}
+
 func TestLoadConfigNotFound(t *testing.T) {
 	viper.Reset()
 	_, err := LoadConfig("testdataInvalid")

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -37,12 +37,14 @@ type HTTPController struct {
 	statusesOnce sync.Once
 
 	// maxQueueDepth bounds the number of scans tryAdmit will let through; see
-	// WithMaxQueueDepth. Zero (the default) means unbounded.
+	// WithMaxQueueDepth. Zero (the default) or a negative value means unbounded.
 	maxQueueDepth int
 	// pending counts scans currently accepted but not yet finished (queued or running),
 	// guarded against maxQueueDepth by tryAdmit/release below. Unused when maxQueueDepth
-	// is zero.
-	pending atomic.Int32
+	// is zero. int64, not int32: comparing against int64(h.maxQueueDepth) instead of
+	// narrowing maxQueueDepth into an int32 avoids the wraparound a large configured
+	// value would otherwise cause on a 64-bit build (int is 64 bits there).
+	pending atomic.Int64
 }
 
 // NewHTTPController initializes the HTTPController struct with the injected scanService
@@ -109,9 +111,10 @@ func (h *HTTPController) tryAdmit() bool {
 	if h.maxQueueDepth <= 0 {
 		return true
 	}
+	limit := int64(h.maxQueueDepth)
 	for {
 		current := h.pending.Load()
-		if current >= int32(h.maxQueueDepth) { // #nosec G115 -- maxQueueDepth is operator-configured, not attacker-controlled
+		if current >= limit {
 			return false
 		}
 		if h.pending.CompareAndSwap(current, current+1) {

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	wssc "github.com/armosec/armoapi-go/apis"
@@ -34,6 +35,14 @@ type HTTPController struct {
 	diagnostics  func(ctx context.Context) domain.Diagnostics
 	statuses     *scanStatusStore
 	statusesOnce sync.Once
+
+	// maxQueueDepth bounds the number of scans tryAdmit will let through; see
+	// WithMaxQueueDepth. Zero (the default) means unbounded.
+	maxQueueDepth int
+	// pending counts scans currently accepted but not yet finished (queued or running),
+	// guarded against maxQueueDepth by tryAdmit/release below. Unused when maxQueueDepth
+	// is zero.
+	pending atomic.Int32
 }
 
 // NewHTTPController initializes the HTTPController struct with the injected scanService
@@ -73,6 +82,70 @@ func (h *HTTPController) WithMetrics(m *metrics.Metrics) (*HTTPController, error
 func (h *HTTPController) WithDiagnostics(f func(ctx context.Context) domain.Diagnostics) *HTTPController {
 	h.diagnostics = f
 	return h
+}
+
+// WithMaxQueueDepth bounds the number of scans this controller will accept but not yet
+// finish (queued or running) to n. workerpool.Submit never blocks and its waiting queue is
+// unbounded regardless of scanConcurrency, so without an admission check here a sustained
+// burst of requests grows the backlog -- and the registry credentials each queued job's
+// closure holds onto -- without limit (see #748). Once at capacity, new scan requests are
+// rejected with a 503 (domain.ErrQueueFull) instead of being queued.
+//
+// n <= 0, including never calling this (the struct's zero value), means unbounded, preserving
+// the pre-existing behavior for anyone who doesn't opt in.
+func (h *HTTPController) WithMaxQueueDepth(n int) *HTTPController {
+	h.maxQueueDepth = n
+	return h
+}
+
+// tryAdmit atomically reserves one slot of the controller's admission budget, returning false
+// without side effects if maxQueueDepth is already reached. Every caller that receives true
+// owns exactly one matching release() call once that job's outcome (success or failure) is
+// recorded -- for GenerateSBOM/ScanCVE/ScanRegistry that's runTrackedScan's worker closure
+// returning; ScanCP's own copy of that closure does the same. Always true when maxQueueDepth
+// is unbounded (<= 0), which also skips touching pending, so the unbounded default carries no
+// extra synchronization cost over the pre-#748 behavior.
+func (h *HTTPController) tryAdmit() bool {
+	if h.maxQueueDepth <= 0 {
+		return true
+	}
+	for {
+		current := h.pending.Load()
+		if current >= int32(h.maxQueueDepth) { // #nosec G115 -- maxQueueDepth is operator-configured, not attacker-controlled
+			return false
+		}
+		if h.pending.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+// release returns one slot of admission budget reserved by a prior successful tryAdmit call.
+// A no-op when maxQueueDepth is unbounded, matching tryAdmit never having reserved anything in
+// that case.
+func (h *HTTPController) release() {
+	if h.maxQueueDepth <= 0 {
+		return
+	}
+	h.pending.Add(-1)
+}
+
+// admitQueueSlot reserves one slot of admission budget for endpoint via tryAdmit. If the
+// controller is at capacity, it writes the 503/ErrQueueFull rejection response to c itself
+// (mirroring the ErrTooManyRequests handling each handler already does for its own validation
+// errors) and returns false; the caller must stop processing the request without reserving a
+// slot. On true, the caller owns exactly one release() call once the accepted job's outcome is
+// recorded.
+func (h *HTTPController) admitQueueSlot(c *gin.Context, ctx context.Context, endpoint string, details problem.Option) bool {
+	if h.tryAdmit() {
+		return true
+	}
+	logger.L().Ctx(ctx).Warning("rejecting scan, queue is full",
+		helpers.String("endpoint", endpoint),
+		helpers.Int("maxQueueDepth", h.maxQueueDepth))
+	h.recordRejection(ctx, endpoint, domain.ErrQueueFull)
+	_, _ = problem.Of(validationStatusCode(domain.ErrQueueFull)).Append(details).WriteTo(c.Writer)
+	return false
 }
 
 func (h *HTTPController) ensureStatuses() *scanStatusStore {
@@ -127,16 +200,20 @@ func scanFailureReason(outcome string, err error) string {
 }
 
 // recordRejection records a validation-time rejection for the given endpoint. reason is
-// "too_many_requests" for registry back-pressure (ErrTooManyRequests) and "invalid_request"
-// for every other validation error, keeping the rejection-rate signal distinct from
-// malformed-payload noise while staying low cardinality.
+// "too_many_requests" for registry back-pressure (ErrTooManyRequests), "queue_full" for local
+// admission control (ErrQueueFull, see WithMaxQueueDepth), and "invalid_request" for every
+// other validation error, keeping the rejection-rate signal distinct from malformed-payload
+// noise while staying low cardinality.
 func (h *HTTPController) recordRejection(ctx context.Context, endpoint string, err error) {
 	if h.metrics == nil {
 		return
 	}
 	reason := "invalid_request"
-	if errors.Is(err, domain.ErrTooManyRequests) {
+	switch {
+	case errors.Is(err, domain.ErrTooManyRequests):
 		reason = "too_many_requests"
+	case errors.Is(err, domain.ErrQueueFull):
+		reason = "queue_full"
 	}
 	h.metrics.RejectCounter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("endpoint", endpoint),
@@ -171,6 +248,10 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 		return
 	}
 
+	if !h.admitQueueSlot(c, ctx, "generateSBOM", details) {
+		return
+	}
+
 	h.ensureStatuses().recordAccepted(newScan.JobID, "generateSBOM")
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
@@ -192,8 +273,13 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 // ScanCP keeps its own copy: ErrPartialContainerProfile is a third outcome there, recorded
 // as "partial" for the metric while still marking the job succeeded, and it has no
 // equivalent in the other three.
+//
+// Called only once the caller has already reserved a slot via admitQueueSlot, so the
+// submitted closure owns exactly one matching release() call; deferred first so it still
+// fires on the claimTrackedJob early return below.
 func (h *HTTPController) runTrackedScan(bgCtx context.Context, jobID, endpoint string, scan func(context.Context) error, errMsg string, errDetails ...helpers.IDetails) {
 	h.workerPool.Submit(func() {
+		defer h.release()
 		if !h.claimTrackedJob(jobID) {
 			return
 		}
@@ -278,6 +364,10 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 		return
 	}
 
+	if !h.admitQueueSlot(c, ctx, "scanCP", details) {
+		return
+	}
+
 	h.ensureStatuses().recordAccepted(newScan.JobID, "scanCP")
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
@@ -285,6 +375,7 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
 	h.workerPool.Submit(func() {
+		defer h.release()
 		if !h.claimTrackedJob(newScan.JobID) {
 			return
 		}
@@ -340,6 +431,10 @@ func (h *HTTPController) ScanCVE(c *gin.Context) {
 		return
 	}
 
+	if !h.admitQueueSlot(c, ctx, "scanCVE", details) {
+		return
+	}
+
 	h.ensureStatuses().recordAccepted(newScan.JobID, "scanCVE")
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
@@ -354,12 +449,17 @@ func (h *HTTPController) ScanCVE(c *gin.Context) {
 		helpers.String("imageHash", newScan.ImageHash))
 }
 
-// validationStatusCode maps a validation error to the HTTP status code that best
-// describes it. ErrTooManyRequests reflects transient registry back-pressure, not
-// a malformed request, so it maps to 429 rather than 400.
+// validationStatusCode maps a validation/admission error to the HTTP status code that best
+// describes it. ErrTooManyRequests reflects transient registry back-pressure caused by the
+// caller's own request, so it maps to 429; ErrQueueFull reflects the controller's own local
+// capacity, not anything wrong with the request, so it maps to 503 rather than either 429 or
+// 400 -- a retry against the same instance may well succeed once the backlog drains.
 func validationStatusCode(err error) int {
-	if errors.Is(err, domain.ErrTooManyRequests) {
+	switch {
+	case errors.Is(err, domain.ErrTooManyRequests):
 		return http.StatusTooManyRequests
+	case errors.Is(err, domain.ErrQueueFull):
+		return http.StatusServiceUnavailable
 	}
 	return http.StatusBadRequest
 }
@@ -417,6 +517,10 @@ func (h *HTTPController) ScanRegistry(c *gin.Context) {
 			helpers.String("imageHash", newScan.ImageHash))
 		h.recordRejection(ctx, "scanRegistry", err)
 		_, _ = problem.Of(validationStatusCode(err)).Append(details).WriteTo(c.Writer)
+		return
+	}
+
+	if !h.admitQueueSlot(c, ctx, "scanRegistry", details) {
 		return
 	}
 

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -558,6 +560,7 @@ func TestHTTPController_GenerateSBOM_EmptyJobIDStillRuns(t *testing.T) {
 
 func TestValidationStatusCode(t *testing.T) {
 	assert.Equal(t, http.StatusTooManyRequests, validationStatusCode(domain.ErrTooManyRequests))
+	assert.Equal(t, http.StatusServiceUnavailable, validationStatusCode(domain.ErrQueueFull))
 	assert.Equal(t, http.StatusBadRequest, validationStatusCode(domain.ErrMissingCpInfo))
 	assert.Equal(t, http.StatusBadRequest, validationStatusCode(domain.ErrMockError))
 }
@@ -1068,4 +1071,201 @@ func TestHTTPController_NoValueReceiverMethods(t *testing.T) {
 		offenders = append(offenders, valueType.Method(i).Name)
 	}
 	assert.Empty(t, offenders, "these take a value receiver and so copy the sync.Once: %v", offenders)
+}
+
+// TestHTTPController_TryAdmitRelease exercises tryAdmit/release directly (regression
+// coverage for #748: workerpool.Submit never blocks and its queue is otherwise unbounded, so
+// this pair is the only thing standing between a request burst and unbounded memory growth).
+func TestHTTPController_TryAdmitRelease(t *testing.T) {
+	t.Run("unbounded by default", func(t *testing.T) {
+		h := &HTTPController{}
+		for range 1000 {
+			require.True(t, h.tryAdmit())
+		}
+		// release is a no-op when unbounded: it must not panic or drive pending negative.
+		h.release()
+		assert.EqualValues(t, 0, h.pending.Load())
+	})
+
+	t.Run("bounded rejects at capacity and admits again after release", func(t *testing.T) {
+		h := (&HTTPController{}).WithMaxQueueDepth(2)
+
+		require.True(t, h.tryAdmit())
+		require.True(t, h.tryAdmit())
+		assert.False(t, h.tryAdmit(), "a third admission must be rejected once at capacity")
+		assert.EqualValues(t, 2, h.pending.Load())
+
+		h.release()
+		assert.EqualValues(t, 1, h.pending.Load())
+		assert.True(t, h.tryAdmit(), "a slot freed by release must be admittable again")
+		assert.EqualValues(t, 2, h.pending.Load())
+	})
+
+	t.Run("non-positive depth means unbounded", func(t *testing.T) {
+		for _, depth := range []int{0, -1} {
+			h := (&HTTPController{}).WithMaxQueueDepth(depth)
+			for range 100 {
+				require.True(t, h.tryAdmit(), "depth=%d", depth)
+			}
+		}
+	})
+}
+
+// TestHTTPController_TryAdmitNoOvershootUnderConcurrency proves the CAS loop in tryAdmit
+// admits exactly maxQueueDepth callers when many race it at once, not more (an unguarded
+// check-then-act against pending could overshoot) and not fewer (a buggy CAS could starve a
+// caller that should have been admitted).
+func TestHTTPController_TryAdmitNoOvershootUnderConcurrency(t *testing.T) {
+	const depth = 10
+	const racers = 200
+
+	h := (&HTTPController{}).WithMaxQueueDepth(depth)
+
+	var admitted atomic.Int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(racers)
+	for range racers {
+		go func() {
+			defer wg.Done()
+			<-start
+			if h.tryAdmit() {
+				admitted.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.EqualValues(t, depth, admitted.Load())
+	assert.EqualValues(t, depth, h.pending.Load())
+}
+
+// TestHTTPController_GenerateSBOM_QueueFull is the HTTP-level regression test for #748:
+// once the controller is at its configured maxQueueDepth, a new scan request must be
+// rejected with 503/ErrQueueFull instead of being queued, and a slot freed by a finished
+// job must be usable by the next request.
+func TestHTTPController_GenerateSBOM_QueueFull(t *testing.T) {
+	c := (&HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	}).WithMaxQueueDepth(1)
+	defer c.Shutdown(2 * time.Second)
+
+	// Simulate one job already occupying the controller's only admission slot -- the same
+	// state a real in-flight scan would leave pending in, without needing to synchronize
+	// against a background goroutine.
+	require.True(t, c.tryAdmit())
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+
+	file, err := os.Open("../api/v1/testdata/scan.yaml")
+	require.NoError(t, err)
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", file)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code, w.Body.String())
+
+	// Freeing the slot must let the next request through.
+	c.release()
+
+	file2, err := os.Open("../api/v1/testdata/scan.yaml")
+	require.NoError(t, err)
+	req2, _ := http.NewRequest("POST", "/v1/generateSBOM", file2)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+}
+
+// TestHTTPController_ScanCP_QueueFull mirrors TestHTTPController_GenerateSBOM_QueueFull for
+// ScanCP, which submits to the worker pool via its own closure rather than runTrackedScan
+// (see runTrackedScan's doc comment) and so needs its own regression coverage that it
+// respects admission control the same way.
+func TestHTTPController_ScanCP_QueueFull(t *testing.T) {
+	c := (&HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	}).WithMaxQueueDepth(1)
+	defer c.Shutdown(2 * time.Second)
+
+	require.True(t, c.tryAdmit())
+
+	router := gin.Default()
+	router.POST("/v1/scanCP", c.ScanCP)
+
+	req, _ := http.NewRequest("POST", "/v1/scanCP", strings.NewReader(`{
+		"wlid": "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy",
+		"args": {"name": "daemonset-kube-proxy", "namespace": "kube-system"}
+	}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code, w.Body.String())
+}
+
+// TestHTTPController_MaxQueueDepth_ReleasesSlotAfterScanCompletes is an end-to-end regression
+// test that runTrackedScan's deferred release() actually fires once a real (non-simulated)
+// tracked scan finishes, not just that tryAdmit/release are individually correct.
+func TestHTTPController_MaxQueueDepth_ReleasesSlotAfterScanCompletes(t *testing.T) {
+	spy := &contextSpyScanService{generateSBOMCh: make(chan struct{})}
+	c := (&HTTPController{
+		scanService: spy,
+		workerPool:  workerpool.New(1),
+	}).WithMaxQueueDepth(1)
+	defer c.Shutdown(2 * time.Second)
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"jobID": "job-1"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	select {
+	case <-spy.generateSBOMCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("GenerateSBOM worker was not executed in time")
+	}
+
+	require.Eventually(t, func() bool { return c.pending.Load() == 0 }, time.Second, 5*time.Millisecond,
+		"pending should drop back to 0 once the tracked scan's closure finishes")
+}
+
+// TestHTTPController_MetricsEndpoint_RecordsQueueFullRejection mirrors
+// TestHTTPController_MetricsEndpoint_RecordsRejection for the queue_full rejection reason,
+// proving it's recorded distinctly from too_many_requests/invalid_request rather than
+// conflated with either.
+func TestHTTPController_MetricsEndpoint_RecordsQueueFullRejection(t *testing.T) {
+	c := (&HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	}).WithMaxQueueDepth(1)
+	require.True(t, c.tryAdmit())
+
+	m, err := metrics.New()
+	require.NoError(t, err)
+	c, err = c.WithMetrics(m)
+	require.NoError(t, err)
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+	router.GET("/metrics", gin.WrapH(m.Handler()))
+
+	file, err := os.Open("../api/v1/testdata/scan.yaml")
+	require.NoError(t, err)
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", file)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, w.Body.String())
+
+	req, _ = http.NewRequest("GET", "/metrics", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, `kubevuln_scan_rejections_total{endpoint="generateSBOM",reason="queue_full"} 1`), body)
+	assert.False(t, strings.Contains(body, `reason="too_many_requests"`), body)
+	assert.False(t, strings.Contains(body, `reason="invalid_request"`), body)
 }

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1108,6 +1109,16 @@ func TestHTTPController_TryAdmitRelease(t *testing.T) {
 				require.True(t, h.tryAdmit(), "depth=%d", depth)
 			}
 		}
+	})
+
+	// A depth above math.MaxInt32 must not be admittable at all: an int32-narrowed limit
+	// wraps negative, so an unguarded comparison would make every admission attempt read
+	// pending (0) as already past the limit and reject unconditionally, on a 64-bit build
+	// where int is 64 bits.
+	t.Run("depth above math.MaxInt32 does not wrap and still admits", func(t *testing.T) {
+		h := (&HTTPController{}).WithMaxQueueDepth(math.MaxInt32 + 1)
+		require.True(t, h.tryAdmit(), "a depth above math.MaxInt32 must still admit, not wrap negative and reject everything")
+		assert.EqualValues(t, 1, h.pending.Load())
 	})
 }
 

--- a/core/domain/scan.go
+++ b/core/domain/scan.go
@@ -36,6 +36,10 @@ var (
 	ErrCastingWorkload          = errors.New("casting workload")
 	ErrMockError                = errors.New("mock error")
 	ErrTooManyRequests          = errors.New("too many requests")
+	// ErrQueueFull indicates the HTTP controller's worker pool is already holding
+	// maxQueueDepth accepted-but-unfinished scans and cannot admit another one. See
+	// HTTPController.WithMaxQueueDepth (controllers/http.go).
+	ErrQueueFull = errors.New("scan queue is full")
 	// ErrExceptionsDegraded indicates the SecurityException set is incomplete
 	// (e.g. the CRD list failed). Callers must not treat missing exceptions as
 	// deletions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,6 +73,7 @@ Kubevuln follows the hexagonal architecture pattern to achieve:
 |----------|-----------|
 | Async processing | Scan requests return immediately; work is queued |
 | Worker pool | Prevents resource exhaustion with concurrent scans |
+| Queue admission control | `maxQueueDepth` (default unbounded) rejects new scans with `503` once too many are queued/running, instead of growing the backlog without limit |
 | Graceful shutdown | Abandons queued scans and waits for in-flight scans to complete, bounded by `shutdownTimeout` |
 | Modular adapters | Easy to upgrade Syft/Grype versions |
 | Interface-driven | All external dependencies accessed via ports |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -169,6 +169,7 @@ The main configuration file. All options can be overridden via environment varia
 | `maxImageSize` | int | `536870912` | Maximum image size to scan in bytes (default: 512 MB) |
 | `maxSBOMSize` | int | `20971520` | Maximum SBOM size in bytes (default: 20 MB). Enforced after SBOM generation completes, not during it — Syft doesn't expose an incremental size hook, so an oversized SBOM is rejected only once it has already been built in memory. During generation, actual memory use is bounded by the memory limit of whichever container runs Syft, not by this value: the `sbom-scanner` sidecar container when `SBOM_SCANNER_SOCKET` is configured, or the main kubevuln container otherwise (in-process `SyftAdapter`). The scanner protocol carries this limit as a 32-bit value, so when the sidecar is in use a configured limit above `2147483647` (2 GiB) is clamped to that maximum and a warning is logged. The in-process adapter has no such ceiling. |
 | `scanConcurrency` | int | `1` | Number of concurrent scans |
+| `maxQueueDepth` | int | `0` | Maximum number of scans accepted but not yet finished (queued or running) that the HTTP controller will hold at once. `0` means unbounded, matching the pre-existing behavior: `workerpool.Submit` never blocks, so without this a sustained burst of requests past `scanConcurrency` grows the backlog — and the registry credentials each queued job holds onto — without limit. Once set and reached, new scan requests are rejected with `503` instead of being queued, so a caller handling that status can retry later rather than assuming the scan is in flight. This counts total pending scans (queued + running), which differs from the `kubevuln_worker_pool_queue_depth` metric (queued only, via the worker pool's own `WaitingQueueSize()`) — a scan can count against this limit while that gauge reads `0`. |
 | `scanTimeout` | duration | `5m` | Timeout for SBOM generation. The scanner protocol carries this as whole seconds, so when the `sbom-scanner` sidecar is in use a sub-second value is rounded up to `1s` and any fractional part is rounded up to the next second. The in-process `SyftAdapter` applies the value exactly. |
 | `scanEmbeddedSBOMs` | bool | `false` | Scan for embedded SBOMs in images |
 | `scannerReadinessTimeout` | duration | `60s` | Maximum time to wait for the SBOM scanner sidecar to become ready at startup. A value of `0` or less does not mean "wait forever": it makes the readiness deadline expire immediately, causing startup to fall back to the built-in Syft scanner right away. |
@@ -234,6 +235,11 @@ The main configuration file. All options can be overridden via environment varia
     "maxImageSize": {
       "type": "integer",
       "default": 536870912
+    },
+    "maxQueueDepth": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0
     },
     "maxSBOMSize": {
       "type": "integer",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -169,7 +169,7 @@ The main configuration file. All options can be overridden via environment varia
 | `maxImageSize` | int | `536870912` | Maximum image size to scan in bytes (default: 512 MB) |
 | `maxSBOMSize` | int | `20971520` | Maximum SBOM size in bytes (default: 20 MB). Enforced after SBOM generation completes, not during it — Syft doesn't expose an incremental size hook, so an oversized SBOM is rejected only once it has already been built in memory. During generation, actual memory use is bounded by the memory limit of whichever container runs Syft, not by this value: the `sbom-scanner` sidecar container when `SBOM_SCANNER_SOCKET` is configured, or the main kubevuln container otherwise (in-process `SyftAdapter`). The scanner protocol carries this limit as a 32-bit value, so when the sidecar is in use a configured limit above `2147483647` (2 GiB) is clamped to that maximum and a warning is logged. The in-process adapter has no such ceiling. |
 | `scanConcurrency` | int | `1` | Number of concurrent scans |
-| `maxQueueDepth` | int | `0` | Maximum number of scans accepted but not yet finished (queued or running) that the HTTP controller will hold at once. `0` means unbounded, matching the pre-existing behavior: `workerpool.Submit` never blocks, so without this a sustained burst of requests past `scanConcurrency` grows the backlog — and the registry credentials each queued job holds onto — without limit. Once set and reached, new scan requests are rejected with `503` instead of being queued, so a caller handling that status can retry later rather than assuming the scan is in flight. This counts total pending scans (queued + running), which differs from the `kubevuln_worker_pool_queue_depth` metric (queued only, via the worker pool's own `WaitingQueueSize()`) — a scan can count against this limit while that gauge reads `0`. |
+| `maxQueueDepth` | int | `0` | Maximum number of scans accepted but not yet finished (queued or running) that the HTTP controller will hold at once. `0` or a negative value means unbounded, matching the pre-existing behavior: `workerpool.Submit` never blocks, so without this a sustained burst of requests past `scanConcurrency` grows the backlog — and the registry credentials each queued job holds onto — without limit. Once set to a positive value and reached, new scan requests are rejected with `503` instead of being queued, so a caller handling that status can retry later rather than assuming the scan is in flight. This counts total pending scans (queued + running), which differs from the `kubevuln_worker_pool_queue_depth` metric (queued only, via the worker pool's own `WaitingQueueSize()`) — a scan can count against this limit while that gauge reads `0`. |
 | `scanTimeout` | duration | `5m` | Timeout for SBOM generation. The scanner protocol carries this as whole seconds, so when the `sbom-scanner` sidecar is in use a sub-second value is rounded up to `1s` and any fractional part is rounded up to the next second. The in-process `SyftAdapter` applies the value exactly. |
 | `scanEmbeddedSBOMs` | bool | `false` | Scan for embedded SBOMs in images |
 | `scannerReadinessTimeout` | duration | `60s` | Maximum time to wait for the SBOM scanner sidecar to become ready at startup. A value of `0` or less does not mean "wait forever": it makes the readiness deadline expire immediately, causing startup to fall back to the built-in Syft scanner right away. |
@@ -238,8 +238,7 @@ The main configuration file. All options can be overridden via environment varia
     },
     "maxQueueDepth": {
       "type": "integer",
-      "default": 0,
-      "minimum": 0
+      "default": 0
     },
     "maxSBOMSize": {
       "type": "integer",


### PR DESCRIPTION
## Overview

**Problem:** every scan handler (`GenerateSBOM`/`ScanCP`/`ScanCVE`/`ScanRegistry`) validates a request, writes `200 OK`, and hands the work to `HTTPController.workerPool` via `Submit(...)`. `gammazero/workerpool`'s `Submit` never blocks and its waiting queue is unbounded regardless of `scanConcurrency` (default `1`) — confirmed directly from the vendored library source, not inferred. Under a sustained burst of requests, accepted-but-not-started jobs pile up without limit, each one holding a closure over the full `domain.ScanCommand`, including registry pull credentials, for as long as it waits.

**Root cause:** `workerpool.New(concurrency)` bounds concurrent *workers*, not the *queue* behind them, and nothing in the request path enforced any limit before this change — admission control (whether to accept a job at all) had never been implemented.

**Solution:** an opt-in `maxQueueDepth` config option (default `0` = unbounded, so this ships with no behavior change for anyone who doesn't set it). Once the controller is holding `maxQueueDepth` accepted-but-unfinished scans (queued + running), a new request is rejected with `503`/`ErrQueueFull` *before* it is queued, instead of joining an unbounded backlog. The rejection reuses the same machinery `ErrTooManyRequests` already goes through (`recordRejection`, `RejectCounter`, `validationStatusCode`), so it shows up in the existing `kubevuln_scan_rejections_total` metric under a new `queue_full` reason, distinct from `too_many_requests`/`invalid_request`.

Admission is tracked with a small CAS-guarded counter (`tryAdmit`/`release`) that is independent of the worker pool's own internal queue, so the same check applies uniformly across all four scan endpoints — including `ScanCP`, which submits to the pool via its own closure rather than the shared `runTrackedScan` helper the other three use.

This resolves the follow-up decision #499 asked for (deferred out of #468/#467's scope at the time) and that #748 re-raised with current evidence after #499 was closed without an implementing change.

## How to Test

```
go build ./...
go vet ./...
golangci-lint run --timeout=10m --new-from-rev="$(git merge-base HEAD upstream/main)"
go test ./...
```

New regression coverage added in `controllers/http_test.go`:
- `TestHTTPController_TryAdmitRelease` — unbounded default, bounded reject-at-capacity, release freeing a slot, and non-positive depth meaning unbounded.
- `TestHTTPController_TryAdmitNoOvershootUnderConcurrency` — 200 goroutines racing a depth-10 budget admit exactly 10, proving the CAS loop doesn't overshoot or starve.
- `TestHTTPController_GenerateSBOM_QueueFull` / `TestHTTPController_ScanCP_QueueFull` — HTTP-level: a full queue returns `503` for both submission paths, and a freed slot is usable by the next request.
- `TestHTTPController_MaxQueueDepth_ReleasesSlotAfterScanCompletes` — end-to-end: a real tracked scan's `runTrackedScan` closure actually calls the deferred `release()` once it finishes, not just that `tryAdmit`/`release` are correct in isolation.
- `TestHTTPController_MetricsEndpoint_RecordsQueueFullRejection` — the `queue_full` reason is recorded distinctly from the other two rejection reasons.
- `TestValidationStatusCode` extended for `ErrQueueFull` → `503`.
- `config.TestLoadConfigMaxQueueDepthDefault` — default is `0`.

All of the above pass locally. The full `go test ./...` run also shows two failures in `adapters/v1` (`Test_syftAdapter_CreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft`, `Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout`); this branch does not touch `adapters/` at all, and both pass individually when re-run in isolation — they're pre-existing, timing-sensitive tests that flake under full-suite load on this machine (Windows file-locking noise visible in their output), not a regression from this change.

## Related issues/PRs:

* Resolved #748
* Follow-up to #499, #467, #468

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for queued and running scans.
  * Requests exceeding the configured queue capacity now receive HTTP 503 responses.
  * Added queue-full metrics to distinguish capacity-based rejections.

* **Documentation**
  * Documented the `maxQueueDepth` setting, including its unbounded default and configuration schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->