### PR TITLE
feat: resolve CSAF composite product IDs to real purls

### DIFF
--- a/internal/csafresolve/csafresolve.go
+++ b/internal/csafresolve/csafresolve.go
@@ -7,10 +7,14 @@
 // 26 relationships in a real, downloaded advisory for CVE-2024-3094 carry a
 // purl there). The real purl exists elsewhere in the same document: each
 // relationship's product_reference names a bare product ID (e.g. "xz"), and
-// that bare ID has its own entry deeper in product_tree.branches, carrying
-// a real product_identification_helper.purl. This package walks both
-// structures and connects them - verified against a real, unmodified
-// advisory, where all 26 composite IDs resolved successfully.
+// that bare ID has its own real entry with a purl - either nested under
+// product_tree.branches, or declared directly under the separate top-level
+// product_tree.full_product_names field. This package resolves the
+// composite ID down to that bare reference, then reuses gocsaf/csaf's own
+// ProductTree.CollectProductIdentificationHelpers to find its purl,
+// wherever in the document it is actually declared - rather than
+// hand-walking the tree ourselves and risking missing a location the
+// upstream package already knows about.
 //
 // This does not fix grype's matcher itself - it is a standalone translator
 // that anything wiring CSAF matching into a real scan can use to get a real
@@ -32,71 +36,49 @@ var (
 
 	// ErrNoPURL is returned when compositeID resolves to a real
 	// product_reference, but that reference has no
-	// product_identification_helper.purl anywhere in the branches tree.
-	// This is a real, expected outcome for some products, not a bug: not
+	// product_identification_helper.purl anywhere in the document. This
+	// is a real, expected outcome for some products, not a bug: not
 	// every advisory attaches a purl to every product it mentions.
 	ErrNoPURL = errors.New("csafresolve: resolved product has no purl in this advisory")
 )
 
 // Resolver resolves composite product IDs to purls for one CSAF advisory.
-// Build one with New and reuse it across every lookup for that advisory,
-// rather than re-walking the document per call.
+// Build one with New and reuse it across every lookup for that advisory.
 type Resolver struct {
+	tree *csaf.ProductTree
+
 	// compositeToRef maps a composite product ID (from a relationship's
 	// full_product_name.product_id) to that relationship's bare
-	// product_reference.
+	// product_reference. Built once in New; the purl lookup itself is
+	// done lazily per Resolve call via the upstream package's own
+	// tree-walking helper, so this resolver never needs to duplicate
+	// that logic or risk missing a location it doesn't know about.
 	compositeToRef map[string]string
-
-	// refToPURL maps a bare product ID (from anywhere in the branches
-	// tree) to its real purl, where one exists.
-	refToPURL map[string]string
 }
 
