### PR TITLE
chore: clear the standing lint findings so make lint-all exits clean

### DIFF
--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // linearExceptionLookup is the straightforward scan the index replaced, kept here so the
@@ -146,7 +146,7 @@ func TestGetCVEExceptionMatchCVENameFromList(t *testing.T) {
 					VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
 						{Name: "CVE-2021-1234"},
 					},
-					ExpiredOnFix: pointer.Bool(true),
+					ExpiredOnFix: ptr.To(true),
 				},
 				{
 					VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{
@@ -159,7 +159,7 @@ func TestGetCVEExceptionMatchCVENameFromList(t *testing.T) {
 						{Name: "CVE-2021-1234"},
 						{Name: "CVE-2021-9012"},
 					},
-					ExpiredOnFix: pointer.Bool(true),
+					ExpiredOnFix: ptr.To(true),
 				},
 			},
 			CVEName: "CVE-2021-1234",
@@ -531,7 +531,7 @@ func Test_summarize(t *testing.T) {
 						IsLastScan:        1,
 						Layers:            []containerscan.ESLayer{{LayerHash: dummyLayer}},
 						Vulnerability: containerscan.Vulnerability{
-							IsRelevant: pointer.Bool(false),
+							IsRelevant: ptr.To(false),
 							ImageID:    imageHash,
 							ImageTag:   imageTag,
 							Severity:   "Negligible",
@@ -548,7 +548,7 @@ func Test_summarize(t *testing.T) {
 						IsLastScan:        1,
 						Layers:            []containerscan.ESLayer{{LayerHash: dummyLayer}},
 						Vulnerability: containerscan.Vulnerability{
-							IsRelevant: pointer.Bool(false),
+							IsRelevant: ptr.To(false),
 							ImageID:    imageHash,
 							ImageTag:   imageTag,
 							Severity:   "Medium",
@@ -566,7 +566,7 @@ func Test_summarize(t *testing.T) {
 						IsLastScan:        1,
 						Layers:            []containerscan.ESLayer{{LayerHash: dummyLayer}},
 						Vulnerability: containerscan.Vulnerability{
-							IsRelevant:  pointer.Bool(false),
+							IsRelevant:  ptr.To(false),
 							ImageID:     imageHash,
 							ImageTag:    imageTag,
 							Description: "code execution",
@@ -585,7 +585,7 @@ func Test_summarize(t *testing.T) {
 						IsLastScan:        1,
 						Layers:            []containerscan.ESLayer{{LayerHash: dummyLayer}},
 						Vulnerability: containerscan.Vulnerability{
-							IsRelevant:  pointer.Bool(true),
+							IsRelevant:  ptr.To(true),
 							ImageID:     imageHash,
 							ImageTag:    imageTag,
 							Description: "command injection",

--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -171,7 +171,7 @@ func DomainToArmo(ctx context.Context, grypeDocument v1beta1.GrypeDocument, vuln
 			vulnerabilityResult.Categories.IsRCE = vulnerabilityResult.IsRCE()
 			// add layer information
 			// make sure we have at least one location
-			if m.Artifact.Locations == nil || len(m.Artifact.Locations) < 1 {
+			if len(m.Artifact.Locations) == 0 {
 				m.Artifact.Locations = []v1beta1.SyftCoordinates{
 					{
 						FileSystemID: dummyLayer,

--- a/pkg/sbomscanner/v1/integration_test.go
+++ b/pkg/sbomscanner/v1/integration_test.go
@@ -28,7 +28,11 @@ func startIntegrationServer(t *testing.T) (SBOMScannerClient, *grpc.Server, stri
 		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
 	)
 	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
-	go srv.Serve(lis)
+	go func() {
+		// Serve returns ErrServerStopped on the graceful Stop below; nothing else to do
+		// with it here, but ignoring it silently is what errcheck flags.
+		_ = srv.Serve(lis)
+	}()
 
 	conn, err := grpc.NewClient("unix:"+sock,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -76,7 +76,11 @@ func startTestServer(t *testing.T) (pb.SBOMScannerClient, func()) {
 		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
 	)
 	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
-	go srv.Serve(lis)
+	go func() {
+		// Serve returns ErrServerStopped on the graceful Stop below; nothing else to do
+		// with it here, but ignoring it silently is what errcheck flags.
+		_ = srv.Serve(lis)
+	}()
 
 	conn, err := grpc.NewClient("unix:"+sock,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -461,7 +465,7 @@ func TestCreateSBOM_ImageTooLarge_LocalRegistry(t *testing.T) {
 		}
 		if r.URL.Path == "/v2/test-image/manifests/latest" {
 			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
-			w.Write([]byte(fmt.Sprintf(`{
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
 				"schemaVersion": 2,
 				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
 				"config": {
@@ -480,11 +484,11 @@ func TestCreateSBOM_ImageTooLarge_LocalRegistry(t *testing.T) {
 			return
 		}
 		if r.URL.Path == fmt.Sprintf("/v2/test-image/blobs/sha256:%s", configHash) {
-			w.Write(configBytes)
+			_, _ = w.Write(configBytes)
 			return
 		}
 		if r.URL.Path == fmt.Sprintf("/v2/test-image/blobs/sha256:%s", layerHash) {
-			w.Write(layerBytes)
+			_, _ = w.Write(layerBytes)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -595,7 +599,7 @@ func TestCreateSBOM_PlatformMismatch_LocalRegistry(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case r.URL.Path == "/v2/test-image/manifests/latest":
 			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
-			w.Write([]byte(fmt.Sprintf(`{
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
 				"schemaVersion": 2,
 				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
 				"config": {
@@ -612,9 +616,9 @@ func TestCreateSBOM_PlatformMismatch_LocalRegistry(t *testing.T) {
 				]
 			}`, len(configBytes), configHash, len(layerBytes), layerHash)))
 		case r.URL.Path == fmt.Sprintf("/v2/test-image/blobs/sha256:%s", configHash):
-			w.Write(configBytes)
+			_, _ = w.Write(configBytes)
 		case r.URL.Path == fmt.Sprintf("/v2/test-image/blobs/sha256:%s", layerHash):
-			w.Write(layerBytes)
+			_, _ = w.Write(layerBytes)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}


### PR DESCRIPTION
## Overview

CI lints only what a PR changed, via `--new-from-rev`. That was the right call for #566/#567, and this is its known cost: nothing ever runs the full tree, so anything predating the diff stays invisible. `lint-all` exists in the Makefile for exactly this and no workflow runs it.

Running it with the version CI pins, `golangci-lint@v1.64.8`, turned up ten sites. This clears them, so `make lint-all` exits 0.

## Additional Information

The command reports seven, not ten. `max-same-issues` defaults to 3, so the repeated `w.Write` message is truncated at three of six.

| linter | sites | where |
| --- | --- | --- |
| gosimple (S1009) | 1 | `adapters/v1/domain_to_armo.go` |
| staticcheck (SA1019) | 1 | `adapters/v1/backend_utils_test.go` |
| errcheck (`srv.Serve`) | 2 | `pkg/sbomscanner/v1/{server,integration}_test.go` |
| errcheck (`w.Write`) | 6 | `pkg/sbomscanner/v1/server_test.go` |

One is production code:

```go
if m.Artifact.Locations == nil || len(m.Artifact.Locations) < 1 {
```

`len()` on a nil slice is defined as zero, so the nil half is redundant. Behaviour is identical either way.

The rest are test-only, and none of them was hiding a failure, which is worth being explicit about rather than just silencing them:

- `srv.Serve` returns `ErrServerStopped` on the graceful `Stop` those tests already perform, so there is nothing to handle. Discarded explicitly, with the reason written down.
- The `w.Write` calls are `httptest` handlers writing fixture bytes to a recorder.

They are still worth clearing, because standing findings are what stops `lint-all` being usable as a signal at all: with seven in the output, nobody can tell a new one from the existing noise.

`k8s.io/utils/pointer` is deprecated in favour of `k8s.io/utils/ptr`, already an indirect dependency, so `pointer.Bool(x)` becomes `ptr.To(x)`.

Deliberately **not** included: a workflow that enforces the full tree. Whether that should be a scheduled job, a non-blocking one, or nothing at all is a maintainer call, and bundling it here would mix a cleanup with a policy change. This just makes that decision available.

## How to Test

`make lint-all` (or `golangci-lint run --timeout=15m`) now exits 0 with no output. Before this it printed the seven findings above.

`go build ./... && go vet ./... && go test ./adapters/v1/ ./pkg/sbomscanner/v1/ -count=1`

The only production change is the redundant nil check, which is covered by the existing `domain_to_armo` tests: the branch it guards still fires for an empty `Locations` slice, which is the case that matters, since that is what makes the dummy-layer fallback run.

Reopens the work from #851, which was closed before review. Rebased onto current `main` and re-verified there: `golangci-lint` still reports the same 7 findings on `main` at `aa98d6d`, and exits clean on this branch.

## Related issues/PRs:

* Resolved #850
* Supersedes #851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of vulnerability matches with empty artifact-location data.

* **Chores**
  * Updated internal test utilities to use the current pointer API.
  * Improved test server and mock response error handling to satisfy linting requirements.

* **Tests**
  * Maintained existing test coverage and behavior while improving integration test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->