### PR TITLE
fix(config): say why clusterData.json was rejected instead of only that it is missing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -330,10 +330,16 @@ func LoadBackendServicesConfig(configDir, apiURL string) (schema.IBackendService
 	}
 
 	if apiURL == "" {
-		if services, err := loadBackendServicesFromClusterData(configDir); err == nil {
+		services, err := loadBackendServicesFromClusterData(configDir)
+		if err == nil {
 			return services, nil
 		}
-		return nil, fmt.Errorf("no service configuration: provide %s/services.json, set API_URL, or set backendOpenAPI/eventReceiverRestURL in clusterData.json", configDir)
+		// Wrapped rather than replaced: clusterData.json being absent is only one of the
+		// three ways this fails. It also reports a parse failure and a file that parses but
+		// carries no usable URLs, and dropping those told an operator who had already set
+		// backendOpenAPI to go and set it, with nothing saying the file had been read and
+		// rejected. This runs at startup and is fatal, so it is the only message they get.
+		return nil, fmt.Errorf("no service configuration: provide %s/services.json, set API_URL, or set backendOpenAPI/eventReceiverRestURL in clusterData.json: %w", configDir, err)
 	}
 
 	client, err := v3.NewServiceDiscoveryClientV3(apiURL)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -363,3 +363,46 @@ func TestLoadConfigEnvBindingKeepsFilePrecedence(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "from-env", c.AccountID, "the environment must still win over the file")
 }
+
+// With no API_URL, clusterData.json is the last place LoadBackendServicesConfig looks, and
+// its failure used to be discarded in favour of a fixed message telling the operator to set
+// backendOpenAPI. That reads as "the file is missing" for all three ways it can fail, two of
+// which mean the file was found and rejected. This runs at startup and is fatal, so it is
+// the only message they get.
+func TestLoadBackendServicesConfig_NoAPIURL_SurfacesClusterDataError(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		wantIn   string
+	}{
+		{
+			name:     "clusterData parses but carries no usable URLs",
+			contents: `{"clusterName":"test"}`,
+			wantIn:   "no static backend URLs",
+		},
+		{
+			name:     "clusterData is not valid json",
+			contents: "{invalid-json",
+			wantIn:   "failed to parse",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "clusterData.json"), []byte(tt.contents), 0o600))
+
+			_, err := LoadBackendServicesConfig(dir, "")
+			require.Error(t, err)
+			// the guidance is still there, so a genuinely absent file still reads the same
+			assert.Contains(t, err.Error(), "no service configuration")
+			// and now says why the file it did find was rejected
+			assert.Contains(t, err.Error(), tt.wantIn)
+		})
+	}
+
+	t.Run("a genuinely absent clusterData still reports the guidance", func(t *testing.T) {
+		_, err := LoadBackendServicesConfig(t.TempDir(), "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no service configuration")
+	})
+}


### PR DESCRIPTION
## Overview

With no `API_URL`, `clusterData.json` is the last place `LoadBackendServicesConfig` looks, and its error was discarded in favour of a fixed message telling the operator to set `backendOpenAPI`/`eventReceiverRestURL`. That file fails three ways and only one of them is absence, so a file that was found and rejected reported as one that was never there.

## Additional Information

the third failure mode is the one worth surfacing: `normalizeServiceURL` returns empty for anything it cannot make sense of, so a typo in either URL produces "no static backend URLs" and the operator was told to set a field sitting in the file in front of them.

this runs at startup and `cmd/http/main.go` treats it as fatal, so it is the only message they get.

the branch below in the same function already keeps its errors rather than replacing them, with `errors.Join(err, fallbackErr)`. this one now wraps for the same reason.

the guidance text is kept rather than swapped out: when the file genuinely is absent, which is the common case, the message reads as it did.

## How to Test

`go build ./... && go vet ./... && go test ./config/ -count=1`

`TestLoadBackendServicesFromClusterData_Errors` passes unchanged; it covers the three failures at the level below this one.

`TestLoadBackendServicesConfig_NoAPIURL_SurfacesClusterDataError` is new and covers the path that discarded them: a file that parses but carries no usable URLs, and a file that is not valid JSON. Each asserts the guidance is still present *and* that the reason now is too. A third case pins that a genuinely absent file still reports the guidance.

restoring the old branch fails the first two and leaves the third passing.

## Related issues/PRs:

* Resolved #794
