### PR TITLE
fix(services): report a failed container scan from ScanCP instead of nil

### DIFF
--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -858,6 +858,11 @@ func (s scanErrorService) ScanRegistry(context.Context) error {
 	return s.err
 }
 
+func (s scanErrorService) ScanCP(context.Context) error {
+	s.signalStarted()
+	return s.err
+}
+
 func (s scanErrorService) ValidateGenerateSBOM(ctx context.Context, _ domain.ScanCommand) (context.Context, error) {
 	return ctx, nil
 }
@@ -913,6 +918,15 @@ func TestHTTPController_MetricsEndpoint_RecordsScanFailureReason(t *testing.T) {
 			register:     func(router *gin.Engine, c *HTTPController) { router.POST("/v1/generateSBOM", c.GenerateSBOM) },
 			wantReason:   scanfailure.ReasonUnexpected,
 			unclassified: true,
+		},
+		{
+			// regression test for #816: a real per-container failure inside ScanCP must
+			// surface as outcome="error" with a classified reason, not "success".
+			name:       "scanCP, classified reason",
+			path:       "/v1/scanCP",
+			endpoint:   "scanCP",
+			register:   func(router *gin.Engine, c *HTTPController) { router.POST("/v1/scanCP", c.ScanCP) },
+			wantReason: scanfailure.ReasonCVEMatchingFailed,
 		},
 	}
 	for _, tt := range tests {
@@ -995,6 +1009,22 @@ func (s statusFlowScanService) ValidateGenerateSBOM(ctx context.Context, _ domai
 	return ctx, nil
 }
 
+func (s statusFlowScanService) ScanCP(ctx context.Context) error {
+	if s.phase != "" {
+		domain.UpdateScanPhase(ctx, s.phase)
+	}
+	if s.startedCh != nil {
+		select {
+		case s.startedCh <- struct{}{}:
+		default:
+		}
+	}
+	if s.blockCh != nil {
+		<-s.blockCh
+	}
+	return s.err
+}
+
 func TestHTTPController_ScanStatus_Succeeded(t *testing.T) {
 	c := NewHTTPController(statusFlowScanService{
 		MockScanService: services.NewMockScanService(true),
@@ -1067,6 +1097,49 @@ func TestHTTPController_ScanStatus_Failed(t *testing.T) {
 
 	assert.Equal(t, scanfailure.ReasonCVEMatchingFailed, status.Reason)
 	assert.Equal(t, "completed", status.Phase)
+	require.NotNil(t, status.FinishedAt)
+	assert.False(t, status.FinishedAt.IsZero())
+}
+
+// TestHTTPController_ScanStatus_ScanCPFailed is a regression test for #816: ScanCP's own
+// closure (it does not go through runTrackedScan, see that function's doc comment) used to
+// mark the job succeeded no matter what its per-container loop actually did. A failure
+// returned from the scan service must now reach /v1/scanStatus as state="failed" with its
+// classified reason, exactly like GenerateSBOM/ScanCVE/ScanRegistry already do.
+func TestHTTPController_ScanStatus_ScanCPFailed(t *testing.T) {
+	c := NewHTTPController(statusFlowScanService{
+		MockScanService: services.NewMockScanService(true),
+		err:             &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: errors.New("boom")},
+	}, 1)
+	t.Cleanup(func() { c.Shutdown(5 * time.Second) })
+
+	router := gin.Default()
+	router.POST("/v1/scanCP", c.ScanCP)
+	router.GET("/v1/scanStatus/:jobID", c.ScanStatus)
+
+	req, _ := http.NewRequest("POST", "/v1/scanCP", strings.NewReader(`{
+		"jobID": "job-scancp-failed",
+		"args": {"name": "daemonset-kube-proxy", "namespace": "kube-system"}
+	}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var status domain.ScanStatus
+	require.Eventually(t, func() bool {
+		req, _ = http.NewRequest("GET", "/v1/scanStatus/job-scancp-failed", nil)
+		w = httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			return false
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+			return false
+		}
+		return status.State == domain.ScanStateFailed
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, scanfailure.ReasonCVEMatchingFailed, status.Reason)
 	require.NotNil(t, status.FinishedAt)
 	assert.False(t, status.FinishedAt.IsZero())
 }

--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -225,6 +225,15 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		return fmt.Errorf("getting container relevancy scans: %w", err)
 	}
 
+	// failed counts containers that did not produce a scan result; lastFailure is the most
+	// recent one's classified error. If any container fails, ScanCP must not report success
+	// (see #816): a container-level failure is a real scan failure, not the informational
+	// "come back once the profile is complete" signal domain.ErrPartialContainerProfile
+	// carries from the relevancy lookup above, so it is surfaced the same way GenerateSBOM,
+	// ScanCVE and ScanRegistry surface theirs — as a returned *domain.ScanError.
+	var failed int
+	var lastFailure *domain.ScanError
+
 	for _, scan := range scans {
 		imageTagNormalized := tools.NormalizeReference(scan.ImageTag)
 		slug, err := names.ImageInfoToSlug(imageTagNormalized, scan.ImageID)
@@ -232,6 +241,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			logger.L().Ctx(mainCtx).Error("getting image slug, skipping scan", helpers.Error(err),
 				helpers.String("imageTag", scan.ImageTag),
 				helpers.String("imageID", scan.ImageID))
+			failed++
+			lastFailure = &domain.ScanError{Reason: scanfailure.ReasonUnexpected, Err: fmt.Errorf("getting image slug: %w", err)}
 			continue // we need the slug
 		}
 
@@ -274,11 +285,20 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			if sbomErr != nil {
 				logger.L().Ctx(ctx).Error("creating SBOM, skipping scan", helpers.Error(sbomErr),
 					helpers.String("imageSlug", slug))
+				failed++
+				reason := classifySBOMError(sbomErr)
+				var scanErr *domain.ScanError
+				if errors.As(sbomErr, &scanErr) {
+					reason = scanErr.Reason
+				}
+				lastFailure = &domain.ScanError{Reason: reason, Err: fmt.Errorf("creating SBOM: %w", sbomErr)}
 				continue // we need the SBOM
 			}
 			if !s.sbomGeneration && sbom.Content == nil {
 				logger.L().Ctx(ctx).Error("missing SBOM, skipping scan",
 					helpers.String("imageSlug", slug))
+				failed++
+				lastFailure = &domain.ScanError{Reason: scanfailure.ReasonUnexpected, Err: domain.ErrMissingSBOM}
 				continue // we need the SBOM
 			}
 
@@ -286,8 +306,10 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			if sbom.Status == helpersv1.Incomplete || sbom.Status == helpersv1.TooLarge {
 				logger.L().Ctx(ctx).Warning("incomplete or too large SBOM, skipping scan",
 					helpers.String("imageSlug", slug))
-				_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration,
-					classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations), nil)
+				reason := classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations)
+				_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureSBOMGeneration, reason, nil)
+				failed++
+				lastFailure = &domain.ScanError{Reason: reason, Err: domain.ErrIncompleteSBOM}
 				continue // do not process this SBOM
 			}
 		}
@@ -304,6 +326,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 					helpers.String("imageSlug", slug))
 				_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureCVE,
 					scanfailure.ReasonCVEMatchingFailed, err)
+				failed++
+				lastFailure = &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: fmt.Errorf("scanning SBOM: %w", err)}
 				continue // we need the CVE
 			}
 
@@ -339,6 +363,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			if err != nil {
 				logger.L().Ctx(ctx).Error("filtering SBOM, skipping scan", helpers.Error(err),
 					helpers.String("instanceID", scan.InstanceID.GetStringFormatted()))
+				failed++
+				lastFailure = &domain.ScanError{Reason: scanfailure.ReasonUnexpected, Err: fmt.Errorf("filtering SBOM: %w", err)}
 				continue // we need the SBOM'
 			}
 			if s.storeFilteredSbom {
@@ -359,6 +385,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 			if err != nil {
 				logger.L().Ctx(ctx).Error("scanning filtered SBOM, skipping scan", helpers.Error(err),
 					helpers.String("instanceID", scan.InstanceID.GetStringFormatted()))
+				failed++
+				lastFailure = &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: fmt.Errorf("scanning filtered SBOM: %w", err)}
 				continue // we need the CVE'
 			}
 
@@ -395,6 +423,8 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 				helpers.String("instanceID", scan.InstanceID.GetStringFormatted()))
 			_ = s.platform.ReportScanFailure(ctx, scanfailure.ScanFailureBackendPost,
 				scanfailure.ReasonResultUploadFailed, err)
+			failed++
+			lastFailure = &domain.ScanError{Reason: scanfailure.ReasonResultUploadFailed, Err: fmt.Errorf("submitting CVEs: %w", err)}
 			continue // we need to submit the CVE
 		}
 	}
@@ -403,6 +433,9 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 		helpers.String("name", name),
 		helpers.String("namespace", namespace),
 		helpers.String("jobID", workload.JobID))
+	if failed > 0 {
+		return lastFailure
+	}
 	return nil
 }
 

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -337,6 +337,7 @@ func TestScanService_ScanCP(t *testing.T) {
 		wantCvep        bool
 		wantEmptyReport bool
 		wantErr         bool
+		wantReason      string
 	}{
 		{
 			name:    "no workload",
@@ -347,14 +348,20 @@ func TestScanService_ScanCP(t *testing.T) {
 			workload: true,
 		},
 		{
+			// regression test for #816: ScanCP used to swallow this failure and return nil
 			name:            "create SBOM error",
 			createSBOMError: true,
 			workload:        true,
+			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
+			// regression test for #816: ScanCP used to swallow this failure and return nil
 			name:            "create SBOM too many requests",
 			toomanyrequests: true,
 			workload:        true,
+			wantErr:         true,
+			wantReason:      scanfailure.ReasonSBOMGenerationFailed,
 		},
 		{
 			name:      "empty wlid",
@@ -399,11 +406,14 @@ func TestScanService_ScanCP(t *testing.T) {
 			workload:      true,
 		},
 		{
-			name:     "timeout SBOM",
-			sbom:     true,
-			storage:  true,
-			timeout:  true,
-			workload: true,
+			// regression test for #816: ScanCP used to swallow this failure and return nil
+			name:       "timeout SBOM",
+			sbom:       true,
+			storage:    true,
+			timeout:    true,
+			workload:   true,
+			wantErr:    true,
+			wantReason: scanfailure.ReasonSBOMIncomplete,
 		},
 		{
 			name:     "with SBOMp",
@@ -480,8 +490,18 @@ func TestScanService_ScanCP(t *testing.T) {
 			err := storageCP.StoreContainerProfile(ctx, ap)
 			require.NoError(t, err)
 
-			if err := s.ScanCP(ctx); (err != nil) != tt.wantErr {
-				t.Errorf("ScanCP() error = %v, wantErr %v", err, tt.wantErr)
+			scanCPErr := s.ScanCP(ctx)
+			if (scanCPErr != nil) != tt.wantErr {
+				t.Errorf("ScanCP() error = %v, wantErr %v", scanCPErr, tt.wantErr)
+			}
+			if tt.wantReason != "" {
+				// regression coverage for #816: a per-container failure inside ScanCP must
+				// come back as a classified *domain.ScanError, exactly like the single-image
+				// scan flows already do, so the HTTP layer can resolve a bounded reason
+				// label instead of collapsing every failure into "unexpected_error".
+				var scanErr *domain.ScanError
+				require.ErrorAsf(t, scanCPErr, &scanErr, "expected a *domain.ScanError, got %T: %v", scanCPErr, scanCPErr)
+				assert.Equal(t, tt.wantReason, scanErr.Reason)
 			}
 			if tt.toomanyrequests {
 				// the 429 marker must be recorded under the same canonical key every
@@ -497,6 +517,90 @@ func TestScanService_ScanCP(t *testing.T) {
 			}
 		})
 	}
+}
+
+// stubRelevancyProvider is a ports.Relevancy test double that returns a fixed list of scans,
+// letting tests exercise ScanCP's per-container loop with more than one container -- something
+// the real ContainerProfileAdapter never does today (one ContainerProfile resolves to at most
+// one scan), but that the ports.Relevancy contract and ScanCP's loop are both written for.
+type stubRelevancyProvider struct {
+	scans []ports.ContainerRelevancyScan
+}
+
+func (s stubRelevancyProvider) GetContainerRelevancyScans(_ context.Context, _, _ string, _ bool) ([]ports.ContainerRelevancyScan, error) {
+	return s.scans, nil
+}
+
+// TestScanService_ScanCP_PartialContainerFailure is a regression test for #816. When a
+// ContainerProfile fans out to multiple containers, one container succeeding must not mask
+// another container failing: that is a real scan failure, not the "come back once relevancy
+// data is complete" signal domain.ErrPartialContainerProfile carries from the relevancy lookup,
+// so it has to surface the same way a total failure does -- as a non-nil, classified error --
+// rather than being reported as a plain success because at least one container scanned cleanly.
+func TestScanService_ScanCP_PartialContainerFailure(t *testing.T) {
+	sbomAdapter := adapters.NewMockSBOMAdapter(false, false, false)
+	cveAdapter := adapters.NewMockCVEAdapter()
+	storageSBOM := repositories.NewMemoryStorage(false, false)
+	storageCVE := repositories.NewMemoryStorage(false, false)
+
+	wlid := "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy"
+	instanceID, err := instanceidhandlerv1.GenerateInstanceIDFromString(
+		"apiVersion-apps/v1/namespace-kube-system/kind-DaemonSet/name-kube-proxy/containerName-kube-proxy")
+	require.NoError(t, err)
+
+	goodImageID := "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137"
+	goodImageTag := "k8s.gcr.io/kube-proxy:v1.24.3"
+
+	relevancy := stubRelevancyProvider{scans: []ports.ContainerRelevancyScan{
+		{
+			ContainerName: "kube-proxy",
+			ImageID:       goodImageID,
+			ImageTag:      goodImageTag,
+			InstanceID:    instanceID,
+			Labels:        map[string]string{},
+			RelevantFiles: mapset.NewSet[string](),
+			Wlid:          wlid,
+		},
+		{
+			// an empty ImageID fails names.ImageInfoToSlug (see ImageInfoToSlug's
+			// imageIDSlugHashLength check) before this container ever reaches SBOM
+			// creation -- a deterministic, adapter-independent way to fail just this
+			// one container without touching the mock SBOM adapter's shared state.
+			ContainerName: "sidecar",
+			ImageID:       "",
+			ImageTag:      "k8s.gcr.io/sidecar:v1",
+			InstanceID:    instanceID,
+			Labels:        map[string]string{},
+			RelevantFiles: mapset.NewSet[string](),
+			Wlid:          wlid,
+		},
+	}}
+
+	s := NewScanService(sbomAdapter, storageSBOM, cveAdapter, storageCVE, adapters.NewMockPlatform(false, nil), relevancy, true, false, true, false, false)
+	ctx := context.TODO()
+	s.Ready(ctx)
+
+	workload := domain.ScanCommand{
+		Args: map[string]interface{}{
+			domain.ArgsName:      "daemonset-kube-proxy",
+			domain.ArgsNamespace: "kube-system",
+		},
+		Wlid: wlid,
+	}
+	ctx, err = s.ValidateScanCP(ctx, workload)
+	require.NoError(t, err)
+
+	scanCPErr := s.ScanCP(ctx)
+	require.Error(t, scanCPErr, "one container failing must not be hidden just because another container succeeded")
+
+	var scanErr *domain.ScanError
+	require.ErrorAsf(t, scanCPErr, &scanErr, "expected a *domain.ScanError, got %T: %v", scanCPErr, scanCPErr)
+	assert.NotEmpty(t, scanErr.Reason)
+
+	slug, err := names.ImageInfoToSlug(tools.NormalizeReference(goodImageTag), goodImageID)
+	require.NoError(t, err)
+	_, getErr := storageCVE.GetCVE(ctx, slug, sbomAdapter.Version(), cveAdapter.Version(), cveAdapter.DBVersion(ctx))
+	assert.NoError(t, getErr, "the container that scanned successfully must still have had its result stored")
 }
 
 // countingSBOMCreator wraps a ports.SBOMCreator and counts CreateSBOM invocations, so tests can
@@ -564,7 +668,12 @@ func TestScanService_ScanCP_SkipsPullForAlreadyRateLimitedImage(t *testing.T) {
 	// the canonical key ScanCP writes to (ImageTagNormalized, see rateLimitCacheKey)
 	s.tooManyRequests.Set(tools.NormalizeReference(imageTag), true, ttl)
 
-	require.NoError(t, s.ScanCP(ctx))
+	// skipping the pull still means this container produced no scan result, so ScanCP must
+	// report the failure (see #816) even though the skip itself worked correctly.
+	err = s.ScanCP(ctx)
+	var scanErr *domain.ScanError
+	require.ErrorAsf(t, err, &scanErr, "expected a *domain.ScanError, got %T: %v", err, err)
+	assert.Equal(t, scanfailure.ReasonSBOMGenerationFailed, scanErr.Reason)
 	assert.Equal(t, 0, sbomAdapter.calls, "ScanCP should not attempt to pull an image already known to be rate limited")
 }
 


### PR DESCRIPTION
## Problem

`ScanCP` (the ContainerProfile/relevancy scan flow behind `POST /v1/applicationProfileScan`) loops over a profile's containers and `continue`s past any per-container failure -- bad image slug, SBOM creation error, an `Incomplete`/`TooLarge` SBOM, CVE matching failure, relevancy filtering error, or result-upload failure -- but the function always `return nil`s once the loop ends, regardless of how many containers failed.

The HTTP layer treats that `nil` as unqualified success: it records `kubevuln_scans_completed_total{endpoint="scanCP",outcome="success"}` and marks the job `succeeded` on `/v1/scanStatus`, even when zero `VulnerabilityManifest`s were produced.

## Root cause

`GenerateSBOM`, `ScanCVE` and `ScanRegistry` each scan a single image and already return a classified `*domain.ScanError` on failure. `ScanCP` scans multiple containers per call, and the per-container loop was written so one bad container doesn't abort the rest -- correct -- but nothing ever aggregated a per-container failure back into the function's return value. It was the only one of the four scan flows with zero `*domain.ScanError` construction sites.

This was pinned by the existing test suite: `TestScanService_ScanCP`'s `create SBOM error`, `create SBOM too many requests` and `timeout SBOM` cases all asserted `ScanCP` returns `nil` in exactly these failure scenarios.

## Fix

`ScanCP` now tracks whether any container failed to produce a scan result and, if so, returns the most recently observed failure classified via the same `scanfailure.Reason*` taxonomy the other three flows already use (reusing the classification already computed at each failure site where one existed, e.g. `classifySBOMError`, `classifySBOMStatusWithAnnotation`, or the existing `*domain.ScanError` returned by `getOrCreateSBOM`). No changes were needed in `controllers/http.go`: `ScanCP`'s existing error branch already records `outcome="error"` and marks the job `failed` with the reason for any non-nil, non-`ErrPartialContainerProfile` error -- `ScanCP` just wasn't giving it one.

A container-level scan failure is treated as a full failure of the job regardless of whether other containers in the same profile succeeded, rather than introducing a new partial-success state: `ErrPartialContainerProfile`'s existing "partial" outcome specifically means "the relevancy data itself isn't ready yet, try again later" and still marks the job succeeded, which would be the wrong signal to reuse for a real per-container scan failure.

## Testing

- `TestScanService_ScanCP`'s `create SBOM error`, `create SBOM too many requests` and `timeout SBOM` cases now assert the classified failure instead of `nil`.
- `TestScanService_ScanCP_SkipsPullForAlreadyRateLimitedImage` (rate-limit backoff regression) updated: skipping the pull is still a failed container scan, so it now asserts the classified error while still asserting zero pull attempts.
- Added `TestScanService_ScanCP_PartialContainerFailure`: a multi-container profile where one container succeeds and another fails at slug derivation -- asserts the overall call still fails, the failure is a classified `*domain.ScanError`, and the successful container's CVE result was still stored.
- Added a `scanCP` case to `TestHTTPController_MetricsEndpoint_RecordsScanFailureReason`, and added `TestHTTPController_ScanStatus_ScanCPFailed`, asserting a `ScanCP` failure reaches `/v1/scanStatus` as `state="failed"` with its reason.
- `go build ./...`, `go vet ./core/services/... ./controllers/...`, `go test ./core/services/...`, `go test ./controllers/...`, and `golangci-lint run --new-from-rev=main` all pass clean.

## Impact

Alerting on `kubevuln_scans_completed_total{outcome="error"}` and `/v1/scanStatus` consumers now see real ScanCP failures instead of a false `success`, for the primary scan path in kubescape-integrated clusters.

Fixes #816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scan failures now consistently report classified error reasons and completion status.
  * Scans continue processing remaining containers when one container fails, while still surfacing the failure.
  * SBOM, vulnerability matching, filtering, uploads, rate limits, and timeouts now provide more reliable failure reporting.
  * Rate-limited image pulls avoid unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->