### PR TITLE
fix(registryauth): bound the credential cache with a size-capped LRU

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/google/go-containerregistry v0.21.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kinbiko/jsonassert v1.2.0
 	github.com/kubescape/backend v0.0.40
 	github.com/kubescape/go-logger v0.0.33
@@ -259,7 +260,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.8.6 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect

--- a/internal/registryauth/cache.go
+++ b/internal/registryauth/cache.go
@@ -2,6 +2,7 @@ package registryauth
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
@@ -47,8 +48,15 @@ type credentialFetch func(ctx context.Context) (*image.RegistryCredentials, time
 // HTTP controller's worker pool runs many scans in parallel) each fired their own upstream
 // request, risking cloud provider rate limiting. See #569.
 type credentialCache struct {
-	// entries is a size-bounded LRU, not a plain map: it is already safe for concurrent
-	// use, so entries no longer needs a mutex of its own the way a map would.
+	// mu guards the compound operations below, not individual entries calls: lru.Cache is
+	// already safe for a single Get/Add/Remove call on its own, but lookup's
+	// read-expiry-then-remove and get's re-check-then-add are each a check-then-act
+	// sequence across two separate calls into it, and lru.Cache exposes no compare-and-
+	// delete or compare-and-add to make either one atomic by itself. Without mu, one
+	// goroutine's expiry-driven Remove can race a concurrent refresh's Add for the same
+	// key and delete the fresh entry the refresh just cached instead of the stale one it
+	// observed. See #753 review.
+	mu       sync.Mutex
 	entries  *lru.Cache[string, cacheEntry]
 	group    singleflight.Group
 	strategy string
@@ -129,7 +137,9 @@ func (c *credentialCache) get(ctx context.Context, key string, fetch credentialF
 			return nil, ferr
 		}
 		if !expiry.IsZero() {
+			c.mu.Lock()
 			c.entries.Add(key, cacheEntry{creds: creds, expiry: expiry.Add(-expiryLeeway)})
+			c.mu.Unlock()
 		}
 		return creds, nil
 	})
@@ -154,6 +164,8 @@ func (c *credentialCache) get(ctx context.Context, key string, fetch credentialF
 }
 
 func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	entry, ok := c.entries.Get(key)
 	if !ok {
 		return nil, false
@@ -161,7 +173,11 @@ func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) 
 	if !c.now().Before(entry.expiry) {
 		// Remove it now instead of leaving it for the LRU to evict on its own schedule: a
 		// key that's looked up once and never again would otherwise sit in the cache,
-		// still occupying a slot, until capacity eventually forced it out.
+		// still occupying a slot, until capacity eventually forced it out. Removing it
+		// under the same mu critical section as the Get/expiry-check above -- rather than
+		// as a separate, later call -- is what keeps this atomic: a concurrent refresh's
+		// Add for this key can only happen entirely before this section starts or entirely
+		// after it ends, never in the middle of it.
 		c.entries.Remove(key)
 		return nil, false
 	}
@@ -172,5 +188,7 @@ func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) 
 // need the next Credentials() call to actually reach the override instead of a value
 // cached by an earlier test.
 func (c *credentialCache) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.entries.Purge()
 }

--- a/internal/registryauth/cache.go
+++ b/internal/registryauth/cache.go
@@ -2,10 +2,10 @@ package registryauth
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/kubescape/kubevuln/internal/metrics"
 	"golang.org/x/sync/singleflight"
 )
@@ -22,6 +22,17 @@ const expiryLeeway = 1 * time.Minute
 // the result -- for every other caller still waiting on it.
 const fetchTimeout = 30 * time.Second
 
