### PR TITLE
fix(adapters,sbomscanner): guard the pull, not just cataloguing, against the temp-dir sweep

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -222,6 +222,18 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	pullMutexUnlockOnce := sync.Once{}
 	unlockPullMutex := func() { pullMutexUnlockOnce.Do(s.pullMutex.Unlock) }
 
+	// Registered before the pull, not just cataloguing: registryauth.ResolveSource below is
+	// what actually creates the stereoscope temp dir and downloads image layers into it, and
+	// that used to run fully unprotected against a concurrent StartPeriodicTempDirSweep pass
+	// -- in this process or the sidecar's, which shares the same os.TempDir() -- deleting the
+	// directory out from under a still-in-progress pull (see #796). Ownership of ending it
+	// transfers to the dl.Run closure below once source resolution succeeds, the same way
+	// pullMutex's unlock does; every early-return branch between here and there must end it
+	// for itself.
+	endTempDirUseOnce := sync.Once{}
+	endTempDirUseFn := tools.BeginActiveTempDirUse(os.TempDir())
+	endActiveTempDirUse := func() { endTempDirUseOnce.Do(endTempDirUseFn) }
+
 	// The MANIFEST_UNKNOWN and 401 fallback ladder lives in internal/registryauth, shared
 	// with the sidecar scanner, which ran a copy of it. The pull keeps its own context,
 	// carrying the size limit; ctxWithTimeout is what bounds the credential lookup.
@@ -243,6 +255,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		logger.L().Ctx(ctx).Warning("Syft timed out during image resolution",
 			helpers.String("imageID", imageID))
 		domainSBOM.Status = helpersv1.Incomplete
+		endActiveTempDirUse()
 		unlockPullMutex()
 		return domainSBOM, nil
 	case err != nil && (errors.Is(err, image.ErrImageTooLarge) || strings.Contains(err.Error(), image.ErrImageTooLarge.Error())):
@@ -253,10 +266,12 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		domainSBOM.Status = helpersv1.TooLarge
 		domainSBOM.Annotations[domain.StatusReasonAnnotationKey] = domain.ReasonImageTooLarge
 		domainSBOM.Annotations[domain.MaxImageSizeAnnotationKey] = fmt.Sprintf("%d", s.maxImageSize)
+		endActiveTempDirUse()
 		unlockPullMutex()
 		return domainSBOM, nil
 	case err != nil && strings.Contains(err.Error(), "401 Unauthorized"):
 		domainSBOM.Status = helpersv1.Unauthorize
+		endActiveTempDirUse()
 		unlockPullMutex()
 		return domainSBOM, err
 	case err != nil:
@@ -274,6 +289,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		// match options.Platform). Propagated as-is: classifySBOMError in core/services
 		// recognizes it via errors.As and reports a distinct "platform not found" reason
 		// instead of the generic SBOM-generation-failed fallback (see #512).
+		endActiveTempDirUse()
 		unlockPullMutex()
 		return domainSBOM, err
 	}
@@ -302,10 +318,6 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// or failure, late if the deadline fired first - is what makes pullMutex serialize the
 	// disk-touching work itself, not just the synchronous portion of the call.
 	dl := deadline.New(s.scanTimeout)
