### PR TITLE
fix(repositories): stop MemoryStore answering a manifest read with a summary write

### DIFF
--- a/repositories/memory.go
+++ b/repositories/memory.go
@@ -1,7 +1,9 @@
 package repositories
 
 import (
+	"cmp"
 	"context"
+	"slices"
 
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
@@ -30,6 +32,7 @@ type sbomID struct {
 type MemoryStore struct {
 	aps          map[apID]v1beta1.ContainerProfile
 	cveManifests map[cveID]domain.CVEManifest
+	cveSummaries map[cveID]domain.CVEManifest
 	sboms        map[sbomID]domain.SBOM
 	summaryStubs []string // statuses passed to StoreCVESummaryStub, recorded for tests
 	sbomStores   int      // number of StoreSBOM calls, recorded for tests
@@ -54,6 +57,7 @@ func NewMemoryStorage(getError, storeError bool) *MemoryStore {
 	return &MemoryStore{
 		aps:          map[apID]v1beta1.ContainerProfile{},
 		cveManifests: map[cveID]domain.CVEManifest{},
+		cveSummaries: map[cveID]domain.CVEManifest{},
 		sboms:        map[sbomID]domain.SBOM{},
 		getError:     getError,
 		storeError:   storeError,
@@ -115,7 +119,14 @@ func (m *MemoryStore) GetCVE(ctx context.Context, name, SBOMCreatorVersion, CVES
 	return domain.CVEManifest{}, nil
 }
 
-// GetCVESummary returns a CVE summary from an in-memory map
+// GetCVESummary always reports no summary. It is a stub rather than a read of what
+// StoreCVESummary recorded, because building a real VulnerabilityManifestSummary here would
+// mean duplicating parseSeverities and parseVulnerabilitiesComponents in the test double.
+//
+// Nothing depends on it: the CVERepository port declares GetCVESummary, but no production
+// caller has existed since the cache-hit "store the summary only if it does not exist"
+// check was replaced with an unconditional re-store. Tests wanting to know what a scan flow
+// handed to the summary write should use CVESummaries.
 func (m *MemoryStore) GetCVESummary(ctx context.Context) (*v1beta1.VulnerabilityManifestSummary, error) {
 	_, span := otel.Tracer("").Start(ctx, "MemoryStore.GetCVESummary")
 	defer span.End()
@@ -141,7 +152,14 @@ func (m *MemoryStore) StoreCVE(ctx context.Context, cve domain.CVEManifest, _ bo
 	return nil
 }
 
-// StoreCVESummary stores a CVE summary to an in-memory map
+// StoreCVESummary records the manifests a summary write was given, in a map of its own.
+//
+// It used to write them into m.cveManifests, the map StoreCVE writes and GetCVE reads, which
+// made a summary write answer a manifest read: a flow that stored a summary without storing
+// the manifest looked cached on the next scan here, and did not against APIServerStore,
+// where the two are separate resources (VulnerabilityManifest, VulnerabilityManifestSummary).
+// Sharing the map also meant the two calls overwrote each other's entry under the same
+// cveID, so neither could be inspected afterwards.
 func (m *MemoryStore) StoreCVESummary(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, withRelevancy bool) error {
 	_, span := otel.Tracer("").Start(ctx, "MemoryStore.StoreCVESummary")
 	defer span.End()
@@ -164,10 +182,10 @@ func (m *MemoryStore) StoreCVESummary(ctx context.Context, cve domain.CVEManifes
 			CVEScannerVersion:  cvep.CVEScannerVersion,
 			CVEDBVersion:       cvep.CVEDBVersion,
 		}
-		m.cveManifests[idSumm] = cvep
+		m.cveSummaries[idSumm] = cvep
 	}
 
-	m.cveManifests[id] = cve
+	m.cveSummaries[id] = cve
 	return nil
 }
 
@@ -187,6 +205,25 @@ func (m *MemoryStore) StoreCVESummaryStub(ctx context.Context, status string) er
 // CVESummaryStubs returns the statuses passed to StoreCVESummaryStub, for tests
 func (m *MemoryStore) CVESummaryStubs() []string {
 	return m.summaryStubs
+}
+
+// CVESummaries returns every manifest handed to StoreCVESummary, so a test can check which
+// one a scan flow summarised without wrapping the repository to intercept the call. Sorted
+// so the result does not depend on Go's randomised map iteration order.
+func (m *MemoryStore) CVESummaries() []domain.CVEManifest {
+	out := make([]domain.CVEManifest, 0, len(m.cveSummaries))
+	for _, cve := range m.cveSummaries {
+		out = append(out, cve)
+	}
+	slices.SortFunc(out, func(a, b domain.CVEManifest) int {
+		return cmp.Or(
+			cmp.Compare(a.Name, b.Name),
+			cmp.Compare(a.SBOMCreatorVersion, b.SBOMCreatorVersion),
+			cmp.Compare(a.CVEScannerVersion, b.CVEScannerVersion),
+			cmp.Compare(a.CVEDBVersion, b.CVEDBVersion),
+		)
+	})
+	return out
 }
 
 // GetSBOM returns a SBOM from an in-memory map

--- a/repositories/memory_test.go
+++ b/repositories/memory_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemoryStore_GetCVE(t *testing.T) {
@@ -40,4 +41,90 @@ func TestMemoryStore_GetSBOM(t *testing.T) {
 	_ = m.StoreSBOM(ctx, sbom, false)
 	got, _ = m.GetSBOM(ctx, "name", "")
 	assert.NotNil(t, got.Content)
+}
+
+// TestMemoryStore_SummaryWriteDoesNotSatisfyManifestRead is the property that went wrong
+// while summaries shared the manifest map.
+//
+// Against APIServerStore these are two different resources, VulnerabilityManifest and
+// VulnerabilityManifestSummary, so storing a summary can never make GetCVE find a manifest.
+// A test double that answers the read anyway lets a flow look cached here that would miss
+// in production, which is the wrong direction for a double to be wrong in.
+func TestMemoryStore_SummaryWriteDoesNotSatisfyManifestRead(t *testing.T) {
+	m := NewMemoryStorage(false, false)
+	ctx := context.TODO()
+
+	cve := domain.CVEManifest{Name: "name", Content: &v1beta1.GrypeDocument{}}
+	require.NoError(t, m.StoreCVESummary(ctx, cve, domain.CVEManifest{}, false))
+
+	got, err := m.GetCVE(ctx, "name", "", "", "")
+	require.NoError(t, err)
+	assert.Nil(t, got.Content, "a summary write must not satisfy a manifest read")
+}
+
+// TestMemoryStore_ManifestAndSummaryDoNotOverwriteEachOther covers the other half: sharing
+// one map meant the second of the two calls replaced the first one's entry under the same
+// cveID, so neither could be read back afterwards.
+func TestMemoryStore_ManifestAndSummaryDoNotOverwriteEachOther(t *testing.T) {
+	m := NewMemoryStorage(false, false)
+	ctx := context.TODO()
+
+	manifest := domain.CVEManifest{Name: "name", Wlid: "manifest", Content: &v1beta1.GrypeDocument{}}
+	summarised := domain.CVEManifest{Name: "name", Wlid: "summary", Content: &v1beta1.GrypeDocument{}}
+
+	require.NoError(t, m.StoreCVE(ctx, manifest, false))
+	require.NoError(t, m.StoreCVESummary(ctx, summarised, domain.CVEManifest{}, false))
+
+	got, err := m.GetCVE(ctx, "name", "", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "manifest", got.Wlid, "the summary write must not replace the stored manifest")
+
+	summaries := m.CVESummaries()
+	require.Len(t, summaries, 1)
+	assert.Equal(t, "summary", summaries[0].Wlid)
+}
+
+// TestMemoryStore_CVESummaries covers the accessor that makes the summary write inspectable
+// without wrapping the repository, including the relevancy case where StoreCVESummary is
+// handed two manifests and both are recorded.
+func TestMemoryStore_CVESummaries(t *testing.T) {
+	m := NewMemoryStorage(false, false)
+	ctx := context.TODO()
+
+	assert.Empty(t, m.CVESummaries())
+
+	cve := domain.CVEManifest{Name: "image", Content: &v1beta1.GrypeDocument{}}
+	cvep := domain.CVEManifest{Name: "container", Content: &v1beta1.GrypeDocument{}}
+	require.NoError(t, m.StoreCVESummary(ctx, cve, cvep, true))
+
+	// Sorted by name, so the result does not depend on map iteration order.
+	summaries := m.CVESummaries()
+	require.Len(t, summaries, 2)
+	assert.Equal(t, "container", summaries[0].Name)
+	assert.Equal(t, "image", summaries[1].Name)
+
+	// withRelevancy false records only the unfiltered manifest.
+	m2 := NewMemoryStorage(false, false)
+	require.NoError(t, m2.StoreCVESummary(ctx, cve, cvep, false))
+	require.Len(t, m2.CVESummaries(), 1)
+	assert.Equal(t, "image", m2.CVESummaries()[0].Name)
+}
+
+func TestMemoryStore_StoreCVESummary_ReportsStoreError(t *testing.T) {
+	m := NewMemoryStorage(false, true)
+	err := m.StoreCVESummary(context.TODO(), domain.CVEManifest{Name: "name"}, domain.CVEManifest{}, false)
+	assert.ErrorIs(t, err, domain.ErrMockError)
+	assert.Empty(t, m.CVESummaries(), "a failed store must record nothing")
+}
+
+// TestMemoryStore_GetCVESummary_IsAStub pins the stub as deliberate rather than an oversight,
+// so a future change that starts returning something has to update this too.
+func TestMemoryStore_GetCVESummary_IsAStub(t *testing.T) {
+	m := NewMemoryStorage(false, false)
+	ctx := context.TODO()
+	require.NoError(t, m.StoreCVESummary(ctx, domain.CVEManifest{Name: "name"}, domain.CVEManifest{}, false))
+
+	summary, err := m.GetCVESummary(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, summary)
 }


### PR DESCRIPTION
## Overview

`MemoryStore.StoreCVESummary` wrote into `m.cveManifests`, the map `StoreCVE` writes and `GetCVE` reads. Against `APIServerStore` those are separate resources, `VulnerabilityManifest` and `VulnerabilityManifestSummary`, so a summary write can never make `GetCVE` find a manifest. Against the double it could.

Summaries now go in a map of their own, with a `CVESummaries` accessor so a test can inspect the summary write without wrapping the repository.

## Additional Information

`ScanCP`'s relevancy branch is where the two stores diverge. It stores `filteredCvep` as the manifest and then hands `filteredCve` to the summary write, so `filteredCve` reached the manifest map through the summary call. On a cache hit `reconcileCachedCVE` only stores `filteredCve` when suppressions actually changed and the removal-safety rule allows it, so there is a real case where the double holds a manifest the real store does not. A flow can look cached here and miss in production, which is the wrong direction for a double to be wrong in.

Sharing one map also meant the two calls overwrote each other under the same `cveID`, so neither was readable afterwards. That was already known, and worked around rather than fixed. From `core/services/scan_test.go`:

```go
// summaryCapturingRepo wraps a ports.CVERepository and records every StoreCVESummary call
// verbatim, so a test can inspect exactly which manifest a scan flow handed to the summary
// write. MemoryStore alone can't answer that: StoreCVE and StoreCVESummary key their map off
// the same cveID, so a later call silently overwrites an earlier one's entry.
```

`CVESummaries` is what that wrapper needed. It is left in place, since it also records call order and `withRelevancy`, which the accessor does not.

Two comments corrected while here.

`StoreCVESummary` now records why the maps are separate, so the next person to reach for the manifest map has the reason in front of them.

`GetCVESummary` no longer claims to "return a CVE summary from an in-memory map". It returns `nil, nil` unconditionally and never touches a map. It stays a stub, because building a real `VulnerabilityManifestSummary` in the double would mean duplicating `parseSeverities` and `parseVulnerabilitiesComponents`, and nothing depends on it: the port declares `GetCVESummary`, but no production caller has existed since `f57f6af` replaced the cache-hit "store the summary only if it does not exist" check with an unconditional re-store. Whether it stays on the port at all is a maintainer call, so this changes nothing about that.

## How to Test

`go build ./... && go vet ./... && go test ./... -count=1`

The full suite passes unchanged with the maps separated, which is the evidence that nothing depended on the conflation.

Reverting just the map split, so summaries share the manifest map again, fails the three new tests:

```
--- FAIL: TestMemoryStore_SummaryWriteDoesNotSatisfyManifestRead
--- FAIL: TestMemoryStore_ManifestAndSummaryDoNotOverwriteEachOther
--- FAIL: TestMemoryStore_CVESummaries
```

The first is the property itself: store a summary, then `GetCVE` must still report nothing. The second covers the overwrite, asserting the manifest survives a later summary write and that the summary is separately readable. The third covers the accessor, including the relevancy case where both manifests are recorded, and the sorted order that keeps the result independent of Go's map iteration.

`TestMemoryStore_GetCVESummary_IsAStub` pins the stub as deliberate, so a change that starts returning something has to come here too.

## Related issues/PRs:

* Resolved #838