+// maxCacheEntries bounds a credentialCache's size. The cache is keyed by registry host
+// (registryauth.go), and that key space is not a small, operator-controlled set: an ECR
+// hostname embeds a 12-digit account ID and region, and a GCR/Artifact Registry hostname is
+// only pattern-matched, not looked up against a known list. Both are read straight out of a
+// scanned workload's image reference, so without a cap, a fleet with many distinct
+// registries -- or a workload able to set its own image reference -- can grow the cache
+// without bound for the life of the process. Bounding it with an LRU also means an entry
+// that's never looked up again after it expires doesn't sit in the map forever: it ages out
+// under normal turnover instead of only being removed by the lazy check in lookup. See #750.
+const maxCacheEntries = 1024
+
 // credentialFetch is a provider's underlying fetch: it returns credentials plus the time
 // they stop being valid. A zero expiry means "no reported expiry" -- the credential is
 // still returned, but not cached, since there's nothing to bound the cache entry's
@@ -36,8 +47,9 @@ type credentialFetch func(ctx context.Context) (*image.RegistryCredentials, time
 // HTTP controller's worker pool runs many scans in parallel) each fired their own upstream
 // request, risking cloud provider rate limiting. See #569.
 type credentialCache struct {
-	mu       sync.Mutex
-	entries  map[string]cacheEntry
+	// entries is a size-bounded LRU, not a plain map: it is already safe for concurrent
+	// use, so entries no longer needs a mutex of its own the way a map would.
+	entries  *lru.Cache[string, cacheEntry]
 	group    singleflight.Group
 	strategy string
 	// now is overridable in tests so expiry can be exercised without a real time.Sleep.
@@ -61,7 +73,12 @@ type cacheEntry struct {
 }
 
 func newCredentialCache(strategy string) *credentialCache {
-	return &credentialCache{entries: map[string]cacheEntry{}, strategy: strategy, now: time.Now}
+	entries, err := lru.New[string, cacheEntry](maxCacheEntries)
+	if err != nil {
+		// lru.New only errors when size <= 0, and maxCacheEntries is a positive constant.
+		panic(err)
+	}
+	return &credentialCache{entries: entries, strategy: strategy, now: time.Now}
 }
 
 // get returns a cached, still-valid credential for key if one exists, otherwise calls
@@ -112,9 +129,7 @@ func (c *credentialCache) get(ctx context.Context, key string, fetch credentialF
 			return nil, ferr
 		}
 		if !expiry.IsZero() {
-			c.mu.Lock()
-			c.entries[key] = cacheEntry{creds: creds, expiry: expiry.Add(-expiryLeeway)}
-			c.mu.Unlock()
+			c.entries.Add(key, cacheEntry{creds: creds, expiry: expiry.Add(-expiryLeeway)})
 		}
 		return creds, nil
 	})
@@ -139,17 +154,15 @@ func (c *credentialCache) get(ctx context.Context, key string, fetch credentialF
 }
 
 func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	entry, ok := c.entries[key]
+	entry, ok := c.entries.Get(key)
 	if !ok {
 		return nil, false
 	}
 	if !c.now().Before(entry.expiry) {
-		// expired entries are never overwritten by get() until something asks for this
-		// key again, so without deleting here they'd sit in the map forever -- across
-		// however many distinct ECR/GCR hosts a cluster ever pulls from.
-		delete(c.entries, key)
+		// Remove it now instead of leaving it for the LRU to evict on its own schedule: a
+		// key that's looked up once and never again would otherwise sit in the cache,
+		// still occupying a slot, until capacity eventually forced it out.
+		c.entries.Remove(key)
 		return nil, false
 	}
 	return entry.creds, true
@@ -159,7 +172,5 @@ func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) 
 // need the next Credentials() call to actually reach the override instead of a value
 // cached by an earlier test.
 func (c *credentialCache) reset() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.entries = map[string]cacheEntry{}
+	c.entries.Purge()
 }

--- a/internal/registryauth/cache_test.go
+++ b/internal/registryauth/cache_test.go
@@ -226,6 +226,52 @@ func TestCredentialCache_BoundedSizeEvictsLeastRecentlyUsed(t *testing.T) {
 		"the least-recently-used key must have been evicted to make room, forcing a refetch")
 }
 
