### PR TITLE
test(metrics): cover the three recorders with no test and the unpinned outcome labels

### DIFF
--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -97,3 +97,179 @@ func TestMeterRegistersObservableGauge(t *testing.T) {
 
 	assert.True(t, strings.Contains(w.Body.String(), "kubevuln_test_gauge_local"), w.Body.String())
 }
+
+// scrape renders the current metric state the way the /metrics endpoint would, so the
+// assertions below read the exposition text an operator actually sees rather than the
+// SDK's internal state.
+func scrape(t *testing.T, m *Metrics) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	m.Handler().ServeHTTP(w, req)
+	require.Equal(t, 200, w.Code)
+	return w.Body.String()
+}
+
+// TestRecordSingleflightHit covers the counter that says how often a duplicate SBOM
+// request was served by an in-flight one rather than pulling the image again. It is the
+// only evidence singleflight is doing anything, so the target label has to be right:
+// without it the series cannot be attributed to a stage.
+func TestRecordSingleflightHit(t *testing.T) {
+	m, err := New()
+	require.NoError(t, err)
+
+	// "sbom_generation" is the only target used in production today
+	// (ScanService.getOrCreateSBOM), so it is the one worth pinning.
+	RecordSingleflightHit(context.Background(), "sbom_generation")
+	RecordSingleflightHit(context.Background(), "sbom_generation")
+	RecordSingleflightHit(context.Background(), "other_target")
+
+	body := scrape(t, m)
+	assert.Contains(t, body, `kubevuln_singleflight_hits_total{target="sbom_generation"} 2`, body)
+	assert.Contains(t, body, `kubevuln_singleflight_hits_total{target="other_target"} 1`, body)
+}
+
+// TestRecordRetryAttempt covers all three outcomes RetryWithBackoff can report. They are
+// distinct signals and only useful if they stay distinct: "attempt" says the operation is
+// under rate-limit pressure, "success" says backing off resolved it, and "exhausted" says
+// it did not and the scan failed.
+func TestRecordRetryAttempt(t *testing.T) {
+	m, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	RecordRetryAttempt(ctx, "sbom_generation", RetryOutcomeAttempt)
+	RecordRetryAttempt(ctx, "sbom_generation", RetryOutcomeAttempt)
+	RecordRetryAttempt(ctx, "sbom_generation", RetryOutcomeSuccess)
+	RecordRetryAttempt(ctx, "sbom_generation", RetryOutcomeExhausted)
+
+	body := scrape(t, m)
+	assert.Contains(t, body, `kubevuln_retry_attempts_total{operation="sbom_generation",outcome="attempt"} 2`, body)
+	assert.Contains(t, body, `kubevuln_retry_attempts_total{operation="sbom_generation",outcome="success"} 1`, body)
+	assert.Contains(t, body, `kubevuln_retry_attempts_total{operation="sbom_generation",outcome="exhausted"} 1`, body)
+}
+
+// TestRecordSourceResolution_AllOutcomes covers the (usedFallback, success) to outcome
+// mapping. Only fallback_assisted_success was previously exercised, leaving the other
+// three arms of the switch free to be wrong.
+//
+// The two that matter most are the ones that look similar and mean opposite things:
+// fallback_assisted_success is the auth ladder working as designed, first_pass_failure is
+// a resolution that failed without a fallback ever being tried.
+func TestRecordSourceResolution_AllOutcomes(t *testing.T) {
+	tests := []struct {
+		name         string
+		usedFallback bool
+		success      bool
+		want         string
+	}{
+		{"first pass succeeded", false, true, SourceResolutionFirstPassSuccess},
+		{"fallback rescued it", true, true, SourceResolutionFallbackAssistedSuccess},
+		{"fallback tried and failed", true, false, SourceResolutionFallbackFailed},
+		{"failed before any fallback", false, false, SourceResolutionFirstPassFailure},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := New()
+			require.NoError(t, err)
+
+			RecordSourceResolution(context.Background(), ComponentSidecar, tt.usedFallback, tt.success)
+
+			body := scrape(t, m)
+			assert.Contains(t, body,
+				`kubevuln_scan_source_resolution_total{component="sidecar",outcome="`+tt.want+`"} 1`, body)
+		})
+	}
+}
+
+// TestRecordSourceResolution_OutcomesAreDistinct guards the mapping as a whole rather than
+// one arm at a time: four different inputs must produce four different labels, so a switch
+// arm cannot be collapsed into another without failing here.
+func TestRecordSourceResolution_OutcomesAreDistinct(t *testing.T) {
+	m, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	RecordSourceResolution(ctx, ComponentInProcess, false, true)
+	RecordSourceResolution(ctx, ComponentInProcess, true, true)
+	RecordSourceResolution(ctx, ComponentInProcess, true, false)
+	RecordSourceResolution(ctx, ComponentInProcess, false, false)
+
+	body := scrape(t, m)
+	for _, outcome := range []string{
+		SourceResolutionFirstPassSuccess,
+		SourceResolutionFallbackAssistedSuccess,
+		SourceResolutionFallbackFailed,
+		SourceResolutionFirstPassFailure,
+	} {
+		assert.Contains(t, body,
+			`kubevuln_scan_source_resolution_total{component="in_process",outcome="`+outcome+`"} 1`, body)
+	}
+}
+
+// TestShutdown covers the graceful-shutdown hook cmd/http calls on its way out.
+//
+// Recording after shutdown is checked too. The package-level counters outlive the provider
+// they came from, and a scan goroutine can still be unwinding while shutdown runs, so a
+// record on a shut-down provider has to be harmless rather than a panic on the way out.
+func TestShutdown(t *testing.T) {
+	// New installs the package-level counters, so leave a live provider behind whatever
+	// this test does to them; test order must not decide whether later tests can record.
+	defer func() {
+		_, err := New()
+		require.NoError(t, err)
+	}()
+
+	m, err := New()
+	require.NoError(t, err)
+	RecordSingleflightHit(context.Background(), "sbom_generation")
+	require.Contains(t, scrape(t, m), "kubevuln_singleflight_hits_total")
+
+	require.NoError(t, m.Shutdown(context.Background()))
+
+	// Shutdown really stopped the reader rather than just returning nil: the exporter now
+	// has nothing to collect, so the endpoint still answers 200 but with an empty body.
+	assert.Empty(t, scrape(t, m), "reader should be stopped after Shutdown")
+
+	// And the provider saw it. A second Shutdown reports the reader is already down, which
+	// a Shutdown that never reached the provider could not do.
+	assert.ErrorContains(t, m.Shutdown(context.Background()), "shutdown")
+
+	assert.NotPanics(t, func() {
+		RecordSingleflightHit(context.Background(), "sbom_generation")
+		RecordRetryAttempt(context.Background(), "sbom_generation", RetryOutcomeAttempt)
+		RecordScanFallback(context.Background(), ComponentInProcess,
+			FallbackCategoryRegistryAuth, FallbackStrategyAnonymous, FallbackOutcomeFailed)
+	})
+}
+
+// TestRecordersBeforeNewAreNoOps extends the guarantee TestRecordTempDirSweep_BeforeNewIsANoOp
+// makes for one recorder to the rest of them. cmd/sbom-scanner never calls metrics.New, so
+// every recorder reachable from the sidecar runs against a nil counter in production.
+func TestRecordersBeforeNewAreNoOps(t *testing.T) {
+	recorderMu.Lock()
+	prevFallback, prevSource := fallbackCounter, sourceResolutionCounter
+	prevAuth, prevSingleflight := registryAuthCacheCounter, singleflightHitsCounter
+	prevRetry := retryAttemptsCounter
+	fallbackCounter, sourceResolutionCounter = nil, nil
+	registryAuthCacheCounter, singleflightHitsCounter = nil, nil
+	retryAttemptsCounter = nil
+	recorderMu.Unlock()
+	defer func() {
+		recorderMu.Lock()
+		fallbackCounter, sourceResolutionCounter = prevFallback, prevSource
+		registryAuthCacheCounter, singleflightHitsCounter = prevAuth, prevSingleflight
+		retryAttemptsCounter = prevRetry
+		recorderMu.Unlock()
+	}()
+
+	ctx := context.Background()
+	assert.NotPanics(t, func() {
+		RecordScanFallback(ctx, ComponentSidecar, FallbackCategoryPlatform,
+			FallbackStrategyPlatformMismatch, FallbackOutcomeFailed)
+		RecordSourceResolution(ctx, ComponentSidecar, true, false)
+		RecordRegistryAuthCache(ctx, FallbackStrategyECR, RegistryAuthCacheMiss)
+		RecordSingleflightHit(ctx, "sbom_generation")
+		RecordRetryAttempt(ctx, "sbom_generation", RetryOutcomeExhausted)
+	})
+}


