### PR TITLE
chore(ci): pin GitHub workflow refs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,12 +21,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: true

--- a/.github/workflows/offline-db.yaml
+++ b/.github/workflows/offline-db.yaml
@@ -24,17 +24,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
             - name: Login to Quay.io
-              uses: docker/login-action@v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
               with:
                   registry: quay.io/kubescape
                   username: ${{ secrets.QUAYIO_REGISTRY_USERNAME }}
                   password: ${{ secrets.QUAYIO_REGISTRY_PASSWORD }}
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
             - name: Build the Image and Push to Quay.io
               id: build-and-push-image
               run: docker buildx build --file build/Dockerfile.offline-db --platform linux/amd64,linux/arm64 --tag quay.io/kubescape/grype-offline-db:v6-latest --push .

--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       pull-requests: write
       security-events: write
-    uses: kubescape/workflows/.github/workflows/incluster-comp-pr-created.yaml@main
+    uses: kubescape/workflows/.github/workflows/incluster-comp-pr-created.yaml@52bcdc0a1e5c86dacf1450fc65429b1246e2b354
     with:
       CGO_ENABLED: 0
       GO_VERSION: "1.26"

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -20,10 +20,10 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAYIO_REGISTRY_PASSWORD }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Login to Quay.io
         if: ${{ env.QUAY_USERNAME != '' && env.QUAY_PASSWORD != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: quay.io/kubescape
           username: ${{ secrets.QUAYIO_REGISTRY_USERNAME }}

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -53,7 +53,7 @@ jobs:
       contents: write
       pull-requests: read
       attestations: write  # required by actions/attest-build-provenance in the shared workflow
-    uses: kubescape/workflows/.github/workflows/incluster-comp-pr-merged.yaml@main
+    uses: kubescape/workflows/.github/workflows/incluster-comp-pr-merged.yaml@52bcdc0a1e5c86dacf1450fc65429b1246e2b354
     with:
       IMAGE_NAME: quay.io/${{ github.repository_owner }}/kubevuln
       IMAGE_TAG: v0.3.${{ needs.reset-run-number.outputs.run-number }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security-insights.yaml
+++ b/.github/workflows/security-insights.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
- pin mutable GitHub Action and reusable workflow refs to full commit SHAs
- add Dependabot updates for GitHub Actions so pinned refs still receive update PRs
- keep the change scoped to workflow supply-chain reproducibility only

## Validation
- ran `actionlint .github/workflows/*`
- remaining `pr-image.yaml` shellcheck warnings are pre-existing and unchanged by this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added weekly automated updates for GitHub Actions.
  * Pinned CI/CD and security workflow actions to immutable versions for more predictable and secure builds.
  * Pinned reusable workflow references to specific revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->