### PR TITLE
fix(adapters): stop metadata-only history entries claiming a layer's order

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -347,6 +347,11 @@ func syftCoordinatesToCoordinates(c []v1beta1.SyftCoordinates) []containerscan.C
 
 }
 
+// metadataOnlyLayerOrder marks a history entry that produced no layer (ENV, LABEL, CMD and
+// the like). Real layers are numbered from zero, so there is no in-range value that means
+// "not a layer"; a negative one says so without colliding with any of them.
+const metadataOnlyLayerOrder = -1
+
 func ParseImageManifest(grypeDocument *v1beta1.GrypeDocument) (*containerscan.ImageManifest, error) {
 	if grypeDocument == nil || grypeDocument.Source == nil {
 		return nil, fmt.Errorf("empty grype document")
@@ -376,13 +381,22 @@ func ParseImageManifest(grypeDocument *v1beta1.GrypeDocument) (*containerscan.Im
 	// etc.) that don't produce a layer; counting those too, as the raw loop index would,
 	// gives every real layer a different LayerOrder here than in the vulnerability report
 	// for the same layer hash, breaking any lookup that correlates the two by LayerOrder.
+	// A metadata-only entry has no layer, so it gets metadataOnlyLayerOrder rather than a
+	// real one. Stamping it with layerIndex, as this used to, handed it the order of the
+	// next real layer, which is the one thing LayerOrder must not do: on the nginx image
+	// six ENV/LABEL/CMD entries and the RUN layer they precede all came out as order 1, so
+	// the lookup this exists to serve returned seven entries for one layer.
 	layerIndex := 0
 	for _, historyLayer := range config.History {
+		order := metadataOnlyLayerOrder
+		if !historyLayer.EmptyLayer {
+			order = layerIndex
+		}
 		layerInfo := containerscan.ESLayer{
 			LayerInfo: &containerscan.LayerInfo{
 				CreatedBy:   historyLayer.CreatedBy,
 				CreatedTime: &historyLayer.Created.Time,
-				LayerOrder:  layerIndex,
+				LayerOrder:  order,
 			},
 		}
 		if !historyLayer.EmptyLayer && layerIndex < len(rawManifest.Layers) {

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -420,3 +420,46 @@ func Test_domainToArmo_introducedInLayer(t *testing.T) {
 		})
 	}
 }
+
+// LayerOrder is what correlates a vulnerability, which carries the order parseLayersPayload
+// assigned, with the layer in the manifest that produced it. That only works if one order
+// names one layer. Metadata-only history entries used to be stamped with layerIndex, which
+// is the order of the next real layer, so on nginx six ENV/LABEL/CMD entries and the RUN
+// layer after them all came out as order 1.
+func TestParseImageManifest_LayerOrderNamesOneLayer(t *testing.T) {
+	rawConfig := []byte(`{
+	  "architecture":"amd64","os":"linux",
+	  "rootfs":{"type":"layers","diff_ids":[
+	    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]},
+	  "history":[
+	    {"created":"2024-01-01T00:00:00Z","created_by":"ADD file"},
+	    {"created":"2024-01-01T00:00:01Z","created_by":"ENV x=1","empty_layer":true},
+	    {"created":"2024-01-01T00:00:02Z","created_by":"CMD [\"sh\"]","empty_layer":true},
+	    {"created":"2024-01-01T00:00:03Z","created_by":"RUN apk add"}]
+	}`)
+	target, err := json.Marshal(source.ImageMetadata{
+		RawConfig: rawConfig,
+		Layers: []source.LayerMetadata{
+			{Digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111", Size: 100},
+			{Digest: "sha256:2222222222222222222222222222222222222222222222222222222222222222", Size: 200},
+		},
+	})
+	require.NoError(t, err)
+
+	im, err := ParseImageManifest(&v1beta1.GrypeDocument{Source: &v1beta1.Source{Type: "image", Target: target}})
+	require.NoError(t, err)
+	require.Len(t, im.Layers, 4, "every history entry is still reported")
+
+	seen := map[int]int{}
+	for _, l := range im.Layers {
+		if l.LayerHash == "" {
+			assert.Equal(t, metadataOnlyLayerOrder, l.LayerInfo.LayerOrder,
+				"a metadata-only entry must not claim a layer's order")
+			continue
+		}
+		seen[l.LayerInfo.LayerOrder]++
+	}
+	assert.Equal(t, map[int]int{0: 1, 1: 1}, seen,
+		"each real layer holds its own order, numbered from zero")
+}

--- a/adapters/v1/testdata/nginx-image-manifest.json
+++ b/adapters/v1/testdata/nginx-image-manifest.json
@@ -15,42 +15,42 @@
       "parentLayerHash":"",
       "createdBy":"/bin/sh -c #(nop)  CMD [\"bash\"]",
       "createdTime":"2024-05-14T00:39:41.460424266Z",
-      "layerOrder":1
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"LABEL maintainer=NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":1
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NGINX_VERSION=1.27.0",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":1
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NJS_VERSION=0.8.4",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":1
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NJS_RELEASE=2~bookworm",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":1
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV PKG_RELEASE=2~bookworm",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":1
+      "layerOrder":-1
     },
     {
       "layerHash":"sha256:3a0cf035bbfcc7852c38d4d236673b6a0d9454e5f2621800814d1633e729ea20",
@@ -105,28 +105,28 @@
       "parentLayerHash":"",
       "createdBy":"ENTRYPOINT [\"/docker-entrypoint.sh\"]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":7
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"EXPOSE map[80/tcp:{}]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":7
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"STOPSIGNAL SIGQUIT",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":7
+      "layerOrder":-1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"CMD [\"nginx\" \"-g\" \"daemon off;\"]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":7
+      "layerOrder":-1
     }
   ]
 }


