### PR TITLE
fix(adapters): give cloud exceptions precedence over CRD ones on overlap

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -299,6 +299,7 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	if len(seList) > 0 || len(cseList) > 0 {
 		target := BuildExceptionTarget(ctx, workload, seList, cseList, a.securityExceptionRepo)
 		crdPolicies, crdStats := ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
+		crdPolicies = excludeCloudCoveredPolicies(crdPolicies, vulnExceptionList)
 		vulnExceptionList = append(vulnExceptionList, crdPolicies...)
 		stats = crdStats
 
@@ -326,6 +327,42 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	}
 
 	return vulnExceptionList, stats, nil
+}
+
+// excludeCloudCoveredPolicies drops CRD-derived policies that cover a CVE the cloud-fetched
+// list already covers, per docs/security-exception-design.md's "Conflict Resolution &
+// Precedence" section: "If the cloud backend has an exception for a given CVE on a workload,
+// the cloud exception's status and metadata are used, and any conflicting CRD exception for
+// the same CVE on the same workload is ignored." Without this, GetCVEExceptions returned both
+// sources' policies for an overlapping CVE, so the manifest ended up with a CRD-attributed
+// IgnoreRule and exceptions_matched_total{sourceKind="SecurityException"} count that the
+// documented precedence says should not exist once cloud already owns that suppression (#812).
+//
+// Reuses cveExceptionIndex's own name normalization (lower-cased CVE ID/alias) so a CRD
+// exception naming a CVE by an alias the cloud exception names by its canonical ID, or vice
+// versa, still counts as the same CVE. A CRD policy not covered by any cloud policy passes
+// through unchanged, matching the doc's separate "non-overlapping exceptions are merged"
+// clause.
+func excludeCloudCoveredPolicies(crdPolicies, cloudPolicies []armotypes.VulnerabilityExceptionPolicy) []armotypes.VulnerabilityExceptionPolicy {
+	if len(cloudPolicies) == 0 || len(crdPolicies) == 0 {
+		return crdPolicies
+	}
+	cloudIndex := buildCVEExceptionIndex(cloudPolicies)
+
+	var filtered []armotypes.VulnerabilityExceptionPolicy
+	for _, p := range crdPolicies {
+		coveredByCloud := false
+		for _, vp := range p.VulnerabilityPolicies {
+			if len(cloudIndex.byName[strings.ToLower(vp.Name)]) > 0 {
+				coveredByCloud = true
+				break
+			}
+		}
+		if !coveredByCloud {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
 }
 
 // ReportError reports the given error to the platform

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -1067,6 +1067,114 @@ func TestGetCVEExceptions_MergesCRDExceptions(t *testing.T) {
 	assert.Empty(t, stats.ExpiredBySource, "nothing expired in this scenario")
 }
 
+// TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD is the regression test for #812:
+// docs/security-exception-design.md documents that when both a cloud and a CRD exception
+// cover the same CVE on the same workload, the cloud exception's status/metadata are used and
+// the conflicting CRD exception is ignored. GetCVEExceptions used to append CRD policies
+// unconditionally, so a CVE covered by both sources reached the caller (and, downstream, the
+// manifest's IgnoreRule provenance and the exceptions_matched_total metric) twice.
+func TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD(t *testing.T) {
+	cloudPolicies := []armotypes.VulnerabilityExceptionPolicy{
+		{
+			PortalBase:            armotypes.PortalBase{Name: "cloud-rule"},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2024-0001"}},
+		},
+	}
+
+	mockRepo := &mockSecurityExceptionRepo{
+		exceptions: []sev1beta1.SecurityException{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "crd-rule", Namespace: "default"},
+				Spec: sev1beta1.SecurityExceptionSpec{
+					Vulnerabilities: []sev1beta1.VulnerabilityException{
+						// Same CVE the cloud already covers.
+						{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2024-0001"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
+						// Not covered by cloud: must still come through.
+						{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2024-0002"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
+					},
+				},
+			},
+		},
+	}
+
+	a := &BackendAdapter{
+		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
+		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return cloudPolicies, nil
+		},
+		securityExceptionRepo: mockRepo,
+	}
+
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid: "wlid://cluster-test/namespace-default/deployment-myapp",
+	})
+
+	exceptions, _, err := a.GetCVEExceptions(ctx)
+	require.NoError(t, err)
+
+	var names []string
+	for _, e := range exceptions {
+		for _, vp := range e.VulnerabilityPolicies {
+			names = append(names, vp.Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{"CVE-2024-0001", "CVE-2024-0002"}, names,
+		"CVE-2024-0001 must appear exactly once (cloud's), not twice; CVE-2024-0002 (CRD-only) must still come through")
+
+	// The one CVE-2024-0001 entry must be the cloud's own policy (identifiable by its rule
+	// name), not the CRD's - the CRD's conflicting entry must be dropped, not merely deduplicated.
+	for _, e := range exceptions {
+		if e.VulnerabilityPolicies[0].Name == "CVE-2024-0001" {
+			assert.Equal(t, "cloud-rule", e.Name, "the surviving CVE-2024-0001 policy must be the cloud's, per the documented precedence")
+		}
+	}
+}
+
+func TestExcludeCloudCoveredPolicies(t *testing.T) {
+	cloud := func(names ...string) []armotypes.VulnerabilityExceptionPolicy {
+		var vp []armotypes.VulnerabilityPolicy
+		for _, n := range names {
+			vp = append(vp, armotypes.VulnerabilityPolicy{Name: n})
+		}
+		return []armotypes.VulnerabilityExceptionPolicy{{VulnerabilityPolicies: vp}}
+	}
+	crd := func(names ...string) []armotypes.VulnerabilityExceptionPolicy {
+		var vp []armotypes.VulnerabilityPolicy
+		for _, n := range names {
+			vp = append(vp, armotypes.VulnerabilityPolicy{Name: n})
+		}
+		return []armotypes.VulnerabilityExceptionPolicy{{PortalBase: armotypes.PortalBase{Name: "crd-rule"}, VulnerabilityPolicies: vp}}
+	}
+
+	tests := []struct {
+		name        string
+		crdPolicies []armotypes.VulnerabilityExceptionPolicy
+		cloud       []armotypes.VulnerabilityExceptionPolicy
+		wantLen     int
+	}{
+		{"no cloud policies: CRD passes through unchanged", crd("CVE-1"), nil, 1},
+		{"no CRD policies: nothing to filter", nil, cloud("CVE-1"), 0},
+		{"no overlap: CRD policy is kept", crd("CVE-1"), cloud("CVE-2"), 1},
+		{"exact overlap: CRD policy is dropped", crd("CVE-1"), cloud("CVE-1"), 0},
+		{"case-insensitive overlap: CRD policy is dropped", crd("cve-1"), cloud("CVE-1"), 0},
+		{
+			"alias overlap: a CRD policy naming the CVE by an alias the cloud policy names by its canonical ID is still dropped",
+			crd("CVE-2024-ALIAS"), cloud("CVE-2024-0001", "CVE-2024-ALIAS"), 0,
+		},
+		{
+			"a CRD policy listing multiple names (ID + aliases) is dropped entirely if any one of them overlaps",
+			crd("CVE-2024-0001", "CVE-2024-ALIAS"), cloud("CVE-2024-ALIAS"), 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := excludeCloudCoveredPolicies(tt.crdPolicies, tt.cloud)
+			assert.Len(t, got, tt.wantLen)
+		})
+	}
+}
+
 func TestGetCVEExceptions_ScopesCRDByMatch(t *testing.T) {
 	// A cluster exception scoped to redis images must NOT be applied to an
 	// nginx workload — this is the fail-open regression the match logic fixes.


### PR DESCRIPTION
## Problem

`docs/security-exception-design.md`'s "Conflict Resolution & Precedence" section specifies exactly how `GetCVEExceptions()` should merge cloud and CRD exceptions when both cover the same CVE on the same workload — the implementation didn't do it.

## Root cause

The documented contract:

> **Cloud exceptions take precedence.** If the cloud backend has an exception for a given CVE on a workload, the cloud exception's status and metadata are used, and any conflicting CRD exception for the same CVE on the same workload is ignored.
>
> **Implementation**: During the merge in `GetCVEExceptions()`, cloud exceptions are added first. CRD exceptions are only appended for CVE+workload combinations not already covered by a cloud exception.

The actual code (`adapters/v1/backend.go`) appended `crdPolicies` unconditionally:

```go
vulnExceptionList = append(vulnExceptionList, crdPolicies...)
```

There was no check of which CVEs the cloud-fetched `vulnExceptionList` already covered. Downstream, `buildIgnoreRules` records one `IgnoreRule` per Ignore-actioned policy matching a CVE, and `recordExceptionsMatched` increments `kubevuln_exceptions_matched_total{sourceKind="SecurityException"}` per matched CRD-attributed policy — so an overlapping CVE ended up with two provenance entries and an inflated CRD-suppression count, both contradicting the documented "conflicting CRD exception is ignored." Not a suppression-correctness bug (the CVE was suppressed either way, by whichever source), but a real gap in the audit/provenance guarantee the design doc treats as a first-class, compliance-motivated behavior.

## Fix

Added `excludeCloudCoveredPolicies` in `adapters/v1/backend.go`, called between converting CRD exceptions and appending them to the result:

```go
crdPolicies, crdStats := ConvertToVulnerabilityExceptionPolicies(seList, cseList, target)
crdPolicies = excludeCloudCoveredPolicies(crdPolicies, vulnExceptionList)
vulnExceptionList = append(vulnExceptionList, crdPolicies...)
```

It reuses the existing `cveExceptionIndex`/`buildCVEExceptionIndex` (already the canonical lower-cased CVE/alias name index used elsewhere in this file) to build a set of CVEs the cloud list covers, then drops any CRD policy whose `VulnerabilityPolicies[].Name` matches one of them — including via alias, so a CRD exception naming a CVE by an alias the cloud exception names by its canonical ID (or vice versa) is still recognized as the same CVE. A CRD policy not covered by any cloud policy passes through unchanged, preserving the doc's "non-overlapping exceptions are merged" behavior (already correct before this change).

## Testing

- `TestExcludeCloudCoveredPolicies` — table-driven unit test of the new helper directly: no cloud policies (pass-through), no CRD policies, no overlap, exact overlap, case-insensitive overlap, alias overlap, and a multi-name CRD policy dropped entirely when any one of its names overlaps.
- `TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD` — the regression test for #812: cloud and CRD both cover `CVE-2024-0001`, CRD alone covers `CVE-2024-0002`. Asserts `CVE-2024-0001` appears exactly once in the result (the cloud's own policy, identified by its rule name — not merely deduplicated to *some* entry) and `CVE-2024-0002` still comes through.
- Existing `TestGetCVEExceptions_MergesCRDExceptions` and `TestGetCVEExceptions_ScopesCRDByMatch` still pass unmodified, confirming the non-overlapping merge and match-scoping behavior are unaffected.

Ran:
- `go build ./adapters/v1/...` — clean
- `go vet ./adapters/v1/...` — clean
- `go test ./adapters/v1/... -run "TestExcludeCloudCoveredPolicies|TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD|TestGetCVEExceptions_MergesCRDExceptions|TestGetCVEExceptions_ScopesCRDByMatch" -v` — all pass

I did not run the full `go test ./adapters/v1/...` package suite to completion — it isn't hermetic (#676: many `Test_syftAdapter_CreateSBOM` subtests pull real images from public registries and can time out on network conditions unrelated to any change in the package), so I ran the targeted tests above instead, which is what actually exercises this change.

## Impact

`GetCVEExceptions` now matches its own documented merge contract. No change to suppression outcomes for any CVE (a CVE either source flags for suppression is still suppressed) — this only corrects which source's provenance is recorded and counted when both sources cover the same CVE.

Fixes #812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud-defined CVE exceptions now take precedence over conflicting CRD-defined exceptions.
  * Non-conflicting CRD exceptions continue to be included.
  * CVE matching now consistently handles case differences and aliases.

* **Tests**
  * Added coverage for exact, case-insensitive, and alias-based CVE overlaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->