### PR TITLE
fix(services): stop ScanRegistry handing the CVE scanner a nil SBOM

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -591,6 +591,17 @@ func (s *ScanService) ScanRegistry(ctx context.Context) error {
 			return &domain.ScanError{Reason: reason, Err: sbomErr}
 		}
 
+		// With sbomGeneration off, getOrCreateSBOM returns a zero SBOM and a nil error, so
+		// nothing about err says the SBOM is missing and only Content does. ScanCVE and
+		// ScanCP each stop here for the same reason: the CVE scanner dereferences
+		// sbom.Content, so handing it a zero SBOM is a nil dereference, on a worker-pool
+		// goroutine that does not recover. See #846.
+		if !s.sbomGeneration && sbom.Content == nil {
+			logger.L().Ctx(ctx).Warning("missing SBOM",
+				helpers.String("imageSlug", workload.ImageSlug))
+			return &domain.ScanError{Reason: scanfailure.ReasonUnexpected, Err: domain.ErrMissingSBOM}
+		}
+
 		// do not process timed out SBOM
 		if sbom.Status == helpersv1.Incomplete || sbom.Status == helpersv1.TooLarge {
 			reason := classifySBOMStatusWithAnnotation(sbom.Status, sbom.Annotations)

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -3332,3 +3332,102 @@ func TestScanService_SingleflightSBOMFailure_ReportsEveryWaiter(t *testing.T) {
 	assert.ElementsMatch(t, wantJobIDs, platform.jobIDs,
 		"each ReportScanFailure call must carry the reporting caller's own JobID, not just the leader's")
 }
+
+// recordingScanner records every SBOM handed to it, so a test can assert not just what a
+// scan flow returned but what it passed downstream on the way there.
+type recordingScanner struct {
+	ports.CVEScanner
+	got []domain.SBOM
+}
+
+func (r *recordingScanner) DBVersion(context.Context) string { return "v1.0.0" }
+func (r *recordingScanner) Ready(context.Context) bool       { return true }
+func (r *recordingScanner) Version() string                  { return "v1.0.0" }
+
+func (r *recordingScanner) ScanSBOM(_ context.Context, sbom domain.SBOM) (domain.CVEManifest, error) {
+	r.got = append(r.got, sbom)
+	return domain.CVEManifest{
+		Name:              sbom.Name,
+		CVEScannerVersion: "v1.0.0",
+		CVEDBVersion:      "v1.0.0",
+		Content:           &v1beta1.GrypeDocument{},
+	}, nil
+}
+
+// newScanServiceWithoutSBOMGeneration builds a service configured the way
+// nodeSbomGeneration: true configures it, where kubevuln generates no SBOM itself and
+// expects to find one already in storage.
+func newScanServiceWithoutSBOMGeneration(scanner ports.CVEScanner) (*ScanService, *repositories.MemoryStore) {
+	storage := repositories.NewMemoryStorage(false, false)
+	return NewScanService(
+		adapters.NewMockSBOMAdapter(false, false, false), storage,
+		scanner, storage,
+		adapters.NewMockPlatform(false, nil), adapters.NewMockRelevancyAdapter(),
+		false, // storage
+		false, // vexGeneration
+		false, // sbomGeneration -- the setting under test
+		false, false,
+	), storage
+}
+
+func registryWorkload() domain.ScanCommand {
+	return domain.ScanCommand{
+		ImageSlug:          "imageSlug",
+		ImageTagNormalized: "k8s.gcr.io/kube-proxy:v1.24.3",
+	}
+}
+
+// TestScanService_MissingSBOM_NoFlowScansANilSBOM is the property all three CVE flows have
+// to agree on.
+//
+// With sbomGeneration off, getOrCreateSBOM returns a zero domain.SBOM and a nil error, so
+// sbom.Content is nil and nothing about the error tells a flow that. ScanCVE and ScanCP
+// each check for it and stop with domain.ErrMissingSBOM. ScanRegistry did not, and handed
+// the zero SBOM to the CVE scanner, which dereferences Content.
+func TestScanService_MissingSBOM_NoFlowScansANilSBOM(t *testing.T) {
+	t.Run("ScanRegistry", func(t *testing.T) {
+		scanner := &recordingScanner{}
+		s, _ := newScanServiceWithoutSBOMGeneration(scanner)
+
+		ctx, err := s.ValidateScanRegistry(context.TODO(), registryWorkload())
+		require.NoError(t, err)
+
+		err = s.ScanRegistry(ctx)
+
+		assert.ErrorIs(t, err, domain.ErrMissingSBOM)
+		assert.Empty(t, scanner.got, "no SBOM may reach the CVE scanner when none was produced")
+	})
+
+	t.Run("ScanCVE", func(t *testing.T) {
+		scanner := &recordingScanner{}
+		s, _ := newScanServiceWithoutSBOMGeneration(scanner)
+
+		// ScanCVE additionally requires ImageHash; ScanRegistry does not.
+		workload := registryWorkload()
+		workload.ImageHash = "sha256:aaaa"
+		ctx, err := s.ValidateScanCVE(context.TODO(), workload)
+		require.NoError(t, err)
+
+		err = s.ScanCVE(ctx)
+
+		assert.ErrorIs(t, err, domain.ErrMissingSBOM)
+		assert.Empty(t, scanner.got, "no SBOM may reach the CVE scanner when none was produced")
+	})
+}
+
+// TestScanService_MissingSBOM_ScannerNeverSeesNilContent states the consequence directly.
+// The production scanner, GrypeAdapter.ScanSBOM, does `domainToSyft(*sbom.Content)`, so a
+// zero SBOM reaching it is a nil dereference. The scan runs on a worker-pool goroutine
+// with no recover, so that panic takes the process down rather than failing one scan.
+func TestScanService_MissingSBOM_ScannerNeverSeesNilContent(t *testing.T) {
+	scanner := &recordingScanner{}
+	s, _ := newScanServiceWithoutSBOMGeneration(scanner)
+
+	ctx, err := s.ValidateScanRegistry(context.TODO(), registryWorkload())
+	require.NoError(t, err)
+	_ = s.ScanRegistry(ctx)
+
+	for _, sbom := range scanner.got {
+		assert.NotNil(t, sbom.Content, "the CVE scanner dereferences Content; it must never be handed a nil one")
+	}
+}


### PR DESCRIPTION
## Overview

With `nodeSbomGeneration` on, `getOrCreateSBOM` returns a zero `domain.SBOM` and a **nil error**, so nothing about the error says the SBOM is missing and only `Content` being nil does.

`ScanCVE` checks for that. `ScanCP` checks for it per container. `ScanRegistry` did not, and handed the zero SBOM to the CVE scanner, which dereferences `Content`.

## Additional Information

`ScanRegistry` went from the `sbomErr != nil` branch straight to the `Incomplete || TooLarge` status check, which a zero SBOM passes since its `Status` is `""`, and then called `ScanSBOM`.

`GrypeAdapter.ScanSBOM` does:

```go
s, err := domainToSyft(*sbom.Content)
```

That is a nil pointer dereference, on a `workerpool` goroutine. `gammazero/workerpool` has no `recover()`, so it takes the process down rather than failing the one scan.

`domain.ErrMissingSBOM` had no test anywhere in the repo, which is presumably why the gap survived: the guard exists twice, is load-bearing in both places, and nothing exercised it.

Two notes on scope, both stated so review can weigh them rather than take my word for it:

The dereference needs an initialised Grype store, since `ScanSBOM` returns `ErrInitVulnDB` before reaching it when the DB is not loaded. In production the DB is loaded and `Ready()` gates scanning on it, so that is the live path.

`nodeSbomGeneration` defaults to `false`, so a default deployment is unaffected. It is a documented setting, bound to the environment in `config.go` alongside `storage` and `riskAcceptance`, so this is reachable by configuration rather than only in theory.

The returned error is a `*domain.ScanError` wrapping `ErrMissingSBOM`, rather than the bare sentinel `ScanCVE` returns. That matches `ScanRegistry`'s other failures and `ScanCP`'s handling of this same case, so the HTTP layer's existing reason labelling picks it up unchanged, and `errors.Is` still finds the sentinel through `ScanError.Unwrap`.

## How to Test

`go build ./... && go vet ./... && go test ./core/services/ -count=1`

`TestScanService_MissingSBOM_NoFlowScansANilSBOM` covers `ScanRegistry` and `ScanCVE` together against the same configuration, so the two cannot drift apart again. Reverting just the guard fails it against current main:

```
--- FAIL: TestScanService_MissingSBOM_NoFlowScansANilSBOM/ScanRegistry
    Error:    Should be empty, but was [{nil map[] map[]    }]
    Messages: no SBOM may reach the CVE scanner when none was produced
[info] registry scan started. imageSlug: imageSlug
[info] registry scan complete. imageSlug: imageSlug
```

Two things in that output. The recorded SBOM has a nil `Content`, and `ScanRegistry` returned no error at all: it logged a completed scan for one that never had anything to scan. The `ScanCVE` subtest passes unchanged either way, which is what makes it the control rather than just a second assertion.

`TestScanService_MissingSBOM_ScannerNeverSeesNilContent` states the consequence separately, asserting on what the scanner was handed rather than on what the flow returned, since that is the part that panics in production.

The tests use a recording `ports.CVEScanner` rather than the mock adapter on purpose: `MockCVEAdapter.ScanSBOM` never touches `sbom.Content`, so it would have returned a perfectly healthy manifest for an empty SBOM and hidden this.

## Related issues/PRs:

* Resolved #846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scans now report a clear missing-SBOM error when SBOM generation is disabled and no SBOM content is available.
  * Prevented CVE scanning from proceeding with empty SBOM data, improving scan reliability and error handling.

* **Tests**
  * Added coverage to verify consistent errors and prevent invalid SBOM data from being submitted for vulnerability scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->