### PR TITLE
test: add coverage for remaining BrokenStore methods

### DIFF
--- a/repositories/broken_test.go
+++ b/repositories/broken_test.go
@@ -31,3 +31,40 @@ func TestBrokenStore_StoreSBOM(t *testing.T) {
 	err := b.StoreSBOM(context.TODO(), domain.SBOM{}, false)
 	assert.Error(t, err)
 }
+
+func TestBrokenStore_GetContainerProfile(t *testing.T) {
+	b := NewBrokenStorage()
+	_, err := b.GetContainerProfile(context.TODO(), "", "")
+	assert.Error(t, err)
+}
+
+func TestBrokenStore_GetCVESummary(t *testing.T) {
+	b := NewBrokenStorage()
+	summary, err := b.GetCVESummary(context.TODO())
+	assert.NoError(t, err)
+	assert.NotNil(t, summary)
+}
+
+func TestBrokenStore_StoreCVESummary(t *testing.T) {
+	b := NewBrokenStorage()
+	err := b.StoreCVESummary(context.TODO(), domain.CVEManifest{}, domain.CVEManifest{}, false)
+	assert.Error(t, err)
+}
+
+func TestBrokenStore_StoreCVESummaryStub(t *testing.T) {
+	b := NewBrokenStorage()
+	err := b.StoreCVESummaryStub(context.TODO(), "")
+	assert.Error(t, err)
+}
+
+func TestBrokenStore_StoreVEX(t *testing.T) {
+	b := NewBrokenStorage()
+	err := b.StoreVEX(context.TODO(), domain.CVEManifest{}, domain.CVEManifest{}, false)
+	assert.Error(t, err)
+}
+
+func TestBrokenStore_DeleteSBOM(t *testing.T) {
+	b := NewBrokenStorage()
+	err := b.DeleteSBOM(context.TODO(), "")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Overview

`repositories/broken.go` defines `BrokenStore`, a stub repository used across the test suite to simulate a storage backend that always fails. It implements three interfaces `ContainerProfileRepository`, `CVERepository`, and `SBOMRepository`  for a total of 10 methods.

Only 4 of those methods (`GetCVE`, `GetSBOM`, `StoreCVE`, `StoreSBOM`) had existing unit tests in `repositories/broken_test.go`. This PR adds tests for the remaining 6 methods, bringing `BrokenStore` to full coverage:

- `GetContainerProfile`
- `GetCVESummary`
- `StoreCVESummary`
- `StoreCVESummaryStub`
- `StoreVEX`
- `DeleteSBOM`

## Additional Information

Each new test follows the same pattern as the existing ones in the file: construct a `BrokenStore` via `NewBrokenStorage()`, call the method with zero-value/empty arguments, and assert on the returned error.

One method behaves differently from the rest and is worth calling out for reviewers: `GetCVESummary` does **not** return `domain.ErrExpectedError` like every other method on `BrokenStore`  it returns a nil error along with an empty `VulnerabilityManifestSummary`. Rather than "fixing" this to be consistent, the new test (`TestBrokenStore_GetCVESummary`) asserts the actual current behavior (`assert.NoError`), so that:
- the test suite documents this asymmetry explicitly instead of silently relying on it.
- any future change to this behavior (intentional or accidental) will be caught by CI rather than discovered downstream.

No production code was touched  this is a test-only change, isolated to a single file, with no risk of behavioral impact.

## How to Test

go test ./repositories/... -run TestBrokenStore -v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for storage failure handling across container profiles, CVE summaries, VEX data, and SBOM deletion.
  * Verified expected errors are returned for failed operations.
  * Confirmed CVE summary retrieval returns a valid result without an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->