### PR TITLE
fix(build): fail the offline-db build when a download fails

### DIFF
--- a/build/Dockerfile.offline-db
+++ b/build/Dockerfile.offline-db
@@ -7,13 +7,26 @@ RUN apk add --no-cache curl jq
 # Set the working directory
 WORKDIR /app/grype-db
 
-# Download the listing.json file
+# Download the listing.json file.
+#
+# --fail on every download: without it curl treats an HTTP error as a successful transfer,
+# exits 0, and writes the error body to the file. The database download below is the last
+# command in its RUN, so its exit status is the layer's, and a 404 would ship an error page
+# to air-gapped clusters as their vulnerability database. --location follows a redirect
+# rather than saving it, and --show-error keeps the reason visible under --silent.
 ARG GRYPE_DB_ROOT=https://grype.anchore.io/databases/v6
-RUN curl -O $GRYPE_DB_ROOT/latest.json
+RUN curl --fail --location --silent --show-error -O $GRYPE_DB_ROOT/latest.json
 
-# Extract the database URL from the listing file and download it
+# Extract the database URL from the listing file and download it.
+#
+# DB_PATH is checked before use: jq prints "null" and exits 0 for a well-formed listing that
+# has no .path, which would otherwise be requested as a URL and fail the same quiet way.
 RUN DB_PATH=$(jq -r '.path' latest.json) && \
-    curl -O ${GRYPE_DB_ROOT}/$DB_PATH
+    if [ -z "$DB_PATH" ] || [ "$DB_PATH" = "null" ]; then \
+        echo "latest.json has no .path" >&2; \
+        exit 1; \
+    fi && \
+    curl --fail --location --silent --show-error -O ${GRYPE_DB_ROOT}/$DB_PATH
 
 # Stage 2: The final production image
 FROM busybox:latest


### PR DESCRIPTION
## Overview

curl treats an HTTP error as a successful transfer unless `--fail` is given: it exits 0 and writes the response body to the file. The database download is the last command in its `RUN`, so that exit status is the layer's, and a 404 there produces an image that builds clean and serves an error page to air-gapped clusters as their vulnerability database.

Verified against the real host: a 404 gives exit 0 and a 27150-byte error page saved under the requested name, where `--fail` gives exit 22 and no file.

## Additional Information

the listing download is caught today, but only incidentally: `jq` fails to parse the error page it gets handed and exits non-zero. that is a side effect rather than a check, and it does not hold for a listing that parses but carries no `.path`, where `jq -r '.path'` prints `null` and exits 0. `null` is then requested as a URL and 404s into the same silent path, so `DB_PATH` is checked explicitly rather than relying on the download to reject it.

`--location` and `--show-error` come along for the ride: a redirect is followed rather than saved as the file, and `--silent` still reports the reason on failure.

the nightly `offline-db` workflow pushes this image to `quay.io/kubescape/grype-offline-db:v6-latest`, so a bad build replaces a good one on a schedule rather than waiting for someone to notice.

two things deliberately not in scope. there is no integrity check on the downloaded database, no checksum against anything in `latest.json`, which is a larger change. and the builder stage is `FROM alpine` with no tag while the final stage is `FROM busybox:latest`, which is worth pinning but is a separate concern from this failing quietly.

## How to Test

The shell in the changed `RUN` parses as `sh`, and the guard behaves:

```
DB_PATH=""                              -> rejected
DB_PATH="null"                          -> rejected
DB_PATH="vulnerability-db_v6_....zst"   -> accepted
```

Building the image is the real test: `docker buildx build --file build/Dockerfile.offline-db .` still succeeds against the live listing, and pointing `GRYPE_DB_ROOT` at a path that 404s now fails the build instead of producing an image.

## Related issues/PRs:

* Resolved #804
