### PR TITLE
refactor(controllers): bind the scan command in one place

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -224,23 +224,33 @@ func (h *HTTPController) recordRejection(ctx context.Context, endpoint string, e
 	))
 }
 
+// bindScanCommand decodes the request body into T and converts it to a domain.ScanCommand.
+// A body that will not bind is answered here with the same 400 each handler used to write
+// for itself, and reported as ok=false so the caller returns without scanning. T is the
+// wire command the endpoint accepts, which is WebsocketScanCommand for three of the four
+// and RegistryScanCommand for ScanRegistry.
+func bindScanCommand[T any](c *gin.Context, ctx context.Context, convert func(T) domain.ScanCommand) (domain.ScanCommand, bool) {
+	var cmd T
+	if err := c.ShouldBindJSON(&cmd); err != nil {
+		logger.L().Ctx(ctx).Error("handler error", helpers.Error(err))
+		_, _ = problem.Of(http.StatusBadRequest).WriteTo(c.Writer)
+		return domain.ScanCommand{}, false
+	}
+	return convert(cmd), true
+}
+
 // GenerateSBOM unmarshalls the payload and calls scanService.GenerateSBOM
 func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var websocketScanCommand wssc.WebsocketScanCommand
-	err := c.ShouldBindJSON(&websocketScanCommand)
-	if err != nil {
-		logger.L().Ctx(ctx).Error("handler error", helpers.Error(err))
-		_, _ = problem.Of(http.StatusBadRequest).WriteTo(c.Writer)
+	newScan, ok := bindScanCommand(c, ctx, websocketScanCommandToScanCommand)
+	if !ok {
 		return
 	}
 
-	newScan := websocketScanCommandToScanCommand(websocketScanCommand)
-
 	details := problem.Detailf("ImageHash=%s", newScan.ImageHash)
 
-	ctx, err = h.scanService.ValidateGenerateSBOM(ctx, newScan)
+	ctx, err := h.scanService.ValidateGenerateSBOM(ctx, newScan)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("validation error", helpers.Error(err),
 			helpers.String("imageSlug", newScan.ImageSlug),
@@ -342,21 +352,16 @@ func (h *HTTPController) ScanStatus(c *gin.Context) {
 func (h *HTTPController) ScanCP(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var websocketScanCommand wssc.WebsocketScanCommand
-	err := c.ShouldBindJSON(&websocketScanCommand)
-	if err != nil {
-		logger.L().Ctx(ctx).Error("handler error", helpers.Error(err))
-		_, _ = problem.Of(http.StatusBadRequest).WriteTo(c.Writer)
+	newScan, ok := bindScanCommand(c, ctx, websocketScanCommandToScanCommand)
+	if !ok {
 		return
 	}
-
-	newScan := websocketScanCommandToScanCommand(websocketScanCommand)
 	name, _ := newScan.Args[domain.ArgsName].(string)
 	namespace, _ := newScan.Args[domain.ArgsNamespace].(string)
 
 	details := problem.Detailf("Wlid=%s, Name=%s, Namespace=%s", newScan.Wlid, name, namespace)
 
-	ctx, err = h.scanService.ValidateScanCP(ctx, newScan)
+	ctx, err := h.scanService.ValidateScanCP(ctx, newScan)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("validation error", helpers.Error(err),
 			helpers.String("wlid", newScan.Wlid),
@@ -411,19 +416,14 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 func (h *HTTPController) ScanCVE(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var websocketScanCommand wssc.WebsocketScanCommand
-	err := c.ShouldBindJSON(&websocketScanCommand)
-	if err != nil {
-		logger.L().Ctx(ctx).Error("handler error", helpers.Error(err))
-		_, _ = problem.Of(http.StatusBadRequest).WriteTo(c.Writer)
+	newScan, ok := bindScanCommand(c, ctx, websocketScanCommandToScanCommand)
+	if !ok {
 		return
 	}
 
-	newScan := websocketScanCommandToScanCommand(websocketScanCommand)
-
 	details := problem.Detailf("Wlid=%s, ImageHash=%s", newScan.Wlid, newScan.ImageHash)
 
-	ctx, err = h.scanService.ValidateScanCVE(ctx, newScan)
+	ctx, err := h.scanService.ValidateScanCVE(ctx, newScan)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("validation error", helpers.Error(err),
 			helpers.String("imageSlug", newScan.ImageSlug),
@@ -500,19 +500,14 @@ func sessionChainToSession(s wssc.SessionChain) domain.Session {
 func (h *HTTPController) ScanRegistry(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var registryScanCommand wssc.RegistryScanCommand
-	err := c.ShouldBindJSON(&registryScanCommand)
-	if err != nil {
-		logger.L().Ctx(ctx).Error("handler error", helpers.Error(err))
-		_, _ = problem.Of(http.StatusBadRequest).WriteTo(c.Writer)
+	newScan, ok := bindScanCommand(c, ctx, registryScanCommandToScanCommand)
+	if !ok {
 		return
 	}
 
-	newScan := registryScanCommandToScanCommand(registryScanCommand)
-
 	details := problem.Detailf("ImageTag=%s", newScan.ImageTag)
 
-	ctx, err = h.scanService.ValidateScanRegistry(ctx, newScan)
+	ctx, err := h.scanService.ValidateScanRegistry(ctx, newScan)
 	if err != nil {
 		logger.L().Ctx(ctx).Error("validation error", helpers.Error(err),
 			helpers.String("imageSlug", newScan.ImageSlug),

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -1288,12 +1288,15 @@ func TestHTTPController_ScanCP_InvalidRequest(t *testing.T) {
 		scanService: services.NewMockScanService(true),
 		workerPool:  workerpool.New(1),
 	}
+	defer c.Shutdown(5 * time.Second)
+
 	router := gin.Default()
 	path := "/v1/scanApplicationProfile"
 	router.POST(path, c.ScanCP)
 
 	file, err := os.Open("../api/v1/testdata/scan-invalid.yaml")
 	require.NoError(t, err)
+	defer file.Close()
 	req, _ := http.NewRequest("POST", path, file)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -1280,3 +1280,24 @@ func TestHTTPController_MetricsEndpoint_RecordsQueueFullRejection(t *testing.T) 
 	assert.False(t, strings.Contains(body, `reason="too_many_requests"`), body)
 	assert.False(t, strings.Contains(body, `reason="invalid_request"`), body)
 }
+
+// The other three endpoints each cover a body that will not bind; ScanCP did not, which
+// left the one handler whose worker closure is its own copy unexercised on that path.
+func TestHTTPController_ScanCP_InvalidRequest(t *testing.T) {
+	c := HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	}
+	router := gin.Default()
+	path := "/v1/scanApplicationProfile"
+	router.POST(path, c.ScanCP)
+
+	file, err := os.Open("../api/v1/testdata/scan-invalid.yaml")
+	require.NoError(t, err)
+	req, _ := http.NewRequest("POST", path, file)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "{\"status\":400,\"title\":\"Bad Request\"}", w.Body.String())
+}

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -158,7 +158,7 @@ func (s *scanStatusStore) markPhase(jobID, phase string) {
 	if !ok {
 		return
 	}
-	if status.State == domain.ScanStateSucceeded || status.State == domain.ScanStateFailed || status.State == domain.ScanStateAbandoned {
+	if isTerminal(status.State) {
 		return
 	}
 	status.Phase = phase


### PR DESCRIPTION
## Overview

The four scan handlers each opened with the same ten lines: read the request context, bind the body, log and answer 400 if it will not bind, convert to a `domain.ScanCommand`. Three were byte identical; `ScanRegistry` differed only in which wire type it binds and which converter it calls.

`bindScanCommand` is that once, generic over the wire type so `ScanRegistry` uses it too.

## Additional Information

no behaviour change. same 400 status and body, same log line and message, same order of operations, and the converters are unchanged.

the generic parameter is the wire command rather than the result, because the result is a `domain.ScanCommand` in all four cases and only the input type differs.

`err` in each handler now comes from the validation call rather than from the bind, so the assignments below became declarations. nothing else read it between the two.

two small things came with it, both in the same package:

`markPhase` spelled out the terminal-state check by hand while `isTerminal` sits two functions above it and `markTerminal` calls it, so adding a terminal state needed two edits and only one of them said so.

`ScanCP` had no test for a body that will not bind. the other three each have an "invalid request" case; `ScanCP` had `_MissingArgsDoesNotPanic` and `_QueueFull` but nothing on that path, and it is the handler whose worker closure is still its own copy rather than `runTrackedScan`, so it is the one the others cover least.

for scale, a 6-line duplicate scan over non-test, non-generated code goes from 2.4% to 2.1% of lines with this.

## How to Test

`go build ./... && go vet ./... && go test ./controllers/ -race -count=1`

no changes to the existing tests. the "invalid request" cases in `TestHTTPController_GenerateSBOM`, `TestHTTPController_ScanCVE` and `TestHTTPController_ScanRegistry` assert the exact 400 body, `{"status":400,"title":"Bad Request"}`, so them passing unchanged is what says the response is the same one.

`TestHTTPController_ScanCP_InvalidRequest` is new and gives `ScanCP` the same case.

they constrain the helper rather than just compiling against it: making `bindScanCommand` report success on a body that will not bind fails all four, `GenerateSBOM`, `ScanCVE`, `ScanRegistry` and the new `ScanCP` one. before adding the last one it failed three.

## Related issues/PRs:

* Resolved #756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid scan requests with consistent `400 Bad Request` responses.
  - Prevented updates to scans that have already reached a terminal state.

- **Tests**
  - Added regression coverage for invalid application profile requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->