### PR TITLE
fix(services): stop dropping registry credentials that carry only half a pair

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -898,8 +898,15 @@ func registryCredentialsFromCredentialsList(credentials []registry.AuthConfig) [
 			rc.Token = cred.RegistryToken
 		}
 		username, password := cred.Username, cred.Password
-		if username == "" && password == "" && cred.Auth != "" {
-			username, password = credentialsFromAuth(cred.Auth)
+		// Consulted whenever the pair is incomplete, not only when both halves are
+		// missing: an entry carrying a username but no password is still an entry whose
+		// credentials live in auth, and requiring both to be empty dropped it entirely
+		// rather than falling back. Only a complete decoded pair is taken, so a
+		// malformed auth cannot overwrite a username that was set.
+		if (username == "" || password == "") && cred.Auth != "" {
+			if u, p := credentialsFromAuth(cred.Auth); u != "" && p != "" {
+				username, password = u, p
+			}
 		}
 		if username != "" && password != "" {
 			rc.Username = username
@@ -935,8 +942,11 @@ func parseAuthorityFromServerAddress(serverAddress string) string {
 		return ""
 	}
 
-	// server address has no scheme
-	if !strings.HasPrefix(serverAddress, "http") {
+	// A scheme is "http://" or "https://", not a host that merely starts with those
+	// letters. Treating http-registry.internal as a URL sends it to url.Parse, which
+	// returns an empty Host for a string with no scheme, so the whole thing came back
+	// as the authority with its path still attached and matched no registry.
+	if !strings.HasPrefix(serverAddress, "http://") && !strings.HasPrefix(serverAddress, "https://") {
 		res, _, _ := strings.Cut(serverAddress, "/")
 		return res
 	}

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1442,6 +1442,61 @@ func Test_parseAuthorityFromServerAddress(t *testing.T) {
 	assert.Equal(t, "quay.io", parseAuthorityFromServerAddress("quay.io"))
 	assert.Equal(t, "x.quay.io", parseAuthorityFromServerAddress("https://x.quay.io"))
 	assert.Equal(t, "europe-docker.pkg.dev", parseAuthorityFromServerAddress("europe-docker.pkg.dev/xxx/xxx"))
+	assert.Equal(t, "quay.io:5000", parseAuthorityFromServerAddress("quay.io:5000"))
+
+	// A host is not a URL just because it starts with those four letters. These went to
+	// url.Parse, which reports an empty Host for a string with no scheme, so the whole
+	// address came back with its path still attached and matched no registry.
+	assert.Equal(t, "http-registry.internal", parseAuthorityFromServerAddress("http-registry.internal/v2/"))
+	assert.Equal(t, "httpsregistry.example.com", parseAuthorityFromServerAddress("httpsregistry.example.com/v2/"))
+}
+
+// The auth field is the canonical one; username and password are supplementary and an entry
+// may carry one without the other. The fallback used to require both halves to be missing,
+// so an entry with a username but no password fell through it and then failed the
+// "both non-empty" check below it, and its credentials were dropped entirely: the pull went
+// out anonymous and came back 401.
+func Test_registryCredentialsFromCredentialsList_incompletePair(t *testing.T) {
+	auth := base64.StdEncoding.EncodeToString([]byte("realuser:realpass"))
+	tests := []struct {
+		name     string
+		cred     registry.AuthConfig
+		wantUser string
+		wantPass string
+	}{
+		{
+			name:     "username without password falls back to auth",
+			cred:     registry.AuthConfig{ServerAddress: "reg.example.com", Username: "realuser", Auth: auth},
+			wantUser: "realuser",
+			wantPass: "realpass",
+		},
+		{
+			name:     "password without username falls back to auth",
+			cred:     registry.AuthConfig{ServerAddress: "reg.example.com", Password: "realpass", Auth: auth},
+			wantUser: "realuser",
+			wantPass: "realpass",
+		},
+		{
+			name:     "a complete pair is kept over auth",
+			cred:     registry.AuthConfig{ServerAddress: "reg.example.com", Username: "explicit", Password: "explicitpass", Auth: auth},
+			wantUser: "explicit",
+			wantPass: "explicitpass",
+		},
+		{
+			name:     "a malformed auth does not clobber the username that was set",
+			cred:     registry.AuthConfig{ServerAddress: "reg.example.com", Username: "realuser", Auth: "not-base64!!"},
+			wantUser: "",
+			wantPass: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := registryCredentialsFromCredentialsList([]registry.AuthConfig{tt.cred})
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.wantUser, got[0].Username)
+			assert.Equal(t, tt.wantPass, got[0].Password)
+		})
+	}
 }
 
 func Test_filterSBOM(t *testing.T) {


### PR DESCRIPTION
## Overview

Two ways a pull secret's credentials silently never reached the registry. Both ended the same, an anonymous pull and a 401, with nothing saying they had been discarded.

The auth field is the canonical one and username/password are supplementary, so an entry can carry one without the other. The fallback to auth required both halves to be missing, so an entry with a username and no password fell through it, then failed the both-non-empty check below it, and was dropped.

`parseAuthorityFromServerAddress` treated any address starting with the four letters `http` as a URL, so `http-registry.internal/v2/` came back as the authority with its path still attached and matched no registry.

## Additional Information

`credentialsFromAuth`'s comment already describes the intent: auth is canonical, username and password "are only supplementary and are often absent", and the fallback is "required for those credentials to reach the registry pull at all, rather than being silently dropped". Requiring both halves to be empty is what left the incomplete case outside it.

only a complete decoded pair is taken, so a malformed auth cannot overwrite a username that was set: that entry ends up with no credentials, as it did before, rather than with half a pair from a failed decode.

on the authority, `url.Parse` reports an empty Host for a string with no scheme, which is why the whole address came back. `Authority` is what stereoscope matches a credential against the registry being pulled from, so one carrying a path matches nothing.

the hostname half needs a registry literally named `http...` to bite, which is narrow; the credential half does not depend on the hostname at all.

## How to Test

`go build ./... && go vet ./... && go test ./core/... -count=1`

`Test_registryCredentialsFromCredentialsList` passes unchanged, including its #611 case where only auth is set, so the canonical shapes still convert the way they did.

`Test_registryCredentialsFromCredentialsList_incompletePair` is new: username without password, password without username, a complete pair being kept over auth, and a malformed auth not clobbering a username that was set.

`Test_parseAuthorityFromServerAddress` gains `http-registry.internal/v2/` and `httpsregistry.example.com/v2/`, plus a host:port case.

putting either condition back fails them: the old fallback fails both incomplete-pair cases, and the old prefix check fails the authority test.

## Related issues/PRs:

* Resolved #765
