### PR TITLE
ci: enable go test -race on every PR

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -22,6 +22,8 @@ jobs:
       security-events: write
     uses: kubescape/workflows/.github/workflows/incluster-comp-pr-created.yaml@main
     with:
-      CGO_ENABLED: 0
+      # go-basic-tests.yaml only runs `go test -race` when CGO_ENABLED is 1 (-race requires
+      # cgo); 0 silently selected the race-free branch on every PR. See #852.
+      CGO_ENABLED: 1
       GO_VERSION: "1.26"
     secrets: inherit

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -58,7 +58,6 @@ jobs:
       IMAGE_NAME: quay.io/${{ github.repository_owner }}/kubevuln
       IMAGE_TAG: v0.3.${{ needs.reset-run-number.outputs.run-number }}
       COMPONENT_NAME: kubevuln
-      CGO_ENABLED: 0
       GO111MODULE: "on"
       BUILD_PLATFORM: linux/amd64,linux/arm64
       GO_VERSION: "1.26"

--- a/repositories/memory.go
+++ b/repositories/memory.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"sync"
 
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
@@ -26,8 +27,15 @@ type sbomID struct {
 	SBOMCreatorVersion string
 }
 
-// MemoryStore implements both CVERepository and SBOMRepository with in-memory storage (maps) to be used for tests
+// MemoryStore implements both CVERepository and SBOMRepository with in-memory storage (maps) to be used for tests.
+//
+// mu guards every field below it: production code never runs more than one scan concurrently
+// against the same MemoryStore instance (only APIServerStore is wired up outside of tests), but
+// the test suite deliberately does -- singleflight and worker-pool concurrency tests construct
+// several goroutines against one shared MemoryStore -- so unsynchronized map/slice access here
+// is a real data race under `go test -race`, not a hypothetical one.
 type MemoryStore struct {
+	mu           sync.RWMutex
 	aps          map[apID]v1beta1.ContainerProfile
 	cveManifests map[cveID]domain.CVEManifest
 	sboms        map[sbomID]domain.SBOM
@@ -46,6 +54,8 @@ var _ ports.SBOMRepository = (*MemoryStore)(nil)
 // SBOMStores reports how many times StoreSBOM was called, so a test can tell an SBOM that
 // was written from one that was only read back.
 func (m *MemoryStore) SBOMStores() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.sbomStores
 }
 
