### PR TITLE
fix(adapters): stop a zero Retry-After turning a retry into a hot loop

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -158,11 +158,17 @@ func httpPostWithContext(ctx context.Context, httpClient httputils.IHttpClient, 
 				return nil, backoff.Permanent(retryErr)
 			}
 			if wait, ok := parseRetryAfter(resp); ok {
-				if wait > 0 {
-					wait = wait.Round(time.Second)
-					if wait == 0 {
-						wait = time.Second
-					}
+				// Rounded because backoff.RetryAfter takes whole seconds, and floored at one
+				// because a zero wait is worse than no header at all: backoff resets its
+				// interval whenever it sees a RetryAfterError, so a zero one retries
+				// immediately with no backoff left, for the whole remaining budget. Zero
+				// arrives from Retry-After: 0 and from a date-form header that has already
+				// passed, which a few seconds of clock skew is enough to produce, and this
+				// path retries 429, so the request being throttled is the one that would
+				// spin against a backend already asking it to slow down.
+				wait = wait.Round(time.Second)
+				if wait <= 0 {
+					wait = time.Second
 				}
 				return nil, backoff.RetryAfter(int(wait.Seconds()))
 			}

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -1524,3 +1524,42 @@ func TestHttpPostWithContext_HonorsRetryAfter(t *testing.T) {
 		"should have waited close to the requested 1s, not the default ~500ms backoff interval")
 	assert.Less(t, elapsed, 5*time.Second, "should not have waited far longer than requested")
 }
+
+// A Retry-After of zero used to be honoured literally. backoff resets its interval whenever
+// it sees a RetryAfterError, so a zero one left no backoff at all and the retry spun for the
+// rest of the budget: measured at roughly 25,000 requests in two seconds against about three
+// with ordinary backoff. Zero arrives from an explicit "0" and from a date-form header that
+// has already passed, which a few seconds of clock skew produces on its own, and this path
+// retries 429, so the request being throttled was the one that would spin.
+func TestHttpPostWithContext_ZeroRetryAfterDoesNotSpin(t *testing.T) {
+	tests := []struct {
+		name   string
+		header func() string
+	}{
+		{"explicit zero", func() string { return "0" }},
+		{"date already passed", func() string {
+			return time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&attempts, 1)
+				w.Header().Set("Retry-After", tt.header())
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+			defer server.Close()
+
+			_, err := httpPostWithContext(context.Background(), server.Client(), server.URL, nil, nil, 3*time.Second)
+			require.Error(t, err, "the server never succeeds, so the budget should be spent and give up")
+
+			got := atomic.LoadInt32(&attempts)
+			// one second floor over a three second budget, so a handful of attempts. the
+			// bound is loose on purpose: what it rules out is the thousands the hot loop made.
+			assert.LessOrEqual(t, got, int32(10),
+				"a zero Retry-After must still back off, got %d attempts", got)
+			assert.GreaterOrEqual(t, got, int32(2), "should still have retried at least once")
+		})
+	}
+}


### PR DESCRIPTION
## Overview

A `Retry-After` of zero was honoured literally, which turned the report retry into a hot loop: around 25,000 requests in two seconds against a server answering 429, versus about three with ordinary backoff.

The guard that was there covered a wait that rounds *down* to zero, not one that is already zero. Rounding and flooring unconditionally covers both.

## Additional Information

zero does more than wait zero. backoff resets its interval whenever it sees a `RetryAfterError`, so every attempt threw away the exponential interval it had built and then slept for nothing, leaving no backoff at all for the rest of the budget.

it arrives two ways, and `TestParseRetryAfter` already recorded both as valid parses: an explicit `Retry-After: 0`, and a date-form header that has already passed. the second needs no misbehaving server, only a few seconds of clock skew between kubevuln and the backend.

`shouldRetryReport` deliberately retries 429, so the request being throttled was the one that spun hardest against a backend already asking it to slow down. `httpPostFunc` defaults to this function, with a 30 second budget from `ReportScanFailure` and 60 from the scan-result submission in `backend_utils.go`.

nothing else about the header handling changes. a positive `Retry-After` is still honoured as before, and `parseRetryAfter` is untouched, so absent, negative, overflowing and garbage values still fall through to ordinary backoff.

## How to Test

`go build ./... && go vet ./... && go test ./adapters/... -count=1`

`TestHttpPostWithContext_HonorsRetryAfter` and `TestParseRetryAfter` pass unchanged, which is what says a positive wait and the parsing are the same as before.

`TestHttpPostWithContext_ZeroRetryAfterDoesNotSpin` is new and covers both routes to zero, the explicit `0` and the date already passed. it spends a three second budget against a server that always answers 429 and asserts the attempt count stays in single figures. the bound is loose on purpose: what it rules out is thousands, not a precise number.

putting the old `if wait > 0` back fails it with 38350 attempts on the explicit case and 6490 on the date case.

## Related issues/PRs:

* Resolved #754


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry behavior when servers return zero or past `Retry-After` values.
  - Ensures retries wait at least one second, preventing rapid retry loops after rate limiting.

- **Tests**
  - Added regression coverage for zero-valued and expired `Retry-After` responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->