### PR TITLE
fix(repositories): canonicalize a VEX component's maps in sorted order

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1750,15 +1750,33 @@ func cstringFromVulnerability(v v1beta1.VexVulnerability) string {
 	return cString
 }
 
+// cstringFromComponent renders one component into the canonicalization string. Both maps are
+// walked in sorted key order because Go randomizes map iteration, and this feeds the document's
+// canonical hash, which becomes its Metadata.ID: the same content has to render the same string
+// every time or the document changes identity between runs for no reason.
+//
+// Statements kubevuln writes itself carry only an ID (see createProductStructForImageAndPackage),
+// so both maps are empty today and the order never showed. An ingested OpenVEX component
+// routinely carries several identifiers and hashes, which is where it would.
 func cstringFromComponent(c v1beta1.Component) string {
 	s := fmt.Sprintf(":%s", c.ID)
 
-	for algo, val := range c.Hashes {
-		s += fmt.Sprintf(":%s@%s", algo, val)
+	algos := make([]string, 0, len(c.Hashes))
+	for algo := range c.Hashes {
+		algos = append(algos, string(algo))
+	}
+	sort.Strings(algos)
+	for _, algo := range algos {
+		s += fmt.Sprintf(":%s@%s", algo, c.Hashes[v1beta1.Algorithm(algo)])
 	}
 
-	for t, id := range c.Identifiers {
-		s += fmt.Sprintf(":%s@%s", t, id)
+	types := make([]string, 0, len(c.Identifiers))
+	for t := range c.Identifiers {
+		types = append(types, string(t))
+	}
+	sort.Strings(types)
+	for _, t := range types {
+		s += fmt.Sprintf(":%s@%s", t, c.Identifiers[v1beta1.IdentifierType(t)])
 	}
 
 	return s

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2488,9 +2488,6 @@ func TestAPIServerStore_ListClusterSecurityExceptions_DoesNotRepopulateAfterRaci
 	assert.False(t, ok, "a List() that raced an invalidation must not repopulate the cache with its now-stale result")
 }
 
-
-
-
 // TestAPIServerStore_TrySetSecurityExceptionCache_GenerationMismatchSkipsWrite unit-tests the
 // compare-and-swap primitive directly, without goroutines: the write must be skipped whenever an
 // invalidation bumped the generation after the snapshot the caller took before its List() call.
@@ -3659,4 +3656,57 @@ func TestAPIServerStore_StoreCVESummary_reportsTheSummaryName(t *testing.T) {
 	// and nothing was written under the CVE manifest's name
 	_, err = a.StorageClient.VulnerabilityManifestSummaries(ns).Get(ctx, cve.Name, metav1.GetOptions{})
 	assert.True(t, apierrors.IsNotFound(err), "expected no summary stored under the CVE manifest name, got %v", err)
+}
+
+// calculateVexCanonicalHash becomes the document's Metadata.ID, so the same content has to
+// render the same hash every time. cstringFromComponent walked Component.Hashes and
+// Identifiers with a bare range, and Go randomizes map iteration, so a component carrying
+// more than one of either hashed differently between runs and the document changed identity
+// for no reason. Statements kubevuln writes itself carry only an ID, so both maps are empty
+// today and it never showed; an ingested OpenVEX component routinely carries several.
+func TestCalculateVexCanonicalHash_StableAcrossMapOrder(t *testing.T) {
+	docFor := func(c v1beta1.Component) v1beta1.VEX {
+		return v1beta1.VEX{
+			Metadata: v1beta1.Metadata{Timestamp: "2026-08-19T10:00:00Z", Version: 1, Author: "kubescape"},
+			Statements: []v1beta1.Statement{{
+				Vulnerability: v1beta1.VexVulnerability{Name: "CVE-2021-44228"},
+				Status:        "not_affected",
+				Products:      []v1beta1.Product{{Component: c}},
+			}},
+		}
+	}
+	distinctHashes := func(t *testing.T, c v1beta1.Component) int {
+		t.Helper()
+		seen := map[string]struct{}{}
+		// enough iterations that a randomized order shows up: an unsorted three-entry map
+		// produced nine distinct hashes over this many runs
+		for i := 0; i < 200; i++ {
+			h, err := calculateVexCanonicalHash(docFor(c))
+			require.NoError(t, err)
+			seen[h] = struct{}{}
+		}
+		return len(seen)
+	}
+
+	t.Run("component with several identifiers and hashes", func(t *testing.T) {
+		c := v1beta1.Component{
+			ID: "pkg:oci/nginx",
+			Identifiers: map[v1beta1.IdentifierType]string{
+				"purl":  "pkg:oci/nginx",
+				"cpe22": "cpe:/a:nginx:nginx",
+				"cpe23": "cpe:2.3:a:nginx:nginx",
+			},
+			Hashes: map[v1beta1.Algorithm]v1beta1.Hash{
+				"sha256": "aaa",
+				"sha512": "bbb",
+				"md5":    "ccc",
+			},
+		}
+		assert.Equal(t, 1, distinctHashes(t, c), "the same component must canonicalize to one hash")
+	})
+
+	t.Run("component carrying only an ID, as kubevuln writes today", func(t *testing.T) {
+		assert.Equal(t, 1, distinctHashes(t, v1beta1.Component{ID: "pkg:oci/nginx"}),
+			"the shape already in use must hash exactly as it did before")
+	})
 }


### PR DESCRIPTION
## Overview

`calculateVexCanonicalHash` becomes the document's `Metadata.ID`, so the same content has to render the same hash every time. `cstringFromComponent` walked `Component.Hashes` and `Identifiers` with a bare range, and Go randomizes map iteration, so a component carrying more than one of either hashed differently between runs and the document changed identity for no reason.

Hashing one unchanged document two hundred times: a component with three identifiers and three hashes produced **nine** distinct hashes. A component carrying only an ID produced one.

## Additional Information

it does not bite today. `createProductStructForImageAndPackage` builds products with an ID and nothing else, so both maps are empty for everything kubevuln writes, and one entry orders the same as none. that is the shape currently in storage.

where it starts mattering is external VEX. an ingested OpenVEX component routinely carries several identifiers (purl, cpe22, cpe23) and several hashes, and `updateVEX` recalculates the hash over every statement in the container rather than only the ones kubevuln authored, so one foreign statement with two identifiers is enough to make the container's ID unstable.

sorting the keys leaves the empty case rendering the exact string it rendered before, so nothing already stored rehashes and no existing document changes ID on the next update. that is what the second subtest pins.

the keys are converted to `string` for sorting because `Algorithm` and `IdentifierType` are distinct named string types; the values are read back through the original key types so nothing about the rendered pairs changes.

`sort` was already imported here, so no new dependency.

## How to Test

`go build ./... && go vet ./... && go test ./repositories/ -count=1`

every existing test passes unchanged, including the VEX ones that assert on stored documents, which is what says the shape already in storage hashes as it did.

`TestCalculateVexCanonicalHash_StableAcrossMapOrder` is new and has two subtests. The first hashes a component with three identifiers and three hashes two hundred times and requires exactly one distinct result. The second does the same for a component carrying only an ID, pinning that the shape kubevuln writes today is unaffected.

putting the bare ranges back fails the first subtest and leaves the second passing, which is the gap.

## Related issues/PRs:

* Resolved #774
