### PR TITLE
fix(repositories): make GetSBOM's version-freshness check symmetric

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1780,9 +1780,15 @@ func (a *APIServerStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion s
 	case err != nil:
 		return domain.SBOM{}, fmt.Errorf("failed to get SBOM from apiserver: %w", err)
 	}
-	// discard the manifest if it was created by an older version of the scanner
-	if semver.Compare(manifest.Spec.Metadata.Tool.Version, SBOMCreatorVersion) == -1 {
-		logger.L().Debug("discarding SBOM with outdated scanner version",
+	// Discard the manifest if it was created by a different version of the scanner, in
+	// either direction. A manifest older than SBOMCreatorVersion may predate a schema or
+	// content change the caller now relies on; a manifest newer than SBOMCreatorVersion may
+	// carry one the caller isn't known to handle yet (e.g. one replica of a rolling
+	// deployment/rollback writes it, and a different-versioned replica serving the same
+	// image slug reads it back next). Comparing only for "older" let the newer case through
+	// as if it were fresh (see #768).
+	if semver.Compare(manifest.Spec.Metadata.Tool.Version, SBOMCreatorVersion) != 0 {
+		logger.L().Debug("discarding SBOM with mismatched scanner version",
 			helpers.String("name", name),
 			helpers.String("manifest scanner version", manifest.Spec.Metadata.Tool.Version),
 			helpers.String("wanted scanner version", SBOMCreatorVersion))
@@ -1802,7 +1808,10 @@ func (a *APIServerStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion s
 		Name:               name,
 		Annotations:        manifest.Annotations,
 		Labels:             manifest.Labels,
-		SBOMCreatorVersion: SBOMCreatorVersion,
+		// The manifest's own recorded version, not the caller's requested SBOMCreatorVersion:
+		// semver.Compare treats build-metadata differences as equal, so the two can still
+		// differ as strings even when the check above passes.
+		SBOMCreatorVersion: manifest.Spec.Metadata.Tool.Version,
 		Content:            &manifest.Spec.Syft,
 	}
 	if status, ok := manifest.Annotations[helpersv1.StatusMetadataKey]; ok {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -164,11 +164,13 @@ func TestAPIServerStore_GetSBOM(t *testing.T) {
 		SBOMCreatorVersion string
 	}
 	tests := []struct {
-		name          string
-		args          args
-		sbom          domain.SBOM
-		wantErr       error
-		wantEmptySBOM bool
+		name                    string
+		args                    args
+		sbom                    domain.SBOM
+		wantErr                 error
+		wantEmptySBOM           bool
+		wantSBOMCreatorVersion  string
+		checkSBOMCreatorVersion bool
 	}{
 		{
 			"valid SBOM is retrieved",
@@ -181,6 +183,8 @@ func TestAPIServerStore_GetSBOM(t *testing.T) {
 				Content: &v1beta1.SyftDocument{},
 			},
 			nil,
+			false,
+			"",
 			false,
 		},
 		{
@@ -195,9 +199,13 @@ func TestAPIServerStore_GetSBOM(t *testing.T) {
 			},
 			nil,
 			false,
+			"",
+			false,
 		},
 		{
-			"SBOMCreatorVersion mismatch",
+			// The stored manifest predates the version the caller wants: content it was
+			// never validated against would otherwise be served as if it were current.
+			"SBOMCreatorVersion mismatch, manifest older than requested",
 			args{
 				ctx:                context.TODO(),
 				name:               name,
@@ -210,6 +218,48 @@ func TestAPIServerStore_GetSBOM(t *testing.T) {
 			},
 			domain.ErrOutdatedSBOM,
 			false,
+			"v1.0.0",
+			true,
+		},
+		{
+			// The stored manifest is newer than the caller's version, e.g. written by a
+			// different-versioned replica during a rolling deploy/rollback of the same
+			// image slug. The caller's own version has no compatibility guarantee with it
+			// either, so this must be discarded exactly like the older-manifest case (#768).
+			"SBOMCreatorVersion mismatch, manifest newer than requested",
+			args{
+				ctx:                context.TODO(),
+				name:               name,
+				SBOMCreatorVersion: "v1.0.0",
+			},
+			domain.SBOM{
+				Name:               name,
+				SBOMCreatorVersion: "v1.1.0",
+				Content:            &v1beta1.SyftDocument{},
+			},
+			domain.ErrOutdatedSBOM,
+			false,
+			"v1.1.0",
+			true,
+		},
+		{
+			// On a match, the returned SBOMCreatorVersion must be what the manifest actually
+			// records, not merely echo the caller's requested value back (#768).
+			"SBOMCreatorVersion match",
+			args{
+				ctx:                context.TODO(),
+				name:               name,
+				SBOMCreatorVersion: "v1.2.3",
+			},
+			domain.SBOM{
+				Name:               name,
+				SBOMCreatorVersion: "v1.2.3",
+				Content:            &v1beta1.SyftDocument{},
+			},
+			nil,
+			false,
+			"v1.2.3",
+			true,
 		},
 		{
 			"empty name",
@@ -225,6 +275,8 @@ func TestAPIServerStore_GetSBOM(t *testing.T) {
 			},
 			nil,
 			true,
+			"",
+			false,
 		},
 	}
 	for _, tt := range tests {
@@ -243,6 +295,10 @@ func TestAPIServerStore_GetSBOM(t *testing.T) {
 			if (gotSBOM.Content == nil) != tt.wantEmptySBOM {
 				t.Errorf("GetSBOM() gotSBOM.Content = %v, wantEmptySBOM %v", gotSBOM.Content, tt.wantEmptySBOM)
 				return
+			}
+			if tt.checkSBOMCreatorVersion {
+				require.Equal(t, tt.wantSBOMCreatorVersion, gotSBOM.SBOMCreatorVersion,
+					"GetSBOM() must return the manifest's own recorded version, not the caller's requested one")
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`GetSBOM`'s version-freshness check only discarded a stored SBOM when it was **older** than the version the caller asked for. A manifest written by a **newer** scanner version passed straight through as "fresh" and was handed back mislabeled with the caller's own (older, wrong) requested version instead of the manifest's actual one.

## Root cause

```go
if semver.Compare(manifest.Spec.Metadata.Tool.Version, SBOMCreatorVersion) == -1 {
    // discard as outdated
}
result := domain.SBOM{
    ...
    SBOMCreatorVersion: SBOMCreatorVersion, // the caller's requested version, not the manifest's actual one
    ...
}
```

`semver.Compare(a, b) == -1` only catches "manifest older than requested." `GetCVE`, right above it in the same file, does the equivalent check with exact equality across all its version fields, discarding a mismatch in either direction — `GetSBOM` was the only one-directional gate of the two.

`SBOMSyft` objects are shared cluster state, keyed by image slug rather than by scanner version, and read by whichever kubevuln replica handles the next request for that slug. During a rolling deploy/rollback, replicas at different versions run concurrently and can serve the same slug, so an older replica could read back a newer replica's SBOM as if it were its own — the exact case the check exists to prevent, just missed in one direction.

The mislabeled version wasn't just cosmetic either: `filterSBOM` (`core/services/scan.go`) copies it into the filtered SBOM it builds, which then gets persisted as *that* object's own `Tool.Version`, and `GrypeAdapter.ScanSBOM` copies it into the `CVEManifest.SBOMCreatorVersion` that's submitted to the platform backend.

## Fix

- Changed the comparison to `semver.Compare(...) != 0`, so a mismatch in either direction is discarded, matching `GetCVE`'s pattern.
- The success path now always returns `manifest.Spec.Metadata.Tool.Version` (what was actually read) instead of echoing back the caller's requested value — `semver.Compare` treats build-metadata differences as equal, so the two strings can still legitimately differ even when the check passes.

Both changes are confined to `GetSBOM`; the existing outdated-manifest branch already returned the manifest's own version, so this brings the success branch in line with it.

## Testing

Extended `TestAPIServerStore_GetSBOM` in `repositories/apiserver_test.go`:
- New case: manifest **newer** than the requested version is now discarded as outdated (previously silently accepted — this is the regression test for the bug).
- New case: matching versions return the SBOM as before.
- Every version-comparison case now also asserts the returned `SBOMCreatorVersion` reflects the manifest's own recorded value rather than the caller's input, covering the mislabeling half of the bug independently of the discard decision.

Existing callers (`core/services/scan_test.go`) round-trip `GetSBOM` using the same version on write and read, so they're unaffected by the now-symmetric check.

Fixes #768