### PR DESCRIPTION
## Overview

`internal/metrics` was at 68.3%, concentrated in the exported surface. `Shutdown`, `RecordSingleflightHit` and `RecordRetryAttempt` were at 0% each, and all three have production callers: `cmd/http`'s graceful-shutdown sequence, `ScanService.getOrCreateSBOM`, and three sites in `RetryWithBackoff`.

68.3% to 86.1%. Every recorder and `Shutdown` now at 100%; what is left in `New` is instrument-construction error paths.

Tests only, no production code changes.

## Additional Information

`RecordSourceResolution` was the gap worth the most. It maps `(usedFallback, success)` onto four outcome labels, and `TestNewAndHandler` exercised exactly one:

```go
RecordSourceResolution(context.Background(), ComponentInProcess, true, true)
```

Three switch arms were free to be wrong, and two of them mean opposite things while reading similarly on a dashboard: `fallback_assisted_success` is the registry-auth ladder working as designed, `first_pass_failure` is a resolution that failed before any fallback was tried. `TestRecordSourceResolution_OutcomesAreDistinct` guards the mapping as a whole, so one arm cannot be collapsed into another.

The nil-counter safety property was pinned for `RecordTempDirSweep` alone, with the note that `cmd/sbom-scanner` never calls `metrics.New`. That reasoning applies to every recorder the sidecar reaches, and `RecordScanFallback` alone is called from seven places in `pkg/sbomscanner/v1/server.go`. `TestRecordersBeforeNewAreNoOps` extends it to the rest.