-	// Registered here, not deferred at CreateSBOM's own top level: this closure can outlive
-	// CreateSBOM's return (see the comment below), so the periodic temp-dir sweep must stay
-	// blind to this closure's completion, not to CreateSBOM's.
-	endActiveTempDirUse := tools.BeginActiveTempDirUse(os.TempDir())
 	err = dl.Run(func(stopper <-chan struct{}) error {
 		defer unlockPullMutex()
 		defer endActiveTempDirUse()

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -269,6 +269,12 @@ func activeScanLockPathForTest() string {
 // acquireSweepLease needs before it will remove anything - proving the guard is held for the
 // pull, not just for cataloguing afterward.
 func Test_syftAdapter_CreateSBOM_PullHoldsTempDirGuard(t *testing.T) {
+	// Both this test and its sidecar counterpart (pkg/sbomscanner/v1) contend for the same
+	// process-global lease file under os.TempDir(), and go test runs packages as concurrent
+	// processes. Redirect os.TempDir() to a directory private to this test - it reads TMPDIR
+	// at call time - so the two can never observe each other's lease.
+	t.Setenv("TMPDIR", t.TempDir())
+
 	release := make(chan struct{})
 	pullStarted := make(chan struct{})
 	var once sync.Once
@@ -305,7 +311,8 @@ func Test_syftAdapter_CreateSBOM_PullHoldsTempDirGuard(t *testing.T) {
 
 	independentLease := flock.New(activeScanLockPathForTest())
 	locked, lockErr := independentLease.TryLock()
-	if lockErr == nil && locked {
+	require.NoError(t, lockErr, "probing the sweep's exclusive lease must not itself fail")
+	if locked {
 		_ = independentLease.Unlock()
 	}
 	assert.False(t, locked, "a sweep's exclusive lease must not be acquirable while a pull is still in flight, before cataloguing has even started")

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	"github.com/anchore/syft/syft/format/syftjson/model"
+	"github.com/gofrs/flock"
 	"github.com/kinbiko/jsonassert"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
@@ -245,6 +247,89 @@ func Test_syftAdapter_CreateSBOM_TimeoutContext(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, helpersv1.Incomplete, sbom.Status)
+}
+
+// activeScanLockPathForTest must match internal/tools' own unexported activeScanLockPath(os.TempDir()):
+// same directory (os.TempDir(), which BeginActiveTempDirUse is always called with here and in
+// pkg/sbomscanner/v1), same filename. There is no exported way to ask tools for this path, so it
+// is duplicated here deliberately, the same way #796's own evidence had to cite it as a literal
+// to describe the mechanism from outside internal/tools.
+func activeScanLockPathForTest() string {
+	return filepath.Join(os.TempDir(), ".kubevuln-active-scan.lock")
+}
+
+// Test_syftAdapter_CreateSBOM_PullHoldsTempDirGuard is the regression test for #796:
+// BeginActiveTempDirUse used to be registered only once the pull had already finished (right
+// before cataloguing started), leaving the pull itself - which is what actually creates the
+// stereoscope temp dir and downloads layers into it - completely unprotected against a
+// concurrent StartPeriodicTempDirSweep pass in this process or the sidecar's, sharing the same
+// os.TempDir(). This stalls a real pull mid-flight (the manifest request never completes until
+// released) and, while it's stalled, asserts that a fresh, independent handle on the same
+// cross-process lease file cannot take the exclusive lock StartPeriodicTempDirSweep's own
+// acquireSweepLease needs before it will remove anything - proving the guard is held for the
+// pull, not just for cataloguing afterward.
+func Test_syftAdapter_CreateSBOM_PullHoldsTempDirGuard(t *testing.T) {
+	release := make(chan struct{})
+	pullStarted := make(chan struct{})
+	var once sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Never respond to the manifest request until the test releases it - a connection
+		// that accepts the request but stalls, not one that errors or refuses outright, so
+		// the pull is genuinely still in flight while this test inspects the lease.
+		once.Do(func() { close(pullStarted) })
+		<-release
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	adapter := NewSyftAdapter(30*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = adapter.CreateSBOM(context.Background(), "test", "", u.Host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+	}()
+
+	select {
+	case <-pullStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("pull never reached the manifest request")
+	}
+
+	independentLease := flock.New(activeScanLockPathForTest())
+	locked, lockErr := independentLease.TryLock()
+	if lockErr == nil && locked {
+		_ = independentLease.Unlock()
+	}
+	assert.False(t, locked, "a sweep's exclusive lease must not be acquirable while a pull is still in flight, before cataloguing has even started")
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("CreateSBOM never returned after the pull was released")
+	}
+
+	// The lease must be fully released once CreateSBOM has returned, so a genuinely stale
+	// directory left by some other, truly abandoned run can still be swept afterward.
+	require.Eventually(t, func() bool {
+		l := flock.New(activeScanLockPathForTest())
+		ok, lockErr := l.TryLock()
+		if lockErr != nil {
+			return false
+		}
+		if ok {
+			_ = l.Unlock()
+		}
+		return ok
+	}, 5*time.Second, 50*time.Millisecond, "the temp-dir guard must be released once CreateSBOM returns")
 }
 
 // mockRegistryImage serves a minimal single-layer image so syft.GetSource resolves without a

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DmitriyVTitov/size"
@@ -162,6 +163,18 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	logger.L().Debug("downloading image", helpers.String("imageID", imageID))
 	ctxWithTimeout, cancelPull := context.WithTimeout(ctx, timeout)
 	defer cancelPull()
+
+	// Registered before the pull, not just cataloguing: resolveSource below is what actually
+	// creates the stereoscope temp dir and downloads image layers into it, and that used to
+	// run fully unprotected against a concurrent StartPeriodicTempDirSweep pass -- in this
+	// process or the in-process adapter's, which shares the same os.TempDir() -- deleting the
+	// directory out from under a still-in-progress pull (see #796). Ownership of ending it
+	// transfers to the dl.Run closure below once source resolution succeeds; every early-return
+	// branch between here and there must end it for itself.
+	endTempDirUseOnce := sync.Once{}
+	endTempDirUseFn := tools.BeginActiveTempDirUse(os.TempDir())
+	endActiveTempDirUse := func() { endTempDirUseOnce.Do(endTempDirUseFn) }
+
 	src, err := resolveSource(ctxWithTimeout, func(_ context.Context, ref string, opts *image.RegistryOptions) (source.Source, error) {
 		return tools.RetryWithBackoff(ctxWithTimeout, "source_resolution", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (source.Source, error) {
 			ctxWithSize := context.WithValue(retryCtx, image.MaxImageSize, req.MaxImageSize) //nolint:staticcheck // stereoscope requires string context key
@@ -177,6 +190,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	case err != nil && (errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "context deadline exceeded")):
 		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategorySizeClassification, metrics.FallbackStrategyIncomplete, metrics.FallbackOutcomeClassified)
 		logger.L().Warning("image pull timed out", helpers.String("imageID", imageID))
+		endActiveTempDirUse()
 		return &pb.CreateSBOMResponse{
 			Status: helpersv1.Incomplete,
 		}, nil
@@ -185,11 +199,13 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		logger.L().Warning("Image exceeds size limit",
 			helpers.Int("maxImageSize", int(req.MaxImageSize)),
 			helpers.String("imageID", imageID))
+		endActiveTempDirUse()
 		return &pb.CreateSBOMResponse{
 			Status:       helpersv1.TooLarge,
 			StatusReason: domain.ReasonImageTooLarge,
 		}, nil
 	case err != nil && strings.Contains(err.Error(), "401 Unauthorized"):
+		endActiveTempDirUse()
 		return &pb.CreateSBOMResponse{
 			Status:       helpersv1.Unauthorize,
 			ErrorMessage: err.Error(),
@@ -205,6 +221,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 			helpers.String("platform", req.Platform),
 			helpers.String("imageID", imageID),
 			helpers.Error(err))
+		endActiveTempDirUse()
 		return &pb.CreateSBOMResponse{
 			ErrorMessage: err.Error(),
 			StatusReason: domain.ReasonPlatformNotFound,
@@ -214,6 +231,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		// SidecarSBOMAdapter.CreateSBOM) reconstructs a *transport.Error from it to keep
 		// ScanService.checkCreateSBOM's errors.As(...) check working the same way it does
 		// for the in-process syft adapter.
+		endActiveTempDirUse()
 		return &pb.CreateSBOMResponse{
 			ErrorMessage: err.Error(),
 			StatusReason: domain.ReasonTooManyRequests,
@@ -222,6 +240,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		if isPlatformMismatch(err) {
 			metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryPlatform, metrics.FallbackStrategyPlatformMismatch, metrics.FallbackOutcomeFailed)
 		}
+		endActiveTempDirUse()
 		return &pb.CreateSBOMResponse{
 			ErrorMessage: err.Error(),
 		}, nil
@@ -241,10 +260,6 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// Buffered so the abandoned goroutine below can always publish and exit, even when
 	// nobody is left to receive.
 	generated := make(chan *sbom.SBOM, 1)
-	// Registered here rather than deferred at the handler's own top level: this closure can
-	// outlive the handler's return (see the comment below), so the periodic temp-dir sweep
-	// must stay blind to this closure's completion, not the handler's.
-	endActiveTempDirUse := tools.BeginActiveTempDirUse(os.TempDir())
 	err = dl.Run(func(stopper <-chan struct{}) error {
 		defer endActiveTempDirUse()
 		defer func(src source.Source) {

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -780,6 +780,12 @@ func activeScanLockPathForTest() string {
 // acquireSweepLease needs before it will remove anything - proving the guard is held for the
 // pull, not just for cataloguing afterward.
 func TestCreateSBOM_PullHoldsTempDirGuard(t *testing.T) {
+	// Both this test and its in-process counterpart (adapters/v1) contend for the same
+	// process-global lease file under os.TempDir(), and go test runs packages as concurrent
+	// processes. Redirect os.TempDir() to a directory private to this test - it reads TMPDIR
+	// at call time - so the two can never observe each other's lease.
+	t.Setenv("TMPDIR", t.TempDir())
+
 	release := make(chan struct{})
 	pullStarted := make(chan struct{})
 	var once sync.Once
@@ -825,7 +831,8 @@ func TestCreateSBOM_PullHoldsTempDirGuard(t *testing.T) {
 
 	independentLease := flock.New(activeScanLockPathForTest())
 	locked, lockErr := independentLease.TryLock()
-	if lockErr == nil && locked {
+	require.NoError(t, lockErr, "probing the sweep's exclusive lease must not itself fail")
+	if locked {
 		_ = independentLease.Unlock()
 	}
 	assert.False(t, locked, "a sweep's exclusive lease must not be acquirable while a pull is still in flight, before cataloguing has even started")

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
+	"github.com/gofrs/flock"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/kubevuln/core/domain"
@@ -756,6 +758,98 @@ func TestCreateSBOM_PullTimeout_ReturnsIncompleteInsteadOfHanging(t *testing.T) 
 		// truly never returns, fail with a clear message instead of hanging the suite.
 		t.Fatal("CreateSBOM never returned after the pull's TimeoutSeconds elapsed - the pull is not bounded by any deadline")
 	}
+}
+
+// activeScanLockPath must match internal/tools' own unexported activeScanLockPath(os.TempDir()):
+// same directory (os.TempDir(), which BeginActiveTempDirUse is always called with in this
+// package and adapters/v1), same filename. There is no exported way to ask tools for this path,
+// so it is duplicated here deliberately, the same way #796's own evidence had to cite it as a
+// literal to describe the mechanism from outside internal/tools.
+func activeScanLockPathForTest() string {
+	return filepath.Join(os.TempDir(), ".kubevuln-active-scan.lock")
+}
+
+// TestCreateSBOM_PullHoldsTempDirGuard is the regression test for #796: BeginActiveTempDirUse
+// used to be registered only once the pull had already finished (right before cataloguing
+// started), leaving the pull itself - which is what actually creates the stereoscope temp dir
+// and downloads layers into it - completely unprotected against a concurrent
+// StartPeriodicTempDirSweep pass in this process or the in-process adapter's, sharing the same
+// os.TempDir(). This stalls a real pull mid-flight (the manifest request never completes until
+// released) and, while it's stalled, asserts that a fresh, independent handle on the same
+// cross-process lease file cannot take the exclusive lock StartPeriodicTempDirSweep's own
+// acquireSweepLease needs before it will remove anything - proving the guard is held for the
+// pull, not just for cataloguing afterward.
+func TestCreateSBOM_PullHoldsTempDirGuard(t *testing.T) {
+	release := make(chan struct{})
+	pullStarted := make(chan struct{})
+	var once sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Never respond to the manifest request until the test releases it - a connection
+		// that accepts the request but stalls, not one that errors or refuses outright, so
+		// the pull is genuinely still in flight while this test inspects the lease.
+		once.Do(func() { close(pullStarted) })
+		<-release
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
+			ImageId:         u.Host + "/test-image",
+			ImageTag:        u.Host + "/test-image:latest",
+			Platform:        "linux/amd64",
+			MaxImageSize:    1 << 30,
+			MaxSbomSize:     1 << 30,
+			TimeoutSeconds:  30,
+			InsecureUseHttp: true,
+		})
+	}()
+
+	select {
+	case <-pullStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("pull never reached the manifest request")
+	}
+
+	independentLease := flock.New(activeScanLockPathForTest())
+	locked, lockErr := independentLease.TryLock()
+	if lockErr == nil && locked {
+		_ = independentLease.Unlock()
+	}
+	assert.False(t, locked, "a sweep's exclusive lease must not be acquirable while a pull is still in flight, before cataloguing has even started")
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("CreateSBOM never returned after the pull was released")
+	}
+
+	// The lease must be fully released once CreateSBOM has returned, so a genuinely stale
+	// directory left by some other, truly abandoned run can still be swept afterward.
+	require.Eventually(t, func() bool {
+		l := flock.New(activeScanLockPathForTest())
+		ok, lockErr := l.TryLock()
+		if lockErr != nil {
+			return false
+		}
+		if ok {
+			_ = l.Unlock()
+		}
+		return ok
+	}, 5*time.Second, 50*time.Millisecond, "the temp-dir guard must be released once CreateSBOM returns")
 }
 
 // TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft covers the deadline path: deadline.Run


### PR DESCRIPTION
## Problem

The periodic stereoscope temp-dir sweep (`internal/tools.StartPeriodicTempDirSweep`) is meant to never touch a directory a live pull or cataloguing pass is still using. `BeginActiveTempDirUse` — the call that registers that protection, both in-process (`activeTempDirUsers`) and across the `cmd/http`/`cmd/sbom-scanner` process boundary (a shared flock lease) — was only registered once cataloguing started, *after* the image pull had already finished. The pull itself, which is what actually creates the stereoscope temp directory and downloads layers into it, ran with no protection at all.

## Root cause

`adapters/v1/syft.go` and `pkg/sbomscanner/v1/server.go` both had the same shape:

```go
src, err := registryauth.ResolveSource(...)   // the pull — creates and writes the temp dir
...
endActiveTempDirUse := tools.BeginActiveTempDirUse(os.TempDir())   // the guard — too late
err = dl.Run(func(stopper <-chan struct{}) error { ... })          // cataloguing
```

`cmd/http` and `cmd/sbom-scanner` run as separate processes sharing the same `/tmp` volume and the same `"stereoscope-"` prefix, so a sweep in *either* process could win the race against a pull still running in the *other*. A pull that's still comfortably within its own configured timeout (an operator commonly raises `scanTimeout` well past the sidecar's fixed 5-minute sweep threshold for large images) had no guard in place for exactly the phase most likely to run long.

## Fix

Move `BeginActiveTempDirUse` to cover the whole operation — pull and cataloguing together — in both files:
- Registered right before `ResolveSource`/`resolveSource`, not after.
- Released on every early-return failure branch between the pull and cataloguing (mirroring how `adapters/v1/syft.go`'s existing `pullMutex` unlock is already threaded through those branches).
- Ownership handed off to the cataloguing closure's `defer` once the pull succeeds, since that closure can outlive the caller's own return (documented `deadline.Run` behavior already relied on for `pullMutex`).

Since `activeTempDirUsers`/the cross-process lease gate the sweep's *entire* pass rather than exempting one specific directory, this closes the gap regardless of how the sweep's staleness threshold compares to any given request's timeout — no separate change to the sidecar's sweep constant is needed.

## Testing

Added `Test_syftAdapter_CreateSBOM_PullHoldsTempDirGuard` (`adapters/v1/syft_test.go`) and `TestCreateSBOM_PullHoldsTempDirGuard` (`pkg/sbomscanner/v1/server_test.go`). Both stall a real pull mid-flight against a local `httptest` registry server (the manifest request never completes until the test releases it) and, while the pull is genuinely still in progress, assert that an independent handle on the same cross-process lease file cannot take the exclusive lock a sweep needs before removing anything — then assert the lease is released once `CreateSBOM` returns.

Verified both tests actually catch the regression: with the production fix stashed out, `TestCreateSBOM_PullHoldsTempDirGuard` fails with `Should be false ... a sweep's exclusive lease must not be acquirable while a pull is still in flight`, exactly the bug this PR fixes. With the fix applied, both tests pass.

- `go build ./adapters/v1/... ./pkg/sbomscanner/v1/...` — clean
- `go test ./adapters/v1/... -run Test_syftAdapter_CreateSBOM_PullHoldsTempDirGuard -v` — PASS
- `go test ./pkg/sbomscanner/v1/... -run TestCreateSBOM_PullHoldsTempDirGuard -v` — PASS

## Impact

Closes the window where a legitimately still-running image pull can have its own temp directory deleted mid-download by a concurrent sweep, in either process sharing `/tmp`. No behavior change for the success path or existing error handling — this only widens when the existing safety mechanism is active.

Fixes #796


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented temporary files from being cleaned up while an image is still being pulled or an SBOM is being generated.
  * Ensured temporary resources are released correctly after image-pull errors, completion, or timeouts.
  * Improved reliability for SBOM generation involving image downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->