### PR TITLE
refactor(platform): share the platform helpers both SBOM paths duplicate

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -34,20 +34,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-// formatResolvedPlatform builds an OCI-style "os/arch[/variant]" string from the platform
-// fields Syft/stereoscope actually resolved an image against. Returns "" unless both os and
-// architecture are known.
-func formatResolvedPlatform(os, arch, variant string) string {
-	if os == "" || arch == "" {
-		return ""
-	}
-	parts := []string{os, arch}
-	if variant != "" {
-		parts = append(parts, variant)
-	}
-	return strings.Join(parts, "/")
-}
-
 // createSBOMFn is an indirection over syft.CreateSBOM so the deadline handling in
 // CreateSBOM can be unit-tested without cataloguing a real image.
 var createSBOMFn = syft.CreateSBOM
@@ -281,15 +267,9 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		// match options.Platform). Propagated as-is: classifySBOMError in core/services
 		// recognizes it via errors.As and reports a distinct "platform not found" reason
 		// instead of the generic SBOM-generation-failed fallback (see #512).
-		var platformErr *image.ErrPlatformMismatch
-		if errors.As(err, &platformErr) {
+		if syftsource.IsPlatformMismatch(err) {
 			metrics.RecordScanFallback(ctx, metrics.ComponentInProcess, metrics.FallbackCategoryPlatform, metrics.FallbackStrategyPlatformMismatch, metrics.FallbackOutcomeFailed)
 		}
-		// Requested-but-unavailable platforms surface here as *image.ErrPlatformMismatch
-		// (from stereoscope, once it has positively resolved the image but its OS/arch don't
-		// match options.Platform). Propagated as-is: classifySBOMError in core/services
-		// recognizes it via errors.As and reports a distinct "platform not found" reason
-		// instead of the generic SBOM-generation-failed fallback (see #512).
 		endActiveTempDirUse()
 		unlockPullMutex()
 		return domainSBOM, err
@@ -298,7 +278,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 	// record the platform actually resolved, whether it was explicitly requested or left for
 	// Syft to pick, so a silently-wrong-arch SBOM is inspectable after the fact (see #512).
 	if meta, ok := src.Describe().Metadata.(source.ImageMetadata); ok {
-		if resolved := formatResolvedPlatform(meta.OS, meta.Architecture, meta.Variant); resolved != "" {
+		if resolved := syftsource.FormatResolvedPlatform(meta.OS, meta.Architecture, meta.Variant); resolved != "" {
 			domainSBOM.Annotations[domain.ResolvedPlatformAnnotationKey] = resolved
 		}
 	}

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -39,26 +39,6 @@ func fileContent(path string) []byte {
 	return b
 }
 
-func TestFormatResolvedPlatform(t *testing.T) {
-	tests := []struct {
-		name    string
-		os      string
-		arch    string
-		variant string
-		want    string
-	}{
-		{name: "os and arch", os: "linux", arch: "amd64", want: "linux/amd64"},
-		{name: "os, arch and variant", os: "linux", arch: "arm", variant: "v7", want: "linux/arm/v7"},
-		{name: "neither known", want: ""},
-		{name: "arch known, os unknown", arch: "amd64", want: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, formatResolvedPlatform(tt.os, tt.arch, tt.variant))
-		})
-	}
-}
-
 func Test_syftAdapter_Version(t *testing.T) {
 	s := NewSyftAdapter(5*time.Minute, 512*1024*1024, 20*1024*1024, false, nil)
 	version := s.Version()

--- a/internal/syftsource/syftsource.go
+++ b/internal/syftsource/syftsource.go
@@ -1,5 +1,6 @@
-// Package syftsource holds the two pieces of Syft source setup that both SBOM paths need:
-// the in-process adapter in adapters/v1 and the sidecar scanner in pkg/sbomscanner/v1.
+// Package syftsource holds the pieces of Syft source setup and platform handling that both
+// SBOM paths need: the in-process adapter in adapters/v1 and the sidecar scanner in
+// pkg/sbomscanner/v1.
 //
 // They were written out separately in each, with a comment in both pointing at the other
 // saying it mirrors it. Platform resolution in particular is what #512 was about, so the
@@ -8,11 +9,41 @@
 package syftsource
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
 )
+
+// FormatResolvedPlatform builds an OCI-style "os/arch[/variant]" string from the platform
+// fields Syft/stereoscope actually resolved an image against, so a silently-wrong-arch SBOM
+// is inspectable after the fact (#512). Returns "" unless both os and architecture are
+// known, since a half-known platform is not a platform.
+func FormatResolvedPlatform(os, arch, variant string) string {
+	if os == "" || arch == "" {
+		return ""
+	}
+	parts := []string{os, arch}
+	if variant != "" {
+		parts = append(parts, variant)
+	}
+	return strings.Join(parts, "/")
+}
+
+// IsPlatformMismatch reports whether err is, or wraps, stereoscope's
+// *image.ErrPlatformMismatch: the error raised once an image has been positively
+// resolved but its OS/arch do not match the requested platform.
+//
+// Both SBOM paths classify this error, and both must agree on what counts as one, for the
+// same reason ParsePlatform is shared: #512 was about the two paths disagreeing on
+// platform handling. Matching on the typed error rather than on message text is what keeps
+// an unrelated error that merely mentions "mismatched platform" from being classified as
+// a platform failure.
+func IsPlatformMismatch(err error) bool {
+	var platformErr *image.ErrPlatformMismatch
+	return errors.As(err, &platformErr)
+}
 
 // ParsePlatform normalizes a platform specifier for multi-arch image resolution. The
 // specifier uses OCI format, "os/arch[/variant]" such as "linux/amd64", and an