@@ -72,6 +82,8 @@ func (m *MemoryStore) GetContainerProfile(ctx context.Context, namespace string,
 		Namespace: namespace,
 		Name:      name,
 	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if value, ok := m.aps[id]; ok {
 		return value, nil
 	}
@@ -90,6 +102,8 @@ func (m *MemoryStore) StoreContainerProfile(ctx context.Context, ap v1beta1.Cont
 		Namespace: ap.Namespace,
 		Name:      ap.Name,
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.aps[id] = ap
 	return nil
 }
@@ -109,6 +123,8 @@ func (m *MemoryStore) GetCVE(ctx context.Context, name, SBOMCreatorVersion, CVES
 		CVEScannerVersion:  CVEScannerVersion,
 		CVEDBVersion:       CVEDBVersion,
 	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if value, ok := m.cveManifests[id]; ok {
 		return value, nil
 	}
@@ -137,6 +153,8 @@ func (m *MemoryStore) StoreCVE(ctx context.Context, cve domain.CVEManifest, _ bo
 		CVEScannerVersion:  cve.CVEScannerVersion,
 		CVEDBVersion:       cve.CVEDBVersion,
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.cveManifests[id] = cve
 	return nil
 }
@@ -156,6 +174,9 @@ func (m *MemoryStore) StoreCVESummary(ctx context.Context, cve domain.CVEManifes
 		CVEScannerVersion:  cve.CVEScannerVersion,
 		CVEDBVersion:       cve.CVEDBVersion,
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	if withRelevancy {
 		idSumm := cveID{
@@ -180,12 +201,16 @@ func (m *MemoryStore) StoreCVESummaryStub(ctx context.Context, status string) er
 		return domain.ErrMockError
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.summaryStubs = append(m.summaryStubs, status)
 	return nil
 }
 
 // CVESummaryStubs returns the statuses passed to StoreCVESummaryStub, for tests
 func (m *MemoryStore) CVESummaryStubs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.summaryStubs
 }
 
@@ -202,6 +227,8 @@ func (m *MemoryStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion stri
 		Name:               name,
 		SBOMCreatorVersion: SBOMCreatorVersion,
 	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if value, ok := m.sboms[id]; ok {
 		if value.Content == nil {
 			// APIServerStore always reads back a document (Content: &manifest.Spec.Syft),
@@ -219,6 +246,9 @@ func (m *MemoryStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion stri
 func (m *MemoryStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, _ bool) error {
 	_, span := otel.Tracer("").Start(ctx, "MemoryStore.StoreSBOM")
 	defer span.End()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	m.sbomStores++
 
@@ -242,6 +272,8 @@ func (m *MemoryStore) DeleteSBOM(ctx context.Context, name string) error {
 		return domain.ErrMockError
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for id := range m.sboms {
 		if id.Name == name {
 			delete(m.sboms, id)

--- a/repositories/memory_test.go
+++ b/repositories/memory_test.go
@@ -2,6 +2,8 @@ package repositories
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/kubescape/kubevuln/core/domain"
@@ -40,4 +42,59 @@ func TestMemoryStore_GetSBOM(t *testing.T) {
 	_ = m.StoreSBOM(ctx, sbom, false)
 	got, _ = m.GetSBOM(ctx, "name", "")
 	assert.NotNil(t, got.Content)
+}
+
+// TestMemoryStore_ConcurrentAccessIsRaceFree exercises every exported MemoryStore method from
+// many goroutines at once. It exists to catch a regression of #852: MemoryStore's maps and
+// counters used to have no synchronization, which `go test -race` never ran to catch because CI
+// forced CGO_ENABLED=0. Concurrent access to a shared MemoryStore is not hypothetical -- the
+// singleflight and worker-pool tests in core/services do exactly this -- so this test both
+// stands on its own and documents why mu exists.
+//
+// It does not assert on the values read back: with concurrent writers racing on overlapping
+// keys, which write "wins" is undefined by design. The only thing under test is that running
+// every method concurrently is race- and panic-free (no "fatal error: concurrent map writes"),
+// which `go test -race` verifies for us.
+func TestMemoryStore_ConcurrentAccessIsRaceFree(t *testing.T) {
+	m := NewMemoryStorage(false, false)
+	ctx := context.TODO()
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			// A mix of distinct and overlapping keys: overlapping keys are what actually
+			// puts concurrent goroutines on the same map bucket.
+			name := fmt.Sprintf("image-%d", i%3)
+
+			ap := v1beta1.ContainerProfile{}
+			ap.Namespace = "ns"
+			ap.Name = name
+			_ = m.StoreContainerProfile(ctx, ap)
+			_, _ = m.GetContainerProfile(ctx, "ns", name)
+
+			cve := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
+			_ = m.StoreCVE(ctx, cve, false)
+			_, _ = m.GetCVE(ctx, name, "", "", "")
+
+			cvep := domain.CVEManifest{Name: name + "-relevant", Content: &v1beta1.GrypeDocument{}}
+			_ = m.StoreCVESummary(ctx, cve, cvep, true)
+			_, _ = m.GetCVESummary(ctx)
+
+			_ = m.StoreCVESummaryStub(ctx, "stub-status")
+			_ = m.CVESummaryStubs()
+
+			sbom := domain.SBOM{Name: name, Content: &v1beta1.SyftDocument{}}
+			_ = m.StoreSBOM(ctx, sbom, false)
+			_, _ = m.GetSBOM(ctx, name, "")
+			_ = m.SBOMStores()
+			_ = m.DeleteSBOM(ctx, name)
+
+			_ = m.StoreVEX(ctx, cve, cvep, false)
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem

Every PR to kubevuln runs its Go test suite with the race detector disabled, because `.github/workflows/pr-created.yaml` set `CGO_ENABLED: 0`. The shared `go-basic-tests.yaml` workflow only runs `go test -race` when `CGO_ENABLED == 1` (`-race` requires cgo); `0` silently selects the race-free branch instead. `docs/DEVELOPMENT.md` itself tells contributors to run `go test -race ./...` locally, but CI never has.

This isn't a theoretical gap: this repo has a long track record of real data races found only by hand, months apart, in different packages — #427, #580/#601, #690, #628/#629, #733/#734, #753, #758/#759. That's exactly the class of bug `-race` exists to catch continuously.

## Root Cause

`.github/workflows/pr-created.yaml:25` passed `CGO_ENABLED: 0` into `kubescape/workflows/.github/workflows/incluster-comp-pr-created.yaml`, which forwards it to `go-basic-tests.yaml`. That workflow's `Environment-Test` job branches:

```yaml
- name: Test race conditions
  if: ${{ env.CGO_ENABLED == 1 }}
  run: go test -v -race ...
- name: Test without race conditions
  if: ${{ env.CGO_ENABLED != 1 }}
  run: go test -v ...
```

`pr-merged.yaml` also set `CGO_ENABLED: 0`, but that input is declared and never used by `incluster-comp-pr-merged.yaml` — it had zero effect there. Removed it so it doesn't look load-bearing to the next reader.

## Solution

- `pr-created.yaml`: `CGO_ENABLED: 0` → `1`, with a comment pointing at why.
- `pr-merged.yaml`: dropped the inert `CGO_ENABLED: 0`.
- Turning `-race` on locally immediately found a real, previously-invisible data race: `repositories/memory.go`'s `MemoryStore` had no synchronization around its maps (`aps`, `cveManifests`, `sboms`) and counters (`sbomStores`, `summaryStubs`). It's test-only in production (`cmd/http/main.go` only ever constructs `*APIServerStore`), but the singleflight and worker-pool concurrency tests in `core/services` already run several goroutines against one shared `MemoryStore` — exactly the scenario `-race` is meant to catch. Added a `sync.RWMutex` guarding every field, with `RLock`/`Lock` on each accessor.

## Testing

- Added `TestMemoryStore_ConcurrentAccessIsRaceFree` (`repositories/memory_test.go`): runs 20 goroutines against a shared `MemoryStore`, calling every exported method with a mix of distinct and overlapping keys. It doesn't assert on final values (concurrent writes to overlapping keys are inherently unordered) — the point is that it's race- and panic-free under `-race`, which is what actually catches a regression of this fix.
- `go build ./...` — clean.
- `go vet ./...` — clean.
- `golangci-lint run --new-from-rev=upstream/main ./repositories/...` — 0 issues.
- `go test ./...` (excluding e2e) — all green.
- `go test -race ./repositories/...` — clean, including the new concurrent test (confirmed both before and after the fix: without the mutex it fails under `-race`; with it, it passes).
- `go test -race` across the rest of the suite (`adapters`, `controllers`, `core/domain`, `internal/*`, `pkg/sbomscanner/v1`, `cmd/*`, `config`) — all clean.

## Impact

Every future PR will actually run `go test -race`, matching what `docs/DEVELOPMENT.md` already tells contributors to do locally. Given this project's history, that's the single check most likely to catch the next concurrency regression before merge instead of after.

Fixes #852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple operations access stored data concurrently.
  * Reduced the risk of inconsistent results or data races during simultaneous updates and reads.

* **Tests**
  * Added concurrent-access coverage to validate consistent behavior under high parallel activity.
  * Enabled race detection in pull request testing to catch synchronization issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->