### PR TITLE
fix(adapters): report unknown, not empty, when no fix version is above installed

### DIFF
--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -500,3 +500,81 @@ func TestParseImageManifest_LayerOrderNamesOneLayer(t *testing.T) {
 	assert.Equal(t, map[int]int{0: 1, 1: 1}, seen,
 		"each real layer holds its own order, numbered from zero")
 }
+
+// TestDomainToArmo_IsFixedAgreesWithFixes pins the two "is there a fix?" answers a single
+// report record carries, which are produced from different halves of hasKnownFix.
+//
+// IsFixed comes from the bool. Fixes[].Version comes from the version string, and the
+// backend summary counts fixes from that, via containerscan.CalculateFixed, which ignores
+// an entry whose Version is "" or "None". So an empty version alongside a true bool makes a
+// record contradict itself: IsFixed=1, yet contributing 0 to FixAvailableOfTotalCount.
+//
+// The two cases below are the ones that reach it, both being "a fix exists but nothing
+// above what is installed": every listed fix version older than current, and the only
+// listed one equal to it.
+func TestDomainToArmo_IsFixedAgreesWithFixes(t *testing.T) {
+	tests := []struct {
+		name        string
+		installed   string
+		fixVersions []string
+		wantVersion string
+	}{
+		{
+			name:        "a real upgrade is suggested",
+			installed:   "1.0.0",
+			fixVersions: []string{"1.5.0", "1.2.0"},
+			wantVersion: "1.2.0",
+		},
+		{
+			name:        "every fix version is older than installed",
+			installed:   "2.0.0",
+			fixVersions: []string{"1.5.0", "1.2.0"},
+			wantVersion: unknownFixVersion,
+		},
+		{
+			name:        "the only fix version equals installed",
+			installed:   "1.5.0",
+			fixVersions: []string{"1.5.0"},
+			wantVersion: unknownFixVersion,
+		},
+		{
+			name:        "installed version is not a version",
+			installed:   "not-a-version",
+			fixVersions: []string{"1.5.0"},
+			wantVersion: "1.5.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := v1beta1.GrypeDocument{
+				Source: &v1beta1.Source{Target: json.RawMessage(threeLayerSource)},
+				Matches: []v1beta1.Match{{
+					Vulnerability: v1beta1.Vulnerability{
+						VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2024-0001", Severity: "High"},
+						Fix:                   v1beta1.Fix{State: fixStateFixed, Versions: tt.fixVersions},
+					},
+					Artifact: v1beta1.GrypePackage{Name: "pkg", Version: tt.installed},
+				}},
+			}
+
+			ctx := context.TODO()
+			ctx = context.WithValue(ctx, domain.TimestampKey{}, time.Now().Unix())
+			ctx = context.WithValue(ctx, domain.ScanIDKey{}, uuid.New().String())
+			ctx = context.WithValue(ctx, domain.WorkloadKey{}, domain.ScanCommand{})
+
+			got, err := DomainToArmo(ctx, doc, nil)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+
+			r := got[0]
+			require.Len(t, r.Fixes, 1)
+			assert.Equal(t, tt.wantVersion, r.Fixes[0].Version)
+
+			// The property itself: a record that says it is fixed has to count as fixed.
+			assert.Equal(t, 1, r.IsFixed)
+			assert.Equal(t, 1, containerscan.CalculateFixed(r.Fixes),
+				"IsFixed=%d but CalculateFixed=%d: the record contradicts itself",
+				r.IsFixed, containerscan.CalculateFixed(r.Fixes))
+		})
+	}
+}

