### PR TITLE
fix: reject a scan jobID that already has an active scan in progress

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -177,21 +177,41 @@ func (h *HTTPController) admitQueueSlot(c *gin.Context, ctx context.Context, end
 // active job -- it writes the appropriate rejection response itself, releases any queue slot
 // it reserved, and returns false; either way the caller must stop processing the request
 // without doing anything else.
+//
+// The isActive check runs before admitQueueSlot on purpose: without it, a jobID that
+// collides with the very job occupying the controller's last admission slot would be
+// rejected as queue-full (503) before recordAccepted ever got a chance to diagnose it as a
+// duplicate (409), since admission capacity would already be exhausted by the time
+// recordAccepted ran. It's a precedence check only -- recordAccepted's own atomic
+// check-and-write remains the actual guard against a genuine race between two admissions
+// for the same jobID, so a duplicate that slips past this read-only check is still caught
+// there.
 func (h *HTTPController) admitJob(c *gin.Context, ctx context.Context, endpoint, jobID string, details problem.Option) bool {
+	if h.ensureStatuses().isActive(jobID) {
+		h.rejectDuplicateJobID(c, ctx, endpoint, jobID, details)
+		return false
+	}
 	if !h.admitQueueSlot(c, ctx, endpoint, details) {
 		return false
 	}
 	if !h.ensureStatuses().recordAccepted(jobID, endpoint) {
 		h.release()
-		logger.L().Ctx(ctx).Warning("rejecting scan, jobID already has an active scan in progress",
-			helpers.String("endpoint", endpoint),
-			helpers.String("jobID", jobID))
-		h.recordRejection(ctx, endpoint, domain.ErrDuplicateJobID)
-		_, _ = problem.Of(validationStatusCode(domain.ErrDuplicateJobID)).Append(details).WriteTo(c.Writer)
+		h.rejectDuplicateJobID(c, ctx, endpoint, jobID, details)
 		return false
 	}
 	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 	return true
+}
+
+// rejectDuplicateJobID writes the 409/ErrDuplicateJobID rejection response for jobID and
+// records it, shared by admitJob's two rejection points (the isActive precedence check and
+// the recordAccepted race fallback).
+func (h *HTTPController) rejectDuplicateJobID(c *gin.Context, ctx context.Context, endpoint, jobID string, details problem.Option) {
+	logger.L().Ctx(ctx).Warning("rejecting scan, jobID already has an active scan in progress",
+		helpers.String("endpoint", endpoint),
+		helpers.String("jobID", jobID))
+	h.recordRejection(ctx, endpoint, domain.ErrDuplicateJobID)
+	_, _ = problem.Of(validationStatusCode(domain.ErrDuplicateJobID)).Append(details).WriteTo(c.Writer)
 }
 
 // submit hands task to the worker pool, unless Shutdown has already begun, in which case

--- a/controllers/http.go
+++ b/controllers/http.go
@@ -169,6 +169,31 @@ func (h *HTTPController) admitQueueSlot(c *gin.Context, ctx context.Context, end
 	return false
 }
 
+// admitJob reserves a queue slot for endpoint via admitQueueSlot and then records jobID as
+// newly accepted via recordAccepted, rejecting a jobID that already belongs to an active
+// (queued or running) job instead of silently resetting its tracking record out from under
+// it (see #856). On success it writes the 200 OK response the caller uses to start polling
+// ScanStatus and returns true. On failure -- the queue is full, or jobID collides with an
+// active job -- it writes the appropriate rejection response itself, releases any queue slot
+// it reserved, and returns false; either way the caller must stop processing the request
+// without doing anything else.
+func (h *HTTPController) admitJob(c *gin.Context, ctx context.Context, endpoint, jobID string, details problem.Option) bool {
+	if !h.admitQueueSlot(c, ctx, endpoint, details) {
+		return false
+	}
+	if !h.ensureStatuses().recordAccepted(jobID, endpoint) {
+		h.release()
+		logger.L().Ctx(ctx).Warning("rejecting scan, jobID already has an active scan in progress",
+			helpers.String("endpoint", endpoint),
+			helpers.String("jobID", jobID))
+		h.recordRejection(ctx, endpoint, domain.ErrDuplicateJobID)
+		_, _ = problem.Of(validationStatusCode(domain.ErrDuplicateJobID)).Append(details).WriteTo(c.Writer)
+		return false
+	}
+	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
+	return true
+}
+
 // submit hands task to the worker pool, unless Shutdown has already begun, in which case
 // it returns false without touching the pool at all. Callers must treat false the same as
 // a lost race with shutdown: release the admission slot task's defer h.release() will now
@@ -240,9 +265,10 @@ func scanFailureReason(outcome string, err error) string {
 
 // recordRejection records a validation-time rejection for the given endpoint. reason is
 // "too_many_requests" for registry back-pressure (ErrTooManyRequests), "queue_full" for local
-// admission control (ErrQueueFull, see WithMaxQueueDepth), and "invalid_request" for every
-// other validation error, keeping the rejection-rate signal distinct from malformed-payload
-// noise while staying low cardinality.
+// admission control (ErrQueueFull, see WithMaxQueueDepth), "duplicate_job_id" for a jobID
+// that already belongs to an active job (ErrDuplicateJobID, see admitJob), and
+// "invalid_request" for every other validation error, keeping the rejection-rate signal
+// distinct from malformed-payload noise while staying low cardinality.
 func (h *HTTPController) recordRejection(ctx context.Context, endpoint string, err error) {
 	if h.metrics == nil {
 		return
@@ -253,6 +279,8 @@ func (h *HTTPController) recordRejection(ctx context.Context, endpoint string, e
 		reason = "too_many_requests"
 	case errors.Is(err, domain.ErrQueueFull):
 		reason = "queue_full"
+	case errors.Is(err, domain.ErrDuplicateJobID):
+		reason = "duplicate_job_id"
 	}
 	h.metrics.RejectCounter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("endpoint", endpoint),
@@ -297,12 +325,9 @@ func (h *HTTPController) GenerateSBOM(c *gin.Context) {
 		return
 	}
 
-	if !h.admitQueueSlot(c, ctx, "generateSBOM", details) {
+	if !h.admitJob(c, ctx, "generateSBOM", newScan.JobID, details) {
 		return
 	}
-
-	h.ensureStatuses().recordAccepted(newScan.JobID, "generateSBOM")
-	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
@@ -414,12 +439,9 @@ func (h *HTTPController) ScanCP(c *gin.Context) {
 		return
 	}
 
-	if !h.admitQueueSlot(c, ctx, "scanCP", details) {
+	if !h.admitJob(c, ctx, "scanCP", newScan.JobID, details) {
 		return
 	}
-
-	h.ensureStatuses().recordAccepted(newScan.JobID, "scanCP")
-	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
@@ -480,12 +502,9 @@ func (h *HTTPController) ScanCVE(c *gin.Context) {
 		return
 	}
 
-	if !h.admitQueueSlot(c, ctx, "scanCVE", details) {
+	if !h.admitJob(c, ctx, "scanCVE", newScan.JobID, details) {
 		return
 	}
-
-	h.ensureStatuses().recordAccepted(newScan.JobID, "scanCVE")
-	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)
@@ -503,12 +522,17 @@ func (h *HTTPController) ScanCVE(c *gin.Context) {
 // caller's own request, so it maps to 429; ErrQueueFull reflects the controller's own local
 // capacity, not anything wrong with the request, so it maps to 503 rather than either 429 or
 // 400 -- a retry against the same instance may well succeed once the backlog drains.
+// ErrDuplicateJobID reflects a conflict with another resource already tracked under the same
+// jobID, so it maps to 409 -- retrying with the same jobID won't help until that job finishes,
+// but retrying with a fresh jobID will.
 func validationStatusCode(err error) int {
 	switch {
 	case errors.Is(err, domain.ErrTooManyRequests):
 		return http.StatusTooManyRequests
 	case errors.Is(err, domain.ErrQueueFull):
 		return http.StatusServiceUnavailable
+	case errors.Is(err, domain.ErrDuplicateJobID):
+		return http.StatusConflict
 	}
 	return http.StatusBadRequest
 }
@@ -564,12 +588,9 @@ func (h *HTTPController) ScanRegistry(c *gin.Context) {
 		return
 	}
 
-	if !h.admitQueueSlot(c, ctx, "scanRegistry", details) {
+	if !h.admitJob(c, ctx, "scanRegistry", newScan.JobID, details) {
 		return
 	}
-
-	h.ensureStatuses().recordAccepted(newScan.JobID, "scanRegistry")
-	_, _ = problem.Of(http.StatusOK).Append(details).WriteTo(c.Writer)
 
 	bgCtx := context.WithoutCancel(domain.WithScanPhaseUpdater(ctx, func(phase string) {
 		h.ensureStatuses().markPhase(newScan.JobID, phase)

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -1446,12 +1446,15 @@ func TestHTTPController_GenerateSBOM_DuplicateJobIDRejected(t *testing.T) {
 	c := (&HTTPController{
 		scanService: services.NewMockScanService(true),
 		workerPool:  workerpool.New(1),
-	})
+	}).WithMaxQueueDepth(1)
 	defer c.Shutdown(2 * time.Second)
 
 	// Simulate a job already accepted under the same jobID the request below uses, without
 	// needing to synchronize against a background goroutine -- the same style
-	// TestHTTPController_GenerateSBOM_QueueFull uses for tryAdmit.
+	// TestHTTPController_GenerateSBOM_QueueFull uses for tryAdmit. maxQueueDepth is bounded
+	// here specifically so pending is actually exercised: with the default unbounded queue,
+	// tryAdmit/release are no-ops and pending stays 0 regardless of whether the rejection
+	// path is correct.
 	require.True(t, c.ensureStatuses().recordAccepted("job-dup", "generateSBOM"))
 
 	router := gin.Default()
@@ -1462,13 +1465,48 @@ func TestHTTPController_GenerateSBOM_DuplicateJobIDRejected(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
 
-	// The rejected duplicate's queue slot must not leak.
+	// admitJob's isActive precedence check catches this before admitQueueSlot ever reserves
+	// a slot for it, so the controller's one slot of capacity must still be free afterward.
 	require.Eventually(t, func() bool { return c.pending.Load() == 0 }, time.Second, 5*time.Millisecond,
-		"the duplicate's admission slot must be released, not leaked, on rejection")
+		"a duplicate rejection must not consume the controller's admission capacity")
 
 	status, ok := c.ensureStatuses().get("job-dup")
 	require.True(t, ok)
 	assert.Equal(t, domain.ScanStateQueued, status.State, "the original job's record must be untouched by the rejected duplicate")
+}
+
+// TestHTTPController_DuplicateJobID_TakesPrecedenceOverQueueFull covers the ordering CodeRabbit
+// flagged on #857: if the job occupying the controller's one and only admission slot is the
+// same jobID a new request reuses, admitQueueSlot alone would reject that request as 503
+// queue-full without ever getting a chance to diagnose it as a 409 duplicate, since capacity
+// is genuinely exhausted. admitJob's isActive check runs before admitQueueSlot specifically
+// so this case is still reported as a duplicate, which more precisely describes the actual
+// conflict and doesn't imply retrying with a fresh jobID would also be rejected.
+func TestHTTPController_DuplicateJobID_TakesPrecedenceOverQueueFull(t *testing.T) {
+	c := (&HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	}).WithMaxQueueDepth(1)
+	defer c.Shutdown(2 * time.Second)
+
+	// The one and only admission slot is occupied by "job-dup" itself, exhausting capacity.
+	require.True(t, c.tryAdmit())
+	require.True(t, c.ensureStatuses().recordAccepted("job-dup", "generateSBOM"))
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:dup","jobID":"job-dup"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code, w.Body.String(),
+		"a jobID collision must be reported as 409, not 503, even when it also happens to be the request holding the only free slot")
+
+	// A different, non-duplicate jobID must still see the queue as genuinely full.
+	req2, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:other","jobID":"job-other"}`))
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusServiceUnavailable, w2.Code, w2.Body.String())
 }
 
 // TestHTTPController_DuplicateJobID_PreservesFirstJobOutcome end-to-end reproduces the

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -1438,6 +1438,139 @@ func TestHTTPController_MetricsEndpoint_RecordsQueueFullRejection(t *testing.T) 
 	assert.False(t, strings.Contains(body, `reason="invalid_request"`), body)
 }
 
+// TestHTTPController_GenerateSBOM_DuplicateJobIDRejected is a regression test for #856:
+// submitting a jobID that already belongs to a job still queued or running must be
+// rejected with 409, not silently accepted -- accepting it would let the new request
+// reset the first job's tracking record out from under it via recordAccepted.
+func TestHTTPController_GenerateSBOM_DuplicateJobIDRejected(t *testing.T) {
+	c := (&HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	})
+	defer c.Shutdown(2 * time.Second)
+
+	// Simulate a job already accepted under the same jobID the request below uses, without
+	// needing to synchronize against a background goroutine -- the same style
+	// TestHTTPController_GenerateSBOM_QueueFull uses for tryAdmit.
+	require.True(t, c.ensureStatuses().recordAccepted("job-dup", "generateSBOM"))
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:dup","jobID":"job-dup"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+
+	// The rejected duplicate's queue slot must not leak.
+	require.Eventually(t, func() bool { return c.pending.Load() == 0 }, time.Second, 5*time.Millisecond,
+		"the duplicate's admission slot must be released, not leaked, on rejection")
+
+	status, ok := c.ensureStatuses().get("job-dup")
+	require.True(t, ok)
+	assert.Equal(t, domain.ScanStateQueued, status.State, "the original job's record must be untouched by the rejected duplicate")
+}
+
+// TestHTTPController_DuplicateJobID_PreservesFirstJobOutcome end-to-end reproduces the
+// scenario from #856: a jobID reused while its first job is genuinely still running (not
+// just simulated store state) must be rejected, and the first job's real outcome must reach
+// ScanStatus uncorrupted once it finishes -- not silently overwritten by the duplicate the
+// way it would have been before recordAccepted rejected the re-admission.
+func TestHTTPController_DuplicateJobID_PreservesFirstJobOutcome(t *testing.T) {
+	blocked := make(chan struct{})
+	started := make(chan struct{}, 1)
+	c := NewHTTPController(statusFlowScanService{
+		MockScanService: services.NewMockScanService(true),
+		err:             &domain.ScanError{Reason: scanfailure.ReasonCVEMatchingFailed, Err: errors.New("boom")},
+		blockCh:         blocked,
+		startedCh:       started,
+	}, 1)
+	t.Cleanup(func() {
+		select {
+		case <-blocked:
+		default:
+			close(blocked)
+		}
+	})
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+	router.GET("/v1/scanStatus/:jobID", c.ScanStatus)
+
+	firstReq, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:4","jobID":"job-reused"}`))
+	firstW := httptest.NewRecorder()
+	router.ServeHTTP(firstW, firstReq)
+	require.Equal(t, http.StatusOK, firstW.Code, firstW.Body.String())
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first job's scan was not started in time")
+	}
+
+	// The first job is now genuinely Running (blocked inside GenerateSBOM). A second request
+	// reusing the same jobID -- a retry, redelivery, or caller bug -- must be rejected rather
+	// than resetting the first job's record back to Queued.
+	dupReq, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:4","jobID":"job-reused"}`))
+	dupW := httptest.NewRecorder()
+	router.ServeHTTP(dupW, dupReq)
+	require.Equal(t, http.StatusConflict, dupW.Code, dupW.Body.String())
+
+	close(blocked)
+
+	var status domain.ScanStatus
+	require.Eventually(t, func() bool {
+		req, _ := http.NewRequest("GET", "/v1/scanStatus/job-reused", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			return false
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+			return false
+		}
+		return status.State == domain.ScanStateFailed
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, scanfailure.ReasonCVEMatchingFailed, status.Reason,
+		"the first job's real outcome must reach ScanStatus, not be silently dropped by the rejected duplicate")
+}
+
+// TestHTTPController_MetricsEndpoint_RecordsDuplicateJobIDRejection mirrors
+// TestHTTPController_MetricsEndpoint_RecordsQueueFullRejection for the duplicate_job_id
+// rejection reason, proving it's recorded distinctly from the other rejection reasons.
+func TestHTTPController_MetricsEndpoint_RecordsDuplicateJobIDRejection(t *testing.T) {
+	c := &HTTPController{
+		scanService: services.NewMockScanService(true),
+		workerPool:  workerpool.New(1),
+	}
+	require.True(t, c.ensureStatuses().recordAccepted("job-dup", "generateSBOM"))
+
+	m, err := metrics.New()
+	require.NoError(t, err)
+	c, err = c.WithMetrics(m)
+	require.NoError(t, err)
+
+	router := gin.Default()
+	router.POST("/v1/generateSBOM", c.GenerateSBOM)
+	router.GET("/metrics", gin.WrapH(m.Handler()))
+
+	req, _ := http.NewRequest("POST", "/v1/generateSBOM", strings.NewReader(`{"imageTag":"nginx:1.24","imageHash":"sha256:dup","jobID":"job-dup"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+
+	req, _ = http.NewRequest("GET", "/metrics", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, `kubevuln_scan_rejections_total{endpoint="generateSBOM",reason="duplicate_job_id"} 1`), body)
+	assert.False(t, strings.Contains(body, `reason="queue_full"`), body)
+	assert.False(t, strings.Contains(body, `reason="invalid_request"`), body)
+}
+
 // The other three endpoints each cover a body that will not bind; ScanCP did not, which
 // left the one handler whose worker closure is its own copy unexercised on that path.
 func TestHTTPController_ScanCP_InvalidRequest(t *testing.T) {

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -106,13 +106,25 @@ func isTerminal(state domain.ScanState) bool {
 	return state == domain.ScanStateSucceeded || state == domain.ScanStateFailed || state == domain.ScanStateAbandoned
 }
 
-func (s *scanStatusStore) recordAccepted(jobID, endpoint string) {
+// recordAccepted admits jobID as a newly queued job and returns true, unless jobID already
+// names a record that is still active (queued or running), in which case it returns false
+// without modifying the store. Overwriting an active record here would reset a job that's
+// already running out from under it -- claimTrackedJob would then let a second, unrelated
+// closure claim the same jobID, and both jobs' eventual markTerminal calls would race for
+// which one's outcome the shared record keeps, silently dropping the other's (see #856).
+// A jobID whose existing record is already terminal -- the ordinary case of a caller
+// reusing an ID once its predecessor is done -- is always accepted, same as before this
+// check existed.
+func (s *scanStatusStore) recordAccepted(jobID, endpoint string) bool {
 	if jobID == "" {
-		return
+		return true
 	}
 	now := time.Now().UTC()
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if existing, ok := s.items[jobID]; ok && !isTerminal(existing.State) {
+		return false
+	}
 	s.items[jobID] = domain.ScanStatus{
 		JobID:      jobID,
 		Endpoint:   endpoint,
@@ -122,6 +134,7 @@ func (s *scanStatusStore) recordAccepted(jobID, endpoint string) {
 		UpdatedAt:  now,
 	}
 	s.evictLocked(now)
+	return true
 }
 
 func (s *scanStatusStore) markRunning(jobID string) bool {

--- a/controllers/scan_status.go
+++ b/controllers/scan_status.go
@@ -137,6 +137,23 @@ func (s *scanStatusStore) recordAccepted(jobID, endpoint string) bool {
 	return true
 }
 
+// isActive reports whether jobID currently names a record that is still queued or running.
+// It's a cheap read-only precedence check for admitJob: without it, a jobID that collides
+// with the very job occupying the controller's last admission slot would be rejected as
+// "queue full" (503) before recordAccepted ever got a chance to diagnose it as a duplicate
+// (409), since admitQueueSlot ran first. recordAccepted's own atomic check-and-write under
+// s.mu remains the actual correctness guard against a genuine race between two admissions;
+// this is only about which rejection reason a caller sees when both are true at once.
+func (s *scanStatusStore) isActive(jobID string) bool {
+	if jobID == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	status, ok := s.items[jobID]
+	return ok && !isTerminal(status.State)
+}
+
 func (s *scanStatusStore) markRunning(jobID string) bool {
 	if jobID == "" {
 		return false

--- a/controllers/scan_status_test.go
+++ b/controllers/scan_status_test.go
@@ -194,6 +194,68 @@ func TestScanStatusStore_MarkRunningOnlyClaimsQueuedJobs(t *testing.T) {
 	require.Equal(t, domain.ScanStateAbandoned, status.State, "terminal jobs must reject later failure writes")
 }
 
+// TestScanStatusStore_RecordAcceptedRejectsActiveJobID is the regression test for #856:
+// reusing a jobID while its prior job is still queued or running must not silently reset
+// that job's tracking record. Before the fix, a second recordAccepted for the same jobID
+// always overwrote the first, letting a second closure claim the same jobID via markRunning
+// and then race the first job's own markTerminal call for which outcome the shared record
+// keeps -- silently dropping whichever one lost the race.
+func TestScanStatusStore_RecordAcceptedRejectsActiveJobID(t *testing.T) {
+	s := newScanStatusStore()
+
+	require.True(t, s.recordAccepted("job", "generateSBOM"), "first admission for a fresh jobID must succeed")
+	require.False(t, s.recordAccepted("job", "generateSBOM"), "reusing a queued jobID must be rejected")
+
+	status, ok := s.get("job")
+	require.True(t, ok)
+	require.Equal(t, domain.ScanStateQueued, status.State, "the rejected re-admission must not have touched the record")
+
+	require.True(t, s.markRunning("job"))
+	require.False(t, s.recordAccepted("job", "generateSBOM"), "reusing a running jobID must be rejected")
+
+	status, ok = s.get("job")
+	require.True(t, ok)
+	require.Equal(t, domain.ScanStateRunning, status.State, "the rejected re-admission must not have reset a running job back to queued")
+	require.NotNil(t, status.StartedAt, "the rejected re-admission must not have discarded StartedAt")
+
+	// The original job's own outcome must survive exactly as if the duplicate admission had
+	// never been attempted.
+	s.markFailed("job", "unexpected_error")
+	status, ok = s.get("job")
+	require.True(t, ok)
+	require.Equal(t, domain.ScanStateFailed, status.State)
+	require.Equal(t, "unexpected_error", status.Reason)
+}
+
+// TestScanStatusStore_RecordAcceptedAllowsReuseOnceTerminal proves the fix is narrowly
+// scoped: reusing a jobID is only rejected while the prior job under that ID is still
+// active. Once it has reached any terminal state, reuse must keep working exactly as
+// before -- this is the ordinary, benign case of a caller reusing an ID once its
+// predecessor is done.
+func TestScanStatusStore_RecordAcceptedAllowsReuseOnceTerminal(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reach func(s *scanStatusStore, jobID string)
+	}{
+		{"succeeded", func(s *scanStatusStore, jobID string) { s.markSucceeded(jobID) }},
+		{"failed", func(s *scanStatusStore, jobID string) { s.markFailed(jobID, "some_reason") }},
+		{"abandoned", func(s *scanStatusStore, jobID string) { s.markAbandoned(jobID, domain.ScanReasonShutdownAbandoned) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newScanStatusStore()
+			require.True(t, s.recordAccepted("job", "generateSBOM"))
+			tc.reach(s, "job")
+
+			require.True(t, s.recordAccepted("job", "generateSBOM"), "reusing a jobID whose prior job is terminal must be accepted")
+
+			status, ok := s.get("job")
+			require.True(t, ok)
+			require.Equal(t, domain.ScanStateQueued, status.State, "the record must reset to a fresh queued job")
+			require.Nil(t, status.StartedAt, "the fresh record must not carry over the prior job's StartedAt")
+		})
+	}
+}
+
 // Before #790, get()'s cost scaled with the store's total size (evictLocked's full sweep).
 // This benchmark's ns/op should stay flat across store sizes now that a lookup only touches
 // the one key it was asked for; run with -benchtime and compare sizes to see the effect, e.g.

--- a/core/domain/scan.go
+++ b/core/domain/scan.go
@@ -44,6 +44,12 @@ var (
 	// (e.g. the CRD list failed). Callers must not treat missing exceptions as
 	// deletions.
 	ErrExceptionsDegraded = errors.New("exception set is incomplete")
+	// ErrDuplicateJobID indicates the submitted jobID already belongs to a scan that is
+	// still queued or running. Admitting it again would let two unrelated jobs share one
+	// scanStatusStore record and race over which one's terminal outcome the record
+	// retains, silently dropping the other (see #856). The caller must not reuse a jobID
+	// until the job it named has reached a terminal state.
+	ErrDuplicateJobID = errors.New("jobID already has an active scan in progress")
 )
 
 // ScanError wraps a scan-flow error together with the scanfailure.Reason* classification

--- a/docs/API.md
+++ b/docs/API.md
@@ -292,6 +292,7 @@ POST /v1/sbomCreation
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
 | `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
+| `409 Conflict` | `jobID` already belongs to a scan that is still queued or running; retry with a fresh `jobID`, or wait for the existing one to finish |
 
 #### Example
 
@@ -346,6 +347,7 @@ POST /v1/scanImage
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
 | `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
+| `409 Conflict` | `jobID` already belongs to a scan that is still queued or running; retry with a fresh `jobID`, or wait for the existing one to finish |
 
 #### Example
 
@@ -397,6 +399,7 @@ POST /v1/scanRegistryImage
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `429 Too Many Requests` | Registry rate limit hit on a previous pull for this image |
 | `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
+| `409 Conflict` | `jobID` already belongs to a scan that is still queued or running; retry with a fresh `jobID`, or wait for the existing one to finish |
 
 #### Example
 
@@ -452,6 +455,7 @@ POST /v1/applicationProfileScan
 | `200 OK` | Request accepted, profile scan started |
 | `400 Bad Request` | Invalid request payload or validation failed |
 | `503 Service Unavailable` | Scan admission capacity is full (positive `maxQueueDepth` reached; unset or non-positive means unbounded admission); retry later. Unrelated to `/v1/readiness` |
+| `409 Conflict` | `jobID` already belongs to a scan that is still queued or running; retry with a fresh `jobID`, or wait for the existing one to finish |
 
 #### Example
 
@@ -550,6 +554,7 @@ All responses follow RFC 7807.
 |------|---------|------|
 | `200` | OK | Request accepted |
 | `400` | Bad Request | Invalid JSON, missing required fields, or validation failed |
+| `409` | Conflict | A scan endpoint's `jobID` already belongs to a scan that is still queued or running |
 | `429` | Too Many Requests | Registry rate limit hit on a previous pull for this image |
 | `500` | Internal Server Error | Internal error |
 | `503` | Service Unavailable | Two distinct causes, unrelated to each other: `/v1/readiness` reports it when the vulnerability DB isn't loaded, and a scan endpoint reports it when scan admission capacity is full (positive `maxQueueDepth` reached) |


### PR DESCRIPTION
Fixes #856

## Problem

`scanStatusStore.recordAccepted` (`controllers/scan_status.go`) unconditionally overwrote the status record for a `jobID` on every admission, with no check for whether that ID already belonged to a job still queued or running. `docs/API.md` documents `jobID` as a caller-supplied "Unique job identifier", but nothing enforced it.

If the same `jobID` was submitted a second time while the first job was still in flight — a client retry after a dropped response, at-least-once redelivery from a queue, or a caller bug — the second admission silently reset the shared tracking record. Both jobs' worker closures could then claim the same `jobID` via `markRunning`, and whichever reached a terminal state first permanently won the record; the other's real outcome was silently dropped. A client polling `GET /v1/scanStatus/:jobID` could be told the wrong result with no error and no log signal.

## Root cause

`recordAccepted` treated every call as authoritative and had no per-record identity to let `markRunning`/`markTerminal` detect that a record had been reset by a different request after their own job had already claimed it — see the full reproduction sequence in #856.

## Solution

- `recordAccepted` now rejects re-admission when an existing record for the same `jobID` is non-terminal (queued or running), leaving that record untouched. Reusing a `jobID` once its prior job has reached any terminal state (succeeded/failed/abandoned) is unaffected — that's the ordinary case of a caller reusing an ID once its predecessor is done.
- The four scan handlers (`GenerateSBOM`, `ScanCP`, `ScanCVE`, `ScanRegistry`) now go through a new `admitJob` helper that combines `admitQueueSlot` and `recordAccepted`, turning a rejected re-admission into a `409 Conflict` response (`domain.ErrDuplicateJobID`) and releasing the admission slot it reserved — the same pattern `admitQueueSlot` already uses for `ErrQueueFull`/503. This also removes the duplicated three-line admission block that was repeated across all four handlers.
- `recordRejection`'s `duplicate_job_id` reason and `docs/API.md`'s per-endpoint response tables and status-code summary are updated to document the new `409`.

## Testing

- `controllers/scan_status_test.go`: `TestScanStatusStore_RecordAcceptedRejectsActiveJobID` reproduces the collision at the store level — a queued job's own re-admission is rejected without touching its record, a running job's `StartedAt` survives an attempted collision, and the job's real `markFailed` outcome is preserved afterward. `TestScanStatusStore_RecordAcceptedAllowsReuseOnceTerminal` proves the fix is narrowly scoped: reuse after succeeded/failed/abandoned still works exactly as before.
- `controllers/http_test.go`: `TestHTTPController_GenerateSBOM_DuplicateJobIDRejected` covers the 409 response and confirms the admission slot isn't leaked. `TestHTTPController_DuplicateJobID_PreservesFirstJobOutcome` is an end-to-end reproduction using a real blocking scan (not simulated store state) — submits a job, waits for it to genuinely start running, submits a duplicate under the same `jobID` and asserts 409, then lets the first job finish and asserts `GET /v1/scanStatus/:jobID` reports its real (failed) outcome, uncorrupted. `TestHTTPController_MetricsEndpoint_RecordsDuplicateJobIDRejection` covers the new rejection-reason metric label.
- `go build ./...`, `go vet ./controllers/... ./core/domain/...` — pass.
- `go test ./controllers/... ./core/domain/... -v` — pass, all new and existing tests green, no failures.
- `golangci-lint` was started locally but did not finish in a reasonable time on this machine; CI will run the repo's standard lint job on this PR.

## Impact

Any caller relying on `GET /v1/scanStatus/:jobID` to learn a scan's real outcome can no longer be told the wrong result due to `jobID` reuse while the prior job under that ID is still active. The change is additive and narrowly scoped: it only rejects the specific case of reusing an ID that is still active, and does not change behavior for a fresh `jobID` or one reused after its predecessor has finished.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Duplicate job IDs for active scans are now rejected with an HTTP 409 Conflict response.
  - Rejected requests no longer consume queue capacity or alter the original scan’s status or outcome.
  - Job IDs can be reused after the previous scan reaches a terminal state.
  - Duplicate-job rejections are recorded separately in scan metrics.

- **Documentation**
  - Updated API documentation to describe 409 responses for duplicate active job IDs across scan endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->