### PR TITLE
fix(vexdoc): drop the error crypto/rand.Read cannot return, and cover the one that happens

### DIFF
--- a/internal/vexdoc/vexdoc.go
+++ b/internal/vexdoc/vexdoc.go
@@ -59,12 +59,7 @@ func WriteToTempFile(data []byte) (path string, cleanup func(), err error) {
 		return "", noop, ErrEmptyDocument
 	}
 
-	name, err := randomFilename()
-	if err != nil {
-		return "", noop, fmt.Errorf("vexdoc: generating a random filename: %w", err)
-	}
-
-	path = filepath.Join(os.TempDir(), name)
+	path = filepath.Join(os.TempDir(), randomFilename())
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
@@ -92,10 +87,14 @@ func WriteToTempFile(data []byte) (path string, cleanup func(), err error) {
 // randomFilename returns an unpredictable filename with a recognizable
 // prefix and extension, so a leaked or leftover file is identifiable as
 // belonging to this package during debugging.
-func randomFilename() (string, error) {
+//
+// It returns no error because it cannot fail. crypto/rand.Read "never
+// returns an error, and always fills b entirely"; on a failure it crashes
+// the program irrecoverably rather than reporting one. That has been its
+// contract since Go 1.24, and this module requires 1.26, so the error this
+// used to return was unreachable and every caller's check for it was dead.
+func randomFilename() string {
 	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("kubevuln-vexdoc-%s.json", hex.EncodeToString(b)), nil
+	rand.Read(b) //nolint:errcheck // documented to never fail; it crashes instead
+	return fmt.Sprintf("kubevuln-vexdoc-%s.json", hex.EncodeToString(b))
 }

--- a/internal/vexdoc/vexdoc_test.go
+++ b/internal/vexdoc/vexdoc_test.go
@@ -2,7 +2,9 @@ package vexdoc
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,5 +152,68 @@ func TestWriteToTempFile_ManyCallsNeverProduceADuplicatePath(t *testing.T) {
 
 		require.False(t, seen[path], "path %q was generated more than once across %d calls", path, n)
 		seen[path] = true
+	}
+}
+
+// redirectTempDir points os.TempDir at dir for the duration of the test, skipping if this
+// platform resolves it some other way. os.TempDir reads TMPDIR on unix and TMP/TEMP on
+// Windows, so all three are set and the result is checked rather than assumed.
+func redirectTempDir(t *testing.T, dir string) {
+	t.Helper()
+	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+		t.Setenv(key, dir)
+	}
+	if got := os.TempDir(); got != dir {
+		t.Skipf("cannot redirect os.TempDir on %s: got %q, want %q", runtime.GOOS, got, dir)
+	}
+}
+
+// TestWriteToTempFile_ReportsCreateFailure covers the one failure this function can
+// actually hit: the temp directory not being usable. Everything else it guards against is
+// either impossible (the filename is generated, never supplied) or not reachable without
+// changing the signature to accept a writer.
+//
+// The contract on that path is what matters to a caller: no path, a wrapped error naming
+// the step, and a cleanup that is still safe to defer.
+func TestWriteToTempFile_ReportsCreateFailure(t *testing.T) {
+	redirectTempDir(t, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	path, cleanup, err := WriteToTempFile([]byte(`{"@context":"https://openvex.dev/ns/v0.2.0"}`))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "creating temp file")
+	assert.Empty(t, path, "no path may be returned when the file was never created")
+	require.NotNil(t, cleanup, "cleanup must be non-nil so a caller can defer it unconditionally")
+	assert.NotPanics(t, cleanup)
+	assert.NotPanics(t, cleanup, "cleanup must stay safe when called more than once")
+}
+
+// TestWriteToTempFile_CreateFailureIsNotMistakenForAnEmptyDocument keeps the two error
+// paths distinguishable. Both return an empty path, so a caller telling them apart depends
+// on the errors themselves, and ErrEmptyDocument is the sentinel one.
+func TestWriteToTempFile_CreateFailureIsNotMistakenForAnEmptyDocument(t *testing.T) {
+	redirectTempDir(t, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	_, _, err := WriteToTempFile([]byte("real content"))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrEmptyDocument)
+
+	_, _, emptyErr := WriteToTempFile(nil)
+	assert.ErrorIs(t, emptyErr, ErrEmptyDocument)
+}
+
+// TestRandomFilename covers the shape the debugging story depends on: a leftover file has
+// to be identifiable as this package's, and two calls must not collide.
+func TestRandomFilename(t *testing.T) {
+	seen := make(map[string]struct{}, 1000)
+	for i := 0; i < 1000; i++ {
+		name := randomFilename()
+		assert.True(t, strings.HasPrefix(name, "kubevuln-vexdoc-"), name)
+		assert.True(t, strings.HasSuffix(name, ".json"), name)
+		// 16 random bytes hex-encoded, between the fixed prefix and suffix.
+		assert.Len(t, name, len("kubevuln-vexdoc-")+32+len(".json"), name)
+		_, dup := seen[name]
+		require.False(t, dup, "duplicate filename %q after %d draws", name, i)
+		seen[name] = struct{}{}
 	}
 }


