### PR TITLE
refactor(controllers): drop the sort before deleting every evicted record

### DIFF
--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"container/heap"
-	"slices"
 	"sync"
 	"time"
 
@@ -71,9 +70,8 @@ func (s *scanStatusStore) evictLocked(now time.Time) {
 			heap.Fix(&selected, 0)
 		}
 	}
-	slices.SortFunc([]candidate(selected), func(a, b candidate) int {
-		return a.finishedAt.Compare(b.finishedAt)
-	})
+	// Not sorted first: every selected entry is deleted, so their order changes nothing
+	// about which records survive. The heap above is what picks them.
 	for _, cand := range selected {
 		delete(s.items, cand.jobID)
 	}


### PR DESCRIPTION
## Overview

`evictLocked` sorted the candidates it was about to delete and then deleted all of them, so the ordering could not change which records survived. The heap above already picks the oldest terminal entries; the sort was work done on the way to discarding its own result.

## Additional Information

no behaviour change: every element of `selected` is deleted either way, and the heap that chooses them is untouched.

`slices` was imported for this and nothing else here, so the import goes with it.

a short comment replaces it saying why nothing sorts, since "these are deleted in no particular order" is the kind of thing the next reader would otherwise re-derive from the loop below.

## How to Test

`go build ./... && go vet ./controllers/... && go test ./controllers/ -race -count=1`

The eviction tests pass unchanged, which is the point: they assert which records survive, and that is decided by the heap rather than by the order they are removed in.

```
TestScanStatusStore_EvictsExpiredTerminalEntries
TestScanStatusStore_GetEvictsExpiredTerminalEntries
TestScanStatusStore_EvictsOldestTerminalEntriesOverCap
```

## Related issues/PRs:

* Resolved #779
