### PR TITLE
fix(services): make ScanCP's summary totals agree with every other scan flow

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -374,9 +374,17 @@ func (s *ScanService) ScanCP(mainCtx context.Context) error {
 						helpers.String("instanceID", scan.InstanceID.GetStringFormatted()))
 					// no continue, storing the CVE' is not critical
 				}
-				// Summary uses original cve (all matches for total counts) and
-				// filteredCvep (exceptions applied to relevant matches only).
-				err = s.cveRepository.StoreCVESummary(ctx, cve, filteredCvep, true)
+				// Summary uses filteredCve (all matches, exceptions applied) and
+				// filteredCvep (exceptions applied to relevant matches only), matching
+				// every other StoreCVESummary call site (storeFilteredCVE,
+				// reconcileCachedCVE, and ScanCP's own non-relevancy branch above) so
+				// severities.*.all means the same thing regardless of which scan flow
+				// last wrote this workload/container's VulnerabilityManifestSummary.
+				// See #819: this used to pass the unfiltered cve, so a
+				// SecurityException-suppressed CVE's presence in severities.*.all
+				// flipped depending on whether ScanCVE/ScanRegistry or ScanCP scanned
+				// last.
+				err = s.cveRepository.StoreCVESummary(ctx, filteredCve, filteredCvep, true)
 				if err != nil {
 					logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
 						helpers.String("imageSlug", slug))

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -1268,6 +1268,124 @@ func TestScanService_ScanRegistry_StorageAndExceptions(t *testing.T) {
 	})
 }
 
