### PR TITLE
ci: give golangci-lint headroom over its actual runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ lint:
 	@base_ref=$${GITHUB_BASE_REF:-main}; \
 	base=$$(git merge-base HEAD upstream/$$base_ref 2>/dev/null || git merge-base HEAD origin/$$base_ref 2>/dev/null || true); \
 	if [ -n "$$base" ]; then \
-		golangci-lint run --timeout=5m --new-from-rev="$$base"; \
+		golangci-lint run --timeout=15m --new-from-rev="$$base"; \
 	else \
-		golangci-lint run --timeout=5m; \
+		golangci-lint run --timeout=15m; \
 	fi
 
 lint-all:
-	golangci-lint run --timeout=5m
+	golangci-lint run --timeout=15m
 
 verify: build test vet lint
 


### PR DESCRIPTION
## Overview

The lint job is set to `--timeout=5m` and routinely finishes just under it. The last five successful runs of the branch-scoped lint step took 225s, 273s, 274s, 278s and 284s, so it completes at 91 to 95 percent of its own budget and clears it by 15 to 25 seconds. That margin is runner variance, not headroom.

#773's run crossed it at 353s and failed with `Timeout exceeded: try increasing it by passing --timeout option`.

## Additional Information

the failure is worth avoiding rather than re-running because of how it reads: the check goes red with `make: *** [Makefile:19: lint] Error 4` and no findings, which looks like a lint failure. and a contributor working from a fork cannot re-run it, `Must have admin rights to Repository`, so it needs a maintainer for something that is not a code problem.

`--timeout` is a ceiling rather than a wait, so this changes nothing about runs that finish in four minutes. it only stops the ones that would have finished in six from failing for it.

`lint-all` gets the same value. it lints the whole tree rather than a diff, so it has strictly more work to do than the branch-scoped target and carrying the tighter bound there makes less sense still.

15m rather than something tighter because the point is to stop tuning this against observed runtime: the observed runtime is what put it in this position. the ceiling only matters when something is genuinely stuck, and for that a large multiple of the real cost is the right shape.

nothing else in the recipe changes; the `merge-base` logic and `--new-from-rev` behaviour are untouched.

## How to Test

`make lint` locally, or the lint check on this PR.

The recipe's shell logic is unchanged, which can be confirmed by running the same commands it expands to:

```
base_ref=${GITHUB_BASE_REF:-main}
base=$(git merge-base HEAD upstream/$base_ref 2>/dev/null || git merge-base HEAD origin/$base_ref 2>/dev/null || true)
# -> golangci-lint run --timeout=15m --new-from-rev=<base>
```

The diff is three occurrences of the flag value and nothing else.

## Related issues/PRs:

* Resolved #798


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the linting timeout to improve reliability for larger or longer-running checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->