-// New builds a Resolver for the given advisory by walking its product tree
-// once. If tree is nil or has no relationships/branches, the returned
-// Resolver simply resolves nothing - every Resolve call will return
-// ErrNoRelationship - rather than New itself failing.
+// New builds a Resolver for the given advisory. If tree is nil or has no
+// relationships, the returned Resolver simply resolves nothing - every
+// Resolve call will return ErrNoRelationship - rather than New itself
+// failing.
 func New(tree *csaf.ProductTree) *Resolver {
 	r := &Resolver{
+		tree:           tree,
 		compositeToRef: make(map[string]string),
-		refToPURL:      make(map[string]string),
 	}
-	if tree == nil {
+	if tree == nil || tree.RelationShips == nil {
 		return r
 	}
 
-	if tree.RelationShips != nil {
-		for _, rel := range *tree.RelationShips {
-			if rel == nil || rel.FullProductName == nil || rel.FullProductName.ProductID == nil || rel.ProductReference == nil {
-				continue
-			}
-			compositeID := string(*rel.FullProductName.ProductID)
-			ref := string(*rel.ProductReference)
-			r.compositeToRef[compositeID] = ref
+	for _, rel := range *tree.RelationShips {
+		if rel == nil || rel.FullProductName == nil || rel.FullProductName.ProductID == nil || rel.ProductReference == nil {
+			continue
 		}
-	}
-
-	for _, b := range tree.Branches {
-		r.walkBranch(b)
+		compositeID := string(*rel.FullProductName.ProductID)
+		ref := string(*rel.ProductReference)
+		r.compositeToRef[compositeID] = ref
 	}
 
 	return r
-}
-
-// walkBranch recurses through the branches tree, recording every bare
-// product ID that carries a real purl.
-func (r *Resolver) walkBranch(b *csaf.Branch) {
-	if b == nil {
-		return
-	}
-	if b.Product != nil && b.Product.ProductID != nil && b.Product.ProductIdentificationHelper != nil {
-		if purl := b.Product.ProductIdentificationHelper.PURL; purl != nil {
-			r.refToPURL[string(*b.Product.ProductID)] = string(*purl)
-		}
-	}
-	for _, child := range b.Branches {
-		r.walkBranch(child)
-	}
 }
 
 // Resolve returns the real purl for compositeID (e.g.
@@ -107,9 +89,16 @@ func (r *Resolver) Resolve(compositeID string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%w: %q", ErrNoRelationship, compositeID)
 	}
-	purl, ok := r.refToPURL[ref]
-	if !ok {
-		return "", fmt.Errorf("%w: %q (product_reference %q)", ErrNoPURL, compositeID, ref)
+
+	// CollectProductIdentificationHelpers checks full_product_names,
+	// branches (recursively), and relationships - a strictly more
+	// complete search than hand-walking just the branches tree.
+	helpers := r.tree.CollectProductIdentificationHelpers(csaf.ProductID(ref))
+	for _, h := range helpers {
+		if h != nil && h.PURL != nil {
+			return string(*h.PURL), nil
+		}
 	}
-	return purl, nil
+
+	return "", fmt.Errorf("%w: %q (product_reference %q)", ErrNoPURL, compositeID, ref)
 }

--- a/internal/csafresolve/csafresolve.go
+++ b/internal/csafresolve/csafresolve.go
@@ -1,0 +1,115 @@
+// Package csafresolve resolves a CSAF advisory's composite product IDs (e.g.
+// "red_hat_enterprise_linux_10:xz") into real, comparable purls.
+//
+// grype's own CSAF matcher (grype/grype/vex/csaf) compares purls by exact
+// string equality, but only ever looks for a purl directly on a
+// relationships entry - which real Red Hat advisories never populate (0 of
+// 26 relationships in a real, downloaded advisory for CVE-2024-3094 carry a
+// purl there). The real purl exists elsewhere in the same document: each
+// relationship's product_reference names a bare product ID (e.g. "xz"), and
+// that bare ID has its own entry deeper in product_tree.branches, carrying
+// a real product_identification_helper.purl. This package walks both
+// structures and connects them - verified against a real, unmodified
+// advisory, where all 26 composite IDs resolved successfully.
+//
+// This does not fix grype's matcher itself - it is a standalone translator
+// that anything wiring CSAF matching into a real scan can use to get a real
+// purl for a composite product ID before comparing it.
+package csafresolve
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gocsaf/csaf/v3/csaf"
+)
+
+// Errors returned by Resolve.
+var (
+	// ErrNoRelationship is returned when compositeID does not match any
+	// relationship's full_product_name.product_id in the advisory.
+	ErrNoRelationship = errors.New("csafresolve: no relationship found for composite product ID")
+
+	// ErrNoPURL is returned when compositeID resolves to a real
+	// product_reference, but that reference has no
+	// product_identification_helper.purl anywhere in the branches tree.
+	// This is a real, expected outcome for some products, not a bug: not
+	// every advisory attaches a purl to every product it mentions.
+	ErrNoPURL = errors.New("csafresolve: resolved product has no purl in this advisory")
+)
+
+// Resolver resolves composite product IDs to purls for one CSAF advisory.
+// Build one with New and reuse it across every lookup for that advisory,
+// rather than re-walking the document per call.
+type Resolver struct {
+	// compositeToRef maps a composite product ID (from a relationship's
+	// full_product_name.product_id) to that relationship's bare
+	// product_reference.
+	compositeToRef map[string]string
+
+	// refToPURL maps a bare product ID (from anywhere in the branches
+	// tree) to its real purl, where one exists.
+	refToPURL map[string]string
+}
+
+// New builds a Resolver for the given advisory by walking its product tree
+// once. If tree is nil or has no relationships/branches, the returned
+// Resolver simply resolves nothing - every Resolve call will return
+// ErrNoRelationship - rather than New itself failing.
+func New(tree *csaf.ProductTree) *Resolver {
+	r := &Resolver{
+		compositeToRef: make(map[string]string),
+		refToPURL:      make(map[string]string),
+	}
+	if tree == nil {
+		return r
+	}
+
+	if tree.RelationShips != nil {
+		for _, rel := range *tree.RelationShips {
+			if rel == nil || rel.FullProductName == nil || rel.FullProductName.ProductID == nil || rel.ProductReference == nil {
+				continue
+			}
+			compositeID := string(*rel.FullProductName.ProductID)
+			ref := string(*rel.ProductReference)
+			r.compositeToRef[compositeID] = ref
+		}
+	}
+
+	for _, b := range tree.Branches {
+		r.walkBranch(b)
+	}
+
+	return r
+}
+
+// walkBranch recurses through the branches tree, recording every bare
+// product ID that carries a real purl.
+func (r *Resolver) walkBranch(b *csaf.Branch) {
+	if b == nil {
+		return
+	}
+	if b.Product != nil && b.Product.ProductID != nil && b.Product.ProductIdentificationHelper != nil {
+		if purl := b.Product.ProductIdentificationHelper.PURL; purl != nil {
+			r.refToPURL[string(*b.Product.ProductID)] = string(*purl)
+		}
+	}
+	for _, child := range b.Branches {
+		r.walkBranch(child)
+	}
+}
+
+// Resolve returns the real purl for compositeID (e.g.
+// "red_hat_enterprise_linux_10:xz"), or an error explaining why it could
+// not be resolved.
+func (r *Resolver) Resolve(compositeID string) (string, error) {
+	ref, ok := r.compositeToRef[compositeID]
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrNoRelationship, compositeID)
+	}
+	purl, ok := r.refToPURL[ref]
+	if !ok {
+		return "", fmt.Errorf("%w: %q (product_reference %q)", ErrNoPURL, compositeID, ref)
+	}
+	return purl, nil
+}

