### PR TITLE
fix: avoid VEX ignored match key collisions

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1614,10 +1614,10 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 
 	// ignoredMap drives the "reset every statement" pass below; guarded the same way as the
 	// Matches/IgnoredMatches loops above, since it reads the same cve.Content.
-	ignoredMap := make(map[string]ignoredVEXAssessment)
+	ignoredMap := make(map[vexStatementKey]ignoredVEXAssessment)
 	if cve.Content != nil {
 		for _, v := range cve.Content.IgnoredMatches {
-			ignoredMap[v.Vulnerability.ID+v.Artifact.PURL] = ignoredMatchAssessment(v)
+			ignoredMap[vexStatementKey{name: v.Vulnerability.ID, purl: v.Artifact.PURL}] = ignoredMatchAssessment(v)
 		}
 	}
 
@@ -1638,7 +1638,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 
 		var assessment ignoredVEXAssessment
 		isIgnored := anyPURLMatches(vexDoc.Statements[i].Products, func(purl string) bool {
-			if ignoredAssessment, ok := ignoredMap[vexDoc.Statements[i].Vulnerability.Name+purl]; ok {
+			if ignoredAssessment, ok := ignoredMap[vexStatementKey{name: vexDoc.Statements[i].Vulnerability.Name, purl: purl}]; ok {
 				assessment = ignoredAssessment
 				return true
 			}

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1124,6 +1124,24 @@ func createProductStructForImageAndPackage(imagePullable string, packagePURL str
 	return &product, nil
 }
 
+func buildIgnoredVEXAssessmentMap(cve *domain.CVEManifest) map[vexStatementKey]ignoredVEXAssessment {
+	ignoredMap := make(map[vexStatementKey]ignoredVEXAssessment)
+
+	if cve == nil || cve.Content == nil {
+		return ignoredMap
+	}
+
+	for _, v := range cve.Content.IgnoredMatches {
+		key := vexStatementKey{
+			name: v.Vulnerability.ID,
+			purl: v.Artifact.PURL,
+		}
+		ignoredMap[key] = ignoredMatchAssessment(v)
+	}
+
+	return ignoredMap
+}
+
 // anyPURLMatches reports whether fn returns true for any subcomponent PURL across any
 // product in products. This is the shared traversal used by both statementHasPURL and
 // the ignored-vulnerability lookup in updateVEX, so both stay correct together if the
@@ -1614,12 +1632,7 @@ func (a *APIServerStore) updateVEX(ctx context.Context, cve domain.CVEManifest, 
 
 	// ignoredMap drives the "reset every statement" pass below; guarded the same way as the
 	// Matches/IgnoredMatches loops above, since it reads the same cve.Content.
-	ignoredMap := make(map[vexStatementKey]ignoredVEXAssessment)
-	if cve.Content != nil {
-		for _, v := range cve.Content.IgnoredMatches {
-			ignoredMap[vexStatementKey{name: v.Vulnerability.ID, purl: v.Artifact.PURL}] = ignoredMatchAssessment(v)
-		}
-	}
+	ignoredMap := buildIgnoredVEXAssessmentMap(&cve)
 
 	// Reset every statement back to the baseline "not affected" status before
 	// reapplying the current filtered manifest.

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -524,6 +524,7 @@ func TestBuildIgnoredVEXAssessmentMap_DistinguishesVulnerabilityAndPURL(t *testi
 						},
 					},
 					AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+						SourceKind:      "SecurityException",
 						Justification:   "justification-A",
 						ImpactStatement: "impact-A",
 					}},
@@ -540,6 +541,7 @@ func TestBuildIgnoredVEXAssessmentMap_DistinguishesVulnerabilityAndPURL(t *testi
 						},
 					},
 					AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+						SourceKind:      "SecurityException",
 						Justification:   "justification-AB",
 						ImpactStatement: "impact-AB",
 					}},
@@ -552,13 +554,15 @@ func TestBuildIgnoredVEXAssessmentMap_DistinguishesVulnerabilityAndPURL(t *testi
 
 	assessmentA, ok := ignoredMap[vexStatementKey{name: "A", purl: "BC"}]
 	require.True(t, ok)
-	assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), assessmentA.justification)
-	assert.Equal(t, "Vulnerability was ignored by an exception policy", assessmentA.impactStatement)
+
+	assert.Equal(t, v1beta1.Justification("justification-A"), assessmentA.justification)
+	assert.Equal(t, "impact-A", assessmentA.impactStatement)
 
 	assessmentAB, ok := ignoredMap[vexStatementKey{name: "AB", purl: "C"}]
 	require.True(t, ok)
