### PR TITLE
docs(development): fix debug-logging instructions that do nothing

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -149,8 +149,8 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 ### Build Verification
 
 ```bash
-# Check binary
-./kubevuln --help
+# Check the binary runs (it takes no flags, so this starts the server; Ctrl-C to stop)
+./kubevuln
 
 # Check size
 ls -lh kubevuln
@@ -292,13 +292,16 @@ func TestScanService_GenerateSBOM_Error(t *testing.T) {
 
 ### Local Debugging
 
+kubevuln parses no command-line flags: everything is configured through the config file
+and environment. Log level is one of `debug`, `info`, `warning`, `error` or `fatal`.
+
 ```bash
 # Run with debug logging
-./kubevuln -alsologtostderr -v=4
-
-# Or set environment variables
-export GOLOG_LOG_LEVEL=debug
+export KS_LOGGER_LEVEL=debug
 ./kubevuln
+
+# Optionally name the logger in the output
+export KS_LOGGER_NAME=pretty
 ```
 
 ### Using Delve Debugger
@@ -632,9 +635,9 @@ go mod verify
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/http",
       "env": {
-        "CONFIG_DIR": "${workspaceFolder}/.dev/config"
-      },
-      "args": ["-alsologtostderr", "-v=4"]
+        "CONFIG_DIR": "${workspaceFolder}/.dev/config",
+        "KS_LOGGER_LEVEL": "debug"
+      }
     },
     {
       "name": "Test Current Package",


### PR DESCRIPTION
## Overview

`DEVELOPMENT.md` gives two ways to turn on debug logging and neither does anything. `cmd/http/main.go` parses no command-line flags, so `-alsologtostderr -v=4` are ignored, and `GOLOG_LOG_LEVEL` appears nowhere in the codebase. The variable `kubescape/go-logger` actually reads is `KS_LOGGER_LEVEL`, which was not documented anywhere.

## Additional Information

the failure mode is silent: the server starts, logs at the default level, and nothing indicates the setting was ignored.

two smaller corrections follow from the same fact that the binary takes no flags:

- build verification said to run `./kubevuln --help`, which starts the server rather than printing help. now says so.
- the VS Code launch snippet passed `"args": ["-alsologtostderr", "-v=4"]`. those are replaced with `KS_LOGGER_LEVEL` in its `env` block, and the snippet still parses as valid JSON.

`KS_LOGGER_NAME` is mentioned alongside it since it is the other variable the same logger reads, and the accepted levels are listed so the value is not guesswork.

## How to Test

Docs only. The claims are checkable directly:

```
grep -rn "flag\." cmd/http/main.go          # no flag parsing
grep -rn "GOLOG_LOG_LEVEL" --include=*.go . # no hits
```

and `KS_LOGGER_LEVEL` / `KS_LOGGER_NAME` are the constants `EnvLoggerLevel` and `EnvLoggerName` in `kubescape/go-logger`.

Setting `KS_LOGGER_LEVEL=debug` before starting kubevuln produces debug output; the previous instructions produce none.

## Related issues/PRs:

* Resolved #780