### PR DESCRIPTION
## Overview

`randomFilename` returned an error from `crypto/rand.Read`. That call never produces one, so the branch and the caller's check of it were both dead. Removing them, and adding a test for the failure `WriteToTempFile` can actually hit.

`internal/vexdoc` was at 66.7%, the lowest in the repo. Now 75.0%, `randomFilename` at 100%.

## Additional Information

From `crypto/rand` in the toolchain this module builds with:

> Read fills b with cryptographically secure random bytes. It never returns an error, and always fills b entirely.
>
> Read calls `io.ReadFull` on `Reader` and crashes the program irrecoverably if an error is returned.

Infallible since Go 1.24, and `go.mod` says `go 1.26.0`, so there is no build of this module where the check could fire. It cost two uncovered blocks: the check inside `randomFilename` and `WriteToTempFile`'s check of its return, together a third of what was uncovered in the package.

The reachable failure had no test: `os.OpenFile` failing because the temp directory is not usable. It is the only one `WriteToTempFile` can really hit, since the filename is generated rather than supplied, and it is where the contract matters most. Callers are told to `defer cleanup()` immediately after checking `err`, so a failed create has to hand back a non-nil, safe cleanup, and must not hand back a path for a file that was never created. Neither was checked.

`os.TempDir` is redirected by setting `TMPDIR`, `TMP` and `TEMP` and then confirming it actually moved, skipping if not, rather than assuming which one a platform reads. It works on both Linux and Windows, so the test runs rather than skips in CI and locally.

`f.Write` and `f.Close` failing stay uncovered, and this does not try to change that. Reaching them means widening the signature to accept a writer, and this package exists to close one concrete blocker for #387, that grype's `vex.Processor` only accepts real file paths. Not worth reshaping its API for two error branches.

## How to Test

`go build ./... && go vet ./... && go test ./internal/vexdoc/ -count=1 -race -cover`

The full suite passes unchanged. `randomFilename` is package-private with one caller, so dropping its error return touches nothing outside this file.

Three mutations, each caught:

| mutation | fails |
| --- | --- |
| return a path even though the file was never created | `TestWriteToTempFile_ReportsCreateFailure` |
| return a nil cleanup on the create-failure path | `TestWriteToTempFile_ReportsCreateFailure` |
| stop randomising the filename | `TestRandomFilename`, `..._TwoDocumentsNeverCollide`, `..._ManyCallsNeverProduceADuplicatePath` |

`TestWriteToTempFile_CreateFailureIsNotMistakenForAnEmptyDocument` keeps the two error paths apart: both return an empty path, so a caller distinguishing them depends on the errors, and only one is `ErrEmptyDocument`.

## Related issues/PRs:

* Resolved #840