-	assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), assessmentAB.justification)
-	assert.Equal(t, "Vulnerability was ignored by an exception policy", assessmentAB.impactStatement)
+
+	assert.Equal(t, v1beta1.Justification("justification-AB"), assessmentAB.justification)
+	assert.Equal(t, "impact-AB", assessmentAB.impactStatement)
 }
 
 func TestAPIServerStore_storeVEX_ignoredMatchesDoNotCollide(t *testing.T) {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -508,6 +508,146 @@ func TestAPIServerStore_storeVEX_ignoredMatches_append(t *testing.T) {
 	assert.True(t, foundIgnored2, "Second IgnoredMatch should be included in the VEX document during update")
 }
 
+func TestAPIServerStore_storeVEX_ignoredMatchesDoNotCollide(t *testing.T) {
+	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")
+
+	// Keep the test completely focused on the two synthetic ignored matches.
+	cveManifest.Content.Matches = nil
+	cveManifest.Content.IgnoredMatches = nil
+	cveManifestFiltered.Content.Matches = nil
+	cveManifestFiltered.Content.IgnoredMatches = nil
+
+	// These two (vulnerability, PURL) pairs collide when represented as
+	// Vulnerability.ID + Artifact.PURL:
+	//
+	//   A  + BC = ABC
+	//   AB + C  = ABC
+	//
+	// A composite key must keep these two findings distinct.
+	cveManifest.Content.IgnoredMatches = []v1beta1.IgnoredMatch{
+		{
+			Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+						ID:         "A",
+						DataSource: "https://example.test/A",
+					},
+				},
+				Artifact: v1beta1.GrypePackage{
+					PURL: "BC",
+				},
+			},
+			AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+				Vulnerability:   "A",
+				SourceKind:      "SecurityException",
+				SourceName:      "SecurityException/default/A",
+				SourceNamespace: "default",
+				FixState:        string(sev1beta1.VulnerabilityStatusNotAffected),
+				Justification:   "justification-A",
+				ImpactStatement: "impact-A",
+			}},
+		},
+		{
+			Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+						ID:         "AB",
+						DataSource: "https://example.test/AB",
+					},
+				},
+				Artifact: v1beta1.GrypePackage{
+					PURL: "C",
+				},
+			},
+			AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+				Vulnerability:   "AB",
+				SourceKind:      "SecurityException",
+				SourceName:      "SecurityException/default/AB",
+				SourceNamespace: "default",
+				FixState:        string(sev1beta1.VulnerabilityStatusNotAffected),
+				Justification:   "justification-AB",
+				ImpactStatement: "impact-AB",
+			}},
+		},
+	}
+
+	a := NewFakeAPIServerStorage("kubescape")
+
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	// First call creates the VEX document with both ignored statements.
+	err := a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false)
+	require.NoError(t, err)
+
+	// Change the filtered manifest before the second call so StoreVEX
+	// must execute the update path instead of treating the scan as a no-op.
+	secondFiltered := cveManifestFiltered
+	secondFiltered.Content = &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+						ID:         "CVE-UPDATE-TRIGGER",
+						DataSource: "https://example.test/CVE-UPDATE-TRIGGER",
+					},
+				},
+				Artifact: v1beta1.GrypePackage{
+					PURL: "pkg:deb/example/update-trigger@1.0",
+				},
+			},
+		},
+		IgnoredMatches: cveManifestFiltered.Content.IgnoredMatches,
+	}
+
+	// Second call must execute updateVEX. The ignored-match map is rebuilt
+	// during this update, which is the path where the composite-key bug occurs.
+	err = a.StoreVEX(ctx, cveManifest, secondFiltered, false)
+	require.NoError(t, err)
+
+	vexContainer, err := a.StorageClient.
+		OpenVulnerabilityExchangeContainers(a.Namespace).
+		Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, vexContainer)
+
+	var statementA, statementAB *v1beta1.Statement
+
+	for i := range vexContainer.Spec.Statements {
+		stmt := &vexContainer.Spec.Statements[i]
+
+		switch {
+		case stmt.Vulnerability.Name == "A" &&
+			statementHasPURL(stmt.Products, "BC"):
+			statementA = stmt
+
+		case stmt.Vulnerability.Name == "AB" &&
+			statementHasPURL(stmt.Products, "C"):
+			statementAB = stmt
+		}
+	}
+
+	require.NotNil(t, statementA, "statement for A/BC should exist")
+	require.NotNil(t, statementAB, "statement for AB/C should exist")
+
+	// The assessments must remain associated with their own
+	// (vulnerability, PURL) pair. With the old concatenated-string
+	// lookup, A/BC and AB/C both resolve to the same key: "ABC".
+	assert.Equal(t, "justification-A", string(statementA.Justification))
+	assert.Equal(t, "impact-A", statementA.ImpactStatement)
+
+	assert.Equal(t, "justification-AB", string(statementAB.Justification))
+	assert.Equal(t, "impact-AB", statementAB.ImpactStatement)
+}
+
 func TestAPIServerStore_storeVEX_preservesSecurityExceptionSemantics(t *testing.T) {
 	ignoredMatches := []v1beta1.IgnoredMatch{
 		{

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -508,6 +508,59 @@ func TestAPIServerStore_storeVEX_ignoredMatches_append(t *testing.T) {
 	assert.True(t, foundIgnored2, "Second IgnoredMatch should be included in the VEX document during update")
 }
 
+func TestBuildIgnoredVEXAssessmentMap_DistinguishesVulnerabilityAndPURL(t *testing.T) {
+	cve := &domain.CVEManifest{
+		Content: &v1beta1.GrypeDocument{
+			IgnoredMatches: []v1beta1.IgnoredMatch{
+				{
+					Match: v1beta1.Match{
+						Vulnerability: v1beta1.Vulnerability{
+							VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+								ID: "A",
+							},
+						},
+						Artifact: v1beta1.GrypePackage{
+							PURL: "BC",
+						},
+					},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+						Justification:   "justification-A",
+						ImpactStatement: "impact-A",
+					}},
+				},
+				{
+					Match: v1beta1.Match{
+						Vulnerability: v1beta1.Vulnerability{
+							VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+								ID: "AB",
+							},
+						},
+						Artifact: v1beta1.GrypePackage{
+							PURL: "C",
+						},
+					},
+					AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+						Justification:   "justification-AB",
+						ImpactStatement: "impact-AB",
+					}},
+				},
+			},
+		},
+	}
+
+	ignoredMap := buildIgnoredVEXAssessmentMap(cve)
+
+	assessmentA, ok := ignoredMap[vexStatementKey{name: "A", purl: "BC"}]
+	require.True(t, ok)
+	assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), assessmentA.justification)
+	assert.Equal(t, "Vulnerability was ignored by an exception policy", assessmentA.impactStatement)
+
+	assessmentAB, ok := ignoredMap[vexStatementKey{name: "AB", purl: "C"}]
+	require.True(t, ok)
+	assert.Equal(t, v1beta1.Justification(vex.VulnerableCodeNotPresent), assessmentAB.justification)
+	assert.Equal(t, "Vulnerability was ignored by an exception policy", assessmentAB.impactStatement)
+}
+
 func TestAPIServerStore_storeVEX_ignoredMatchesDoNotCollide(t *testing.T) {
 	cveManifest := tools.FileToCVEManifest("testdata/nginx-cve.json")
 	cveManifestFiltered := tools.FileToCVEManifest("testdata/nginx-cve-filtered.json")


### PR DESCRIPTION
Fixes : #842

### Overview

The VEX update path keyed ignored matches by concatenating the ``vulnerability ID`` and ``package PURL``. This could cause distinct (vulnerability, PURL) pairs such as`` A/BC`` and ``AB/C`` to resolve to the same key ``(ABC)``, causing one ignored assessment to overwrite another.

This PR:

- Uses the existing ``vexStatementKey`` composite key for ignored-match lookups.
- Keeps vulnerability ID and package PURL independently identifiable.
- Adds a regression test covering the ambiguous-key case and verifying that each statement retains its own assessment.

This prevents ignored VEX assessments from being incorrectly associated with the wrong vulnerability/package during VEX updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where ignored vulnerability assessments could be incorrectly combined when vulnerability identifiers and package URLs formed identical combined values.
  * Preserved the correct justification and impact details for each assessment during VEX updates.

* **Tests**
  * Added coverage to verify that distinct ignored assessments remain separate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->