--- a/internal/csafresolve/csafresolve_test.go
+++ b/internal/csafresolve/csafresolve_test.go
@@ -1,0 +1,135 @@
+package csafresolve
+
+import (
+	"testing"
+
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadRealAdvisory loads the real, unmodified Red Hat CSAF advisory for
+// CVE-2024-3094 (the XZ Utils backdoor) used throughout this test file. It
+// is the same document used in the kubevuln#387 (External VEX Ingestion)
+// proof of concept's CSAF gap reproduction.
+func loadRealAdvisory(t *testing.T) *csaf.Advisory {
+	t.Helper()
+	adv, err := csaf.LoadAdvisory("testdata/redhat-cve-2024-3094.json")
+	require.NoError(t, err, "the real testdata file should load and validate as genuine CSAF")
+	return adv
+}
+
+// TestResolve_RealAdvisory_AllCompositeIDsResolve is the real end-to-end
+// proof: every composite product ID this real advisory's
+// known_not_affected list names resolves to a real, correct purl. This
+// mirrors exactly what was independently confirmed with a standalone script
+// before writing this package (26 of 26 resolved).
+func TestResolve_RealAdvisory_AllCompositeIDsResolve(t *testing.T) {
+	adv := loadRealAdvisory(t)
+	resolver := New(adv.ProductTree)
+
+	require.NotNil(t, adv.Vulnerabilities)
+	require.Len(t, adv.Vulnerabilities, 1)
+	vuln := adv.Vulnerabilities[0]
+	require.NotNil(t, vuln.ProductStatus)
+	require.NotNil(t, vuln.ProductStatus.KnownNotAffected)
+
+	compositeIDs := *vuln.ProductStatus.KnownNotAffected
+	require.NotEmpty(t, compositeIDs, "sanity check: this advisory should genuinely list affected products")
+
+	resolved := 0
+	for _, cid := range compositeIDs {
+		purl, err := resolver.Resolve(string(*cid))
+		if assert.NoError(t, err, "composite ID %q should resolve", *cid) {
+			assert.Contains(t, purl, "pkg:rpm/redhat/", "resolved purl should be a real Red Hat rpm purl, got %q", purl)
+			resolved++
+		}
+	}
+
+	assert.Equal(t, len(compositeIDs), resolved,
+		"every composite product ID in this real advisory should resolve to a real purl")
+}
+
+// TestResolve_RealAdvisory_KnownXZPurl proves one specific, hand-verified
+// resolution: the main xz package itself resolves to exactly the purl
+// confirmed by direct inspection of the real document.
+func TestResolve_RealAdvisory_KnownXZPurl(t *testing.T) {
+	adv := loadRealAdvisory(t)
+	resolver := New(adv.ProductTree)
+
+	purl, err := resolver.Resolve("red_hat_enterprise_linux_10:xz")
+	require.NoError(t, err)
+	assert.Equal(t, "pkg:rpm/redhat/xz", purl)
+}
+
+// TestResolve_UnknownCompositeID_ReturnsErrNoRelationship proves a
+// composite ID that genuinely does not exist in the advisory is rejected
+// with the correct, specific error - not silently returning an empty
+// string or the wrong error.
+func TestResolve_UnknownCompositeID_ReturnsErrNoRelationship(t *testing.T) {
+	adv := loadRealAdvisory(t)
+	resolver := New(adv.ProductTree)
+
+	_, err := resolver.Resolve("this_product_id_does_not_exist:anywhere")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoRelationship)
+}
+
+// TestResolve_NilProductTree_NeverPanics proves New and Resolve are safe to
+// call on a completely empty/nil tree - every call should return
+// ErrNoRelationship, not panic.
+func TestResolve_NilProductTree_NeverPanics(t *testing.T) {
+	resolver := New(nil)
+
+	assert.NotPanics(t, func() {
+		_, err := resolver.Resolve("anything")
+		assert.ErrorIs(t, err, ErrNoRelationship)
+	})
+}
+
+// TestResolve_ReferenceWithNoPURL_ReturnsErrNoPURL proves the honest,
+// expected case where a relationship exists but its referenced product
+// genuinely carries no purl anywhere in the branches tree - this is real,
+// valid CSAF, not malformed data, and must be reported with the specific
+// ErrNoPURL rather than being confused with a missing relationship.
+func TestResolve_ReferenceWithNoPURL_ReturnsErrNoPURL(t *testing.T) {
+	trueVal := true
+	name := "product_version"
+	category := csaf.BranchCategory("product_version")
+	relCategory := csaf.RelationshipCategory("default_component_of")
+
+	compositeID := csaf.ProductID("distro:no-purl-package")
+	bareRef := csaf.ProductID("no-purl-package")
+	distroRef := csaf.ProductID("distro")
+
+	tree := &csaf.ProductTree{
+		Branches: csaf.Branches{
+			&csaf.Branch{
+				Category: &category,
+				Name:     &name,
+				Product: &csaf.FullProductName{
+					Name:      &name,
+					ProductID: &bareRef,
+					// deliberately no ProductIdentificationHelper at all
+				},
+			},
+		},
+		RelationShips: &csaf.Relationships{
+			&csaf.Relationship{
+				Category: &relCategory,
+				FullProductName: &csaf.FullProductName{
+					Name:      &name,
+					ProductID: &compositeID,
+				},
+				ProductReference:          &bareRef,
+				RelatesToProductReference: &distroRef,
+			},
+		},
+	}
+	_ = trueVal // silence unused warning if left over from copy-paste
+
+	resolver := New(tree)
+	_, err := resolver.Resolve(string(compositeID))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoPURL)
+}

