### PR TITLE
docs(architecture): document the sidecar SBOM scanner and the missing packages

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -182,9 +182,11 @@ Kubevuln follows the hexagonal architecture pattern to achieve:
 kubevuln/
 ├── adapters/                    # External service implementations
 │   ├── v1/
-│   │   ├── syft.go             # SBOM generation using Syft
+│   │   ├── syft.go             # SBOM generation using Syft, in-process
+│   │   ├── sidecar.go          # SBOM generation via the sbom-scanner sidecar
 │   │   ├── grype.go            # CVE scanning using Grype
 │   │   ├── backend.go          # Kubescape backend communication
+│   │   ├── securityexception.go # SecurityException CRDs -> exception policies
 │   │   └── container_profile.go # Relevancy provider
 │   ├── mockcve.go              # Mock CVE scanner for testing
 │   ├── mockplatform.go         # Mock platform for testing
@@ -193,6 +195,8 @@ kubevuln/
 ├── cmd/
 │   ├── http/
 │   │   └── main.go             # HTTP server entry point
+│   ├── sbom-scanner/
+│   │   └── main.go             # Sidecar SBOM scanner entry point (gRPC over a Unix socket)
 │   └── cli/
 │       └── main.go             # CLI entry point (not implemented)
 │
@@ -218,11 +222,20 @@ kubevuln/
 │       └── scan.go             # Main scanning business logic
 │
 ├── internal/
-│   └── tools/                  # Internal utilities
+│   ├── tools/                  # Internal utilities
+│   ├── metrics/                # OpenTelemetry instruments and recorders
+│   ├── registryauth/           # Registry credential resolution, shared by both SBOM paths
+│   ├── syftmeta/               # Syft metadata reattachment
+│   ├── safefetch/              # SSRF-guarded HTTPS fetcher for user-supplied URLs
+│   └── vexdoc/                 # Safe temp-file writer for VEX documents
+│
+├── pkg/                        # Importable by other projects
+│   ├── sbomscanner/v1/         # Sidecar scanner protocol: gRPC client, server, proto
+│   └── securityexception/v1beta1/ # SecurityException / ClusterSecurityException CRD types
 │
 └── repositories/
     ├── apiserver.go            # Kubernetes API server storage
