### PR TITLE
test(domain): cover the scan phase updater, which had none

### DIFF
--- a/core/domain/scan_status_test.go
+++ b/core/domain/scan_status_test.go
@@ -1,7 +1,10 @@
 package domain
 
 import (
+	"context"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,4 +28,113 @@ func TestScanStatusJSON_OmitsZeroLifecycleTimestamps(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &got))
 	require.NotContains(t, got, "startedAt")
 	require.NotContains(t, got, "finishedAt")
+}
+
+// UpdateScanPhase is what every phase reported by /v1/scanStatus travels through, from
+// twenty call sites across the four scan flows, and neither it nor WithScanPhaseUpdater had
+// any coverage. The round trip below is the part that matters: nothing asserted that a phase
+// handed to UpdateScanPhase reaches the function WithScanPhaseUpdater stored, so changing the
+// context key or the stored signature would have silently stopped all twenty reporting
+// without failing anything.
+func TestUpdateScanPhase_ReachesTheUpdater(t *testing.T) {
+	var got []string
+	ctx := WithScanPhaseUpdater(context.Background(), func(phase string) {
+		got = append(got, phase)
+	})
+
+	UpdateScanPhase(ctx, "sbom_generation")
+	UpdateScanPhase(ctx, "cve_matching")
+	UpdateScanPhase(ctx, "result_upload")
+
+	require.Equal(t, []string{"sbom_generation", "cve_matching", "result_upload"}, got,
+		"each phase should reach the updater, in the order reported")
+}
+
+// The rest of UpdateScanPhase is refusals, and each one stands between a scan and a panic or
+// a blanked phase. A scan flow calls it unconditionally; whether anything is listening is the
+// caller's business, not the scan's.
+func TestUpdateScanPhase_RefusesWhatItShould(t *testing.T) {
+	t.Run("an empty phase is ignored rather than blanking the current one", func(t *testing.T) {
+		called := false
+		ctx := WithScanPhaseUpdater(context.Background(), func(string) { called = true })
+
+		UpdateScanPhase(ctx, "")
+
+		assert.False(t, called, "an empty phase must not reach the updater")
+	})
+
+	t.Run("no updater in context is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			UpdateScanPhase(context.Background(), "cve_matching")
+		}, "a scan running without status tracking still calls this")
+	})
+
+	t.Run("a nil updater stored in context is a no-op", func(t *testing.T) {
+		// WithScanPhaseUpdater will store a nil func, and the type assertion succeeds on it,
+		// so the nil check in UpdateScanPhase is the only thing between this and a panic.
+		ctx := WithScanPhaseUpdater(context.Background(), nil)
+
+		assert.NotPanics(t, func() {
+			UpdateScanPhase(ctx, "cve_matching")
+		})
+	})
+
+	t.Run("a value of another type under the key is a no-op", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), scanPhaseUpdaterKey{}, "not a function")
+
+		assert.NotPanics(t, func() {
+			UpdateScanPhase(ctx, "cve_matching")
+		})
+	})
+}
+
+// The key is an unexported struct type, so nothing outside this package can collide with it
+// and no other package's context value can be mistaken for an updater.
+func TestScanPhaseUpdater_KeyIsPrivateToThisPackage(t *testing.T) {
+	ctx := WithScanPhaseUpdater(context.Background(), func(string) {})
+
+	assert.Nil(t, ctx.Value("scanPhaseUpdaterKey"), "a string key must not resolve the updater")
+	assert.Nil(t, ctx.Value(struct{}{}), "an unrelated empty struct must not resolve it either")
+	assert.NotNil(t, ctx.Value(scanPhaseUpdaterKey{}), "the package's own key does")
+}
+
+// ScanCP fans a single request out over several images and reports phases from the loop, so
+// the updater is reached repeatedly from the same context. It is also called from the worker
+// goroutine while the request goroutine has already returned.
+func TestUpdateScanPhase_ConcurrentReportersShareOneContext(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string]int{}
+	ctx := WithScanPhaseUpdater(context.Background(), func(phase string) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen[phase]++
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			UpdateScanPhase(ctx, "sbom_generation")
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 50, seen["sbom_generation"])
+}
+
+// A derived context overrides the updater it was derived from, which is what lets a
+// sub-scan report to its own job without disturbing the parent's.
+func TestWithScanPhaseUpdater_InnerOverridesOuter(t *testing.T) {
+	var outer, inner []string
+	outerCtx := WithScanPhaseUpdater(context.Background(), func(p string) { outer = append(outer, p) })
+	innerCtx := WithScanPhaseUpdater(outerCtx, func(p string) { inner = append(inner, p) })
+
+	UpdateScanPhase(innerCtx, "cve_matching")
+	UpdateScanPhase(outerCtx, "result_upload")
+
+	assert.Equal(t, []string{"cve_matching"}, inner)
+	assert.Equal(t, []string{"result_upload"}, outer, "the outer updater is unaffected")
 }


### PR DESCRIPTION
## Overview

`WithScanPhaseUpdater` and `UpdateScanPhase` were the only two functions in `core/domain` with no coverage, and they are what every phase `/v1/scanStatus` reports travels through, from twenty call sites across the four scan flows.

Nothing asserted the round trip. `core/domain` goes from 28.6% to 100%.

## Additional Information

the round trip is the contract: a phase handed to `UpdateScanPhase` reaching the function `WithScanPhaseUpdater` stored. changing the context key or the stored signature would have stopped all twenty call sites reporting while every test still passed, and the endpoint would have kept answering with the phase frozen wherever it last landed.

the rest of the function is refusals, and each stands between a scan and a panic or a blanked phase: an empty phase, no updater in context, a nil updater stored, and a value of another type under the key. a scan flow calls this unconditionally, so whether anything is listening is the caller's business rather than the scan's.

both guards are load-bearing, and the tests were checked against removing them rather than only against passing:

- dropping `if phase == ""` fails the empty-phase case
- dropping `update != nil` panics the nil-updater case, since the type assertion succeeds on a nil `func(string)`

two of the cases are about what the call sites actually do rather than the function in isolation: repeated reports from concurrent goroutines against one context, which is `ScanCP` fanning a request out over several images while the request goroutine has already returned, and a derived context overriding its parent's updater.

the key being an unexported struct type is also pinned, since that is what keeps another package's context value from being read as an updater.

## How to Test

`go test ./core/domain/ -cover -count=1` reports 100%, and `go test ./core/... -race -count=1` is clean, which the concurrent case needs.

No production code changes, so nothing else moves.

## Related issues/PRs:

* Resolved #806


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for scan-phase update delivery and validation.
  * Verified safe behavior with missing or invalid update handlers.
  * Tested context isolation, nested handler overrides, and concurrent reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->