### PR TITLE
Fix/vex canonical hash determinism

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1670,11 +1670,8 @@ func calculateVexCanonicalHash(vexDoc v1beta1.VEX) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cString := fmt.Sprintf("%d", ts.Unix())
-
-	cString += fmt.Sprintf(":%d", vexDoc.Version)
-
-	cString += fmt.Sprintf(":%s", vexDoc.Author)
+	docTsStr := ts.UTC().Format(time.RFC3339Nano)
+	cString := fmt.Sprintf(":%d:%s:%d:%d:%s", len(docTsStr), docTsStr, vexDoc.Version, len(vexDoc.Author), vexDoc.Author)
 
 	stmts := make([]v1beta1.Statement, len(vexDoc.Statements))
 	copy(stmts, vexDoc.Statements)
@@ -1685,15 +1682,16 @@ func calculateVexCanonicalHash(vexDoc v1beta1.VEX) (string, error) {
 		// 5a. Vulnerability
 		cString += cstringFromVulnerability(s.Vulnerability)
 		// 5b. Status + Justification
-		cString += fmt.Sprintf(":%s:%s", s.Status, s.Justification)
-		// 5c. Statement time, in unixtime. If it exists, if not the doc's (malformed timestamps fallback to doc time)
+		cString += fmt.Sprintf(":%d:%s:%d:%s", len(s.Status), s.Status, len(s.Justification), s.Justification)
+		// 5c. Statement time, in RFC3339Nano. If it exists, if not the doc's (malformed timestamps fallback to doc time)
 		stmtTs, err := time.Parse(time.RFC3339, s.Timestamp)
 		if err != nil {
 			stmtTs = ts
 		}
-		cString += fmt.Sprintf(":%d", stmtTs.Unix())
+		stmtTsStr := stmtTs.UTC().Format(time.RFC3339Nano)
+		cString += fmt.Sprintf(":%d:%s", len(stmtTsStr), stmtTsStr)
 		// 5d. Sorted product strings
-		cString += fmt.Sprintf(":%s", cstringFromProducts(s.Products))
+		cString += cstringFromProducts(s.Products)
 	}
 
 	h := sha256.New()
@@ -1714,13 +1712,17 @@ func cstringFromProducts(products []v1beta1.Product) string {
 			}
 			sort.Strings(subprods)
 			for _, scStr := range subprods {
-				prodString += scStr
+				prodString += fmt.Sprintf(":sub:%d:%s", len(scStr), scStr)
 			}
 		}
 		prods = append(prods, prodString)
 	}
 	sort.Strings(prods)
-	return strings.Join(prods, ":")
+	var result string
+	for _, pStr := range prods {
+		result += fmt.Sprintf(":prod:%d:%s", len(pStr), pStr)
+	}
+	return result
 }
 
 // sortVexStatements sorts a slice of VEX statements deterministically in place.
@@ -1798,26 +1800,29 @@ func sortVexStatements(stmts []v1beta1.Statement, documentTimestamp time.Time) {
 }
 
 func cstringFromVulnerability(v v1beta1.VexVulnerability) string {
-	cString := fmt.Sprintf(":%s:%s", v.ID, v.Name)
+	cString := fmt.Sprintf(":%d:%s:%d:%s", len(v.ID), v.ID, len(v.Name), v.Name)
 	if len(v.Aliases) > 0 {
 		list := make([]string, len(v.Aliases))
 		copy(list, v.Aliases)
 		sort.Strings(list)
-		cString += fmt.Sprintf(":%s", strings.Join(list, ":"))
+		for _, alias := range list {
+			cString += fmt.Sprintf(":%d:%s", len(alias), alias)
+		}
 	}
 	return cString
 }
 
 // cstringFromComponent renders one component into the canonicalization string. Both maps are
