### PR TITLE
test(vexdoc): skip the permission assertion on Windows

### DIFF
--- a/internal/vexdoc/vexdoc_test.go
+++ b/internal/vexdoc/vexdoc_test.go
@@ -2,6 +2,7 @@ package vexdoc
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,6 +71,14 @@ func TestWriteToTempFile_CleanupIsSafeToCallOnErrorPath(t *testing.T) {
 }
 
 func TestWriteToTempFile_FileHasRestrictivePermissions(t *testing.T) {
+	// Windows has no Unix permission bits: os.OpenFile's mode argument is ignored beyond
+	// the read-only flag, so Perm() reads back 0666 however the file was created and the
+	// assertion below can never hold there. The property is still worth asserting on the
+	// platforms kubevuln runs on, so skip rather than weaken it.
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not implemented on Windows")
+	}
+
 	path, cleanup, err := WriteToTempFile([]byte("sensitive vendor data"))
 	require.NoError(t, err)
 	defer cleanup()


### PR DESCRIPTION
## Overview

`TestWriteToTempFile_FileHasRestrictivePermissions` asserts `Perm()` is `0600`, which cannot hold on Windows: it has no Unix permission bits, `os.OpenFile` ignores the mode beyond the read-only flag, and `Perm()` reads back `0666` however the file was created. The package's suite therefore fails for anyone developing on Windows.

## Additional Information

skipped rather than loosened. an assertion that accepted `0600` or `0666` would pass everywhere and stop catching a real permissions regression on Linux, which is where it matters, so the exact check is kept and the platform that cannot satisfy it opts out.

`vexdoc.WriteToTempFile` is unchanged and correct: the file really is created `0600` on Linux. It is only the assertion that was not portable.

the test job runs on Linux and was already green, so this changes nothing in CI. It is developer experience: the repo builds cross-platform, so Windows is a supported place to work from.

## How to Test

`go test ./internal/vexdoc/ -count=1`

On Linux the permission assertion runs exactly as before. On Windows the case reports SKIP and the other seven pass:

```
--- SKIP: TestWriteToTempFile_FileHasRestrictivePermissions
--- PASS: TestWriteToTempFile_WritesRealContent
--- PASS: TestWriteToTempFile_NeverOverwritesAnExistingFile
...
```

## Related issues/PRs:

* Resolved #778
