### PR TITLE
fix(repositories): resolve workload namespace in APIServerStore.GetCVESummary

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -632,20 +632,30 @@ func (a *APIServerStore) GetCVESummary(ctx context.Context) (*v1beta1.Vulnerabil
 		logger.L().Debug("empty name provided, skipping summary CVE retrieval")
 		return nil, nil
 	}
-	manifest, err := a.StorageClient.VulnerabilityManifestSummaries(a.Namespace).Get(ctx, name, metav1.GetOptions{})
+	workloadNamespace, err := GetCVESummaryK8sResourceNamespace(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if workloadNamespace == "" {
+		workloadNamespace = a.Namespace
+	}
+	manifest, err := a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Get(ctx, name, metav1.GetOptions{})
 	switch {
 	case errors.IsNotFound(err):
 		logger.L().Debug("summary CVE manifest not found in storage",
-			helpers.String("name", name))
+			helpers.String("name", name),
+			helpers.String("namespace", workloadNamespace))
 		return nil, nil
 	case err != nil:
 		logger.L().Ctx(ctx).Warning("failed to get summary CVE manifest from apiserver", helpers.Error(err),
-			helpers.String("name", name))
+			helpers.String("name", name),
+			helpers.String("namespace", workloadNamespace))
 		return nil, err
 	}
 
 	logger.L().Debug("got summary CVE manifest from storage",
-		helpers.String("name", name))
+		helpers.String("name", name),
+		helpers.String("namespace", workloadNamespace))
 	return manifest, nil
 }
 

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2250,8 +2250,55 @@ func TestAPIServerStore_GetCVESummary_ctxPropagated(t *testing.T) {
 	ctx := context.WithValue(canaryCtx(), domain.WorkloadKey{}, workload)
 	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
 	_, _ = a.GetCVESummary(ctx)
-	require.Contains(t, wrapped.vulnSummaries, a.Namespace)
-	requireCanaryCtx(t, wrapped.vulnSummaries[a.Namespace].getCtx)
+	require.Contains(t, wrapped.vulnSummaries, "anyNamespaceJob")
+	requireCanaryCtx(t, wrapped.vulnSummaries["anyNamespaceJob"].getCtx)
+}
+
+func TestAPIServerStore_GetCVESummary_WorkloadNamespace(t *testing.T) {
+	clientset := newFakeStorageClientset()
+	a := newFakeAPIServerStore("kubescape", clientset.SpdxV1beta1())
+	workload := domain.ScanCommand{
+		Wlid: "wlid://cluster-aaa/namespace-custom-workload-ns/deployment-my-deployment",
+		Args: map[string]interface{}{
+			domain.ArgsName:      "my-deployment",
+			domain.ArgsNamespace: "custom-workload-ns",
+		},
+		ContainerName: "main",
+		ImageHash:     "sha256:ead0a4a53df89fd173874b46093b6e62d8c72967bbf606d672c9e8c9b601a4fc",
+		ImageTag:      "nginx:latest",
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	require.NoError(t, a.StoreCVESummaryStub(ctx, "Success"))
+
+	summary, err := a.GetCVESummary(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.Equal(t, "deployment-my-deployment-main", summary.Name)
+
+	storedInNs, err := clientset.SpdxV1beta1().VulnerabilityManifestSummaries("custom-workload-ns").Get(ctx, "deployment-my-deployment-main", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, storedInNs)
+
+	_, err = clientset.SpdxV1beta1().VulnerabilityManifestSummaries("kubescape").Get(ctx, "deployment-my-deployment-main", metav1.GetOptions{})
+	require.Error(t, err)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestAPIServerStore_GetCVESummary_FallbackNamespace(t *testing.T) {
+	clientset := newFakeStorageClientset()
+	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}
+	a := newFakeAPIServerStore("kubescape", wrapped)
+
+	workload := domain.ScanCommand{
+		ImageHash: "sha256:ead0a4a53df89fd173874b46093b6e62d8c72967bbf606d672c9e8c9b601a4fc",
+		ImageTag:  "nginx:latest",
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+	_, _ = a.GetCVESummary(ctx)
+
+	require.Contains(t, wrapped.vulnSummaries, "kubescape")
 }
 
 func TestAPIServerStore_GetCVESummary_returnsTransientError(t *testing.T) {


### PR DESCRIPTION
Fixes #824

### Problem
`APIServerStore.GetCVESummary` queried `a.Namespace` (the default `kubevuln` system namespace) instead of resolving the target workload's namespace via `GetCVESummaryK8sResourceNamespace(ctx)`. As a result, calling `GetCVESummary` for any workload deployed in non-system namespaces (e.g. `default`, `kube-system`, `production`) queried the wrong namespace in the API server, returning `NotFound` / `nil`.

### Root Cause
`GetCVESummary` hardcoded `a.Namespace` on line 635 of `repositories/apiserver.go`, creating a read/write namespace mismatch against `StoreCVESummary` and `StoreCVESummaryStub` which derive `workloadNamespace` from context metadata.

### Solution
- Updated `GetCVESummary` in `repositories/apiserver.go` to call `GetCVESummaryK8sResourceNamespace(ctx)` and fall back to `a.Namespace` only if `workloadNamespace == ""`.
- Passed `workloadNamespace` to `a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace).Get(...)`.
- Added unit tests (`TestAPIServerStore_GetCVESummary_WorkloadNamespace` and `TestAPIServerStore_GetCVESummary_FallbackNamespace`) in `repositories/apiserver_test.go` covering custom workload namespaces and fallback behavior.

### Testing
- `go test -v ./repositories -run "TestAPIServerStore_GetCVESummary"` passed cleanly.
- `go vet ./repositories/...` passed cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CVE summaries are now retrieved from the correct workload namespace.
  - Added a fallback to the system namespace when workload namespace information is unavailable.
  - Improved not-found and retrieval logging to identify the selected namespace, making troubleshooting clearer.

- **Tests**
  - Added coverage for workload-specific namespace handling.
  - Verified fallback behavior for workloads without namespace information.
  - Confirmed CVE summary retrieval and context propagation across supported namespace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->