+// Before mu was reintroduced (review on #753), lookup's read-expiry-then-remove and get's
+// re-check-then-add were each a check-then-act sequence spanning two separate, individually
+// thread-safe calls into entries -- with nothing making either sequence atomic across
+// goroutines. A concurrent refresh's Add for a key could land between another caller's Get
+// and Remove for that same key, and get deleted along with the stale entry Remove actually
+// meant to evict. This stress-tests that exact interleaving many times over, with both
+// operations starting from the same barrier so the scheduler has every opportunity to
+// interleave them: a freshly cached credential must never be lost to a concurrent expiry
+// check that observed the key before it was refreshed.
+func TestCredentialCache_ExpiryRemovalDoesNotRaceConcurrentRefresh(t *testing.T) {
+	const iterations = 300
+
+	for i := 0; i < iterations; i++ {
+		c := newCredentialCache("test")
+		now := time.Now()
+		c.now = func() time.Time { return now }
+
+		// Seed an already-expired entry directly: the scenario under test is a caller
+		// finding an existing stale entry, not the fetch path that would have created it.
+		c.entries.Add("k", cacheEntry{creds: &image.RegistryCredentials{Password: "stale"}, expiry: now.Add(-time.Minute)})
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			c.lookup("k") // observes "k" expired and removes it
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := c.get(context.Background(), "k", func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+				return &image.RegistryCredentials{Password: "fresh"}, now.Add(time.Hour), nil
+			})
+			assert.NoError(t, err)
+		}()
+		close(start)
+		wg.Wait()
+
+		creds, ok := c.lookup("k")
+		require.True(t, ok, "iteration %d: a freshly cached credential must survive a concurrent expiry-driven removal of the stale entry it replaced", i)
+		assert.Equal(t, "fresh", creds.Password, "iteration %d", i)
+	}
+}
+
 // scrapeMetrics renders the current metric values in Prometheus text format.
 func scrapeMetrics(t *testing.T, m *metrics.Metrics) string {
 	t.Helper()

--- a/internal/registryauth/cache_test.go
+++ b/internal/registryauth/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -58,24 +59,6 @@ func TestCredentialCache_RefetchesAfterExpiry(t *testing.T) {
 	_, err = c.get(context.Background(), "k", fetch)
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "expired entry must be refetched")
-}
-
-func TestCredentialCache_ExpiredEntryIsEvicted(t *testing.T) {
-	c := newCredentialCache("test")
-	now := time.Now()
-	c.now = func() time.Time { return now }
-
-	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
-		return &image.RegistryCredentials{Password: "p"}, now.Add(time.Minute), nil
-	}
-	_, err := c.get(context.Background(), "k", fetch)
-	require.NoError(t, err)
-	assert.Len(t, c.entries, 1)
-
-	now = now.Add(time.Hour)
-	_, ok := c.lookup("k")
-	assert.False(t, ok)
-	assert.Empty(t, c.entries, "expired entry should be evicted from the map, not left behind")
 }
 
 func TestCredentialCache_DistinctKeysDoNotShareEntries(t *testing.T) {
@@ -185,6 +168,64 @@ func TestCredentialCache_Reset(t *testing.T) {
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "reset must force the next call to refetch")
 }
 