--- a/internal/syftsource/syftsource_test.go
+++ b/internal/syftsource/syftsource_test.go
@@ -1,6 +1,8 @@
 package syftsource
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/image"
@@ -84,4 +86,63 @@ func TestGetSourceConfig_restrictsToRegistry(t *testing.T) {
 	require.NotNil(t, cfg)
 	assert.Equal(t, []string{"registry"}, cfg.Sources,
 		"kubevuln always pulls; falling back to a local daemon or containerd socket is not wanted")
+}
+
+// TestIsPlatformMismatch pins what counts as a platform mismatch for both SBOM paths.
+// The "unrelated error" case is the one that matters: classification is by typed error,
+// so an error that merely mentions the phrase must not be treated as one.
+func TestIsPlatformMismatch(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "typed platform mismatch",
+			err:  &image.ErrPlatformMismatch{ExpectedPlatform: "linux/arm64"},
+			want: true,
+		},
+		{
+			name: "wrapped typed platform mismatch",
+			err:  fmt.Errorf("resolving source: %w", &image.ErrPlatformMismatch{ExpectedPlatform: "linux/arm64"}),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("mismatched platform mentioned but not the typed error"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPlatformMismatch(tt.err))
+		})
+	}
+}
+
+func TestFormatResolvedPlatform(t *testing.T) {
+	tests := []struct {
+		name    string
+		os      string
+		arch    string
+		variant string
+		want    string
+	}{
+		{name: "os and arch", os: "linux", arch: "amd64", want: "linux/amd64"},
+		{name: "os, arch and variant", os: "linux", arch: "arm", variant: "v7", want: "linux/arm/v7"},
+		{name: "neither known", want: ""},
+		{name: "arch known, os unknown", arch: "amd64", want: ""},
+		{name: "os known, arch unknown", os: "linux", want: ""},
+		{name: "variant without arch", variant: "v7", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, FormatResolvedPlatform(tt.os, tt.arch, tt.variant))
+		})
+	}
 }

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -33,30 +33,6 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
 
-// isPlatformMismatch reports whether err is (or wraps) stereoscope's
-// *image.ErrPlatformMismatch, returned once a provider has positively resolved the image but
-// its OS/architecture doesn't match the platform that was requested.
-func isPlatformMismatch(err error) bool {
-	var platformErr *image.ErrPlatformMismatch
-	return errors.As(err, &platformErr)
-}
-
-// formatResolvedPlatform builds an OCI-style "os/arch[/variant]" string from the platform
-// fields Syft/stereoscope actually resolved an image against. Returns "" unless both os and
-// architecture are known. Duplicated from adapters/v1/syft.go's helper of the same name since
-// the two packages don't share a dependency either could live in without introducing one
-// (same rationale as syftToDomain's duplication, documented there).
-func formatResolvedPlatform(os, arch, variant string) string {
-	if os == "" || arch == "" {
-		return ""
-	}
-	parts := []string{os, arch}
-	if variant != "" {
-		parts = append(parts, variant)
-	}
-	return strings.Join(parts, "/")
-}
-
 // createSBOMFn is an indirection over syft.CreateSBOM so the deadline handling in
 // CreateSBOM can be unit-tested without cataloguing a real image.
 var createSBOMFn = syft.CreateSBOM
@@ -202,7 +178,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 			Status:       helpersv1.Unauthorize,
 			ErrorMessage: err.Error(),
 		}, nil
-	case err != nil && isPlatformMismatch(err):
+	case err != nil && syftsource.IsPlatformMismatch(err):
 		metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryPlatform, metrics.FallbackStrategyPlatformMismatch, metrics.FallbackOutcomeFailed)
 		// The requested platform doesn't exist in the image's manifest. StatusReason travels
 		// over gRPC as a plain string; the caller's classifySBOMError also recognizes the
@@ -229,9 +205,9 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 			StatusReason: domain.ReasonTooManyRequests,
 		}, nil
 	case err != nil:
