### PR TITLE
fix(repositories): treat a dropped SecurityException as an incomplete set

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -379,10 +379,16 @@ func unstructuredFromEvent(obj interface{}) *unstructured.Unstructured {
 // GetSecurityExceptions lists both namespaced SecurityExceptions and cluster-scoped
 // ClusterSecurityExceptions. A List() failure is returned as an error rather than only
 // logged: the caller (BackendAdapter.GetCVEExceptions) relies on a non-nil error here to
-// avoid caching a degraded, incomplete exception set for exceptionsCacheTTL — see #477. A
-// conversion failure on an individual item is still only logged and skipped, since that's a
-// malformed single object rather than a listing-wide failure, and skipping it doesn't risk
-// masking a systemic API problem the way swallowing a List() error would.
+// avoid caching a degraded, incomplete exception set for exceptionsCacheTTL — see #477.
+//
+// A conversion failure on an individual item is reported the same way, while the items that
+// did convert are still returned. It used to be only logged and skipped, on the grounds that
+// a malformed single object is not a listing-wide failure. That holds for whether to abandon
+// the list, and this does not abandon it: the caller still receives and applies everything
+// that converted. What it cannot do is call the set complete, because the flag derived from
+// this error is what decides whether a suppression that is now missing counts as a deletion
+// (see reconcileCachedCVE) — and a skipped exception is missing for exactly the same reason
+// a failed List() leaves the set short.
 //
 // Both lists are served from securityExceptionListCache when available and fresh: the raw
 // List() results are the same for every workload in a given namespace (SecurityException) or

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -437,13 +437,25 @@ func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, na
 	}
 
 	var exceptions []sev1beta1.SecurityException
+	var convErrs []error
 	for i := range seList.Items {
 		var se sev1beta1.SecurityException
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(seList.Items[i].Object, &se); err != nil {
-			logger.L().Ctx(ctx).Warning("failed to convert SecurityException", helpers.Error(err))
+			logger.L().Ctx(ctx).Warning("failed to convert SecurityException", helpers.Error(err),
+				helpers.String("namespace", namespace), helpers.String("name", seList.Items[i].GetName()))
+			convErrs = append(convErrs, fmt.Errorf("converting SecurityException %s/%s: %w", namespace, seList.Items[i].GetName(), err))
 			continue
 		}
 		exceptions = append(exceptions, se)
+	}
+
+	// A dropped exception leaves the set incomplete just as a failed List() does, so it is
+	// reported the same way and not cached. Returning it as complete would let the caller
+	// persist the missing suppressions as removals and republish VEX from a set that is
+	// quietly short an entry; caching it would pin that for the TTL rather than letting the
+	// next call self-heal.
+	if len(convErrs) > 0 {
+		return exceptions, stderrors.Join(convErrs...)
 	}
 
 	if a.securityExceptionListCache != nil {
@@ -473,13 +485,22 @@ func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Cont
 	}
 
 	var clusterExceptions []sev1beta1.ClusterSecurityException
+	var convErrs []error
 	for i := range cseList.Items {
 		var cse sev1beta1.ClusterSecurityException
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(cseList.Items[i].Object, &cse); err != nil {
-			logger.L().Ctx(ctx).Warning("failed to convert ClusterSecurityException", helpers.Error(err))
+			logger.L().Ctx(ctx).Warning("failed to convert ClusterSecurityException", helpers.Error(err),
+				helpers.String("name", cseList.Items[i].GetName()))
+			convErrs = append(convErrs, fmt.Errorf("converting ClusterSecurityException %s: %w", cseList.Items[i].GetName(), err))
 			continue
 		}
 		clusterExceptions = append(clusterExceptions, cse)
+	}
+
+	// See listSecurityExceptions: a dropped exception is an incomplete set, reported and
+	// left uncached the same way a failed List() is.
+	if len(convErrs) > 0 {
+		return clusterExceptions, stderrors.Join(convErrs...)
 	}
 
 	if a.securityExceptionListCache != nil {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -4616,3 +4616,57 @@ func TestSortVexStatements_FractionalTimestamp(t *testing.T) {
 	assert.Equal(t, "stmt-earlier", stmts[0].ID, "earlier fractional timestamp should sort first")
 	assert.Equal(t, "stmt-later", stmts[1].ID)
 }
+
+// A SecurityException that fails to convert is dropped from the list. That leaves the set
+// incomplete in exactly the way a failed List() does, and the caller decides whether a
+// suppression that is missing means "deleted" from that flag alone: with the set reported
+// complete, reconcileCachedCVE persists the removals and republishes VEX from a set quietly
+// short an entry. Caching it would pin that for the TTL, against GetSecurityExceptions' own
+// documented property that a failure is never cached.
+func TestAPIServerStore_GetSecurityExceptions_ConversionFailureDegrades(t *testing.T) {
+	good := map[string]interface{}{
+		"apiVersion": "kubescape.io/v1beta1",
+		"kind":       "SecurityException",
+		"metadata":   map[string]interface{}{"name": "good", "namespace": "kubescape"},
+		"spec":       map[string]interface{}{"vulnerabilities": []interface{}{}},
+	}
+	// spec.vulnerabilities is a list on the typed struct, so a string here fails conversion
+	bad := map[string]interface{}{
+		"apiVersion": "kubescape.io/v1beta1",
+		"kind":       "SecurityException",
+		"metadata":   map[string]interface{}{"name": "bad", "namespace": "kubescape"},
+		"spec":       map[string]interface{}{"vulnerabilities": "not-a-list"},
+	}
+
+	var listCalls int32
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+	dynClient.PrependReactor("list", "securityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&listCalls, 1)
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"apiVersion": "kubescape.io/v1beta1", "kind": "SecurityExceptionList"},
+			Items:  []unstructured.Unstructured{{Object: good}, {Object: bad}},
+		}, nil
+	})
+	a := &APIServerStore{
+		DynamicClient:              dynClient,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(securityExceptionListCacheCleaningInterval),
+	}
+
+	got, _, err := a.GetSecurityExceptions(context.TODO(), "kubescape")
+	require.Error(t, err, "a dropped exception leaves the set incomplete and must be reported")
+
+	// the ones that did convert are still applied, the same as a partial result from a
+	// failed List(): losing them too would drop working suppressions as well
+	require.Len(t, got, 1)
+	assert.Equal(t, "good", got[0].Name)
+
+	// and nothing was cached, so the next call re-lists rather than serving the short set
+	_, _, err = a.GetSecurityExceptions(context.TODO(), "kubescape")
+	require.Error(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls),
+		"an incomplete list must not be cached; the second call has to go back to the apiserver")
+}