-    ├── memory.go               # In-memory storage
+    ├── memory.go               # In-memory storage (testing)
     └── broken.go               # Always-failing storage (testing)
 ```
 
@@ -291,6 +304,11 @@ The central business logic component implementing the `ScanService` port.
 - Handles image size limits and timeouts
 - Supports multiple registry authentication methods
 
+**Sidecar SBOM Adapter** (`adapters/v1/sidecar.go`)
+- Implements the same `SBOMCreator` port as the Syft adapter, so the scan service is unaware of which one it holds
+- Delegates SBOM generation to the `sbom-scanner` sidecar over gRPC on a Unix domain socket, instead of running Syft in this process
+- Selected at startup when `SBOM_SCANNER_SOCKET` is set; see [SBOM Generation Modes](#sbom-generation-modes)
+
 **Grype Adapter** (`adapters/v1/grype.go`)
 - Manages vulnerability database updates
 - Scans SBOMs for CVEs using Grype library
@@ -314,6 +332,53 @@ The central business logic component implementing the `ScanService` port.
 - Used with `keepLocal: true`
 
 ---
+
+### SBOM Generation Modes
+
+SBOM generation runs in one of two places, chosen once at startup. Both implement the same
+`SBOMCreator` port, so nothing downstream of `ScanService` behaves differently.
+
+**In-process** (default). `SyftAdapter` runs Syft inside the kubevuln process. This is what
+runs when `SBOM_SCANNER_SOCKET` is unset.
+
+**Sidecar.** Setting `SBOM_SCANNER_SOCKET` points kubevuln at a second binary, `cmd/sbom-scanner`,
+running as another container in the same pod. It serves the gRPC service in `pkg/sbomscanner/v1`
+over a Unix domain socket, and `SidecarSBOMAdapter` calls it in place of running Syft locally.
+
+The reason for the split is memory. Syft's peak usage scales with image size and is hard to bound
+in advance, so a large image can exhaust the container's memory limit. In the sidecar, the kernel
+kills that container instead of kubevuln, and the HTTP server, the scan queue and the Grype
+database stay up.
+
+```
+┌──────────────────────────┐        ┌────────────────────────────┐
+│ kubevuln container       │        │ sbom-scanner container     │
+│                          │        │                            │
+│  SidecarSBOMAdapter ─────┼── gRPC ┼──> scannerServer           │
+│                          │  (uds) │      └─ syft.CreateSBOM    │
+│  GrypeAdapter            │        │                            │
+│  HTTP controller         │        │  OOM here does not take    │
+│                          │        │  kubevuln down             │
+└──────────────────────────┘        └────────────────────────────┘
+```
+
+Startup is fail-soft: `NewSBOMScannerClient` health-checks the sidecar, bounded by
+`scannerReadinessTimeout`, and if it never becomes ready kubevuln logs the failure and falls back
+to the in-process adapter rather than refusing to start. The mode actually in effect is reported
+by `/v1/diagnostics` as `scanMode`.
+
+Two consequences worth knowing when reading the code:
+
+- The two paths are separate implementations of the same behaviour, so a change to one usually
+  needs the same change to the other. Shared pieces have been factored out where practical, for
+  example `internal/registryauth` for the credential fallback ladder.
+- Concurrency differs. The in-process adapter serialises pulls behind a mutex so concurrent scans
+  cannot exhaust local disk; the sidecar intentionally does not, and bounds in-flight work by the
+  caller's `scanConcurrency` instead.
+
+Relevant env vars: `SBOM_SCANNER_SOCKET` selects the mode on the kubevuln side; `SOCKET_PATH`
+and `METRICS_ADDR` configure the sidecar; `SCANNER_MEMORY_LIMIT` is read at startup and passed
+to the adapter, which records it on an SBOM it reports as too large for the scanner.
 
 ## Data Flow
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -307,7 +307,7 @@ The central business logic component implementing the `ScanService` port.
 **Sidecar SBOM Adapter** (`adapters/v1/sidecar.go`)
 - Implements the same `SBOMCreator` port as the Syft adapter, so the scan service is unaware of which one it holds
 - Delegates SBOM generation to the `sbom-scanner` sidecar over gRPC on a Unix domain socket, instead of running Syft in this process
-- Selected at startup when `SBOM_SCANNER_SOCKET` is set; see [SBOM Generation Modes](#sbom-generation-modes)
+- Attempted at startup when `SBOM_SCANNER_SOCKET` is set, and selected only once the sidecar passes its readiness check; startup falls back to the Syft adapter if it does not. See [SBOM Generation Modes](#sbom-generation-modes)
 
 **Grype Adapter** (`adapters/v1/grype.go`)
 - Manages vulnerability database updates


### PR DESCRIPTION
## Overview

`ARCHITECTURE.md` does not mention the sidecar anywhere: searching its 622 lines for `sidecar` or `grpc` returns nothing, and the only hits for `scanner` are a mock file's comment and the `CVEScanner` port name. A reader comes away with one binary and one SBOM path when there are two.

Adds a **SBOM Generation Modes** section, a **Sidecar SBOM Adapter** entry alongside the Syft one, and brings the directory structure back in line with the tree.

## Additional Information

the new section covers which mode runs and when, why the split exists (Syft's peak memory scales with image size, and in the sidecar the kernel kills that container instead of kubevuln), and two things that catch people reading the code:

- startup is fail-soft. the client health-checks the sidecar, bounded by `scannerReadinessTimeout`, and falls back to in-process rather than refusing to start, so a deployment can be in a different mode than its config suggests. `/v1/diagnostics` reports which, as `scanMode`.
- concurrency differs deliberately. the in-process path serialises pulls behind `pullMutex`; the sidecar does not, and bounds in-flight work by the caller's `scanConcurrency` instead.

the second point matters beyond documentation: the two paths are parallel implementations, so a change to one usually needs the same change to the other, and the doc now says so. that is the shape behind #585, #587, #601, #675 and #686.

the directory structure listed `internal/tools` as the only thing under `internal/`, had no `pkg/` tree at all, and no `cmd/sbom-scanner`. Adds `metrics`, `registryauth`, `syftmeta`, `safefetch`, `vexdoc`, `pkg/sbomscanner/v1`, `pkg/securityexception/v1beta1`, and `sidecar.go` next to `syft.go`.

every claim is checked against the code rather than inferred: `SBOM_SCANNER_SOCKET` selecting the mode (`cmd/http/main.go:83`), the fallback log and adapter swap on readiness failure, `var _ ports.SBOMCreator = (*SidecarSBOMAdapter)(nil)`, `ScanModeSidecar` reaching diagnostics, and the "do not add a mutex/semaphore around this method" comment in `pkg/sbomscanner/v1/server.go` for the concurrency difference.

one thing deliberately not claimed: `SCANNER_MEMORY_LIMIT` is described as read at startup and passed to the adapter, not as something recorded when the sidecar is OOM-killed. the path that would record it is `handleCrash`, which nothing currently reaches (#763), and documenting it as live would be wrong until that is settled.

## How to Test

Docs only, no code changes: `go build ./...` and the suite are unaffected.

Read the new **SBOM Generation Modes** section under Component Details, and check the directory structure against `find pkg internal cmd -maxdepth 2 -type d`.

The table of contents is unchanged because it lists `##` headings only and both additions are `###`, consistent with the other subsections.

## Related issues/PRs:

* Resolved #776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated architecture guidance for in-process and sidecar SBOM generation.
  - Documented startup configuration, Unix-socket communication, and automatic fallback behavior.
  - Added an overview of registry authentication, metrics, metadata handling, safe fetching, and VEX support.
  - Clarified diagnostics, memory isolation, concurrency differences, and related environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->