### PR TITLE
ci: ignore markdown changes across all subdirectories in PR workflows

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - '*.yaml'
       - '.github/workflows/*'
 

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -13,7 +13,7 @@ on:
     branches:
     - 'main'
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - '*.yaml'
       - '.github/workflows/*'
 


### PR DESCRIPTION

## Overview
In `.github/workflows/pr-created.yaml` and `.github/workflows/pr-merged.yaml`, `paths-ignore` previously used `'*.md'`. In GitHub Actions glob syntax, `*` does not cross path separators (`/`), so markdown files located in subdirectories (e.g. `docs/ARCHITECTURE.md`, `docs/API.md`, `docs/CONFIGURATION.md`, etc.) were not ignored.

As a result, docs-only PRs and merges unnecessarily triggered the entire in-cluster test matrix, 11 relevancy e2e test suites, Helm e2e tests, and Cosign image signing.

### Changes
- Updated `paths-ignore` in `.github/workflows/pr-created.yaml` and `.github/workflows/pr-merged.yaml` from `'*.md'` to `'**/*.md'` to recursively ignore all documentation files.
- Preserved `'*.yaml'` so test fixtures (such as `api/v1/testdata/*.yaml`) continue to trigger test suites as expected.

## Additional Information
Follow-up to #823 (which narrowed triggers on `pr-image.yaml`).

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation to ignore Markdown file changes in any directory level.
  * Prevented pull request creation and merge workflows from running unnecessarily for documentation-only updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->