### PR TITLE
fix(adapters): pick the nearest fix version, never a downgrade

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -281,23 +281,41 @@ func linkToVuln(id string) string {
 	}
 }
 
+// suggestedVersion returns the nearest version in versions that fixes current: the
+// smallest one strictly greater than current. versions is not guaranteed to be sorted
+// (it comes straight from the upstream vulnerability feed, which may list fix versions
+// for several maintained branches in any order), so the whole slice must be scanned
+// rather than trusting the first qualifying entry.
+//
+// If current is not a version, the first entry is returned, since there is nothing to
+// compare against. If current is a version but no entry in versions is greater than it,
+// "" is returned rather than falling back to versions[0]; versions[0] could be older
+// than current, which would suggest a downgrade.
 func suggestedVersion(current string, versions []string) string {
 	if len(versions) == 0 {
 		return ""
 	}
-	// compare with semver
-	// if current is not a version, return the first version
-	if c, err := semver.NewVersion(current); err == nil {
-		for _, version := range versions {
-			v, err := semver.NewVersion(version)
-			if err == nil {
-				if c.LessThan(v) {
-					return version
-				}
-			}
+	c, err := semver.NewVersion(current)
+	if err != nil {
+		return versions[0]
+	}
+
+	var nearest *semver.Version
+	var nearestStr string
+	for _, version := range versions {
+		v, err := semver.NewVersion(version)
+		if err != nil {
+			continue
+		}
+		if !c.LessThan(v) {
+			continue
+		}
+		if nearest == nil || v.LessThan(nearest) {
+			nearest = v
+			nearestStr = version
 		}
 	}
-	return versions[0]
+	return nearestStr
 }
 
 func parseLayersPayload(target source.ImageMetadata) (map[string]containerscan.ESLayer, error) {

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -288,6 +288,43 @@ func Test_suggestedVersion(t *testing.T) {
 			versions: []string{"10.24.0", "12.21.0", "14.16.0", "15.10.0"},
 			want:     "14.16.0",
 		},
+		{
+			// versions is not guaranteed to be sorted; the fix listed first for an
+			// older branch must not win over the nearer fix listed later.
+			name:     "unsorted branch list picks the nearest fix, not the first entry",
+			current:  "14.7.0",
+			versions: []string{"15.10.0", "10.24.0", "14.16.0"},
+			want:     "14.16.0",
+		},
+		{
+			// every listed fix version is for a branch already superseded by current;
+			// there is no upgrade to suggest, so this must not fall back to versions[0]
+			// and suggest a downgrade.
+			name:     "no version above current returns empty rather than a downgrade",
+			current:  "16.0.0",
+			versions: []string{"10.0.0", "12.0.0"},
+			want:     "",
+		},
+		{
+			name:     "current equal to the only candidate returns empty, not a downgrade",
+			current:  "2.0.0",
+			versions: []string{"2.0.0"},
+			want:     "",
+		},
+		{
+			name:     "unparseable entries are skipped in favour of a valid nearer fix",
+			current:  "1.0.0",
+			versions: []string{"not-a-version", "3.0.0", "2.0.0"},
+			want:     "2.0.0",
+		},
+		{
+			// current parses, but nothing in versions does: there is no comparable
+			// candidate, so nothing is suggested.
+			name:     "current parses but every version is unparseable returns empty",
+			current:  "1.0.0",
+			versions: []string{"not-a-version", "also-not-a-version"},
+			want:     "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -53,6 +53,27 @@ func TestHasKnownFix(t *testing.T) {
 			wantVersion: "2.17.0",
 		},
 		{
+			// #844: the fix-versions list from the upstream feed is not guaranteed to be
+			// sorted, and can list branches older than what's installed. hasKnownFix must
+			// still surface the nearest real upgrade, never a version older than current.
+			name: "unsorted fix versions still suggest the nearest upgrade",
+			match: v1beta1.Match{
+				Artifact:      v1beta1.GrypePackage{Version: "14.7.0"},
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed, Versions: []string{"15.10.0", "10.24.0", "14.16.0"}}},
+			},
+			wantFixed:   true,
+			wantVersion: "14.16.0",
+		},
+		{
+			name: "fix versions all older than current do not suggest a downgrade",
+			match: v1beta1.Match{
+				Artifact:      v1beta1.GrypePackage{Version: "16.0.0"},
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed, Versions: []string{"10.0.0", "12.0.0"}}},
+			},
+			wantFixed:   true,
+			wantVersion: "",
+		},
+		{
 			name: "fix state fixed without versions",
 			match: v1beta1.Match{
 				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed}},


### PR DESCRIPTION
## Problem

`suggestedVersion` (`adapters/v1/domain_to_armo.go`) returns the fix version shown to users as remediation guidance. It picked the *first* entry in `Fix.Versions` that was greater than the installed version, instead of the nearest one, and fell back to `versions[0]` unconditionally when nothing qualified — even suggesting a downgrade if every listed version was older than what's already installed.

`Fix.Versions` is copied verbatim from Grype's match data (`adapters/v1/grype_to_domain.go`), which reflects the upstream vulnerability feed. These feeds commonly list fix versions for multiple maintained branches (e.g. a CVE fixed in `5.4.2`, `5.10.1`, and `5.15.3` on three different LTS lines) in no particular order.

Fixes #844.

## Root cause

```go
if c, err := semver.NewVersion(current); err == nil {
    for _, version := range versions {
        v, err := semver.NewVersion(version)
        if err == nil {
            if c.LessThan(v) {
                return version // first match, not nearest
            }
        }
    }
}
return versions[0] // unconditional fallback, even if older than current
```

## Fix

Scan the full slice and track the minimum version strictly greater than `current`. If none qualifies, return `""` instead of `versions[0]`, so a downgrade is never suggested. The existing documented fallback — return `versions[0]` when `current` itself isn't a parseable semver — is unchanged.

## Testing

- Added table-driven cases to `Test_suggestedVersion` covering: an unsorted multi-branch list (must pick the nearest, not the first), an all-older-than-current list (must return `""`, not a downgrade), current equal to the only candidate, unparseable entries mixed with valid ones, and all-unparseable versions.
- Added regression cases to `TestHasKnownFix` exercising the same unsorted/all-older scenarios through the actual call path used by both the manifest and report paths.
- `go build ./adapters/...` — passes
- `go vet ./adapters/...` — clean
- `go test ./adapters/v1/...` — all passing, including the existing `TestExpiredOnFixAgreesAcrossPaths*` regression tests for #449, unaffected
- `golangci-lint run ./adapters/v1/...` — no new findings; the 21 pre-existing findings it reports are all outside this diff

## Impact

Scoped to remediation guidance shown to end users (the `Fixes[].Version` field surfaced in the Kubescape/ARMO UI). Exception-suppression logic (`hasKnownFix`'s boolean return, used by `ApplySecurityExceptions`) is unaffected — it only ever consumed the fixed/not-fixed boolean, never the version string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version recommendations now select the smallest valid upgrade, even when available versions are unordered.
  * Prevented downgrade suggestions when no newer version is available.
  * Invalid version entries are ignored while preserving fallback behavior for invalid current versions.

* **Tests**
  * Added coverage for unsorted, invalid, equal, and older version scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->