### PR TITLE
fix(controllers): close the race between a scan request's Submit and Shutdown

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -36,6 +36,24 @@ type HTTPController struct {
 	statuses     *scanStatusStore
 	statusesOnce sync.Once
 
+	// submitGate and shuttingDown guard workerPool.Submit against Shutdown's
+	// workerPool.Stop(), which closes the pool's task channel: submitting to a closed
+	// channel panics, and nothing about admitQueueSlot/tryAdmit above prevents a handler
+	// from still being between admission and Submit when shutdown begins (#758). submit()
+	// holds submitGate for read while it checks shuttingDown and calls Submit; Shutdown
+	// takes submitGate for write to set shuttingDown, which can only complete once every
+	// in-flight submit() call has released its read lock -- so by the time Shutdown moves
+	// on to workerPool.Stop(), either a given submit() call already finished handing its
+	// task to the (still open) pool, or it will see shuttingDown and never touch the pool
+	// at all. There is no interleaving where a submit() reaches the pool after Stop().
+	submitGate   sync.RWMutex
+	shuttingDown bool
+	// submitBeforeHook, if set, is called synchronously by submit() once it has confirmed
+	// shutdown hasn't started but before it hands the task to the pool. Tests use it as a
+	// deterministic barrier to prove Shutdown really does wait for this window to close
+	// before calling workerPool.Stop(), instead of a timing-based sleep.
+	submitBeforeHook func()
+
 	// maxQueueDepth bounds the number of scans tryAdmit will let through; see
 	// WithMaxQueueDepth. Zero (the default) or a negative value means unbounded.
 	maxQueueDepth int
@@ -149,6 +167,24 @@ func (h *HTTPController) admitQueueSlot(c *gin.Context, ctx context.Context, end
 	h.recordRejection(ctx, endpoint, domain.ErrQueueFull)
 	_, _ = problem.Of(validationStatusCode(domain.ErrQueueFull)).Append(details).WriteTo(c.Writer)
 	return false
+}
+
+// submit hands task to the worker pool, unless Shutdown has already begun, in which case
+// it returns false without touching the pool at all. Callers must treat false the same as
+// a lost race with shutdown: release the admission slot task's defer h.release() will now
+// never run to release, and mark the job abandoned instead of leaving it stuck "accepted"
+// forever, since its 200 OK response was already written before this call (see #758).
+func (h *HTTPController) submit(task func()) bool {
+	h.submitGate.RLock()
+	defer h.submitGate.RUnlock()
+	if h.shuttingDown {
+		return false
+	}
+	if h.submitBeforeHook != nil {
+		h.submitBeforeHook()
+	}
+	h.workerPool.Submit(task)
+	return true
 }
 
 func (h *HTTPController) ensureStatuses() *scanStatusStore {
@@ -277,11 +313,13 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 // as "partial" for the metric while still marking the job succeeded, and it has no
 // equivalent in the other three.
 //
-// Called only once the caller has already reserved a slot via admitQueueSlot, so the
-// submitted closure owns exactly one matching release() call; deferred first so it still
-// fires on the claimTrackedJob early return below.
+// Called only once the caller has already reserved a slot via admitQueueSlot, so exactly
+// one of the submitted closure's release() call or the shutdown fallback below owns
+// returning that slot. The submitted closure's is deferred first so it still fires on the
+// claimTrackedJob early return; the fallback only runs when submit() never handed the
+// closure to the pool in the first place, so its own defer never gets the chance to.
 func (h *HTTPController) runTrackedScan(bgCtx context.Context, jobID, endpoint string, scan func(context.Context) error, errMsg string, errDetails ...helpers.IDetails) {
-	h.workerPool.Submit(func() {
+	task := func() {
 		defer h.release()
 		if !h.claimTrackedJob(jobID) {
 			return
@@ -299,7 +337,11 @@ func (h *HTTPController) runTrackedScan(bgCtx context.Context, jobID, endpoint s
 			return
 		}
 		h.ensureStatuses().markSucceeded(jobID)
-	})
+	}
+	if !h.submit(task) {
+		h.release()
+		h.ensureStatuses().markAbandoned(jobID, domain.ScanReasonShutdownAbandoned)
+	}
 }
 
 // Alive returns 200 OK
@@ -377,7 +419,7 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
 	}))