### PR DESCRIPTION
## Overview

A SecurityException that fails to convert is skipped with a warning and the list comes back with a nil error, so the caller is told the exception set is complete when it is one entry short. The missing suppression then reads as a deletion.

That flag is what decides whether removals are persisted: `reconcileCachedCVE` writes them and republishes VEX only when the set is complete, so a conversion failure could quietly unsuppress a CVE in the stored manifest and publish a VEX document asserting it. The partial result was cached too, so the short set was served for the TTL.

## Additional Information

this is the outcome the degraded mechanism exists to prevent, in its own words: "a transient SecurityException CRD list failure must not look like a deletion and wipe suppression from the stored manifest." a failed List() is handled; a failed conversion produces the same incomplete set and was not.

the caching half contradicts a property `GetSecurityExceptions` documents for itself, that "a List() failure is never cached, so a transient apiserver hiccup self-heals on the next call instead of being pinned for the TTL".

the current behaviour is deliberate, and `GetSecurityExceptions`' own comment says so: a conversion failure is "only logged and skipped, since that's a malformed single object rather than a listing-wide failure, and skipping it doesn't risk masking a systemic API problem the way swallowing a List() error would".

that reasoning is about whether to abandon the whole list, and this does not abandon it. the caller still receives and applies every entry that converted, so nothing is swallowed and no good suppression is lost. what changes is only whether the set may be called complete, and a skipped exception leaves it short for the same reason a failed List() does. the comment is updated in a second commit so it no longer describes behaviour the code no longer has.

the fix reuses the shape that already exists rather than adding one. `GetSecurityExceptions` joins its errors and returns the lists alongside them, and `GetCVEExceptions` applies those lists even when the error is set, so returning the entries that did convert together with an error marks the set degraded while keeping the suppressions that work. losing them as well would drop good suppressions to report a bad one.

the error names the object, namespace and name, so which exception was dropped is in the message rather than only in the warning above it.

`listClusterSecurityExceptions` had the same loop and gets the same treatment.

how often conversion fails is the open part: it takes an object whose field types do not match the typed struct, so a CRD schema change or version skew rather than an everyday event. the consequence is what makes it worth fixing, not the frequency.

## How to Test

`go build ./... && go vet ./... && go test ./repositories/ ./core/... -count=1`

the existing SecurityException tests pass unchanged, including `_PropagatesListErrors`, `_NoErrorOnSuccess`, `_CachesAcrossWorkloads`, `_DoesNotCacheListFailures` and `_HonorsCallerCancellation`, so the list-failure and caching behaviour either side of this is the same.

`TestAPIServerStore_GetSecurityExceptions_ConversionFailureDegrades` is new. it lists one convertible exception and one whose `spec.vulnerabilities` is a string where the typed struct wants a list, then asserts three things: an error comes back, the one that converted is still returned, and a second call goes to the apiserver again rather than being served a cached short set.

dropping the new early return fails it on the first of those.

## Related issues/PRs:

* Resolved #772


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of security exception conversion failures by preserving valid results, reporting errors clearly, and retrying retrieval when results are incomplete.
  * Prevented incomplete security data from being cached.
  * Improved consistency when enriching summaries and labels.
  * Made VEX output hashing deterministic for more reliable comparisons.
  * SBOM retrieval now clearly rejects incompatible scanner versions and reports the stored manifest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->