### PR TITLE
ci: declare permissions on the two workflows that had none

### DIFF
--- a/.github/workflows/offline-db.yaml
+++ b/.github/workflows/offline-db.yaml
@@ -3,6 +3,13 @@ on:
     workflow_dispatch:
     schedule:
         - cron: "1 1 * * *"
+
+# Default for every job here. workflow-keepalive overrides it below with the actions:write
+# it needs; deploy authenticates to Quay with its own secrets rather than GITHUB_TOKEN, so
+# read access for the checkout is all it wants.
+permissions:
+    contents: read
+
 jobs:
     workflow-keepalive:
         if: github.event_name == 'schedule'

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [synchronize, ready_for_review, opened, reopened]
 
+# The image is pushed to Quay with its own registry secrets, not GITHUB_TOKEN, so read
+# access for the checkout is all this needs.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Overview

`offline-db.yaml` and `pr-image.yaml` were the only workflows with no `permissions` block at either level, so their jobs ran with whatever the repository default grants rather than with what they need. Both now declare `contents: read`.

## Additional Information

neither wants more than that. both authenticate to Quay with `QUAYIO_REGISTRY_USERNAME`/`QUAYIO_REGISTRY_PASSWORD` rather than with `GITHUB_TOKEN`, so read access for the checkout covers them.

`offline-db.yaml` already showed the intent: its `workflow-keepalive` job declares the `actions: write` it needs, and only `deploy` had nothing. that override is unaffected, since a job-level block replaces the top-level one rather than merging with it, so `workflow-keepalive` still holds `actions: write` and nothing else, exactly as before.

the project publishes an OpenSSF scorecard and Token-Permissions currently sits at 0 out of 10, "detected GitHub workflow tokens with excessive permissions". this is the unambiguous part of that: not a judgement about which scopes any given job ought to hold, only the two that never said.

## How to Test

Both files still parse, and every workflow now resolves a permissions block for every job:

```
lint.yaml                  job-level
offline-db.yaml            top-level, workflow-keepalive overriding
pr-created.yaml            top-level
pr-image.yaml              top-level
pr-merged.yaml             top-level
scorecard.yml              top-level
security-insights.yaml     top-level
```

`offline-db` is scheduled and dispatch-only, so it does not run on this PR; `pr-image` does, and building and pushing the image is what exercises the change.

## Related issues/PRs:

* Resolved #800
