### PR TITLE
fix(ci): isolate release workflow concurrency

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- stop `pr-merged` runs from sharing one concurrency group on merged PRs
- use the pull request number in the concurrency key instead of `github.ref`
- keep the release workflow from cancelling another merge that is already in flight

## Validation
- ran `actionlint .github/workflows/*`
- remaining `pr-image.yaml` shellcheck warnings are pre-existing and unrelated to this change