### PR TITLE
ci: pin the two small third-party actions and stop one inheriting write scopes

### DIFF
--- a/.github/workflows/offline-db.yaml
+++ b/.github/workflows/offline-db.yaml
@@ -10,7 +10,9 @@ jobs:
         permissions:
             actions: write
         steps:
-            - uses: liskin/gh-workflow-keepalive@v1
+            # Pinned by commit rather than by the mutable v1 tag, as with
+            # mlilback/build-number in pr-merged.yaml. Update deliberately.
+            - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1
     deploy:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -25,12 +25,20 @@ jobs:
   reset-run-number:
     runs-on: ubuntu-latest
     name: reset github.run_number
+    # This job adds github.run_number to a fixed offset and returns the result. It reads
+    # nothing and writes nothing, so it does not want the workflow-level token at all, and
+    # without this it inherits every scope declared above: contents, packages, id-token and
+    # attestations, all write.
+    permissions: {}
     outputs:
       run-number: ${{ steps.get-build.outputs.build-number }}
     steps:
     - name: Get build number
       id: get-build
-      uses: mlilback/build-number@v1
+      # Pinned by commit rather than by the v1 tag: a tag is mutable, and this action was
+      # last released in February 2023, so whoever holds that repository can change what
+      # runs here at any point. Update deliberately.
+      uses: mlilback/build-number@81a5eb0abae9b77d036138284ba1094d49acbc32 # v1
       with:
         base: -149
         run-id: ${{ github.run_number }}


### PR DESCRIPTION
## Overview

`mlilback/build-number` adds `github.run_number` to a fixed offset and returns it. It reads nothing, writes nothing and needs no token. Its job declared no `permissions`, so it inherited every scope `pr-merged.yaml` sets at the top, `contents`, `packages`, `id-token` and `attestations`, all write, on a `pull_request_target` trigger.

It and `liskin/gh-workflow-keepalive` were both referenced by a mutable `v1` tag.

## Additional Information

`permissions: {}` on `reset-run-number` is what that job actually needs; the action calls no API.

on the pinning: `build-number` has four stars and was last pushed in February 2023, so the tag it is referenced by is one whose author can repoint it at any time, into a job that until now held four write scopes. pinning by commit makes what runs deterministic, and the tag stays in a trailing comment so the intended version is still readable.

the commits are the dereferenced targets. both tags are annotated, so `git/ref/tags/v1` returns the tag object's sha rather than the commit, and pinning to that would have been quietly wrong:

```
liskin/gh-workflow-keepalive  tag 581532d6... -> commit f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c
mlilback/build-number         tag 560761f8... -> commit 81a5eb0abae9b77d036138284ba1094d49acbc32
```

`docker/*` and `ossf/scorecard-action` are deliberately left on their tags. the project's scorecard has Pinned-Dependencies at 0 out of 10 and pinning everything is a bigger conversation with a real maintenance cost; these two are the subset where the maintenance signal behind the tag is thin enough that a moved tag is a realistic risk rather than a theoretical one.

## How to Test

Both files parse, and the resulting job configuration is:

```
reset-run-number  permissions: {}
                  uses: mlilback/build-number@81a5eb0abae9b77d036138284ba1094d49acbc32
workflow-keepalive permissions: {actions: write}   (unchanged)
                  uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c
```

`pr-merged` ignores `.github/workflows/*` in its `paths-ignore`, so it will not fire on this PR; the change is exercised on the next merge to main, where `reset-run-number` still has to produce `build-number` for the job that depends on it.

## Related issues/PRs:

* Resolved #801