--- a/adapters/v1/fixstate.go
+++ b/adapters/v1/fixstate.go
@@ -32,7 +32,16 @@ const (
 // same CVE shows up as ignored in the VulnerabilityManifest but active in the report.
 func hasKnownFix(m v1beta1.Match) (bool, string) {
 	if len(m.Vulnerability.Fix.Versions) != 0 {
-		return true, suggestedVersion(m.Artifact.Version, m.Vulnerability.Fix.Versions)
+		// suggestedVersion returns "" when every listed fix version is at or below the
+		// installed one, so there is nothing to suggest that is not a downgrade (#844).
+		// A fix still exists, so this is the "no concrete version" case rather than the
+		// "no fix" one, and reporting it as "unknown" is what keeps the two meanings
+		// apart: an empty version here would say no fix is known, which is the opposite
+		// of the true this returns alongside it. See #858.
+		if v := suggestedVersion(m.Artifact.Version, m.Vulnerability.Fix.Versions); v != "" {
+			return true, v
+		}
+		return true, unknownFixVersion
 	}
 	if m.Vulnerability.Fix.State == fixStateFixed {
 		return true, unknownFixVersion

--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -15,7 +15,6 @@ import (
 
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
-
 )
 
 // cpeMatchDetail builds a cpe-match detail carrying the given version constraint, the
@@ -65,13 +64,29 @@ func TestHasKnownFix(t *testing.T) {
 			wantVersion: "14.16.0",
 		},
 		{
-			name: "fix versions all older than current do not suggest a downgrade",
+			// #844 established that no downgrade may be suggested here. The version is
+			// "unknown" rather than "" because a fix does exist, and "" is what this
+			// function uses to say one does not: returning it alongside true contradicts
+			// the bool, and downstream leaves the record's own IsFixed=1 disagreeing with
+			// CalculateFixed(Fixes)=0. See #858.
+			name: "fix versions all older than current report unknown, never a downgrade",
 			match: v1beta1.Match{
 				Artifact:      v1beta1.GrypePackage{Version: "16.0.0"},
 				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed, Versions: []string{"10.0.0", "12.0.0"}}},
 			},
 			wantFixed:   true,
-			wantVersion: "",
+			wantVersion: unknownFixVersion,
+		},
+		{
+			// The equal case takes the same path: suggestedVersion compares strictly, so a
+			// package already at the only listed fix version has nothing above it either.
+			name: "fix version equal to current reports unknown",
+			match: v1beta1.Match{
+				Artifact:      v1beta1.GrypePackage{Version: "1.5.0"},
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed, Versions: []string{"1.5.0"}}},
+			},
+			wantFixed:   true,
+			wantVersion: unknownFixVersion,
 		},
 		{
 			name: "fix state fixed without versions",


### PR DESCRIPTION
## Overview

`hasKnownFix` documents that its version is `"unknown"` when a fix exists but no concrete version is available, and **empty when no fix is known**. Since #845 it can return `(true, "")`, which says both at once.

The result is a report record that contradicts itself: `IsFixed: 1`, while its own `Fixes` entry counts as no fix available.

## Additional Information

To be clear about what this is and is not: #845 was right about the underlying problem. `suggestedVersion` used to fall back to `versions[0]` when nothing in the list was above the installed version, which could present a downgrade as the fix. Returning `""` from *that function* is the correct answer, and **its contract is unchanged here** — `Test_suggestedVersion` is untouched and all of its cases still pass.

What changes is what the caller does with that `""`. `hasKnownFix` passed it straight through, while its other two branches already return `unknownFixVersion` for exactly this situation: a fix that exists with no concrete version to name.

**Downstream.** One record carries two independent answers to "is there a fix?", built from the two halves of that return: `IsFixed` from the bool, `Fixes[].Version` from the string. `backend_utils.go` counts fixes from the second, via `containerscan.CalculateFixed`, which ignores an entry whose `Version` is `""` or `"None"`, and feeds `summary.FixAvailableOfTotalCount`.

Measured through `DomainToArmo` end to end, before this change:

```
fix above installed         installed=1.0.0  fixes=[1.5.0 1.2.0] -> IsFixed=1  Version="1.2.0"  CalculateFixed=1
all fixes below installed   installed=2.0.0  fixes=[1.5.0 1.2.0] -> IsFixed=1  Version=""       CalculateFixed=0   <<< DISAGREE
fix equals installed        installed=1.5.0  fixes=[1.5.0]       -> IsFixed=1  Version=""       CalculateFixed=0   <<< DISAGREE
installed not semver        installed=weird  fixes=[1.5.0]       -> IsFixed=1  Version="1.5.0"  CalculateFixed=1
```

The equal case is worth calling out on its own: `suggestedVersion` compares strictly, so a package already sitting on the only listed fix version has nothing above it either and takes the same path.

**Why the fix goes here rather than in the report.** Deriving `IsFixed` from whether the version is non-empty would break what `hasKnownFix` exists to hold. Its doc comment:

> Both the in-cluster manifest path (`ApplySecurityExceptions`) and the backend report path (`DomainToArmo`) must decide "is this fixed?" the same way. When they disagree, an `ExpiredOnFix` exception is honoured on one surface and expired on the other.

Both surfaces feed that same bool into `exceptionIndex.lookup(..., isFixed)`. Changing it on the report side alone reintroduces exactly that divergence. Returning `unknownFixVersion` leaves the bool untouched on both, so `ExpiredOnFix` behaviour is unchanged, keeps #845's rule that no downgrade is ever suggested (`"unknown"` is not a version), and restores agreement.

**One assertion from #845 is revised**, `wantVersion: ""` for the all-older case, now `unknownFixVersion`. Flagging that explicitly rather than burying it, since #845 is recent and that expectation was deliberate. The intent behind it, never suggest a downgrade, is preserved in full.

## How to Test

`go build ./... && go vet ./... && go test ./adapters/v1/ -count=1`

`TestDomainToArmo_IsFixedAgreesWithFixes` covers the four cases above through `DomainToArmo`, asserting on the record rather than on the helper, since the self-contradiction is a property of the record. Reverting `hasKnownFix` to pass the empty string through fails it on both disagreeing cases, and fails `TestHasKnownFix` on the two new expectations:

```
--- FAIL: TestDomainToArmo_IsFixedAgreesWithFixes/every_fix_version_is_older_than_installed
--- FAIL: TestDomainToArmo_IsFixedAgreesWithFixes/the_only_fix_version_equals_installed
--- FAIL: TestHasKnownFix/fix_versions_all_older_than_current_report_unknown,_never_a_downgrade
--- FAIL: TestHasKnownFix/fix_version_equal_to_current_reports_unknown
```

The "installed version is not a version" case is included as a control: it still returns the first entry, which is the documented behaviour for that branch and is not affected either way.

## Related issues/PRs:

* Resolved #858


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fix-status reporting when available fixes are older than or equal to the installed version.
  - Prevented the system from suggesting downgrades.
  - Fixed cases where known fixes were incorrectly reported with missing version information.
- **Tests**
  - Added coverage for upgrade, outdated, matching, and unparseable version scenarios.
  - Verified accurate fixed status and fix counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->