### PR TITLE
fix(registryauth): evict expired entries from the credential cache

### DIFF
--- a/internal/registryauth/cache.go
+++ b/internal/registryauth/cache.go
@@ -142,7 +142,14 @@ func (c *credentialCache) lookup(key string) (*image.RegistryCredentials, bool) 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	entry, ok := c.entries[key]
-	if !ok || !c.now().Before(entry.expiry) {
+	if !ok {
+		return nil, false
+	}
+	if !c.now().Before(entry.expiry) {
+		// expired entries are never overwritten by get() until something asks for this
+		// key again, so without deleting here they'd sit in the map forever -- across
+		// however many distinct ECR/GCR hosts a cluster ever pulls from.
+		delete(c.entries, key)
 		return nil, false
 	}
 	return entry.creds, true

--- a/internal/registryauth/cache_test.go
+++ b/internal/registryauth/cache_test.go
@@ -60,6 +60,24 @@ func TestCredentialCache_RefetchesAfterExpiry(t *testing.T) {
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "expired entry must be refetched")
 }
 
+func TestCredentialCache_ExpiredEntryIsEvicted(t *testing.T) {
+	c := newCredentialCache("test")
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	fetch := func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		return &image.RegistryCredentials{Password: "p"}, now.Add(time.Minute), nil
+	}
+	_, err := c.get(context.Background(), "k", fetch)
+	require.NoError(t, err)
+	assert.Len(t, c.entries, 1)
+
+	now = now.Add(time.Hour)
+	_, ok := c.lookup("k")
+	assert.False(t, ok)
+	assert.Empty(t, c.entries, "expired entry should be evicted from the map, not left behind")
+}
+
 func TestCredentialCache_DistinctKeysDoNotShareEntries(t *testing.T) {
 	c := newCredentialCache("test")
 	fetch := func(password string) credentialFetch {


### PR DESCRIPTION
## Overview

`credentialCache.lookup()` correctly treats an expired entry as a cache miss, but never removes it from the map. The only place that ever deletes from `entries` is `reset()`, which is test-only. So every distinct registry host a cluster ever pulled a private image from stays in the map forever, even long after its credential expired.

This adds the delete on the expired-entry path in `lookup()`.

It doesn't address the other half of #750 (unbounded key cardinality from ECR account/region combinations, before anything even expires) - that needs an actual size cap or LRU, which felt like a separate, bigger decision than this fix. Happy to follow up on that separately if it's wanted.

## How to Test

New test `TestCredentialCache_ExpiredEntryIsEvicted` - fails on current `main` (map still has the entry after it's expired), passes with this change.

## Related issues/PRs:

* Related to #750 (partial fix - see note above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired credential cache entries are now removed during lookup, preventing stale data from being retained.

* **Tests**
  * Added coverage to verify that expired entries are properly evicted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->