### PR TITLE
docs(api): document maxQueueDepth's 503 admission-control response

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -291,7 +291,7 @@ POST /v1/sbomCreation
 | `200 OK` | Request accepted, SBOM generation started |
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
-| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
+| `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -345,7 +345,7 @@ POST /v1/scanImage
 | `200 OK` | Request accepted, CVE scan started |
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
-| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
+| `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -396,7 +396,7 @@ POST /v1/scanRegistryImage
 | `200 OK` | Request accepted, registry scan started |
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
-| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
+| `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -451,7 +451,7 @@ POST /v1/applicationProfileScan
 |--------|-------------|
 | `200 OK` | Request accepted, profile scan started |
 | `400 Bad Request` | Invalid request payload or validation failed |
-| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
+| `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -552,7 +552,7 @@ All responses follow RFC 7807.
 | `400` | Bad Request | Invalid JSON, missing required fields, or validation failed |
 | `429` | Too Many Requests | Registry rate limit hit on a previous pull for this image |
 | `500` | Internal Server Error | Internal error |
-| `503` | Service Unavailable | Two distinct causes, unrelated to each other: `/v1/readiness` reports it when the vulnerability DB isn't loaded, and a scan endpoint reports it when the admission queue is full (`maxQueueDepth` reached) |
+| `503` | Service Unavailable | Two distinct causes, unrelated to each other: `/v1/readiness` reports it when the vulnerability DB isn't loaded, and a scan endpoint reports it when scan admission capacity is full (positive `maxQueueDepth` reached) |
 
 ### Common Errors
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -291,6 +291,7 @@ POST /v1/sbomCreation
 | `200 OK` | Request accepted, SBOM generation started |
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
+| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -344,6 +345,7 @@ POST /v1/scanImage
 | `200 OK` | Request accepted, CVE scan started |
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
+| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -394,6 +396,7 @@ POST /v1/scanRegistryImage
 | `200 OK` | Request accepted, registry scan started |
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
+| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -448,6 +451,7 @@ POST /v1/applicationProfileScan
 |--------|-------------|
 | `200 OK` | Request accepted, profile scan started |
 | `400 Bad Request` | Invalid request payload or validation failed |
+| `503 Service Unavailable` | Scan admission queue is full (`maxQueueDepth` reached); retry later. Unrelated to `/v1/readiness` |
 
 #### Example
 
@@ -548,7 +552,7 @@ All responses follow RFC 7807.
 | `400` | Bad Request | Invalid JSON, missing required fields, or validation failed |
 | `429` | Too Many Requests | Registry rate limit hit on a previous pull for this image |
 | `500` | Internal Server Error | Internal error |
-| `503` | Service Unavailable | Service not ready (vulnerability DB not loaded) |
+| `503` | Service Unavailable | Two distinct causes, unrelated to each other: `/v1/readiness` reports it when the vulnerability DB isn't loaded, and a scan endpoint reports it when the admission queue is full (`maxQueueDepth` reached) |
 
 ### Common Errors
 
@@ -673,7 +677,10 @@ instead of a generic error.
 
 Kubevuln implements internal concurrency control via a worker pool. The number of concurrent scans is controlled by the `scanConcurrency` configuration option.
 
-When the worker queue is full, requests are still accepted but will be queued for processing.
+Whether an accepted-but-unfinished scan past that concurrency is queued or rejected depends on `maxQueueDepth` (see [CONFIGURATION.md](CONFIGURATION.md#scanning-options)):
+
+- **Unset, or `0`/negative (the default):** unbounded. Every request that passes validation is accepted and queued for processing, however large the backlog grows.
+- **A positive value:** bounded. Once that many scans are accepted but not yet finished (queued or running), each of the four scan endpoints (`sbomCreation`, `scanImage`, `scanRegistryImage`, `applicationProfileScan`) rejects further requests with `503 Service Unavailable` instead of queuing them — see each endpoint's Response table above. Callers should treat this as a signal to retry later, not as an error with the request itself.
 
 ---
 


### PR DESCRIPTION
## Problem

`docs/API.md`'s "Rate Limiting" section claimed "when the worker queue is full, requests are still accepted but will be queued for processing," and none of the four scan endpoints' Response tables (Generate SBOM, Scan Image for CVEs, Scan Registry Image, Application Profile Scan) listed a `503` response.

## Root cause

That was accurate before `maxQueueDepth` admission control (#749) existed, but the docs were never updated after it shipped. Every scan handler in `controllers/http.go` (`GenerateSBOM`, `ScanCP`, `ScanCVE`, `ScanRegistry`) calls `admitQueueSlot` before doing any work, which rejects with `503 Service Unavailable` (`domain.ErrQueueFull`) once `maxQueueDepth` accepted-but-unfinished scans are already outstanding, instead of queuing the request. `git log -- docs/API.md` confirms the file was only ever touched for `/v1/diagnostics` (#789) and the metrics table (#604/#655), never for `maxQueueDepth`.

The top-level "HTTP Status Codes" table did list `503`, but scoped it only to the `/v1/readiness` meaning ("vulnerability DB not loaded") — not mentioning that the same code, for an unrelated reason, is also a normal scan-endpoint response.

## Fix

- Added a `503 Service Unavailable` row to each of the four scan endpoints' Response tables.
- Rewrote the "Rate Limiting" section to describe both configurations accurately: unbounded (`maxQueueDepth` unset or `<= 0`, the default) queues every accepted request, while a positive `maxQueueDepth` rejects with `503` once reached. Cross-referenced `CONFIGURATION.md`'s `maxQueueDepth` entry, which already documents the `503` behavior correctly, so the two docs describe the same contract instead of disagreeing.
- Updated the top-level status-code table's `503` row to disambiguate the two unrelated causes (readiness vs. admission control).

## Testing

This is a documentation-only change — no Go code was touched. `lint.yaml` is path-filtered to `**/*.go`/`go.mod`/`go.sum`/`Makefile` and won't run against a docs-only diff, and the repo has no markdown-lint/link-check tooling to run locally. Verified by hand:
- Every edited Markdown table's column count and pipe alignment against its surrounding rows.
- The `CONFIGURATION.md#scanning-options` anchor resolves to the actual `#### Scanning Options` heading containing `maxQueueDepth`.
- Cross-checked every claim against the current code: `controllers/http.go`'s `admitQueueSlot`/`tryAdmit`/`validationStatusCode` (503 behavior and which four handlers call it) and `config/config.go`'s `maxQueueDepth` default (`0`, unbounded).

## Impact

Doc-only; no runtime behavior changes. A client integrating against `docs/API.md` alone can now tell that a scan request may be rejected with `503` under a supported, documented configuration (`maxQueueDepth`), instead of being told the opposite.

Fixes #810


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented `503 Service Unavailable` responses when the scan admission queue reaches its configured limit.
  - Clarified the distinct causes of `503` responses for readiness checks and scan endpoints.
  - Updated rate-limiting guidance to explain bounded and unbounded queue behavior.
  - Added guidance to retry scan requests later when the queue is full.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->