### PR TITLE
fix(safefetch): block IPv4 addresses carried inside an IPv6 one

### DIFF
--- a/internal/safefetch/safefetch.go
+++ b/internal/safefetch/safefetch.go
@@ -31,6 +31,55 @@ var carrierGradeNAT = mustParseCIDR("100.64.0.0/10")
 // working bypass of the loopback check if left unhandled.
 var thisHostOnThisNetwork = mustParseCIDR("0.0.0.0/8")
 
+// The IPv6 transition mechanisms below each carry an IPv4 address inside an IPv6 one,
+// and a packet sent to them is delivered to that IPv4 destination. net.IP.To4 unwraps
+// only the IPv4-mapped form (::ffff:a.b.c.d), so for these the checks in checkIPAllowed
+// see an ordinary global-unicast IPv6 address, match none of them, and allow it: on an
+// IPv6-only cluster running DNS64/NAT64, which is an ordinary Kubernetes setup,
+// 64:ff9b::a9fe:a9fe reaches 169.254.169.254.
+//
+// The embedded address is extracted and checked rather than the prefix being rejected
+// outright, because on such a cluster NAT64 is also how a legitimate public IPv4 host is
+// reached, and blocking the prefix would block those too.
+var (
+	// nat64WellKnown is RFC 6052's well-known prefix, which carries the IPv4 address
+	// in its low 32 bits.
+	nat64WellKnown = mustParseCIDR("64:ff9b::/96")
+	// nat64LocalUse is RFC 8215's local-use prefix. RFC 6052 splits the IPv4 address
+	// around the u octet for prefixes shorter than /96, so rather than reassemble it
+	// this is refused outright: it is a network-specific translation prefix, not
+	// somewhere a public feed is published.
+	nat64LocalUse = mustParseCIDR("64:ff9b:1::/48")
+	// sixToFour is RFC 3056's 6to4 prefix, which carries the IPv4 address in the two
+	// groups after the prefix rather than in the low 32 bits.
+	sixToFour = mustParseCIDR("2002::/16")
+	// ipv4Compatible is the ::a.b.c.d form deprecated by RFC 4291, and ipv4Translated
+	// the ::ffff:0:a.b.c.d form from RFC 2765. Both carry the address in the low 32
+	// bits, and neither is unwrapped by To4.
+	ipv4Compatible = mustParseCIDR("::/96")
+	ipv4Translated = mustParseCIDR("::ffff:0:0:0/96")
+)
+
+// embeddedIPv4 returns the IPv4 address an IPv6 transition mechanism carries inside ip,
+// or nil when ip carries none. It reports nothing for addresses To4 already unwraps,
+// since checkIPAllowed's own checks cover those.
+func embeddedIPv4(ip net.IP) net.IP {
+	if ip.To4() != nil {
+		return nil
+	}
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return nil
+	}
+	switch {
+	case sixToFour.Contains(ip16):
+		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])
+	case nat64WellKnown.Contains(ip16), ipv4Compatible.Contains(ip16), ipv4Translated.Contains(ip16):
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+	return nil
+}
+
 func mustParseCIDR(s string) *net.IPNet {
 	_, ipnet, err := net.ParseCIDR(s)
 	if err != nil {
@@ -141,8 +190,16 @@ func checkIPAllowed(ip net.IP) error {
 		ip.IsUnspecified() ||
 		ip.IsMulticast() ||
 		carrierGradeNAT.Contains(ip) ||
-		thisHostOnThisNetwork.Contains(ip) {
+		thisHostOnThisNetwork.Contains(ip) ||
+		nat64LocalUse.Contains(ip) {
 		return fmt.Errorf("%w: %s", ErrBlockedIP, ip)
+	}
+	// An IPv6 address can carry an IPv4 one that the checks above cannot see; what the
+	// packet reaches is that address, so it is what has to be allowed.
+	if v4 := embeddedIPv4(ip); v4 != nil {
+		if err := checkIPAllowed(v4); err != nil {
+			return fmt.Errorf("%w: %s embeds %s", ErrBlockedIP, ip, v4)
+		}
 	}
 	return nil
 }

--- a/internal/safefetch/safefetch_test.go
+++ b/internal/safefetch/safefetch_test.go
@@ -134,3 +134,44 @@ func TestErrorsAreDistinguishable(t *testing.T) {
 		}
 	}
 }
+
+// An IPv6 address can carry an IPv4 one inside it, and the packet is delivered to that
+// IPv4 destination. net.IP.To4 unwraps only the IPv4-mapped form, so for the rest the
+// checks in checkIPAllowed saw an ordinary global-unicast IPv6 address and allowed it.
+// On an IPv6-only cluster running DNS64/NAT64, an ordinary Kubernetes setup, that meant
+// 64:ff9b::a9fe:a9fe reached 169.254.169.254, the endpoint this package exists to block.
+func TestCheckIPAllowed_EmbeddedIPv4(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		wantErr bool
+	}{
+		{"NAT64 well-known to cloud metadata", "64:ff9b::a9fe:a9fe", true},
+		{"NAT64 well-known to RFC1918", "64:ff9b::a00:1", true},
+		{"NAT64 well-known to loopback", "64:ff9b::7f00:1", true},
+		{"NAT64 local-use prefix (RFC 8215)", "64:ff9b:1::a9fe:a9fe", true},
+		{"6to4 to cloud metadata", "2002:a9fe:a9fe::", true},
+		{"IPv4-compatible to cloud metadata", "::a9fe:a9fe", true},
+		{"IPv4-translated to cloud metadata", "::ffff:0:a9fe:a9fe", true},
+		{"IPv4-mapped to loopback", "::ffff:127.0.0.1", true},
+
+		// the embedded address is what decides it, so translation to a genuinely
+		// public host stays reachable: on an IPv6-only cluster NAT64 is how it is
+		// reached at all.
+		{"NAT64 well-known to public IPv4", "64:ff9b::808:808", false},
+		{"6to4 to public IPv4", "2002:808:808::", false},
+		{"ordinary public IPv6", "2606:4700:4700::1111", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip, "test IP %q failed to parse", tt.ip)
+			err := checkIPAllowed(ip)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, ErrBlockedIP)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

`safefetch` blocked the cloud metadata endpoint written as `169.254.169.254` and allowed it written as `64:ff9b::a9fe:a9fe`.

An IPv6 address can carry an IPv4 one, and the packet is delivered to that IPv4 destination. `net.IP.To4` unwraps only the IPv4-mapped form, so for NAT64, 6to4, IPv4-compatible and IPv4-translated addresses `checkIPAllowed` saw an ordinary global-unicast IPv6 address, matched none of its checks, and allowed it.

## Additional Information

NAT64 is the one that matters. an IPv6-only cluster running DNS64/NAT64 is an ordinary Kubernetes setup, and on one `64:ff9b::a9fe:a9fe` reaches the endpoint this package's doc comment names as what it blocks. `64:ff9b::a00:1` and `64:ff9b::7f00:1` likewise reach `10.0.0.1` and `127.0.0.1`. it is reachable through DNS as well as a literal, which is what the dial-time check exists for.

this is the same shape as the two ranges already handled here. `carrierGradeNAT` and `thisHostOnThisNetwork` are both present because a stdlib check misses a range that still reaches somewhere internal, each with a comment saying so; this is a third.

the embedded address is extracted and run through the same checks rather than the prefixes being refused outright, because on such a cluster NAT64 is also how a legitimate public IPv4 host is reached: refusing `64:ff9b::/96` would refuse `64:ff9b::808:808`, which is 8.8.8.8.

`64:ff9b:1::/48` is refused outright instead. RFC 6052 splits the embedded address around the u octet below /96, so reassembling it is fiddly, and a network-specific translation prefix is not somewhere a public feed is published.

the recursion is one level deep by construction: `embeddedIPv4` returns an IPv4 address, and it returns nil for anything `To4` already unwraps, so the inner call cannot produce another.

no caller changes. nothing calls this package yet; it is the primitive for VEXSource ingestion, #387.

## How to Test

`go build ./... && go vet ./... && go test ./internal/safefetch/ -count=1`

`TestCheckIPAllowed` passes unchanged, so the ranges already covered still are.

`TestCheckIPAllowed_EmbeddedIPv4` is new. it covers each transition mechanism pointed at metadata, RFC1918 and loopback, and the three that must stay allowed: NAT64 and 6to4 to a public IPv4, and an ordinary public IPv6 address.

removing the embedded check fails it on six of its cases, the NAT64, 6to4, IPv4-compatible and IPv4-translated ones, and leaves `TestCheckIPAllowed` passing, which is the gap this closes.

## Related issues/PRs:

* Resolved #761


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network request protection by detecting IPv4 addresses embedded in IPv6 transition formats.
  * Blocked embedded private, loopback, metadata, and local-use destinations.
  * Rejected restricted NAT64 local-use addresses while continuing to allow valid public destinations.

* **Tests**
  * Added coverage for NAT64, 6to4, IPv4-compatible, IPv4-translated, and IPv4-mapped IPv6 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->