### PR TITLE
fix(repositories): copy the caller's maps when enriching a summary object

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -748,10 +748,12 @@ func parseSeverities(cve domain.CVEManifest, cvep domain.CVEManifest, withReleva
 }
 
 func enrichSummaryManifestObjectAnnotations(ctx context.Context, annotations map[string]string) (map[string]string, error) {
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	enrichedAnnotations := annotations
+	// Copied, not aliased: the caller passes its own manifest's map, and the entries added
+	// below belong to the summary object being built rather than to that manifest. Writing
+	// through left a CVE manifest carrying summary annotations it never had, which is the
+	// same hazard applyExceptionsToManifest already clones to avoid.
+	enrichedAnnotations := make(map[string]string, len(annotations)+3)
+	maps.Copy(enrichedAnnotations, annotations)
 
 	workload, ok := ctx.Value(domain.WorkloadKey{}).(domain.ScanCommand)
 	if !ok {
@@ -769,15 +771,14 @@ func enrichSummaryManifestObjectAnnotations(ctx context.Context, annotations map
 }
 
 func enrichSummaryManifestObjectLabels(ctx context.Context, labels map[string]string, withRelevancy bool) (map[string]string, error) {
-	if labels == nil {
-		labels = make(map[string]string)
-	}
+	// Copied for the same reason as the annotations above.
+	enrichedLabels := make(map[string]string, len(labels)+7)
+	maps.Copy(enrichedLabels, labels)
 	if withRelevancy {
-		labels[helpersv1.ContextMetadataKey] = helpersv1.ContextMetadataKeyFiltered
+		enrichedLabels[helpersv1.ContextMetadataKey] = helpersv1.ContextMetadataKeyFiltered
 	} else {
-		labels[helpersv1.ContextMetadataKey] = helpersv1.ContextMetadataKeyNonFiltered
+		enrichedLabels[helpersv1.ContextMetadataKey] = helpersv1.ContextMetadataKeyNonFiltered
 	}
-	enrichedLabels := labels
 
 	workload, ok := ctx.Value(domain.WorkloadKey{}).(domain.ScanCommand)
 	if !ok {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -3766,3 +3766,50 @@ func TestCalculateVexCanonicalHash_StableAcrossMapOrder(t *testing.T) {
 			"the shape already in use must hash exactly as it did before")
 	})
 }
+
+// The enrich helpers take the caller's own manifest maps. They used to alias them and write
+// through, so a CVE manifest came back from StoreCVESummary carrying summary annotations and
+// labels it never had: eight labels where it passed one. applyExceptionsToManifest already
+// clones for this reason; these did not.
+func TestEnrichSummaryManifestObject_DoesNotMutateCaller(t *testing.T) {
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:          "wlid://cluster-a/namespace-b/deployment-c",
+		ContainerName: "app",
+	})
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1))
+
+	annotations := map[string]string{"mine": "keep"}
+	labels := map[string]string{"mine": "keep"}
+
+	gotAnnotations, err := enrichSummaryManifestObjectAnnotations(ctx, annotations)
+	require.NoError(t, err)
+	gotLabels, err := enrichSummaryManifestObjectLabels(ctx, labels, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"mine": "keep"}, annotations, "caller's annotations must be untouched")
+	assert.Equal(t, map[string]string{"mine": "keep"}, labels, "caller's labels must be untouched")
+
+	// and the returned maps still carry both the caller's entries and the added ones
+	assert.Equal(t, "keep", gotAnnotations["mine"])
+	assert.Equal(t, "keep", gotLabels["mine"])
+	assert.Equal(t, helpersv1.ContextMetadataKeyFiltered, gotLabels[helpersv1.ContextMetadataKey])
+	assert.Equal(t, "deployment", gotLabels[helpersv1.RelatedKindMetadataKey])
+	assert.NotEmpty(t, gotAnnotations[helpersv1.WlidMetadataKey])
+}
+
+// A nil map in still gives a usable map out, which is what the nil checks used to provide.
+func TestEnrichSummaryManifestObject_HandlesNilMaps(t *testing.T) {
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid: "wlid://cluster-a/namespace-b/deployment-c",
+	})
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1))
+
+	gotAnnotations, err := enrichSummaryManifestObjectAnnotations(ctx, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, gotAnnotations)
+
+	gotLabels, err := enrichSummaryManifestObjectLabels(ctx, nil, false)
+	require.NoError(t, err)
+	assert.NotNil(t, gotLabels)
+	assert.Equal(t, helpersv1.ContextMetadataKeyNonFiltered, gotLabels[helpersv1.ContextMetadataKey])
+}


### PR DESCRIPTION
## Overview

`enrichSummaryManifestObjectAnnotations` and `enrichSummaryManifestObjectLabels` aliased the caller's manifest maps instead of copying them, so everything they add for the summary object was written into the manifest passed in. A manifest handed to `StoreCVESummary` came back with eight labels where it passed one.

## Additional Information

`applyExceptionsToManifest` already clones both maps before touching them for exactly this reason, so the hazard is recognised elsewhere in the same flow; these two were the pair that did not.

the labels function was slightly worse than the annotations one: it set the context label on the incoming map *before* aliasing, so that entry landed on the caller even on the paths that return an error immediately after.

both now build their own map and copy the caller's entries in, so the returned map is unchanged in content and the input is untouched. the nil handling comes along for free: copying from a nil map is a no-op and the result is still non-nil, which is what the old nil checks provided.

I have not traced an ordering today where a mutated manifest is then stored or submitted with the wrong labels, so this is latent rather than observed. it is cheap to close and the alternative is that the next reordering of the store calls decides it.

## How to Test

`go build ./... && go vet ./repositories/... && go test ./repositories/ -count=1`

Existing tests pass unchanged, including the `StoreCVESummary` ones, which is what says the returned maps still carry what they did.

`TestEnrichSummaryManifestObject_DoesNotMutateCaller` is new: it passes a one-entry map to each, asserts the caller's maps are still exactly that one entry afterwards, and that the returned maps carry both the caller's entry and the added ones.

`TestEnrichSummaryManifestObject_HandlesNilMaps` pins that nil in still gives a usable map out.

restoring the alias fails the first of those.

## Related issues/PRs:

* Resolved #784