--- a/internal/csafresolve/csafresolve_test.go
+++ b/internal/csafresolve/csafresolve_test.go
@@ -133,3 +133,52 @@ func TestResolve_ReferenceWithNoPURL_ReturnsErrNoPURL(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNoPURL)
 }
+
+// TestResolve_PURLUnderFullProductNames_NotBranches proves the fix for a
+// real gap flagged in review: a purl declared under the separate top-level
+// product_tree.full_product_names field, rather than nested inside
+// product_tree.branches, must still resolve correctly. The original
+// hand-rolled tree walk only checked branches, so a document shaped this
+// way would silently return ErrNoPURL even though the purl genuinely
+// exists in the document - this did not trigger against the bundled real
+// Red Hat advisory, which happens to declare everything under branches, so
+// the existing tests did not catch it.
+func TestResolve_PURLUnderFullProductNames_NotBranches(t *testing.T) {
+	category := csaf.RelationshipCategory("default_component_of")
+	name := "some-package"
+	compositeID := csaf.ProductID("distro:some-package")
+	bareRef := csaf.ProductID("some-package")
+	distroRef := csaf.ProductID("distro")
+	purl := csaf.PURL("pkg:rpm/redhat/some-package")
+
+	tree := &csaf.ProductTree{
+		// Deliberately empty Branches - the purl lives only under
+		// FullProductNames, proving Resolve does not depend on the
+		// branches tree to find it.
+		FullProductNames: &csaf.FullProductNames{
+			&csaf.FullProductName{
+				Name:      &name,
+				ProductID: &bareRef,
+				ProductIdentificationHelper: &csaf.ProductIdentificationHelper{
+					PURL: &purl,
+				},
+			},
+		},
+		RelationShips: &csaf.Relationships{
+			&csaf.Relationship{
+				Category: &category,
+				FullProductName: &csaf.FullProductName{
+					Name:      &name,
+					ProductID: &compositeID,
+				},
+				ProductReference:          &bareRef,
+				RelatesToProductReference: &distroRef,
+			},
+		},
+	}
+
+	resolver := New(tree)
+	got, err := resolver.Resolve(string(compositeID))
+	require.NoError(t, err, "a purl declared under full_product_names should resolve, not return ErrNoPURL")
+	assert.Equal(t, "pkg:rpm/redhat/some-package", got)
+}

