### PR TITLE
test(tools): fix the racy stop assertion in the periodic sweep test

### DIFF
--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -360,17 +360,35 @@ func TestStartPeriodicTempDirSweep_StopsTickingOnceStopIsClosed(t *testing.T) {
 		return calls >= 3
 	}, time.Second, 5*time.Millisecond, "expected several periodic sweeps before stopping")
 
+	readCalls := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls
+	}
+
 	close(stop)
-	mu.Lock()
-	observedAtStop := calls
-	mu.Unlock()
+
+	// A sweep already running when stop closes still finishes: the select only stops the
+	// goroutine starting another one, and a sweep is real work (a lease file plus a
+	// directory walk), never instantaneous. Taking the baseline immediately therefore read
+	// a count that an in-flight sweep was about to increment, and this failed with one more
+	// call than expected whenever the machine was loaded enough to widen that window.
+	//
+	// Wait for the count to stop moving first, so what is asserted is that no further sweep
+	// *starts*, which is the property, rather than that close(stop) halts one mid-flight,
+	// which it does not promise.
+	require.Eventually(t, func() bool {
+		before := readCalls()
+		time.Sleep(50 * time.Millisecond)
+		return before == readCalls()
+	}, 5*time.Second, 10*time.Millisecond, "sweeps should quiesce once stop is closed")
+
+	observedAtStop := readCalls()
 
 	// long enough for several more ticks to have fired had the goroutine kept running
 	time.Sleep(100 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Equal(t, observedAtStop, calls, "no sweep should run after stop is closed")
+	assert.Equal(t, observedAtStop, readCalls(), "no sweep should start after stop is closed")
 }
 
 func TestStartPeriodicTempDirSweep_SkipsWhileACallerIsActive(t *testing.T) {


### PR DESCRIPTION
## Overview

`TestStartPeriodicTempDirSweep_StopsTickingOnceStopIsClosed` sampled the call count immediately after `close(stop)`. Closing `stop` does not halt a sweep that is already running, so the baseline could be read while one was mid-flight and about to increment it.

Tests only, no production code changes.

## Additional Information

The goroutine's select only decides whether to start another sweep:

```go
select {
case <-stop:
	return
case <-ticker.C:
	sweep()
}
```

Once `sweep()` has been entered it runs to completion. So the contract is that no *further* sweep starts, and the test was asserting the stronger claim that none finishes either.

The window is real rather than theoretical: `sweep()` acquires a lease file and walks a directory before calling `onSweep`, so it is never instantaneous, and `interval` here is 10ms.

I hit it twice while the machine was loaded by other work:

```
--- FAIL: TestStartPeriodicTempDirSweep_StopsTickingOnceStopIsClosed (0.14s)
    tools_test.go:373: Not equal: expected: 3, actual: 4
        Messages: no sweep should run after stop is closed
```

It is load-dependent and does not reproduce on an idle machine, 0/20 runs of the test alone and 0/12 full-package runs, which makes it the awkward kind: red on a busy CI runner, green every time someone tries to reproduce it.

## How to Test

`go test ./internal/tools/ -count=5`

Timing was not chased. Keeping the assertion exactly as written and only making the sweep non-instantaneous, a 30ms `onSweep`, fails it deterministically with the same signature:

```
--- FAIL: TestZZDemoOriginalAssertionIsRacy (0.21s)  expected: 3, actual: 4
--- FAIL: TestZZDemoOriginalAssertionIsRacy (0.29s)  expected: 3, actual: 4
--- FAIL: TestZZDemoOriginalAssertionIsRacy (0.21s)  expected: 3, actual: 4
```

That is what says the assertion is unsound rather than unlucky. The same 30ms sweep passes 5/5 against the version in this PR, and the full package passes 8/8 with three spinner goroutines pinning the CPU.

The fix waits for the count to stop moving before taking the baseline, then still sleeps 100ms and asserts it has not moved. With a 10ms interval, a goroutine that kept ticking would add roughly ten more calls in that window, so the assertion has not been weakened into something that cannot fail: it is the same property, minus the assumption the code never made.

## Related issues/PRs:

* Resolved #848