-		if isPlatformMismatch(err) {
-			metrics.RecordScanFallback(ctx, metrics.ComponentSidecar, metrics.FallbackCategoryPlatform, metrics.FallbackStrategyPlatformMismatch, metrics.FallbackOutcomeFailed)
-		}
+		// No syftsource.IsPlatformMismatch check here: the arm above already claims every such error,
+		// so a copy of it in this arm can never run. Anything reaching here has no more
+		// specific classification than "SBOM generation failed".
 		endActiveTempDirUse()
 		return &pb.CreateSBOMResponse{
 			ErrorMessage: err.Error(),
@@ -242,7 +218,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// Syft to pick, so a silently-wrong-arch SBOM is inspectable after the fact (see #512).
 	var resolvedPlatform string
 	if meta, ok := src.Describe().Metadata.(source.ImageMetadata); ok {
-		resolvedPlatform = formatResolvedPlatform(meta.OS, meta.Architecture, meta.Variant)
+		resolvedPlatform = syftsource.FormatResolvedPlatform(meta.OS, meta.Architecture, meta.Variant)
 	}
 
 	// Generate SBOM with timeout (reuses the same timeout duration computed above for the

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -577,60 +577,6 @@ func TestIsRegistryRateLimited(t *testing.T) {
 	}
 }
 
-func TestIsPlatformMismatch(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{
-			name: "typed platform mismatch",
-			err:  &image.ErrPlatformMismatch{ExpectedPlatform: "linux/arm64"},
-			want: true,
-		},
-		{
-			name: "wrapped typed platform mismatch",
-			err:  fmt.Errorf("resolving source: %w", &image.ErrPlatformMismatch{ExpectedPlatform: "linux/arm64"}),
-			want: true,
-		},
-		{
-			name: "unrelated error",
-			err:  errors.New("mismatched platform mentioned but not the typed error"),
-			want: false,
-		},
-		{
-			name: "nil error",
-			err:  nil,
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isPlatformMismatch(tt.err))
-		})
-	}
-}
-
-func TestFormatResolvedPlatform(t *testing.T) {
-	tests := []struct {
-		name    string
-		os      string
-		arch    string
-		variant string
-		want    string
-	}{
-		{name: "os and arch", os: "linux", arch: "amd64", want: "linux/amd64"},
-		{name: "os, arch and variant", os: "linux", arch: "arm", variant: "v7", want: "linux/arm/v7"},
-		{name: "neither known", want: ""},
-		{name: "arch known, os unknown", arch: "amd64", want: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, formatResolvedPlatform(tt.os, tt.arch, tt.variant))
-		})
-	}
-}
-
 // TestCreateSBOM_PlatformMismatch_LocalRegistry is a regression test for #512: requesting a
 // platform absent from the image's manifest must surface a distinct "platform not found"
 // reason instead of falling into the generic error path.


### PR DESCRIPTION
## Overview

`adapters/v1/syft.go` and `pkg/sbomscanner/v1/server.go` each carried their own `formatResolvedPlatform`, byte identical down to the test table, and their own way of recognising a stereoscope platform mismatch: `syft.go` inline via `errors.As`, `server.go` behind a local `isPlatformMismatch`.

`internal/syftsource` already exists as the shared home for exactly this, and both files already import it, so the comment on `formatResolvedPlatform` saying the two packages have no shared dependency to put it in was stale.

Both helpers move there as `FormatResolvedPlatform` and `IsPlatformMismatch`, with one test table instead of two.

## Additional Information

Two artefacts of the copies came along with them, both from #546.

`server.go`'s final `case err != nil` arm re-checked the mismatch and recorded the platform fallback counter a second time. That arm is unreachable: the switch has no tag, so arms are tried in order, `case err != nil && isPlatformMismatch(err)` sits above it, and `isPlatformMismatch` is a pure `errors.As` on a fixed target type, so anything satisfying it has already been claimed.

`syft.go` had the same five-line comment twice in a row, above and below the metric block #546 inserted between them.

No behaviour change. Both helpers keep their bodies exactly as they were, and the counter still fires once per mismatch on each path.

The test table gained two cases while being consolidated, `os known, arch unknown` and `variant without arch`. Both copies only covered the reverse direction.

## How to Test

`go build ./... && go vet ./... && go test ./internal/syftsource/ ./adapters/v1/ ./pkg/sbomscanner/v1/ -count=1`

The unreachability claim is checked by mutation rather than argued. Forcing the earlier arm off:

```
case err != nil && false && syftsource.IsPlatformMismatch(err):
```

makes `TestCreateSBOM_PlatformMismatch_LocalRegistry` fail with `StatusReason` empty instead of `platform-not-found`:

```
--- Expected
+++ Actual
-platform-not-found
+
FAIL	github.com/kubescape/kubevuln/pkg/sbomscanner/v1
```

So a platform mismatch only ever reaches the earlier arm, and the copy of the check in the later one could not run.

`TestIsPlatformMismatch` moved from `pkg/sbomscanner/v1/server_test.go` to `internal/syftsource` unchanged, including the case that matters most: an error whose text mentions "mismatched platform" but is not the typed error must not classify as one.

## Related issues/PRs:

* Resolved #828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of platform mismatches, including errors wrapped by other operations.
  * Standardized resolved platform reporting using OCI-compatible formatting.
  * Avoided duplicate platform-mismatch metrics for source-resolution errors.

* **Refactor**
  * Centralized platform handling to provide more consistent behavior across SBOM scanning workflows.

* **Tests**
  * Added coverage for valid, incomplete, wrapped, unrelated, and empty platform-related inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->