--- a/internal/csafresolve/testdata/redhat-cve-2024-3094.json
+++ b/internal/csafresolve/testdata/redhat-cve-2024-3094.json
@@ -1,0 +1,707 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Critical"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright © Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://security.access.redhat.com/data/csaf/v2/vex/2024/cve-2024-3094.json"
+      }
+    ],
+    "title": "xz: malicious code in distributed source",
+    "tracking": {
+      "current_release_date": "2026-08-04T07:05:53+00:00",
+      "generator": {
+        "date": "2026-08-04T07:05:53+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "5.3.8"
+        }
+      },
+      "id": "CVE-2024-3094",
+      "initial_release_date": "2024-03-29T00:00:00+00:00",
+      "revision_history": [
+        {
+          "date": "2024-03-29T00:00:00+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2026-08-04T05:37:43+00:00",
+          "number": "2",
+          "summary": "Current version"
+        },
+        {
+          "date": "2026-08-04T07:05:53+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 10",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 10",
+                  "product_id": "red_hat_enterprise_linux_10",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:10"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 10"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 6",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 6",
+                  "product_id": "red_hat_enterprise_linux_6",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:6"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 6"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 7",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 7",
+                  "product_id": "red_hat_enterprise_linux_7",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 7"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 8",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 8",
+                  "product_id": "red_hat_enterprise_linux_8",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:8"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 8"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 9",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 9",
+                  "product_id": "red_hat_enterprise_linux_9",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 9"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat JBoss Enterprise Application Platform 8",
+                "product": {
+                  "name": "Red Hat JBoss Enterprise Application Platform 8",
+                  "product_id": "red_hat_jboss_enterprise_application_platform_8",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:jboss_enterprise_application_platform:8"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat JBoss Enterprise Application Platform 8"
+          },
+          {
+            "category": "product_version",
+            "name": "xz-libs",
+            "product": {
+              "name": "xz-libs",
+              "product_id": "xz-libs",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/xz-libs"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "xz.src",
+            "product": {
+              "name": "xz.src",
+              "product_id": "xz.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/xz?arch=src"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "xz-devel",
+            "product": {
+              "name": "xz-devel",
+              "product_id": "xz-devel",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/xz-devel"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "xz",
+            "product": {
+              "name": "xz",
+              "product_id": "xz",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/xz"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "xz-lzma-compat",
+            "product": {
+              "name": "xz-lzma-compat",
+              "product_id": "xz-lzma-compat",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/xz-lzma-compat"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "xz-compat-libs",
+            "product": {
+              "name": "xz-compat-libs",
+              "product_id": "xz-compat-libs",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/xz-compat-libs"
+              }
+            }
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:xz"
+        },
+        "product_reference": "xz",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-devel as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:xz-devel"
+        },
+        "product_reference": "xz-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-libs as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:xz-libs"
+        },
+        "product_reference": "xz-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-lzma-compat as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:xz-lzma-compat"
+        },
+        "product_reference": "xz-lzma-compat",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz.src as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:xz.src"
+        },
+        "product_reference": "xz.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-devel as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:xz-devel"
+        },
+        "product_reference": "xz-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-libs as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:xz-libs"
+        },
+        "product_reference": "xz-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-lzma-compat as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:xz-lzma-compat"
+        },
+        "product_reference": "xz-lzma-compat",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz.src as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:xz.src"
+        },
+        "product_reference": "xz.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:xz"
+        },
+        "product_reference": "xz",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-compat-libs as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:xz-compat-libs"
+        },
+        "product_reference": "xz-compat-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-devel as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:xz-devel"
+        },
+        "product_reference": "xz-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-libs as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:xz-libs"
+        },
+        "product_reference": "xz-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-lzma-compat as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:xz-lzma-compat"
+        },
+        "product_reference": "xz-lzma-compat",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz.src as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:xz.src"
+        },
+        "product_reference": "xz.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:xz"
+        },
+        "product_reference": "xz",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-devel as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:xz-devel"
+        },
+        "product_reference": "xz-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-libs as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:xz-libs"
+        },
+        "product_reference": "xz-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-lzma-compat as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:xz-lzma-compat"
+        },
+        "product_reference": "xz-lzma-compat",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz.src as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:xz.src"
+        },
+        "product_reference": "xz.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:xz"
+        },
+        "product_reference": "xz",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-devel as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:xz-devel"
+        },
+        "product_reference": "xz-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-libs as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:xz-libs"
+        },
+        "product_reference": "xz-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz-lzma-compat as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:xz-lzma-compat"
+        },
+        "product_reference": "xz-lzma-compat",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz.src as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:xz.src"
+        },
+        "product_reference": "xz.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "xz as a component of Red Hat JBoss Enterprise Application Platform 8",
+          "product_id": "red_hat_jboss_enterprise_application_platform_8:xz"
+        },
+        "product_reference": "xz",
+        "relates_to_product_reference": "red_hat_jboss_enterprise_application_platform_8"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "acknowledgments": [
+        {
+          "names": [
+            "Andres Freund"
+          ]
+        }
+      ],
+      "cve": "CVE-2024-3094",
+      "cwe": {
+        "id": "CWE-506",
+        "name": "Embedded Malicious Code"
+      },
+      "discovery_date": "2024-03-27T00:00:00+00:00",
+      "flags": [
+        {
+          "label": "vulnerable_code_not_present",
+          "product_ids": [
+            "red_hat_enterprise_linux_10:xz",
+            "red_hat_enterprise_linux_10:xz-devel",
+            "red_hat_enterprise_linux_10:xz-libs",
+            "red_hat_enterprise_linux_10:xz-lzma-compat",
+            "red_hat_enterprise_linux_10:xz.src",
+            "red_hat_enterprise_linux_6:xz-devel",
+            "red_hat_enterprise_linux_6:xz-libs",
+            "red_hat_enterprise_linux_6:xz-lzma-compat",
+            "red_hat_enterprise_linux_6:xz.src",
+            "red_hat_enterprise_linux_7:xz",
+            "red_hat_enterprise_linux_7:xz-compat-libs",
+            "red_hat_enterprise_linux_7:xz-devel",
+            "red_hat_enterprise_linux_7:xz-libs",
+            "red_hat_enterprise_linux_7:xz-lzma-compat",
+            "red_hat_enterprise_linux_7:xz.src",
+            "red_hat_enterprise_linux_8:xz",
+            "red_hat_enterprise_linux_8:xz-devel",
+            "red_hat_enterprise_linux_8:xz-libs",
+            "red_hat_enterprise_linux_8:xz-lzma-compat",
+            "red_hat_enterprise_linux_8:xz.src",
+            "red_hat_enterprise_linux_9:xz",
+            "red_hat_enterprise_linux_9:xz-devel",
+            "red_hat_enterprise_linux_9:xz-libs",
+            "red_hat_enterprise_linux_9:xz-lzma-compat",
+            "red_hat_enterprise_linux_9:xz.src",
+            "red_hat_jboss_enterprise_application_platform_8:xz"
+          ]
+        }
+      ],
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2272210"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. \r\nThrough a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "xz: malicious code in distributed source",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "other",
+          "text": "Current investigation indicates that the packages are only present in Fedora 41 and Fedora Rawhide within the Red Hat community ecosystem. \n\nNo versions of Red Hat Enterprise Linux (RHEL) are affected.\n\nThe malicious injection present in the xz versions 5.6.0 and 5.6.1 libraries is only included in the tarball download package. The Git distribution lacks the M4 macro that triggers the build of the malicious code. The second-stage artifacts are present in the Git repository for the injection during the build time, in case the malicious M4 macro is present. Without the merge into the build, the 2nd-stage file is innocuous.\nIn the finder’s demonstration, it was found that it interfered with the OpenSSH daemon. While OpenSSH is not directly linked to the liblzma library, it does communicate with systemd in such a way that exposes it to the malware due to systemd linking to liblzma.",
+          "title": "Statement"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "red_hat_enterprise_linux_10:xz",
+          "red_hat_enterprise_linux_10:xz-devel",
+          "red_hat_enterprise_linux_10:xz-libs",
+          "red_hat_enterprise_linux_10:xz-lzma-compat",
+          "red_hat_enterprise_linux_10:xz.src",
+          "red_hat_enterprise_linux_6:xz-devel",
+          "red_hat_enterprise_linux_6:xz-libs",
+          "red_hat_enterprise_linux_6:xz-lzma-compat",
+          "red_hat_enterprise_linux_6:xz.src",
+          "red_hat_enterprise_linux_7:xz",
+          "red_hat_enterprise_linux_7:xz-compat-libs",
+          "red_hat_enterprise_linux_7:xz-devel",
+          "red_hat_enterprise_linux_7:xz-libs",
+          "red_hat_enterprise_linux_7:xz-lzma-compat",
+          "red_hat_enterprise_linux_7:xz.src",
+          "red_hat_enterprise_linux_8:xz",
+          "red_hat_enterprise_linux_8:xz-devel",
+          "red_hat_enterprise_linux_8:xz-libs",
+          "red_hat_enterprise_linux_8:xz-lzma-compat",
+          "red_hat_enterprise_linux_8:xz.src",
+          "red_hat_enterprise_linux_9:xz",
+          "red_hat_enterprise_linux_9:xz-devel",
+          "red_hat_enterprise_linux_9:xz-libs",
+          "red_hat_enterprise_linux_9:xz-lzma-compat",
+          "red_hat_enterprise_linux_9:xz.src",
+          "red_hat_jboss_enterprise_application_platform_8:xz"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2024-3094"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2272210",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2024-3094",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2024-3094"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2024-3094",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3094"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+          "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users",
+          "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users"
+        }
+      ],
+      "release_date": "2024-03-29T00:00:00+00:00",
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "red_hat_enterprise_linux_10:xz",
+            "red_hat_enterprise_linux_10:xz-devel",
+            "red_hat_enterprise_linux_10:xz-libs",
+            "red_hat_enterprise_linux_10:xz-lzma-compat",
+            "red_hat_enterprise_linux_10:xz.src",
+            "red_hat_enterprise_linux_6:xz-devel",
+            "red_hat_enterprise_linux_6:xz-libs",
+            "red_hat_enterprise_linux_6:xz-lzma-compat",
+            "red_hat_enterprise_linux_6:xz.src",
+            "red_hat_enterprise_linux_7:xz",
+            "red_hat_enterprise_linux_7:xz-compat-libs",
+            "red_hat_enterprise_linux_7:xz-devel",
+            "red_hat_enterprise_linux_7:xz-libs",
+            "red_hat_enterprise_linux_7:xz-lzma-compat",
+            "red_hat_enterprise_linux_7:xz.src",
+            "red_hat_enterprise_linux_8:xz",
+            "red_hat_enterprise_linux_8:xz-devel",
+            "red_hat_enterprise_linux_8:xz-libs",
+            "red_hat_enterprise_linux_8:xz-lzma-compat",
+            "red_hat_enterprise_linux_8:xz.src",
+            "red_hat_enterprise_linux_9:xz",
+            "red_hat_enterprise_linux_9:xz-devel",
+            "red_hat_enterprise_linux_9:xz-libs",
+            "red_hat_enterprise_linux_9:xz-lzma-compat",
+            "red_hat_enterprise_linux_9:xz.src",
+            "red_hat_jboss_enterprise_application_platform_8:xz"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Critical",
+          "product_ids": [
+            "red_hat_enterprise_linux_10:xz",
+            "red_hat_enterprise_linux_10:xz-devel",
+            "red_hat_enterprise_linux_10:xz-libs",
+            "red_hat_enterprise_linux_10:xz-lzma-compat",
+            "red_hat_enterprise_linux_10:xz.src",
+            "red_hat_enterprise_linux_6:xz-devel",
+            "red_hat_enterprise_linux_6:xz-libs",
+            "red_hat_enterprise_linux_6:xz-lzma-compat",
+            "red_hat_enterprise_linux_6:xz.src",
+            "red_hat_enterprise_linux_7:xz",
+            "red_hat_enterprise_linux_7:xz-compat-libs",
+            "red_hat_enterprise_linux_7:xz-devel",
+            "red_hat_enterprise_linux_7:xz-libs",
+            "red_hat_enterprise_linux_7:xz-lzma-compat",
+            "red_hat_enterprise_linux_7:xz.src",
+            "red_hat_enterprise_linux_8:xz",
+            "red_hat_enterprise_linux_8:xz-devel",
+            "red_hat_enterprise_linux_8:xz-libs",
+            "red_hat_enterprise_linux_8:xz-lzma-compat",
+            "red_hat_enterprise_linux_8:xz.src",
+            "red_hat_enterprise_linux_9:xz",
+            "red_hat_enterprise_linux_9:xz-devel",
+            "red_hat_enterprise_linux_9:xz-libs",
+            "red_hat_enterprise_linux_9:xz-lzma-compat",
+            "red_hat_enterprise_linux_9:xz.src",
+            "red_hat_jboss_enterprise_application_platform_8:xz"
+          ]
+        }
+      ],
+      "title": "xz: malicious code in distributed source"
+    }
+  ]
+}


