### PR TITLE
chore(ci): narrow PR image build triggers

### DIFF
--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -2,6 +2,14 @@ name: PR Image Build
 on:
   pull_request:
     types: [synchronize, ready_for_review, opened, reopened]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.dockerignore'
+      - 'build/**'
+      - '.github/workflows/pr-image.yaml'
 
 # The image is pushed to Quay with its own registry secrets, not GITHUB_TOKEN, so read
 # access for the checkout is all this needs.


### PR DESCRIPTION
## Summary
- add `paths` filters to `PR Image Build`
- run the image build only when Go sources, module files, Docker/build inputs, or the workflow itself change
- avoid spending runner time on docs-only and unrelated PR updates

## Validation
- ran `actionlint .github/workflows/pr-image.yaml`
- remaining shellcheck warnings in the build script are pre-existing and unchanged by this PR