+// Before #750, lookup treated an expired entry as a miss but never removed it, so it sat in
+// the cache's backing map forever unless the exact same key happened to be looked up again.
+// This asserts the entry is actually gone, not merely shadowed by the expiry check.
+func TestCredentialCache_ExpiredEntryIsPurgedNotJustShadowed(t *testing.T) {
+	c := newCredentialCache("test")
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		return &image.RegistryCredentials{Password: "p"}, now.Add(10 * time.Minute), nil
+	}
+	_, err := c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	require.Equal(t, 1, c.entries.Len())
+
+	now = now.Add(time.Hour) // well past expiry
+	_, ok := c.lookup("k")
+	assert.False(t, ok)
+
+	assert.Equal(t, 0, c.entries.Len(),
+		"an expired entry must be removed on lookup, not left sitting in the cache")
+}
+
+// The cache is keyed by registry host, and that key space is not a small, operator-controlled
+// set (see maxCacheEntries' doc comment) -- so without a cap, a burst of distinct keys grows
+// the cache without bound. This asserts the cache stays bounded and evicts the
+// least-recently-used entry, rather than an arbitrary one, to make room.
+func TestCredentialCache_BoundedSizeEvictsLeastRecentlyUsed(t *testing.T) {
+	c := newCredentialCache("test")
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		return &image.RegistryCredentials{Password: "p"}, time.Now().Add(time.Hour), nil
+	}
+
+	for i := 0; i < maxCacheEntries; i++ {
+		_, err := c.get(context.Background(), strconv.Itoa(i), fetch)
+		require.NoError(t, err)
+	}
+	require.Equal(t, maxCacheEntries, c.entries.Len())
+
+	// Key "0" is now the least recently used entry: adding one more distinct key must evict
+	// it rather than growing the cache past its cap.
+	_, err := c.get(context.Background(), "overflow", fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, maxCacheEntries, c.entries.Len(),
+		"cache must stay bounded at its configured capacity")
+
+	var calls int32
+	countingFetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		atomic.AddInt32(&calls, 1)
+		return &image.RegistryCredentials{Password: "p2"}, time.Now().Add(time.Hour), nil
+	}
+	_, err = c.get(context.Background(), "0", countingFetch)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"the least-recently-used key must have been evicted to make room, forcing a refetch")
+}
+
 // scrapeMetrics renders the current metric values in Prometheus text format.
 func scrapeMetrics(t *testing.T, m *metrics.Metrics) string {
 	t.Helper()
@@ -255,9 +296,7 @@ func TestCredentialCache_RecheckInsideSingleflightRecordsHit(t *testing.T) {
 	// which is exactly the window in which another caller can populate the cache, and the
 	// only way the closure's re-check ever finds anything.
 	c.onMiss = func() {
-		c.mu.Lock()
-		c.entries["k"] = cacheEntry{creds: &image.RegistryCredentials{Password: "p"}, expiry: time.Now().Add(time.Hour)}
-		c.mu.Unlock()
+		c.entries.Add("k", cacheEntry{creds: &image.RegistryCredentials{Password: "p"}, expiry: time.Now().Add(time.Hour)})
 	}
 	var calls int32
 	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {

--- a/internal/registryauth/cache_test.go
+++ b/internal/registryauth/cache_test.go
@@ -207,9 +207,14 @@ func TestCredentialCache_BoundedSizeEvictsLeastRecentlyUsed(t *testing.T) {
 	}
 	require.Equal(t, maxCacheEntries, c.entries.Len())
 
-	// Key "0" is now the least recently used entry: adding one more distinct key must evict
-	// it rather than growing the cache past its cap.
-	_, err := c.get(context.Background(), "overflow", fetch)
+	// Re-access key "0" (a cache hit, not a fetch) before overflowing, making key "1" --
+	// not "0" -- the least recently used entry despite "0" still being the oldest by
+	// insertion order. A plain FIFO cache would evict "0" here; only a true LRU evicts "1"
+	// instead, so this is what actually distinguishes the two.
+	_, err := c.get(context.Background(), "0", fetch)
+	require.NoError(t, err)
+
+	_, err = c.get(context.Background(), "overflow", fetch)
 	require.NoError(t, err)
 
 	assert.Equal(t, maxCacheEntries, c.entries.Len(),
@@ -220,7 +225,15 @@ func TestCredentialCache_BoundedSizeEvictsLeastRecentlyUsed(t *testing.T) {
 		atomic.AddInt32(&calls, 1)
 		return &image.RegistryCredentials{Password: "p2"}, time.Now().Add(time.Hour), nil
 	}
+
+	// "0" was re-accessed above, so it must still be cached: no refetch.
 	_, err = c.get(context.Background(), "0", countingFetch)
+	require.NoError(t, err)
+	assert.Zero(t, atomic.LoadInt32(&calls),
+		"key \"0\" was touched after the others and must not have been evicted")
+
+	// "1" is now the true least-recently-used key and must have been evicted instead.
+	_, err = c.get(context.Background(), "1", countingFetch)
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
 		"the least-recently-used key must have been evicted to make room, forcing a refetch")


### PR DESCRIPTION
Fixes #750

## Problem
`credentialCache` (`internal/registryauth/cache.go`) never removed an entry once it was written. `lookup` treated an expired entry as a cache miss but left it sitting in the map, and the only write path (inside `get`'s singleflight closure) only ever added. Nothing ever shrank it.

Both provider caches built on it key by registry host, which is not a small, operator-controlled set: an ECR hostname embeds a 12-digit account ID and region, and a GCR/Artifact Registry hostname is only pattern-matched. Both are read straight out of a scanned workload's image reference, so the key space — and therefore the cache — could grow without bound for the life of a long-running, privileged, cluster-wide process.

## Root cause
- `lookup` (`cache.go`) checked `now().Before(entry.expiry)` and returned "not found" for an expired entry, but never called `delete` on it.
- The only code that ever cleared the map (`reset`) was test-only.
- No size cap existed at all.

## Fix
Replaced the raw `map[string]cacheEntry` with a size-capped LRU (`hashicorp/golang-lru/v2`, already an indirect dependency of this repo — now promoted to direct):
- `lookup` now actively removes an entry it finds expired, instead of leaving it for the LRU to age out on its own schedule.
- The LRU caps `entries` at 1024 and evicts the least-recently-used entry once full, so a burst of distinct keys — adversarial or organic — can't grow the cache past its configured capacity.
- `lru.Cache` is internally thread-safe, so the `sync.Mutex` that only ever guarded `entries` was removed along with it.
- No change to the existing singleflight-dedup / cache-hit-metrics behavior.

## Testing
- `go build ./...` — clean.
- `go vet ./...` — clean (the four `controllers/http.go` diagnostics are unrelated pre-existing findings, confirmed present on `main` before this branch).
- `go test ./internal/registryauth/...` — all 14 tests pass, including two new regression tests:
  - `TestCredentialCache_ExpiredEntryIsPurgedNotJustShadowed` — proves an expired entry is actually removed from the cache, not merely hidden by the expiry check.
  - `TestCredentialCache_BoundedSizeEvictsLeastRecentlyUsed` — fills the cache to its cap, adds one more distinct key, and confirms the cache stays bounded and the least-recently-used key was evicted (forcing a refetch) rather than the cache growing past its limit.
- `go test ./adapters/v1/... ./pkg/sbomscanner/v1/...` (the two callers of this package) — pass.
- `golangci-lint run --new-from-rev=main ./internal/registryauth/...` — 0 issues (note: local golangci-lint is v2.12.2; CI pins v1.64.8, so CI's lint run is the authoritative check).
- Race detector not runnable locally (no C compiler for `-race`/cgo in this environment); the concurrency-sensitive tests in this package (singleflight coalescing, coalesced-metrics) already existed and are unmodified by this change other than the internal storage swap.

## Impact
Bounds memory growth of `internal/registryauth`'s credential caches for the life of the process, and removes the amplification path where each new key also drives a real upstream STS/ADC token fetch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential caching with bounded storage to prevent unbounded growth.
  * Automatically evicts the least recently used entries when the cache reaches capacity.
  * Removes expired credentials from the cache more reliably.
  * Preserves existing credential lookup and refresh behavior.
  * Improved reliability when credentials expire and refresh concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->