### PR TITLE
fix(repositories): align APIServerStore.GetCVESummary resource name resolution for non-workload scans (#860)

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -856,11 +856,11 @@ func GetCVESummaryK8sResourceNameWithCVEName(ctx context.Context, cveName string
 	contName := strings.ToLower(workload.ContainerName)
 
 	if kind == "" && name == "" {
-		if cveName != "" {
-			return cveName, nil
-		}
 		if workload.ImageSlug != "" {
 			return workload.ImageSlug, nil
+		}
+		if cveName != "" {
+			return cveName, nil
 		}
 		if contName != "" {
 			return contName, nil

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1520,6 +1520,32 @@ func TestAPIServerStore_StoreCVESummary_EmptyWlid(t *testing.T) {
 	assert.NotContains(t, got.Labels, helpersv1.ApiGroupMetadataKey)
 }
 
+func TestAPIServerStore_GetCVESummary_EmptyWlid_RetrievalRoundTrip(t *testing.T) {
+	a := NewFakeAPIServerStorage("kubescape")
+	workload := domain.ScanCommand{
+		ImageTag:           "registry.k8s.io/coredns/coredns:v1.10.1",
+		ImageTagNormalized: "registry.k8s.io/coredns/coredns:v1.10.1",
+		ImageSlug:          "registry-k8s-io-coredns-coredns-v1-10-1",
+		Wlid:               "",
+		ContainerName:      "coredns",
+	}
+	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+	cve := domain.CVEManifest{
+		Name: "different-cve-manifest-name",
+	}
+
+	err := a.StoreCVESummary(ctx, cve, domain.CVEManifest{}, false)
+	require.NoError(t, err)
+
+	// GetCVESummary must resolve the same resource name (ImageSlug) as StoreCVESummary for non-workload scans
+	got, err := a.GetCVESummary(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "registry-k8s-io-coredns-coredns-v1-10-1", got.Name)
+}
+
 func TestAPIServerStore_StoreCVESummaryStub_EmptyWlid(t *testing.T) {
 	a := NewFakeAPIServerStorage("kubescape")
 	workload := domain.ScanCommand{


### PR DESCRIPTION
### Problem
`APIServerStore.GetCVESummary(ctx)` failed to retrieve `VulnerabilityManifestSummary` resources for non-workload image scans (scans without a WLID, e.g. registry or standalone image scans), returning `nil, nil` (`NotFound`) even when `StoreCVESummary` successfully wrote the summary into storage.

### Root Cause
`StoreCVESummary` called `GetCVESummaryK8sResourceNameWithCVEName(ctx, cve.Name)`, which prioritized `cveName` over `workload.ImageSlug` for non-workload scans (`kind == "" && name == ""`), saving the summary under `cve.Name`. In contrast, `GetCVESummary` called `GetCVESummaryK8sResourceName(ctx)` (passing `cveName = ""`), causing it to resolve `workload.ImageSlug` instead. Consequently, `GetCVESummary` queried storage using `workload.ImageSlug` and returned `NotFound` (`nil, nil`).

### Solution
- Updated `GetCVESummaryK8sResourceNameWithCVEName` in `repositories/apiserver.go` to prioritize `workload.ImageSlug` over `cveName` when `kind == "" && name == ""`.
- This ensures `StoreCVESummary`, `StoreCVESummaryStub`, and `GetCVESummary` all resolve the exact same deterministic resource name (`workload.ImageSlug`) for non-workload image scans.

### Testing
- Added unit test `TestAPIServerStore_GetCVESummary_EmptyWlid_RetrievalRoundTrip` in `repositories/apiserver_test.go` covering non-workload `StoreCVESummary` and `GetCVESummary` round-trip retrieval when `cve.Name` differs from `workload.ImageSlug`.
- Ran `go test -v ./repositories/...` (all tests pass).
- Ran `go vet ./...` (clean pass).

Closes #860


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of CVE summaries for scans without workload metadata.
  * Ensured summaries remain accessible when the CVE manifest name differs from the stored image identifier.

* **Tests**
  * Added regression coverage for storing and retrieving CVE summaries in non-workload scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->