### PR TITLE
fix(controllers): stop scan status lookups from sweeping the whole store

### DIFF
--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -38,15 +38,18 @@ func newScanStatusStore() *scanStatusStore {
 	}
 }
 
+// expiredTerminal reports whether status is a terminal record whose TTL has elapsed as of
+// now. Used both by evictLocked's full-store sweep and by get's single-key check.
+func expiredTerminal(status domain.ScanStatus, now time.Time, ttl time.Duration) bool {
+	return isTerminal(status.State) && status.FinishedAt != nil && now.Sub(*status.FinishedAt) > ttl
+}
+
 // evictLocked removes terminal records older than s.ttl, then, if still over
 // s.maxEntries, removes the oldest terminal records until the cap is met. Active
 // (queued/running) records are never evicted. Callers must hold s.mu for writing.
 func (s *scanStatusStore) evictLocked(now time.Time) {
 	for jobID, status := range s.items {
-		if !isTerminal(status.State) {
-			continue
-		}
-		if status.FinishedAt != nil && now.Sub(*status.FinishedAt) > s.ttl {
+		if expiredTerminal(status, now, s.ttl) {
 			delete(s.items, jobID)
 		}
 	}
@@ -235,10 +238,30 @@ func (s *scanStatusStore) markTerminal(jobID string, state domain.ScanState, rea
 	s.evictLocked(now)
 }
 
+// get looks up jobID without paying for evictLocked's full-store sweep: recordAccepted and
+// markTerminal already run it on every write, so the store is kept bounded and mostly fresh
+// without a read needing to do that work too (see #790). The one thing a read still owes on
+// its own is not handing back a terminal record whose TTL has elapsed but that no write has
+// evicted yet -- expiredTerminal is the same check evictLocked uses, applied to just this one
+// entry instead of every entry in the store.
 func (s *scanStatusStore) get(jobID string) (domain.ScanStatus, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.evictLocked(time.Now().UTC())
+	s.mu.RLock()
 	status, ok := s.items[jobID]
-	return status, ok
+	s.mu.RUnlock()
+	if !ok {
+		return domain.ScanStatus{}, false
+	}
+	now := time.Now().UTC()
+	if !expiredTerminal(status, now, s.ttl) {
+		return status, true
+	}
+
+	// Evict just this key: re-check under the write lock in case a concurrent write
+	// already removed or changed it between the RUnlock above and here.
+	s.mu.Lock()
+	if cur, ok := s.items[jobID]; ok && expiredTerminal(cur, now, s.ttl) {
+		delete(s.items, jobID)
+	}
+	s.mu.Unlock()
+	return domain.ScanStatus{}, false
 }

--- a/controllers/scan_status_test.go
+++ b/controllers/scan_status_test.go
@@ -99,6 +99,74 @@ func TestScanStatusStore_EvictsOldestTerminalEntriesOverCap(t *testing.T) {
 	require.True(t, ok, "newly accepted job must be retained")
 }
 
+// Before #790, get() ran evictLocked's full-store sweep on every call, so a lookup for one
+// jobID paid for evaluating every other entry in the store too. This proves get() no longer
+// does that: stale, unrelated terminal entries elsewhere in the store must survive a get()
+// call for a different key, since only a write path (recordAccepted/markTerminal) or a get()
+// for that specific key is what evicts them now.
+func TestScanStatusStore_GetDoesNotEvictUnrelatedStaleEntries(t *testing.T) {
+	s := newScanStatusStore()
+	s.ttl = time.Millisecond
+
+	s.recordAccepted("stale-1", "generateSBOM")
+	s.markSucceeded("stale-1")
+	s.recordAccepted("stale-2", "generateSBOM")
+	s.markSucceeded("stale-2")
+
+	// Backdate both past the TTL directly, bypassing the eviction that recordAccepted and
+	// markSucceeded already ran while their own FinishedAt was still fresh.
+	s.mu.Lock()
+	longAgo := time.Now().UTC().Add(-time.Hour)
+	for _, jobID := range []string{"stale-1", "stale-2"} {
+		st := s.items[jobID]
+		st.FinishedAt = &longAgo
+		s.items[jobID] = st
+	}
+	s.mu.Unlock()
+
+	// A get() for an unrelated, non-existent key must not sweep the store.
+	_, ok := s.get("unrelated")
+	require.False(t, ok)
+
+	s.mu.RLock()
+	_, stale1Present := s.items["stale-1"]
+	_, stale2Present := s.items["stale-2"]
+	s.mu.RUnlock()
+	require.True(t, stale1Present, "get() for a different key must not evict unrelated stale entries")
+	require.True(t, stale2Present, "get() for a different key must not evict unrelated stale entries")
+}
+
+// get() must still refuse to hand back a terminal entry whose TTL has elapsed, and must
+// evict exactly the key it was asked about -- not the whole store -- when it finds one.
+func TestScanStatusStore_GetEvictsOnlyTheRequestedStaleKey(t *testing.T) {
+	s := newScanStatusStore()
+	s.ttl = time.Millisecond
+
+	s.recordAccepted("stale", "generateSBOM")
+	s.markSucceeded("stale")
+	s.recordAccepted("other-stale", "generateSBOM")
+	s.markSucceeded("other-stale")
+
+	s.mu.Lock()
+	longAgo := time.Now().UTC().Add(-time.Hour)
+	for _, jobID := range []string{"stale", "other-stale"} {
+		st := s.items[jobID]
+		st.FinishedAt = &longAgo
+		s.items[jobID] = st
+	}
+	s.mu.Unlock()
+
+	_, ok := s.get("stale")
+	require.False(t, ok, "expired terminal entry must not be returned")
+
+	s.mu.RLock()
+	_, stalePresent := s.items["stale"]
+	_, otherPresent := s.items["other-stale"]
+	s.mu.RUnlock()
+	require.False(t, stalePresent, "get() must evict the specific expired key it was asked about")
+	require.True(t, otherPresent, "get() must not evict unrelated expired entries it wasn't asked about")
+}
+
 func TestScanStatusStore_MarkRunningOnlyClaimsQueuedJobs(t *testing.T) {
 	s := newScanStatusStore()
 	s.recordAccepted("job", "generateSBOM")
@@ -124,4 +192,25 @@ func TestScanStatusStore_MarkRunningOnlyClaimsQueuedJobs(t *testing.T) {
 	status, ok = s.get("job")
 	require.True(t, ok)
 	require.Equal(t, domain.ScanStateAbandoned, status.State, "terminal jobs must reject later failure writes")
+}
+
+// Before #790, get()'s cost scaled with the store's total size (evictLocked's full sweep).
+// This benchmark's ns/op should stay flat across store sizes now that a lookup only touches
+// the one key it was asked for; run with -benchtime and compare sizes to see the effect, e.g.
+// go test ./controllers/ -run '^$' -bench BenchmarkScanStatusStore_Get -benchtime=200000x
+func BenchmarkScanStatusStore_Get(b *testing.B) {
+	for _, size := range []int{100, 10000} {
+		b.Run(fmt.Sprintf("storeSize=%d", size), func(b *testing.B) {
+			s := newScanStatusStore()
+			for i := 0; i < size; i++ {
+				jobID := fmt.Sprintf("job-%d", i)
+				s.recordAccepted(jobID, "generateSBOM")
+				s.markSucceeded(jobID)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				s.get("job-0")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`GET /v1/{version}/scanStatus/:jobID` is a single-key lookup, but `scanStatusStore.get()` ran the store's full `evictLocked` sweep — an O(n) walk of every entry in the store — under an **exclusive** lock on every call, regardless of whether anything needed evicting.

```go
func (s *scanStatusStore) get(jobID string) (domain.ScanStatus, bool) {
	s.mu.Lock()
	defer s.mu.Unlock()
	s.evictLocked(time.Now().UTC())
	status, ok := s.items[jobID]
	return status, ok
}
```

## Root cause

`evictLocked` is also called by `recordAccepted` (every scan acceptance) and `markTerminal` (every scan completion), so the store already self-cleans continuously as scans flow through it. `get()` running the same full-store sweep again on every read is redundant work — and because it takes the store's only mutex (`s.mu`) for writing, it serializes against `recordAccepted`/`markRunning`/`markPhase`/`markTerminal` for every other concurrently running scan for the duration of the sweep.

The one thing `get()` genuinely needs, that a write-triggered sweep doesn't guarantee by itself, is: never hand back a terminal record whose TTL has already elapsed but that hasn't been evicted by a write yet (existing test `TestScanStatusStore_GetEvictsExpiredTerminalEntries` asserts exactly this). That only requires checking the *one* entry being requested, not the whole store.

## Fix

- Extracted the per-entry TTL check `evictLocked` already did into `expiredTerminal(status, now, ttl)`, shared by both `evictLocked`'s sweep and `get()`.
- `get()` now takes `s.mu.RLock()`, looks up the one key, and returns immediately if it isn't an expired terminal record — O(1), no sweep.
- If the requested entry *is* an expired terminal record, `get()` upgrades to a narrow write lock and deletes just that key (re-checking it's still expired after acquiring the lock, in case a concurrent write changed it), then reports not-found — matching `evictLocked`'s own deletion behavior for that entry, but scoped to the one key instead of the whole store.
- `maxEntries` capping and routine TTL cleanup are unaffected: they're still fully handled by the existing `recordAccepted`/`markTerminal` → `evictLocked` calls, which never depended on `get()` also running them (map growth only ever happens in `recordAccepted`, which already sweeps right after adding an entry).

## Testing

- All existing `controllers/scan_status_test.go` tests pass unmodified, including `TestScanStatusStore_GetEvictsExpiredTerminalEntries`, which specifically asserts `get()` still never returns an expired-but-unevicted terminal entry.
- New regression tests:
  - `TestScanStatusStore_GetDoesNotEvictUnrelatedStaleEntries` — populates two stale, terminal, unrelated entries, calls `get()` for a different key, and asserts both stale entries are still present in the map afterward. This is the direct regression test for the bug: before the fix, any `get()` call would have swept and removed them.
  - `TestScanStatusStore_GetEvictsOnlyTheRequestedStaleKey` — asserts `get()` on an expired key both reports not-found *and* evicts exactly that key, while a second unrelated expired entry is left untouched (proving eviction is now scoped, not global).
  - `BenchmarkScanStatusStore_Get` — benchmarks `get()` against store sizes of 100 and 10,000 entries; ns/op should stay flat across sizes now, versus scaling with store size before.
- `go build ./controllers/...` and `go vet ./controllers/...` pass.

## Impact

- A status poll no longer pays for evaluating every other entry in the store, and no longer blocks every other in-flight scan's phase-tracking writes for the duration of a full-store scan.
- Purely an internal locking/complexity change: the store's external eviction guarantees (TTL expiry, `maxEntries` cap) are unchanged, and `HTTPController.ScanStatus`, the only caller of `get()`, needs no changes.

Fixes #790


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan status lookups by avoiding unnecessary cleanup of unrelated expired records.
  * Expired entries are now removed only when they are specifically requested.
  * Active and current scan statuses return more efficiently.

* **Tests**
  * Added coverage for selective expiration cleanup.
  * Added performance benchmarks for lookups across stores of different sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->