Assertions read the exposition text `/metrics` actually serves, matching the existing tests, so a renamed label fails rather than passing against SDK internals.

`TestShutdown` restores a live provider on the way out. `New` installs the package-level counters, so without that, test order would decide whether later tests can record anything.

## How to Test

`go test ./internal/metrics/ -count=1 -race -cover`

Five mutations, each caught:

| mutation | fails |
| --- | --- |
| collapse the `fallback_failed` arm into the default | `TestRecordSourceResolution_AllOutcomes`, `..._OutcomesAreDistinct` |
| collapse the `first_pass_success` arm | `TestRecordSourceResolution_AllOutcomes`, `..._OutcomesAreDistinct` |
| drop the `target` label from singleflight hits | `TestRecordSingleflightHit` |
| drop the `outcome` label from retry attempts | `TestRecordRetryAttempt` |
| make `Shutdown` a no-op returning nil | `TestShutdown` |

The last one is worth calling out. A first pass at `TestShutdown` only asserted a nil error and no panic, and the no-op mutation survived it, since a no-op returns nil too. `Shutdown` turns out to be observable, so the test now checks what actually happened: the reader stopped, so a scrape still answers 200 with an empty body, and a second `Shutdown` reports the reader is already down, which a `Shutdown` that never reached the provider could not do.

## Related issues/PRs:

* Resolved #836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for metrics collection, including retries, duplicate requests, source-resolution outcomes, and shutdown behavior.
  * Verified metric labels and counts through the metrics endpoint.
  * Confirmed safe behavior when metrics are uninitialized or after shutdown, without panics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->