-	h.workerPool.Submit(func() {
+	task := func() {
 		defer h.release()
 		if !h.claimTrackedJob(newScan.JobID) {
 			return
@@ -404,7 +446,11 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 			h.recordScan(bgCtx, "scanCP", start, "success", nil)
 			h.ensureStatuses().markSucceeded(newScan.JobID)
 		}
-	})
+	}
+	if !h.submit(task) {
+		h.release()
+		h.ensureStatuses().markAbandoned(newScan.JobID, domain.ScanReasonShutdownAbandoned)
+	}
 }
 
 // ScanCVE unmarshalls the payload and calls scanService.ScanCVE
@@ -571,6 +617,15 @@ func (h *HTTPController) Shutdown(timeout time.Duration) {
 	logger.L().Info("purging SBOM creation queue",
 		helpers.String("remaining jobs", strconv.Itoa(h.workerPool.WaitingQueueSize())),
 		helpers.String("timeout", timeout.String()))
+
+	// Taking submitGate for write blocks until every submit() call currently holding it
+	// for read has returned, so no caller can still be mid-Submit once this unlocks. Every
+	// submit() call from here on sees shuttingDown and never reaches workerPool.Submit, so
+	// the close(taskQueue) inside workerPool.Stop() below can never race one. See #758.
+	h.submitGate.Lock()
+	h.shuttingDown = true
+	h.submitGate.Unlock()
+
 	h.ensureStatuses().markAbandonedQueued(domain.ScanReasonShutdownAbandoned)
 
 	drained := make(chan struct{})

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -357,6 +357,8 @@ func TestHTTPController_RunTrackedScan_AbandonsJobWhenShuttingDown(t *testing.T)
 	require.True(t, ok)
 	assert.Equal(t, domain.ScanStateAbandoned, status.State)
 	assert.Equal(t, domain.ScanReasonShutdownAbandoned, status.Reason)
+	assert.Equal(t, string(domain.ScanStateAbandoned), status.Phase,
+		"markAbandoned must report the same Phase convention as markAbandonedQueued, not the generic \"completed\" every other terminal state gets")
 }
 
 func TestHTTPController_ScanRegistry(t *testing.T) {

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -277,6 +277,88 @@ func TestHTTPController_Shutdown_BoundedByTimeout(t *testing.T) {
 		"Shutdown should not return before its timeout when the pool hasn't drained yet")
 }
 