### PR DESCRIPTION
## Overview

`ParseImageManifest` stamped every history entry with `layerIndex`, the count of real layers seen so far. For an entry that produces no layer that is the order of the *next* real layer, so the entry and that layer come out holding the same one.

On the nginx fixture in this repo, six `ENV`/`LABEL`/`CMD` entries and the `RUN` layer following them are all order 1, and four more entries share order 7. `LayerOrder` is what correlates a vulnerability, carrying the order `parseLayersPayload` gave it, back to the layer that produced it, and the comment above the loop says exactly that, so looking up order 1 there returns seven entries.

Real layers are unchanged. An entry with no layer now gets `metadataOnlyLayerOrder`.

## Additional Information

the order is negative because there is no in-range value that can mean "not a layer". real layers are numbered from zero, so any non-negative sentinel collides with one of them.

every history entry is still reported, with its `CreatedBy` and `CreatedTime` as before. this changes only the number on the ones that are not layers, so nothing is dropped from the manifest.

the numbering of real layers was already right, 0 through 6 on nginx, matching `parseLayersPayload`. this does not touch it.

the golden file moves in exactly that shape: ten metadata rows go from a real layer's order to `-1`, and the seven real layers are untouched.

correction to an earlier version of this description: i had written that `parseLayersPayload` and `ParseImageManifest` key their hashes off different digests and so never intersect. that is wrong, and nothing in this change rests on it. stereoscope fills `LayerMetadata.Digest` from `layer.DiffID()` and documents it as "the sha256 digest of the layer contents (the docker \"diff id\")", so both sides are diff ids and they match. i had tested that claim with invented values instead of real ones. the duplicate orders were read off the fixture in this repo and are unaffected.

## How to Test

`go build ./... && go vet ./... && go test ./adapters/... ./core/... -count=1`

`TestParseImageManifest` still compares against `testdata/nginx-image-manifest.json` and passes with the updated golden file.

`TestParseImageManifest_LayerOrderNamesOneLayer` is new. it builds a config with two real layers and two metadata-only entries between them, then asserts all four entries are still reported, that each entry with no hash carries `metadataOnlyLayerOrder`, and that the real layers hold orders 0 and 1 once each.

putting the old `order := layerIndex` back fails both of them.

## Related issues/PRs:

* Resolved #751