### PR DESCRIPTION
## Overview

grype's own CSAF matcher (`grype/grype/vex/csaf`) compares purls by exact
string equality, but only ever looks for a purl directly on a
`relationships` entry - which real Red Hat advisories never populate. A live
check against a real, unmodified advisory (CVE-2024-3094, the XZ Utils
backdoor) confirms this directly: **0 of 26 relationships carry a purl
there.**

The real purl exists elsewhere in the same document: each relationship's
`product_reference` names a bare product ID (e.g. `"xz"`), and that bare ID
has its own entry deeper in `product_tree.branches`, carrying a real
`product_identification_helper.purl`. This adds a standalone resolver that
walks both structures and connects them.

## Before / After

Real, live output against the same real document:

**Before** - what grype's matcher actually sees:
```
Relationships with NO purl: 26 of 26
-> grype's matcher: 0 usable purls, every match silently fails to suppress
```

**After** - this resolver, same document:
```
red_hat_enterprise_linux_10:xz         -> pkg:rpm/redhat/xz
red_hat_enterprise_linux_10:xz-devel   -> pkg:rpm/redhat/xz-devel
red_hat_enterprise_linux_10:xz-libs    -> pkg:rpm/redhat/xz-libs
Composite IDs resolved to real purls: 26 of 26
```

## Scope

This does **not** wire CSAF matching into a real scan itself, and does not
modify grype - it is a standalone translator that anything doing that wiring
can use to get a real, comparable purl for a composite product ID first.

## Testing

5 tests, all passing:
- Full end-to-end run against the real advisory - all 26 composite IDs
  resolve correctly
- One specific, hand-verified resolution
- A genuinely unknown composite ID is correctly rejected
- A nil product tree never panics
- The honest edge case where a relationship exists but its product
  genuinely has no purl in the document

Full build, `go vet`, and `go test ./internal/csafresolve/...` pass with no
failures.

## Related issues/PRs

* Resolved #814

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CSAF product resolution across complete product trees, including top-level product names and nested branches.
  * Maps composite product identifiers to package URLs more reliably.
  * Safely handles incomplete product-tree data and reports missing relationships or package URLs clearly.

* **Tests**
  * Added coverage for real advisory data, XZ package resolution, unknown identifiers, missing package URLs, top-level product names, and empty product trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->