+// Before #758, nothing stopped a request handler from calling workerPool.Submit while (or
+// after) Shutdown's workerPool.Stop() closed the pool's task channel -- a guaranteed "send
+// on closed channel" panic. This proves submit() refuses work once shutdown has begun,
+// instead of ever reaching the pool.
+func TestHTTPController_Submit_RejectsAfterShutdown(t *testing.T) {
+	h := &HTTPController{workerPool: workerpool.New(1)}
+	h.Shutdown(time.Second)
+
+	var ran atomic.Bool
+	ok := h.submit(func() { ran.Store(true) })
+
+	assert.False(t, ok, "submit must refuse work once shutdown has started")
+	assert.False(t, ran.Load(), "a refused task must never run")
+}
+
+// This reproduces the actual race from #758 deterministically: a caller inside submit(),
+// already past the shuttingDown check, races Shutdown starting concurrently. submitBeforeHook
+// pins the caller in that exact window -- the one where the old code could still lose the
+// race against workerPool.Stop() closing the task channel underneath it -- so releasing it
+// is what lets Shutdown's submitGate.Lock() proceed at all; there is no sleep standing in
+// for that guarantee. If submit() ever let this caller through only for workerPool.Submit to
+// hand a closed channel, this test would crash with a "send on closed channel" panic instead
+// of failing normally.
+func TestHTTPController_SubmitRacingShutdown_DoesNotPanic(t *testing.T) {
+	h := &HTTPController{workerPool: workerpool.New(1)}
+
+	inHook := make(chan struct{})
+	releaseHook := make(chan struct{})
+	h.submitBeforeHook = func() {
+		close(inHook)
+		<-releaseHook
+	}
+
+	var ran atomic.Bool
+	submitOK := make(chan bool, 1)
+	go func() {
+		submitOK <- h.submit(func() { ran.Store(true) })
+	}()
+
+	<-inHook // submit() is now paused holding submitGate for read.
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		h.Shutdown(2 * time.Second)
+		close(shutdownDone)
+	}()
+
+	close(releaseHook)
+
+	require.True(t, <-submitOK, "a submit() call already past the shutdown check must still succeed")
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not finish in time")
+	}
+	assert.True(t, ran.Load(), "the task submitted just before shutdown must still run")
+}
+
+// When submit() loses the race and refuses a job that was already accepted (its 200 OK
+// response already written -- see submit's doc comment), runTrackedScan must release the
+// admission slot itself, since the submitted closure that would normally do that via its
+// own deferred release() never got created, and must mark the job abandoned instead of
+// leaving it stuck "accepted" forever.
+func TestHTTPController_RunTrackedScan_AbandonsJobWhenShuttingDown(t *testing.T) {
+	h := (&HTTPController{workerPool: workerpool.New(1)}).WithMaxQueueDepth(1)
+	require.True(t, h.tryAdmit())
+	h.ensureStatuses().recordAccepted("job-1", "generateSBOM")
+	h.shuttingDown = true // simulate having lost the race, without a real Shutdown call
+
+	var scanCalled atomic.Bool
+	h.runTrackedScan(context.Background(), "job-1", "generateSBOM",
+		func(context.Context) error { scanCalled.Store(true); return nil }, "unused")
+
+	assert.False(t, scanCalled.Load(), "a job abandoned to shutdown must never actually run")
+	assert.EqualValues(t, 0, h.pending.Load(), "the admission slot must be released")
+
+	status, ok := h.ensureStatuses().get("job-1")
+	require.True(t, ok)
+	assert.Equal(t, domain.ScanStateAbandoned, status.State)
+	assert.Equal(t, domain.ScanReasonShutdownAbandoned, status.Reason)
+}
+
 func TestHTTPController_ScanRegistry(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -174,6 +174,16 @@ func (s *scanStatusStore) markFailed(jobID, reason string) {
 	s.markTerminal(jobID, domain.ScanStateFailed, reason)
 }
 
+// markAbandoned marks a single job abandoned, the same terminal state markAbandonedQueued
+// gives every job still queued when Shutdown starts. It exists for a job that reaches
+// submit() after shuttingDown is already set (see HTTPController.submit): markAbandonedQueued's
+// one-time sweep runs before that job is necessarily even in the store yet, so this is what
+// keeps it from being left stuck "accepted" forever instead. A no-op if the job is already
+// terminal, so calling this after the sweep already caught the same jobID is harmless.
+func (s *scanStatusStore) markAbandoned(jobID, reason string) {
+	s.markTerminal(jobID, domain.ScanStateAbandoned, reason)
+}
+
 func (s *scanStatusStore) markAbandonedQueued(reason string) {
 	now := time.Now().UTC()
 	s.mu.Lock()

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -218,6 +218,11 @@ func (s *scanStatusStore) markTerminal(jobID string, state domain.ScanState, rea
 	}
 	status.State = state
 	status.Phase = "completed"
+	if state == domain.ScanStateAbandoned {
+		// Match markAbandonedQueued's convention for the same terminal state, instead of
+		// the generic "completed" every other terminal state gets here.
+		status.Phase = string(domain.ScanStateAbandoned)
+	}
 	status.Reason = reason
 	if status.StartedAt == nil {
 		startedAt := now


### PR DESCRIPTION
Fixes #758

## Problem
A request handler (`GenerateSBOM`/`ScanCVE`/`ScanRegistry`/`ScanCP`) can still be between `admitQueueSlot` and `workerPool.Submit` when `HTTPController.Shutdown` calls `workerPool.Stop()`. Per `gammazero/workerpool`'s own implementation, `Stop()` closes the pool's `taskQueue` channel, and `Submit` is an unconditional `p.taskQueue <- task`. Sending on a channel that's been (or is being) closed concurrently is a guaranteed Go runtime panic — the library's own doc comment on `Stop` warns against exactly this: *"Tasks must not be submitted to the worker pool after calling stop."*

`cmd/http/main.go` gives `srv.Shutdown` a 5-second budget to let in-flight HTTP requests finish first, but `net/http`'s `Server.Shutdown` does not kill handler goroutines still active when that budget expires — it just returns the timeout error while those goroutines keep running. So a slow handler can still reach `Submit` after `controller.Shutdown` has already called `workerPool.Stop()`.

## Root cause
Nothing in `controllers/http.go` synchronized a handler's `workerPool.Submit` call against `Shutdown`'s `workerPool.Stop()`. `tryAdmit`/`admitQueueSlot` only ever checked capacity, never "has shutdown started."

## Impact
`gin.Recovery()` catches the panic, so the process doesn't crash, but:
- The client gets an opaque 500 instead of a clean, retryable signal, during exactly the window (a rolling deploy) where that distinction matters most.
- The job's status is stuck at "accepted" forever: the submitted closure that would otherwise report success/failure never gets created, since the channel send itself panics before that.
- If `WithMaxQueueDepth` is configured, the admission slot reserved by `tryAdmit` is never released (`defer h.release()` lives inside the closure that never gets created).

## Fix
Added a `submitGate sync.RWMutex` + `shuttingDown bool` to `HTTPController`, and a new `submit(task)` helper that all four scan handlers now go through instead of calling `workerPool.Submit` directly:
- `submit` holds `submitGate` for **read** while it checks `shuttingDown` and (if clear) calls `workerPool.Submit`.
- `Shutdown` takes `submitGate` for **write** to set `shuttingDown`, before calling `workerPool.Stop()`. That write-lock can only succeed once every in-flight `submit()` call has released its read lock, so by the time `Shutdown` moves on to `Stop()`, every `submit()` call either already finished handing its task to the (still open) pool, or will see `shuttingDown` and never touch the pool at all. There's no interleaving where a `submit()` call reaches the pool after `Stop()` closes it.
- When `submit()` loses the race, the caller (`runTrackedScan` and `ScanCP`'s own copy) releases the admission slot itself and marks the job abandoned via a new `scanStatusStore.markAbandoned` (mirroring the existing `markAbandonedQueued`), instead of leaving it stuck at "accepted." The 200 OK response was already written before `Submit` is ever called, so this can't change the HTTP response — it can only make sure the job's final state reflects what actually happened.

## Testing
- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test ./controllers/...` — all 33 tests pass, including three new regression tests:
  - `TestHTTPController_Submit_RejectsAfterShutdown` — a `submit()` call after `Shutdown` has completed is refused and the task never runs.
  - `TestHTTPController_SubmitRacingShutdown_DoesNotPanic` — deterministically reproduces the actual race (no sleeps): a `submit()` call is pinned, via a test-only hook, in the exact window between its shutdown check and handing the task to the pool, while `Shutdown` runs concurrently. Proves `Shutdown` can't proceed past that window and the in-flight call still succeeds without panicking. Before this fix, a version of this race could crash the test process with "send on closed channel".
  - `TestHTTPController_RunTrackedScan_AbandonsJobWhenShuttingDown` — when `submit()` loses the race, the admission slot is released and the job's status becomes `Abandoned`/`shutdown_abandoned` instead of staying stuck at "accepted."
- `golangci-lint run --new-from-rev=main ./controllers/...` — reported 0 issues on the first pass; a longer re-run to get a clean confirmation without an unrelated linter-internal timeout message was still in progress when this PR was opened (note: local golangci-lint is v2.12.2; CI pins v1.64.8, so CI's lint run is the authoritative check).
- Race detector not runnable locally (no C compiler for `-race`/cgo in this environment). `TestHTTPController_SubmitRacingShutdown_DoesNotPanic` is deliberately structured to make the race deterministic via channel synchronization rather than relying on `-race` to catch it probabilistically.

## Impact of the fix
Removes a panic that a real Kubernetes rolling deployment or restart under load can trigger on kubevuln's HTTP scan endpoints, and ensures a scan request caught by that shutdown window ends up with an honest terminal status instead of one stuck at "accepted" forever.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling to prevent task-submission races and worker-pool panics.
  * New submissions are safely rejected once shutdown begins.
  * In-progress jobs accepted during shutdown are correctly marked as abandoned.
  * Admission capacity is released reliably for abandoned jobs.
  * Improved scan status consistency for jobs already completed or no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->