+type storeCVESummaryCall struct {
+	cve           domain.CVEManifest
+	cvep          domain.CVEManifest
+	withRelevancy bool
+}
+
+// summaryCapturingRepo wraps a ports.CVERepository and records every StoreCVESummary call
+// verbatim, so a test can inspect exactly which manifest a scan flow handed to the summary
+// write. MemoryStore alone can't answer that: StoreCVE and StoreCVESummary key their map off
+// the same cveID, so a later call silently overwrites an earlier one's entry.
+type summaryCapturingRepo struct {
+	ports.CVERepository
+	calls []storeCVESummaryCall
+}
+
+func (r *summaryCapturingRepo) StoreCVESummary(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, withRelevancy bool) error {
+	r.calls = append(r.calls, storeCVESummaryCall{cve: cve, cvep: cvep, withRelevancy: withRelevancy})
+	return r.CVERepository.StoreCVESummary(ctx, cve, cvep, withRelevancy)
+}
+
+// TestScanService_ScanCP_SummaryExcludesSuppressedCVEFromTotals is a regression test for #819.
+// ScanCP's relevancy branch used to pass the *unfiltered* CVE manifest as StoreCVESummary's
+// first argument, so a SecurityException-suppressed CVE stayed in severities.*.all even though
+// every other StoreCVESummary call site (ScanCP's own non-relevancy branch above it,
+// storeFilteredCVE used by ScanCVE/ScanRegistry, and the cache-hit path in reconcileCachedCVE)
+// already excludes it there. Asserts every StoreCVESummary call ScanCP makes -- both the
+// non-relevancy and relevancy branches -- agrees that the suppressed CVE belongs in
+// IgnoredMatches, never in Matches.
+func TestScanService_ScanCP_SummaryExcludesSuppressedCVEFromTotals(t *testing.T) {
+	const suppressedCVE = "CVE-2023-9999"
+	wlid := "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy"
+
+	mockRepo := &mockSecurityExceptionRepo{
+		exceptions: []sev1beta1.SecurityException{
+			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system"},
+				Spec: sev1beta1.SecurityExceptionSpec{
+					Reason: "test exception",
+					Vulnerabilities: []sev1beta1.VulnerabilityException{
+						{
+							Vulnerability: sev1beta1.VulnerabilityRef{ID: suppressedCVE},
+							Status:        sev1beta1.VulnerabilityStatusNotAffected,
+						},
+					},
+				},
+			},
+		},
+	}
+	mockPlatform := adapters.NewMockPlatform(false, mockRepo)
+	storageCP := repositories.NewMemoryStorage(false, false)
+	cveRepo := &summaryCapturingRepo{CVERepository: repositories.NewMemoryStorage(false, false)}
+
+	s := NewScanService(
+		adapters.NewMockSBOMAdapter(false, false, false),
+		repositories.NewMemoryStorage(false, false),
+		&fakeCVEScannerWithVuln{},
+		cveRepo,
+		mockPlatform,
+		v1.NewContainerProfileAdapter(storageCP),
+		true,  // storage
+		false, // vexGeneration
+		true,  // sbomGeneration
+		false, // storeFilteredSbom
+		false, // partialRelevancy
+	)
+	ctx := context.TODO()
+	s.Ready(ctx)
+
+	workload := domain.ScanCommand{
+		Args: map[string]interface{}{
+			domain.ArgsName:      "daemonset-kube-proxy",
+			domain.ArgsNamespace: "kube-system",
+		},
+		Wlid: wlid,
+	}
+	ctx, err := s.ValidateScanCP(ctx, workload)
+	require.NoError(t, err)
+
+	ap := v1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "daemonset-kube-proxy",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: helpersv1.Full,
+				helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-kube-system/kind-DaemonSet/name-kube-proxy/containerName-kube-proxy",
+				helpersv1.StatusMetadataKey:     helpersv1.Learning,
+				helpersv1.WlidMetadataKey:       wlid,
+			},
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Spec: v1beta1.ContainerProfileSpec{
+			ImageID:  "sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+			ImageTag: "k8s.gcr.io/kube-proxy:v1.24.3",
+		},
+	}
+	require.NoError(t, storageCP.StoreContainerProfile(ctx, ap))
+
+	require.NoError(t, s.ScanCP(ctx))
+	require.NotEmpty(t, cveRepo.calls, "ScanCP should have called StoreCVESummary")
+
+	relevancyCall := cveRepo.calls[len(cveRepo.calls)-1]
+	require.True(t, relevancyCall.withRelevancy, "expected the relevancy-branch StoreCVESummary call last")
+	require.NotNil(t, relevancyCall.cve.Content)
+	assert.Empty(t, relevancyCall.cve.Content.Matches, "suppressed CVE must not be counted toward severities.*.all")
+	require.Len(t, relevancyCall.cve.Content.IgnoredMatches, 1)
+	assert.Equal(t, suppressedCVE, relevancyCall.cve.Content.IgnoredMatches[0].Vulnerability.VulnerabilityMetadata.ID)
+
+	for _, call := range cveRepo.calls {
+		if call.cve.Content == nil {
+			continue
+		}
+		for _, m := range call.cve.Content.Matches {
+			assert.NotEqual(t, suppressedCVE, m.Vulnerability.VulnerabilityMetadata.ID,
+				"a StoreCVESummary call included the suppressed CVE in its unfiltered totals")
+		}
+	}
+}
+
 func TestScanService_ValidateScanRegistry(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Problem

`VulnerabilityManifestSummary`'s `severities.*.all` counters mean different things depending on which scan flow last wrote the object, even though every flow writes to the same K8s object for a given workload/container (name is `kind-name-containerName`, no per-flow discriminator).

## Root cause

`StoreCVESummary`'s `all` counters come straight from `Content.Matches` on whichever manifest is passed as its first argument. Four call sites pass the exception-filtered manifest: `ScanCP`'s own non-relevancy branch, `storeFilteredCVE` (used by both `ScanCVE` and `ScanRegistry`), and the cache-hit path in `reconcileCachedCVE`. `ScanCP`'s relevancy branch was the one exception, passing the unfiltered manifest instead -- so a SecurityException-suppressed CVE stayed in `severities.*.all` there while every other flow already excluded it.

Since `ScanCVE`/`ScanRegistry` and `ScanCP` can both write the same `VulnerabilityManifestSummary` object for the same workload/container, the object's `severities.*.all` flipped depending on which flow scanned last, with no underlying data change.

I want to flag directly: a comment at this call site (added in commit `f6848b9`) documents this specific line's behavior. It doesn't address the inconsistency against the other four call sites, though, which is what this fix targets -- I'm not disputing that comment's intent for its own line, just making all five call sites agree with each other, since right now the same object's meaning depends on which endpoint wrote it last.

## Fix

`core/services/scan.go`: `ScanCP`'s relevancy branch now passes `filteredCve` instead of `cve` to `StoreCVESummary`, matching the other four call sites. `SubmitCVE` (cloud/backend reporting) is untouched -- it still receives the unfiltered manifest everywhere, exactly like `ScanCVE`/`ScanRegistry` already do for their own `SubmitCVE` calls, since that's a different, deliberately unfiltered surface.

## Testing

Added `TestScanService_ScanCP_SummaryExcludesSuppressedCVEFromTotals`: wraps the CVE repository to capture every `StoreCVESummary` call `ScanCP` makes (both the non-relevancy and relevancy branches) and asserts a SecurityException-suppressed CVE lands in `IgnoredMatches`, never `Matches`, on every call.

I verified the test actually catches the regression: reverting the fix locally and re-running it fails with `suppressed CVE must not be counted toward severities.*.all` (the CVE showed up in `Matches` with zero `IgnoredMatches`), confirming the test isn't a false positive.

- `go build ./...` -- clean
- `go test ./core/services/...` -- full package passes (all existing tests plus the new one)
- `golangci-lint run --new-from-rev=main` -- 0 issues

## Impact

`ScanCVE`/`ScanRegistry` scans and `ScanCP` relevancy scans against the same workload/container, with the same `SecurityException`s active, now produce identical `severities.*.all` values, instead of the count oscillating between scans with no configuration change.

Fixes #819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vulnerability summary counts when security exceptions suppress findings.
  * Ensured suppressed vulnerabilities are consistently excluded from active matches across scan workflows.
  * Improved consistency between relevancy and non-relevancy scan results.

* **Tests**
  * Added regression coverage for summaries involving security-exception-suppressed vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->