### PR TITLE
fix(adapters): match a SecurityException pattern that names Docker Hub non-canonically

### DIFF
--- a/adapters/v1/securityexception_match.go
+++ b/adapters/v1/securityexception_match.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	wlidpkg "github.com/armosec/utils-k8s-go/wlid"
+	"github.com/distribution/reference"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -166,7 +167,7 @@ func expandPatternForms(p string) []string {
 			return patterns
 		}
 		patterns = append(patterns, "docker.io/library/"+p)
-		return patterns
+		return appendNormalizedPattern(patterns, p)
 	}
 
 	firstSeg, _, _ := strings.Cut(p, "/")
@@ -175,7 +176,35 @@ func expandPatternForms(p string) []string {
 		patterns = append(patterns, "docker.io/"+p)
 	}
 
-	return patterns
+	return appendNormalizedPattern(patterns, p)
+}
+
+// appendNormalizedPattern adds p's canonical reference form to patterns, when p is a
+// concrete reference rather than a glob.
+//
+// tools.ReferenceMatchForms normalizes the scanned image but patterns were only ever
+// matched literally, so a pattern naming Docker Hub in any spelling other than the
+// canonical docker.io/library/... one silently matched nothing: "docker.io/nginx:1.25",
+// "index.docker.io/library/nginx:1.25" and "docker.io/nginx" are all valid ways to write
+// the official nginx image, and none of them matched it. The expansions above only cover
+// patterns with no registry at all, which is the opposite case.
+//
+// A pattern containing a wildcard is not a parseable reference, so it fails here and keeps
+// only the literal forms, leaving glob behaviour untouched. Nothing widens either: the
+// canonical form carries the same tag and digest as p and pins the registry p named, so a
+// pattern still only matches the registry it asked for (#834). See #863.
+func appendNormalizedPattern(patterns []string, p string) []string {
+	named, err := reference.ParseNormalizedNamed(p)
+	if err != nil {
+		return patterns
+	}
+	canonical := named.String()
+	for _, existing := range patterns {
+		if existing == canonical {
+			return patterns
+		}
+	}
+	return append(patterns, canonical)
 }
 
 // labelSelectorMatches evaluates a standard Kubernetes label selector against a