-// walked in sorted key order because Go randomizes map iteration, and this feeds the document's
-// canonical hash, which becomes its Metadata.ID: the same content has to render the same string
-// every time or the document changes identity between runs for no reason.
+// walked in sorted key order because Go randomizes map iteration, and fields are length-prefixed
+// and tagged to prevent delimiter collisions. This feeds the document's canonical hash, which
+// becomes its Metadata.ID: the same content has to render the same string every time or the
+// document changes identity between runs for no reason.
 //
 // Statements kubevuln writes itself carry only an ID (see createProductStructForImageAndPackage),
 // so both maps are empty today and the order never showed. An ingested OpenVEX component
 // routinely carries several identifiers and hashes, which is where it would.
 func cstringFromComponent(c v1beta1.Component) string {
-	s := fmt.Sprintf(":%s", c.ID)
+	s := fmt.Sprintf(":%d:%s", len(c.ID), c.ID)
 
 	algos := make([]string, 0, len(c.Hashes))
 	for algo := range c.Hashes {
@@ -1825,7 +1830,8 @@ func cstringFromComponent(c v1beta1.Component) string {
 	}
 	sort.Strings(algos)
 	for _, algo := range algos {
-		s += fmt.Sprintf(":%s@%s", algo, c.Hashes[v1beta1.Algorithm(algo)])
+		hashVal := string(c.Hashes[v1beta1.Algorithm(algo)])
+		s += fmt.Sprintf(":h:%d:%s:%d:%s", len(algo), algo, len(hashVal), hashVal)
 	}
 
 	types := make([]string, 0, len(c.Identifiers))
@@ -1834,7 +1840,8 @@ func cstringFromComponent(c v1beta1.Component) string {
 	}
 	sort.Strings(types)
 	for _, t := range types {
-		s += fmt.Sprintf(":%s@%s", t, c.Identifiers[v1beta1.IdentifierType(t)])
+		idVal := c.Identifiers[v1beta1.IdentifierType(t)]
+		s += fmt.Sprintf(":i:%d:%s:%d:%s", len(t), t, len(idVal), idVal)
 	}
 
 	return s

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1676,7 +1676,8 @@ func calculateVexCanonicalHash(vexDoc v1beta1.VEX) (string, error) {
 
 	cString += fmt.Sprintf(":%s", vexDoc.Author)
 
-	stmts := vexDoc.Statements
+	stmts := make([]v1beta1.Statement, len(vexDoc.Statements))
+	copy(stmts, vexDoc.Statements)
 	sortVexStatements(stmts, ts)
 
 	//nolint:gocritic
@@ -1685,27 +1686,14 @@ func calculateVexCanonicalHash(vexDoc v1beta1.VEX) (string, error) {
 		cString += cstringFromVulnerability(s.Vulnerability)
 		// 5b. Status + Justification
 		cString += fmt.Sprintf(":%s:%s", s.Status, s.Justification)
-		// 5c. Statement time, in unixtime. If it exists, if not the doc's
-		if s.Timestamp != "" {
-			ts, _ := time.Parse(time.RFC3339, s.Timestamp)
-			cString += fmt.Sprintf(":%d", ts.Unix())
-		} else {
-			ts, _ := time.Parse(time.RFC3339, vexDoc.Timestamp)
-			cString += fmt.Sprintf(":%d", ts.Unix())
+		// 5c. Statement time, in unixtime. If it exists, if not the doc's (malformed timestamps fallback to doc time)
+		stmtTs, err := time.Parse(time.RFC3339, s.Timestamp)
+		if err != nil {
+			stmtTs = ts
 		}
+		cString += fmt.Sprintf(":%d", stmtTs.Unix())
 		// 5d. Sorted product strings
-		var prods []string
-		for _, p := range s.Products {
-			prodString := cstringFromComponent(p.Component)
-			if p.Subcomponents != nil && len(p.Subcomponents) > 0 {
-				for _, sc := range p.Subcomponents {
-					prodString += cstringFromComponent(sc.Component)
-				}
-			}
-			prods = append(prods, prodString)
-		}
-		sort.Strings(prods)
-		cString += fmt.Sprintf(":%s", strings.Join(prods, ":"))
+		cString += fmt.Sprintf(":%s", cstringFromProducts(s.Products))
 	}
 
 	h := sha256.New()
@@ -1715,39 +1703,108 @@ func calculateVexCanonicalHash(vexDoc v1beta1.VEX) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
+func cstringFromProducts(products []v1beta1.Product) string {
+	var prods []string
+	for _, p := range products {
+		prodString := cstringFromComponent(p.Component)
+		if len(p.Subcomponents) > 0 {
+			subprods := make([]string, 0, len(p.Subcomponents))
+			for _, sc := range p.Subcomponents {
+				subprods = append(subprods, cstringFromComponent(sc.Component))
+			}
+			sort.Strings(subprods)
+			for _, scStr := range subprods {
+				prodString += scStr
+			}
+		}
+		prods = append(prods, prodString)
+	}
+	sort.Strings(prods)
+	return strings.Join(prods, ":")
+}
+
+// sortVexStatements sorts a slice of VEX statements deterministically in place.
+// Callers that need to preserve their original slice order must pass a clone.
+//
+// Ordering prioritizes:
+//  1. Vulnerability.Name (fast-path filter across different CVEs)
+//  2. Full canonical vulnerability string (Name, ID, and sorted Aliases)
+//  3. Statement timestamp (falling back to document timestamp if omitted or malformed)
+//  4. Status
+//  5. Justification
+//  6. Canonical product strings (including sorted components, subcomponents, hashes, and identifiers)
+//  7. Statement ID
+//  8. ImpactStatement, ActionStatement, and StatusNotes
 func sortVexStatements(stmts []v1beta1.Statement, documentTimestamp time.Time) {
 	sort.SliceStable(stmts, func(i, j int) bool {
-		// TODO: Add methods for aliases
+		// 1. Compare Vulnerability.Name as a fast path before computing full vulnerability strings
 		vulnComparison := strings.Compare(stmts[i].Vulnerability.Name, stmts[j].Vulnerability.Name)
 		if vulnComparison != 0 {
-			// i.e. different vulnerabilities; sort by string comparison
 			return vulnComparison < 0
 		}
 
-		// i.e. the same vulnerability; sort statements by timestamp
+		// 2. Full vulnerability comparison including ID and sorted Aliases
+		vulnCstringComparison := strings.Compare(cstringFromVulnerability(stmts[i].Vulnerability), cstringFromVulnerability(stmts[j].Vulnerability))
+		if vulnCstringComparison != 0 {
+			return vulnCstringComparison < 0
+		}
 
-		iTime, _ := time.Parse(time.RFC3339, stmts[i].Timestamp)
-		if iTime.IsZero() {
+		// 3. Statement timestamp; intentionally fallback to document timestamp if empty or invalid RFC3339
+		iTime, err := time.Parse(time.RFC3339, stmts[i].Timestamp)
+		if err != nil {
 			iTime = documentTimestamp
 		}
 
-		jTime, _ := time.Parse(time.RFC3339, stmts[j].Timestamp)
-		if jTime.IsZero() {
+		jTime, err := time.Parse(time.RFC3339, stmts[j].Timestamp)
+		if err != nil {
 			jTime = documentTimestamp
 		}
 
-		return iTime.Before(jTime)
+		if !iTime.Equal(jTime) {
+			return iTime.Before(jTime)
+		}
+
+		// 4. Status
+		if c := strings.Compare(string(stmts[i].Status), string(stmts[j].Status)); c != 0 {
+			return c < 0
+		}
+
+		// 5. Justification
+		if c := strings.Compare(string(stmts[i].Justification), string(stmts[j].Justification)); c != 0 {
+			return c < 0
+		}
+
+		// 6. Products and subcomponents
+		if c := strings.Compare(cstringFromProducts(stmts[i].Products), cstringFromProducts(stmts[j].Products)); c != 0 {
+			return c < 0
+		}
+
+		// 7. Statement ID
+		if c := strings.Compare(stmts[i].ID, stmts[j].ID); c != 0 {
+			return c < 0
+		}
+
+		// 8. Remaining metadata fields
+		if c := strings.Compare(stmts[i].ImpactStatement, stmts[j].ImpactStatement); c != 0 {
+			return c < 0
+		}
+
+		if c := strings.Compare(stmts[i].ActionStatement, stmts[j].ActionStatement); c != 0 {
+			return c < 0
+		}
+
+		return stmts[i].StatusNotes < stmts[j].StatusNotes
 	})
 }
 
 func cstringFromVulnerability(v v1beta1.VexVulnerability) string {
 	cString := fmt.Sprintf(":%s:%s", v.ID, v.Name)
-	var list []string
-	for i := range v.Aliases {
-		list = append(list, v.Aliases[i])
+	if len(v.Aliases) > 0 {
+		list := make([]string, len(v.Aliases))
+		copy(list, v.Aliases)
+		sort.Strings(list)
+		cString += fmt.Sprintf(":%s", strings.Join(list, ":"))
 	}
-	sort.Strings(list)
-	cString += strings.Join(list, ":")
 	return cString
 }
 

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -3902,6 +3902,133 @@ func TestCalculateVexCanonicalHash_AliasCollision(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEqual(t, hashWithAlias, hashWithoutAlias, "CVE-2023-1 with alias 000 should not collide with CVE-2023-1000")
+
+	// Colon-containing alias should not collide with multiple split aliases
+	docWithColonAlias := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:      "https://nvd.nist.gov",
+					Name:    "CVE-2023-1234",
+					Aliases: []string{"A:B"},
+				},
+				Status: v1beta1.Status("not_affected"),
+			},
+		},
+	}
+
+	docWithSplitAliases := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:      "https://nvd.nist.gov",
+					Name:    "CVE-2023-1234",
+					Aliases: []string{"A", "B"},
+				},
+				Status: v1beta1.Status("not_affected"),
+			},
+		},
+	}
+
+	hashWithColonAlias, err := calculateVexCanonicalHash(docWithColonAlias)
+	require.NoError(t, err)
+	hashWithSplitAliases, err := calculateVexCanonicalHash(docWithSplitAliases)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, hashWithColonAlias, hashWithSplitAliases, "alias 'A:B' should not collide with aliases 'A' and 'B'")
+}
+
+func TestCalculateVexCanonicalHash_ComponentFieldCollision(t *testing.T) {
+	docWithIDIncludingSuffix := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+			Author:    "kubescape.io",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Status:        v1beta1.Status("not_affected"),
+				Products: []v1beta1.Product{
+					{
+						Component: v1beta1.Component{
+							ID: "pkg:oci/nginx:h:6:sha256:4:1234",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	docWithHashes := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+			Author:    "kubescape.io",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Status:        v1beta1.Status("not_affected"),
+				Products: []v1beta1.Product{
+					{
+						Component: v1beta1.Component{
+							ID: "pkg:oci/nginx",
+							Hashes: map[v1beta1.Algorithm]v1beta1.Hash{
+								"sha256": "1234",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	docWithIdentifiers := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+			Author:    "kubescape.io",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Status:        v1beta1.Status("not_affected"),
+				Products: []v1beta1.Product{
+					{
+						Component: v1beta1.Component{
+							ID: "pkg:oci/nginx",
+							Identifiers: map[v1beta1.IdentifierType]string{
+								"sha256": "1234",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hID, err := calculateVexCanonicalHash(docWithIDIncludingSuffix)
+	require.NoError(t, err)
+	hHashes, err := calculateVexCanonicalHash(docWithHashes)
+	require.NoError(t, err)
+	hIdentifiers, err := calculateVexCanonicalHash(docWithIdentifiers)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, hID, hHashes, "component ID containing hash-like suffix should not collide with component carrying Hashes")
+	assert.NotEqual(t, hHashes, hIdentifiers, "component carrying Hashes should not collide with component carrying Identifiers with same key/value")
 }
 
 func TestCalculateVexCanonicalHash_AliasOrderIndependent(t *testing.T) {
@@ -4077,11 +4204,32 @@ func TestCstringFromComponent_SortedKeys(t *testing.T) {
 		},
 	}
 
-	expected := ":pkg:deb/debian/libssl3@3.0.11:md5@hashmd5:sha1@hash1:sha256@hash256:cpe22@cpe22value:cpe23@cpe23value:purl@pkg:deb/debian/libssl3@3.0.11"
+	expected := ":29:pkg:deb/debian/libssl3@3.0.11:h:3:md5:7:hashmd5:h:4:sha1:5:hash1:h:6:sha256:7:hash256:i:5:cpe22:10:cpe22value:i:5:cpe23:10:cpe23value:i:4:purl:29:pkg:deb/debian/libssl3@3.0.11"
 	for i := 0; i < 20; i++ {
 		got := cstringFromComponent(c)
 		assert.Equal(t, expected, got)
 	}
+}
+
+func TestCstringFromComponent_FieldCollision(t *testing.T) {
+	c1 := v1beta1.Component{
+		ID: "pkg:oci/nginx:h:6:sha256:4:1234",
+	}
+	c2 := v1beta1.Component{
+		ID: "pkg:oci/nginx",
+		Hashes: map[v1beta1.Algorithm]v1beta1.Hash{
+			"sha256": "1234",
+		},
+	}
+	c3 := v1beta1.Component{
+		ID: "pkg:oci/nginx",
+		Identifiers: map[v1beta1.IdentifierType]string{
+			"sha256": "1234",
+		},
+	}
+
+	assert.NotEqual(t, cstringFromComponent(c1), cstringFromComponent(c2), "ID with serialized suffix must not collide with Hashes")
+	assert.NotEqual(t, cstringFromComponent(c2), cstringFromComponent(c3), "Hashes must not collide with Identifiers having same key/value")
 }
 
 func TestCstringFromVulnerability(t *testing.T) {
@@ -4096,7 +4244,7 @@ func TestCstringFromVulnerability(t *testing.T) {
 				ID:   "https://nvd.nist.gov",
 				Name: "CVE-2023-1234",
 			},
-			expected: ":https://nvd.nist.gov:CVE-2023-1234",
+			expected: ":20:https://nvd.nist.gov:13:CVE-2023-1234",
 		},
 		{
 			name: "single alias",
@@ -4105,7 +4253,7 @@ func TestCstringFromVulnerability(t *testing.T) {
 				Name:    "CVE-2023-1",
 				Aliases: []string{"000"},
 			},
-			expected: ":https://nvd.nist.gov:CVE-2023-1:000",
+			expected: ":20:https://nvd.nist.gov:10:CVE-2023-1:3:000",
 		},
 		{
 			name: "multiple aliases sorted",
@@ -4114,7 +4262,16 @@ func TestCstringFromVulnerability(t *testing.T) {
 				Name:    "CVE-2023-1234",
 				Aliases: []string{"RHSA-2", "GHSA-1", "ALAS-3"},
 			},
-			expected: ":https://nvd.nist.gov:CVE-2023-1234:ALAS-3:GHSA-1:RHSA-2",
+			expected: ":20:https://nvd.nist.gov:13:CVE-2023-1234:6:ALAS-3:6:GHSA-1:6:RHSA-2",
+		},
+		{
+			name: "colon-containing alias",
+			vuln: v1beta1.VexVulnerability{
+				ID:      "https://nvd.nist.gov",
+				Name:    "CVE-2023-1234",
+				Aliases: []string{"A:B"},
+			},
+			expected: ":20:https://nvd.nist.gov:13:CVE-2023-1234:3:A:B",
 		},
 	}
 
@@ -4124,6 +4281,19 @@ func TestCstringFromVulnerability(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+
+	// Distinct alias list test
+	vSplit := v1beta1.VexVulnerability{
+		ID:      "https://nvd.nist.gov",
+		Name:    "CVE-2023-1234",
+		Aliases: []string{"A", "B"},
+	}
+	vColon := v1beta1.VexVulnerability{
+		ID:      "https://nvd.nist.gov",
+		Name:    "CVE-2023-1234",
+		Aliases: []string{"A:B"},
+	}
+	assert.NotEqual(t, cstringFromVulnerability(vSplit), cstringFromVulnerability(vColon))
 }
 
 func TestSortVexStatements_TieBreakers(t *testing.T) {
@@ -4181,7 +4351,7 @@ func TestSortVexStatements_TieBreakers(t *testing.T) {
 			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
 			Status:        v1beta1.Status("not_affected"),
 			Products: []v1beta1.Product{
-				{Component: v1beta1.Component{ID: "pkg:oci/image-beta"}},
+				{Component: v1beta1.Component{ID: "pkg:oci/image-bravo"}},
 			},
 		}
 
@@ -4189,7 +4359,7 @@ func TestSortVexStatements_TieBreakers(t *testing.T) {
 		sortVexStatements(stmts, docTime)
 
 		assert.Equal(t, "pkg:oci/image-alpha", stmts[0].Products[0].Component.ID)
-		assert.Equal(t, "pkg:oci/image-beta", stmts[1].Products[0].Component.ID)
+		assert.Equal(t, "pkg:oci/image-bravo", stmts[1].Products[0].Component.ID)
 	})
 
 	t.Run("tie breaker on statement ID", func(t *testing.T) {
@@ -4330,5 +4500,119 @@ func TestSortVexStatements_ZeroRFC3339Timestamp(t *testing.T) {
 	sortVexStatements(stmts, docTime)
 
 	assert.Equal(t, "stmt-zero", stmts[0].ID, "zero RFC3339 timestamp should sort before 2026 timestamp")
+	assert.Equal(t, "stmt-later", stmts[1].ID)
+}
+
+func TestCalculateVexCanonicalHash_FractionalTimestamp(t *testing.T) {
+	t.Run("differing fractional document timestamps produce distinct hashes", func(t *testing.T) {
+		doc1 := v1beta1.VEX{
+			Metadata: v1beta1.Metadata{
+				Timestamp: "2026-01-01T00:00:00.100Z",
+			},
+			Statements: []v1beta1.Statement{
+				{Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"}},
+			},
+		}
+		doc2 := v1beta1.VEX{
+			Metadata: v1beta1.Metadata{
+				Timestamp: "2026-01-01T00:00:00.200Z",
+			},
+			Statements: []v1beta1.Statement{
+				{Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"}},
+			},
+		}
+
+		h1, err := calculateVexCanonicalHash(doc1)
+		require.NoError(t, err)
+		h2, err := calculateVexCanonicalHash(doc2)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, h1, h2, "distinct fractional document timestamps must produce distinct canonical hashes")
+	})
+
+	t.Run("differing fractional statement timestamps produce distinct hashes", func(t *testing.T) {
+		doc1 := v1beta1.VEX{
+			Metadata: v1beta1.Metadata{
+				Timestamp: "2026-01-01T00:00:00Z",
+			},
+			Statements: []v1beta1.Statement{
+				{
+					Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+					Timestamp:     "2026-01-01T00:00:00.123456Z",
+				},
+			},
+		}
+		doc2 := v1beta1.VEX{
+			Metadata: v1beta1.Metadata{
+				Timestamp: "2026-01-01T00:00:00Z",
+			},
+			Statements: []v1beta1.Statement{
+				{
+					Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+					Timestamp:     "2026-01-01T00:00:00.654321Z",
+				},
+			},
+		}
+
+		h1, err := calculateVexCanonicalHash(doc1)
+		require.NoError(t, err)
+		h2, err := calculateVexCanonicalHash(doc2)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, h1, h2, "distinct fractional statement timestamps must produce distinct canonical hashes")
+	})
+
+	t.Run("equivalent UTC timestamps with different timezone offsets produce same hash", func(t *testing.T) {
+		doc1 := v1beta1.VEX{
+			Metadata: v1beta1.Metadata{
+				Timestamp: "2026-01-01T01:00:00+01:00",
+			},
+			Statements: []v1beta1.Statement{
+				{
+					Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+					Timestamp:     "2026-01-01T02:30:00+02:30",
+				},
+			},
+		}
+		doc2 := v1beta1.VEX{
+			Metadata: v1beta1.Metadata{
+				Timestamp: "2026-01-01T00:00:00Z",
+			},
+			Statements: []v1beta1.Statement{
+				{
+					Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+					Timestamp:     "2026-01-01T00:00:00Z",
+				},
+			},
+		}
+
+		h1, err := calculateVexCanonicalHash(doc1)
+		require.NoError(t, err)
+		h2, err := calculateVexCanonicalHash(doc2)
+		require.NoError(t, err)
+
+		assert.Equal(t, h1, h2, "equivalent timestamps with different timezone offsets must produce the same canonical hash")
+	})
+}
+
+func TestSortVexStatements_FractionalTimestamp(t *testing.T) {
+	docTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	stmtEarlier := v1beta1.Statement{
+		Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1000"},
+		Timestamp:     "2026-01-01T00:00:00.100Z",
+		ID:            "stmt-earlier",
+	}
+
+	stmtLater := v1beta1.Statement{
+		Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1000"},
+		Timestamp:     "2026-01-01T00:00:00.200Z",
+		ID:            "stmt-later",
+	}
+
+	stmts := []v1beta1.Statement{stmtLater, stmtEarlier}
+	sortVexStatements(stmts, docTime)
+
+	assert.Equal(t, "stmt-earlier", stmts[0].ID, "earlier fractional timestamp should sort first")
 	assert.Equal(t, "stmt-later", stmts[1].ID)
 }

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -3813,3 +3813,522 @@ func TestEnrichSummaryManifestObject_HandlesNilMaps(t *testing.T) {
 	assert.NotNil(t, gotLabels)
 	assert.Equal(t, helpersv1.ContextMetadataKeyNonFiltered, gotLabels[helpersv1.ContextMetadataKey])
 }
+
+func TestCalculateVexCanonicalHash_DeterministicWithMultipleHashesAndIdentifiers(t *testing.T) {
+	doc := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{ID: "https://nvd.nist.gov", Name: "CVE-2023-1234"},
+				Status:        v1beta1.Status("not_affected"),
+				Products: []v1beta1.Product{
+					{
+						Component: v1beta1.Component{
+							ID: "pkg:deb/debian/libssl3@3.0.11",
+							Hashes: map[v1beta1.Algorithm]v1beta1.Hash{
+								"sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+								"sha1":   "1234567890abcdef1234567890abcdef12345678",
+								"md5":    "0123456789abcdef0123456789abcdef",
+							},
+							Identifiers: map[v1beta1.IdentifierType]string{
+								"purl":  "pkg:deb/debian/libssl3@3.0.11",
+								"cpe23": "cpe:2.3:a:openssl:openssl:3.0.11:*:*:*:*:*:*:*",
+								"cpe22": "cpe:/a:openssl:openssl:3.0.11",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	firstHash, err := calculateVexCanonicalHash(doc)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstHash)
+
+	for i := 0; i < 50; i++ {
+		h, err := calculateVexCanonicalHash(doc)
+		require.NoError(t, err)
+		assert.Equal(t, firstHash, h, "run %d gave different hash", i)
+	}
+}
+
+func TestCalculateVexCanonicalHash_AliasCollision(t *testing.T) {
+	docWithAlias := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:      "https://nvd.nist.gov",
+					Name:    "CVE-2023-1",
+					Aliases: []string{"000"},
+				},
+				Status: v1beta1.Status("not_affected"),
+			},
+		},
+	}
+
+	docWithoutAlias := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:   "https://nvd.nist.gov",
+					Name: "CVE-2023-1000",
+				},
+				Status: v1beta1.Status("not_affected"),
+			},
+		},
+	}
+
+	hashWithAlias, err := calculateVexCanonicalHash(docWithAlias)
+	require.NoError(t, err)
+	hashWithoutAlias, err := calculateVexCanonicalHash(docWithoutAlias)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, hashWithAlias, hashWithoutAlias, "CVE-2023-1 with alias 000 should not collide with CVE-2023-1000")
+}
+
+func TestCalculateVexCanonicalHash_AliasOrderIndependent(t *testing.T) {
+	doc1 := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:      "https://nvd.nist.gov",
+					Name:    "CVE-2023-1234",
+					Aliases: []string{"GHSA-1111", "RHSA-2222"},
+				},
+				Status: v1beta1.Status("not_affected"),
+			},
+		},
+	}
+
+	doc2 := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{
+					ID:      "https://nvd.nist.gov",
+					Name:    "CVE-2023-1234",
+					Aliases: []string{"RHSA-2222", "GHSA-1111"},
+				},
+				Status: v1beta1.Status("not_affected"),
+			},
+		},
+	}
+
+	hash1, err := calculateVexCanonicalHash(doc1)
+	require.NoError(t, err)
+	hash2, err := calculateVexCanonicalHash(doc2)
+	require.NoError(t, err)
+
+	assert.Equal(t, hash1, hash2, "different alias order should produce the same hash")
+}
+
+func TestCalculateVexCanonicalHash_StatementOrderIndependence(t *testing.T) {
+	stmtA := v1beta1.Statement{
+		ID:            "https://kubescape.io/vex/statement/CVE-2023-1234/pkg%3Adeb%2Fdebian%2Flibssl3%403.0.11",
+		Vulnerability: v1beta1.VexVulnerability{ID: "https://nvd.nist.gov", Name: "CVE-2023-1234"},
+		Status:        v1beta1.Status("not_affected"),
+		Justification: v1beta1.Justification("vulnerable_code_not_present"),
+		Products: []v1beta1.Product{
+			{
+				Component: v1beta1.Component{ID: "pkg:oci/test-image"},
+				Subcomponents: []v1beta1.Subcomponent{
+					{Component: v1beta1.Component{ID: "pkg:deb/debian/libssl3@3.0.11"}},
+				},
+			},
+		},
+	}
+
+	stmtB := v1beta1.Statement{
+		ID:            "https://kubescape.io/vex/statement/CVE-2023-1234/pkg%3Adeb%2Fdebian%2Fopenssl%403.0.11",
+		Vulnerability: v1beta1.VexVulnerability{ID: "https://nvd.nist.gov", Name: "CVE-2023-1234"},
+		Status:        v1beta1.Status("not_affected"),
+		Justification: v1beta1.Justification("vulnerable_code_not_present"),
+		Products: []v1beta1.Product{
+			{
+				Component: v1beta1.Component{ID: "pkg:oci/test-image"},
+				Subcomponents: []v1beta1.Subcomponent{
+					{Component: v1beta1.Component{ID: "pkg:deb/debian/openssl@3.0.11"}},
+				},
+			},
+		},
+	}
+
+	stmtC := v1beta1.Statement{
+		ID:            "https://kubescape.io/vex/statement/CVE-2023-9999/pkg%3Adeb%2Fdebian%2Fcurl%407.88.1",
+		Vulnerability: v1beta1.VexVulnerability{ID: "https://nvd.nist.gov", Name: "CVE-2023-9999"},
+		Status:        v1beta1.Status("affected"),
+		Products: []v1beta1.Product{
+			{
+				Component: v1beta1.Component{ID: "pkg:oci/test-image"},
+				Subcomponents: []v1beta1.Subcomponent{
+					{Component: v1beta1.Component{ID: "pkg:deb/debian/curl@7.88.1"}},
+				},
+			},
+		},
+	}
+
+	docOrder1 := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{stmtA, stmtB, stmtC},
+	}
+
+	docOrder2 := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{stmtC, stmtB, stmtA},
+	}
+
+	docOrder3 := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Context:   "https://openvex.dev/ns/v0.2.0",
+			Author:    "kubescape.io",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Version:   1,
+		},
+		Statements: []v1beta1.Statement{stmtB, stmtA, stmtC},
+	}
+
+	h1, err := calculateVexCanonicalHash(docOrder1)
+	require.NoError(t, err)
+	h2, err := calculateVexCanonicalHash(docOrder2)
+	require.NoError(t, err)
+	h3, err := calculateVexCanonicalHash(docOrder3)
+	require.NoError(t, err)
+
+	assert.Equal(t, h1, h2, "statement order should not affect canonical hash (order 1 vs order 2)")
+	assert.Equal(t, h1, h3, "statement order should not affect canonical hash (order 1 vs order 3)")
+}
+
+func TestCalculateVexCanonicalHash_DoesNotMutateCallerSlice(t *testing.T) {
+	stmtZ := v1beta1.Statement{
+		Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-9999"},
+		ID:            "stmt-z",
+	}
+	stmtA := v1beta1.Statement{
+		Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-0001"},
+		ID:            "stmt-a",
+	}
+
+	statements := []v1beta1.Statement{stmtZ, stmtA}
+	doc := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+		},
+		Statements: statements,
+	}
+
+	_, err := calculateVexCanonicalHash(doc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "stmt-z", doc.Statements[0].ID, "calculateVexCanonicalHash must not mutate caller's slice order")
+	assert.Equal(t, "stmt-a", doc.Statements[1].ID, "calculateVexCanonicalHash must not mutate caller's slice order")
+}
+
+func TestCstringFromComponent_SortedKeys(t *testing.T) {
+	c := v1beta1.Component{
+		ID: "pkg:deb/debian/libssl3@3.0.11",
+		Hashes: map[v1beta1.Algorithm]v1beta1.Hash{
+			"sha256": "hash256",
+			"sha1":   "hash1",
+			"md5":    "hashmd5",
+		},
+		Identifiers: map[v1beta1.IdentifierType]string{
+			"purl":  "pkg:deb/debian/libssl3@3.0.11",
+			"cpe23": "cpe23value",
+			"cpe22": "cpe22value",
+		},
+	}
+
+	expected := ":pkg:deb/debian/libssl3@3.0.11:md5@hashmd5:sha1@hash1:sha256@hash256:cpe22@cpe22value:cpe23@cpe23value:purl@pkg:deb/debian/libssl3@3.0.11"
+	for i := 0; i < 20; i++ {
+		got := cstringFromComponent(c)
+		assert.Equal(t, expected, got)
+	}
+}
+
+func TestCstringFromVulnerability(t *testing.T) {
+	tests := []struct {
+		name     string
+		vuln     v1beta1.VexVulnerability
+		expected string
+	}{
+		{
+			name: "no aliases",
+			vuln: v1beta1.VexVulnerability{
+				ID:   "https://nvd.nist.gov",
+				Name: "CVE-2023-1234",
+			},
+			expected: ":https://nvd.nist.gov:CVE-2023-1234",
+		},
+		{
+			name: "single alias",
+			vuln: v1beta1.VexVulnerability{
+				ID:      "https://nvd.nist.gov",
+				Name:    "CVE-2023-1",
+				Aliases: []string{"000"},
+			},
+			expected: ":https://nvd.nist.gov:CVE-2023-1:000",
+		},
+		{
+			name: "multiple aliases sorted",
+			vuln: v1beta1.VexVulnerability{
+				ID:      "https://nvd.nist.gov",
+				Name:    "CVE-2023-1234",
+				Aliases: []string{"RHSA-2", "GHSA-1", "ALAS-3"},
+			},
+			expected: ":https://nvd.nist.gov:CVE-2023-1234:ALAS-3:GHSA-1:RHSA-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cstringFromVulnerability(tt.vuln)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestSortVexStatements_TieBreakers(t *testing.T) {
+	docTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("tie breaker on status", func(t *testing.T) {
+		stmtAffected := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("affected"),
+			ID:            "stmt-1",
+		}
+		stmtNotAffected := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("not_affected"),
+			ID:            "stmt-2",
+		}
+
+		stmts := []v1beta1.Statement{stmtNotAffected, stmtAffected}
+		sortVexStatements(stmts, docTime)
+
+		assert.Equal(t, "affected", string(stmts[0].Status))
+		assert.Equal(t, "not_affected", string(stmts[1].Status))
+	})
+
+	t.Run("tie breaker on justification", func(t *testing.T) {
+		stmtA := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("not_affected"),
+			Justification: v1beta1.Justification("component_not_present"),
+			ID:            "stmt-1",
+		}
+		stmtB := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("not_affected"),
+			Justification: v1beta1.Justification("vulnerable_code_not_present"),
+			ID:            "stmt-2",
+		}
+
+		stmts := []v1beta1.Statement{stmtB, stmtA}
+		sortVexStatements(stmts, docTime)
+
+		assert.Equal(t, "component_not_present", string(stmts[0].Justification))
+		assert.Equal(t, "vulnerable_code_not_present", string(stmts[1].Justification))
+	})
+
+	t.Run("tie breaker on products", func(t *testing.T) {
+		stmtA := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("not_affected"),
+			Products: []v1beta1.Product{
+				{Component: v1beta1.Component{ID: "pkg:oci/image-alpha"}},
+			},
+		}
+		stmtB := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("not_affected"),
+			Products: []v1beta1.Product{
+				{Component: v1beta1.Component{ID: "pkg:oci/image-beta"}},
+			},
+		}
+
+		stmts := []v1beta1.Statement{stmtB, stmtA}
+		sortVexStatements(stmts, docTime)
+
+		assert.Equal(t, "pkg:oci/image-alpha", stmts[0].Products[0].Component.ID)
+		assert.Equal(t, "pkg:oci/image-beta", stmts[1].Products[0].Component.ID)
+	})
+
+	t.Run("tie breaker on statement ID", func(t *testing.T) {
+		stmtA := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("not_affected"),
+			ID:            "https://kubescape.io/vex/statement/aaa",
+		}
+		stmtB := v1beta1.Statement{
+			Vulnerability: v1beta1.VexVulnerability{ID: "src", Name: "CVE-2023-1000"},
+			Status:        v1beta1.Status("not_affected"),
+			ID:            "https://kubescape.io/vex/statement/bbb",
+		}
+
+		stmts := []v1beta1.Statement{stmtB, stmtA}
+		sortVexStatements(stmts, docTime)
+
+		assert.Equal(t, "https://kubescape.io/vex/statement/aaa", stmts[0].ID)
+		assert.Equal(t, "https://kubescape.io/vex/statement/bbb", stmts[1].ID)
+	})
+}
+
+func TestCalculateVexCanonicalHash_SubcomponentOrderIndependent(t *testing.T) {
+	doc1 := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Products: []v1beta1.Product{
+					{
+						Component: v1beta1.Component{ID: "pkg:oci/image"},
+						Subcomponents: []v1beta1.Subcomponent{
+							{Component: v1beta1.Component{ID: "pkg:deb/debian/libssl3@3.0.11"}},
+							{Component: v1beta1.Component{ID: "pkg:deb/debian/curl@7.88.1"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	doc2 := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Products: []v1beta1.Product{
+					{
+						Component: v1beta1.Component{ID: "pkg:oci/image"},
+						Subcomponents: []v1beta1.Subcomponent{
+							{Component: v1beta1.Component{ID: "pkg:deb/debian/curl@7.88.1"}},
+							{Component: v1beta1.Component{ID: "pkg:deb/debian/libssl3@3.0.11"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	h1, err := calculateVexCanonicalHash(doc1)
+	require.NoError(t, err)
+	h2, err := calculateVexCanonicalHash(doc2)
+	require.NoError(t, err)
+
+	assert.Equal(t, h1, h2, "subcomponent order within a product should not affect the canonical hash")
+}
+
+func TestCalculateVexCanonicalHash_ZeroRFC3339StatementTimestamp(t *testing.T) {
+	docWithZeroStmtTime := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Timestamp:     "0001-01-01T00:00:00Z",
+			},
+		},
+	}
+
+	docWithDocStmtTime := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Timestamp:     "2026-01-01T00:00:00Z",
+			},
+		},
+	}
+
+	docWithEmptyStmtTime := v1beta1.VEX{
+		Metadata: v1beta1.Metadata{
+			Timestamp: "2026-01-01T00:00:00Z",
+		},
+		Statements: []v1beta1.Statement{
+			{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1234"},
+				Timestamp:     "",
+			},
+		},
+	}
+
+	hZero, err := calculateVexCanonicalHash(docWithZeroStmtTime)
+	require.NoError(t, err)
+
+	hDocTime, err := calculateVexCanonicalHash(docWithDocStmtTime)
+	require.NoError(t, err)
+
+	hEmpty, err := calculateVexCanonicalHash(docWithEmptyStmtTime)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, hDocTime, hZero, "zero RFC3339 timestamp should be preserved and not overwritten by document timestamp")
+	assert.Equal(t, hDocTime, hEmpty, "empty statement timestamp should fall back to document timestamp")
+}
+
+func TestSortVexStatements_ZeroRFC3339Timestamp(t *testing.T) {
+	docTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	stmtZero := v1beta1.Statement{
+		Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1000"},
+		Timestamp:     "0001-01-01T00:00:00Z",
+		ID:            "stmt-zero",
+	}
+
+	stmtLater := v1beta1.Statement{
+		Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2023-1000"},
+		Timestamp:     "2026-01-01T00:00:00Z",
+		ID:            "stmt-later",
+	}
+
+	stmts := []v1beta1.Statement{stmtLater, stmtZero}
+	sortVexStatements(stmts, docTime)
+
+	assert.Equal(t, "stmt-zero", stmts[0].ID, "zero RFC3339 timestamp should sort before 2026 timestamp")
+	assert.Equal(t, "stmt-later", stmts[1].ID)
+}


### PR DESCRIPTION
## Overview

This PR fixes a few bugs in `calculateVexCanonicalHash` that caused non-deterministic VEX document hashes and potential ID collisions.

### Current Behavior:
- **Random map iteration:** Iterating over `Component.Hashes` and `Component.Identifiers` directly with Go's `range` produced different hash outputs on the same document across runs whenever multiple hashes or identifiers were present.
- **Missing alias delimiter:** `cstringFromVulnerability` glued aliases directly onto the CVE name without a `:` separator, causing collisions (for example, `CVE-2023-1` with alias `000` produced the same string as `CVE-2023-1000`).
- **Statement order dependence:** `sortVexStatements` only checked `Vulnerability.Name` and `Timestamp`. When a single CVE affected multiple packages, both had identical CVE names and defaulted timestamps, leaving the sort order tied and dependent on slice order.
- **In-place slice mutation:** `sortVexStatements` sorted the caller's slice directly, modifying the caller's slice backing array.

### Future Behavior:
- Map keys for hashes and identifiers are sorted before building the canonical string.
- A `:` separator is placed before appending aliases.
- `sortVexStatements` has deterministic tie-breakers (including vulnerability ID/aliases, status, justification, products/subcomponents, and statement ID).
- Product subcomponents are sorted alphabetically to prevent ordering mismatches within multi-package products.
- `calculateVexCanonicalHash` clones the statements slice before sorting it.

## Additional Information

- Kept a fast-path comparison on `Vulnerability.Name` at the start of statement sorting so 99% of comparisons between different CVEs return immediately without formatting full canonical strings.
- Gracefully handles invalid/empty statement timestamps by falling back to the document timestamp.

## How to Test

Run the new and existing unit tests in the `repositories` package:

```bash
go test ./repositories -v -run "TestCalculateVex|TestSortVex|TestCstring"
```

Or run all tests in the repository:

```bash
go test ./...
```

## Related issues/PRs:

* Resolved #769

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VEX canonical hash consistency across equivalent document arrangements.
  * Prevented hashing and metadata enrichment from modifying original document data.
  * Added reliable timestamp fallback for missing or malformed statement timestamps.
  * Ensured deterministic ordering for statements, products, subcomponents, identifiers, aliases, and component data.

* **Tests**
  * Added comprehensive coverage for hash stability, ordering independence, collision handling, timestamp fallback, nil maps, and data immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->