--- a/adapters/v1/securityexception_match_test.go
+++ b/adapters/v1/securityexception_match_test.go
@@ -23,6 +23,23 @@ func TestMatchImages(t *testing.T) {
 		want     bool
 	}{
 		{name: "no patterns matches everything", patterns: nil, image: "docker.io/library/nginx:1.25", want: true},
+
+		// #834 pinned a registry-less pattern to Docker Hub. The mirror of that: a pattern
+		// that does name Docker Hub, but not in the canonical docker.io/library/... spelling,
+		// used to match nothing at all, since only the image was normalized and patterns were
+		// compared literally. All four spellings below are valid ways to write official nginx.
+		{name: "docker.io without the library namespace matches", patterns: []string{"docker.io/nginx:1.25"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "index.docker.io matches", patterns: []string{"index.docker.io/library/nginx:1.25"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "docker.io repository without namespace matches any tag", patterns: []string{"docker.io/nginx"}, image: "docker.io/library/nginx:1.25", want: true},
+		{name: "docker.io without namespace matches a short image reference", patterns: []string{"docker.io/nginx:1.25"}, image: "nginx:1.25", want: true},
+		// Normalizing the pattern must not widen it. The tag and digest survive, and the
+		// registry stays the one the pattern named.
+		{name: "normalized pattern still does not match another registry", patterns: []string{"docker.io/nginx:1.25"}, image: "myreg.io/nginx:1.25", want: false},
+		{name: "normalized pattern still does not match a different tag", patterns: []string{"docker.io/nginx:1.24"}, image: "docker.io/library/nginx:1.25", want: false},
+		{name: "normalized pattern keeps its digest pin", patterns: []string{"docker.io/nginx@sha256:" + testDigest}, image: "docker.io/library/nginx:1.25", want: false},
+		// A glob is not a parseable reference, so it keeps only its literal forms.
+		{name: "registry wildcard still matches any registry", patterns: []string{"*/nginx:1.25"}, image: "myreg.io/nginx:1.25", want: true},
+		{name: "repository wildcard still works", patterns: []string{"myreg.io/*:1.25"}, image: "myreg.io/nginx:1.25", want: true},
 		{name: "non-empty patterns never match empty image", patterns: []string{"docker.io/library/nginx:*"}, image: "", want: false},
 		{name: "tag wildcard matches", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx:1.25", want: true},
 		{name: "tag wildcard matches digest suffix", patterns: []string{"docker.io/library/nginx:*"}, image: "docker.io/library/nginx:latest@sha256:" + testDigest, want: true},


### PR DESCRIPTION
## Overview

`matchImages` normalizes the scanned image via `tools.ReferenceMatchForms`, but compares patterns literally. `expandPatternForms` covers patterns with no registry at all, so a pattern that *does* name Docker Hub, just not in the canonical `docker.io/library/...` spelling, matched nothing.

Measured against `image = "nginx:1.25"` on current main:

```
pattern="nginx:1.25"                           -> true
pattern="docker.io/library/nginx:1.25"         -> true
pattern="library/nginx:1.25"                   -> true
pattern="docker.io/nginx:1.25"                 -> false
pattern="index.docker.io/library/nginx:1.25"   -> false
pattern="docker.io/nginx"                      -> false
```

All six are valid ways to write the official nginx image, and `reference.ParseNormalizedNamed` resolves every one to `docker.io/library/nginx`. The image side already treats them as the same thing; only the pattern side did not.

## Additional Information

This is the mirror of #834. That one was a registry-less pattern matching *too much*, every registry rather than Docker Hub, and #835 closed it by pinning the fallback. This is the opposite failure: a pattern that names Docker Hub explicitly matches nothing.

Worth being clear about the direction, since it changes how urgent this is. The failure here is a `SecurityException` that silently does **not** suppress: the user sees a finding they thought they had excepted. That is noise, not a security hole, and the dangerous direction is the one #835 already closed. It is still a silent wrong answer to a rule someone wrote deliberately.

Patterns now also carry their canonical reference form, via a small `appendNormalizedPattern` helper alongside the existing expansions.

**Globs are untouched.** A pattern containing a wildcard is not a parseable reference, so `ParseNormalizedNamed` fails and the pattern keeps only its literal forms. `*/nginx:1.25` and `myreg.io/*:1.25` behave exactly as before.

**Nothing widens.** `named.String()` preserves the tag and the digest and pins the registry the pattern named. Three assertions cover that specifically:

- `docker.io/nginx:1.25` still does not match `myreg.io/nginx:1.25`
- `docker.io/nginx:1.24` still does not match tag `1.25`
- a digest-pinned pattern stays pinned to that digest

## How to Test

`go build ./... && go vet ./... && go test ./adapters/v1/ -count=1`

Nine cases added to `TestMatchImages`: four for the spellings that used to match nothing, three for the widening the normalization must not cause, and two confirming glob behaviour is unchanged.

Dropping the `appendNormalizedPattern` calls fails exactly the four positive cases and nothing else, which is what says the tests pin this change rather than the surrounding behaviour:

```
--- FAIL: TestMatchImages/docker.io_without_the_library_namespace_matches
--- FAIL: TestMatchImages/index.docker.io_matches
--- FAIL: TestMatchImages/docker.io_repository_without_namespace_matches_any_tag
--- FAIL: TestMatchImages/docker.io_without_namespace_matches_a_short_image_reference
```

The existing `TestMatchImages` cases, including the short-pattern ones #835 added, all pass unchanged.

## Related issues/PRs:

* Resolved #863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image matching by recognizing equivalent Docker Hub references, including omitted namespaces and registry prefixes.
  * Preserved strict matching for registries, tags, and digests to prevent unintended matches.
  * Maintained existing wildcard behavior while supporting normalized image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->