### PR TITLE
fix(adapters,repositories): recover actionStatement/response for affected SecurityExceptions

### DIFF
--- a/adapters/v1/securityexception.go
+++ b/adapters/v1/securityexception.go
@@ -387,7 +387,8 @@ func buildIgnoreRules(m v1beta1.Match, matched []armotypes.VulnerabilityExceptio
 		if ns, ok := p.Attributes["sourceNamespace"].(string); ok {
 			rule.SourceNamespace = ns
 		}
-		if status, ok := p.Attributes["status"].(string); ok {
+		status, _ := p.Attributes["status"].(string)
+		if status != "" {
 			// FixState is repurposed here to carry the SecurityException's status vocabulary
 			// (not_affected/fixed/affected) rather than Grype's native fix-state vocabulary.
 			// This is safe because every reader of FixState gates on SourceKind being a
@@ -395,11 +396,30 @@ func buildIgnoreRules(m v1beta1.Match, matched []armotypes.VulnerabilityExceptio
 			// never set SourceKind, so they're unaffected.
 			rule.FixState = status
 		}
-		if just, ok := p.Attributes["justification"].(string); ok {
-			rule.Justification = just
-		}
-		if impact, ok := p.Attributes["impactStatement"].(string); ok {
-			rule.ImpactStatement = impact
+		if status == string(sev1beta1.VulnerabilityStatusAffected) {
+			// An affected entry populates actionStatement/response, not justification/
+			// impactStatement (those are the not_affected fields; shouldSuppress requires
+			// actionStatement, never justification, for an affected entry to suppress at
+			// all). IgnoreRule has no dedicated fields for either, so — mirroring the
+			// FixState repurposing above, and gated the same way on FixState=="affected"
+			// plus a SecurityException/ClusterSecurityException SourceKind — ImpactStatement
+			// carries the action statement and Justification carries the comma-joined
+			// response values. ignoredMatchAssessment (repositories/apiserver.go) is the
+			// paired reader; without this, every affected suppression exported the exact
+			// same generic action statement regardless of what its author wrote (#866).
+			if action, ok := p.Attributes["actionStatement"].(string); ok {
+				rule.ImpactStatement = action
+			}
+			if responses, ok := p.Attributes["response"].([]string); ok && len(responses) > 0 {
+				rule.Justification = strings.Join(responses, ",")
+			}
+		} else {
+			if just, ok := p.Attributes["justification"].(string); ok {
+				rule.Justification = just
+			}
+			if impact, ok := p.Attributes["impactStatement"].(string); ok {
+				rule.ImpactStatement = impact
+			}
 		}
 		rules = append(rules, rule)
 	}
@@ -421,9 +441,10 @@ func suppressingPolicies(matched []armotypes.VulnerabilityExceptionPolicy) []arm
 }
 
 // logSuppression records why a CVE disappeared from scan results: which exception object
-// matched, its scope, and the stated reason/justification. This is logged rather than stored on
-// the manifest because the filtered manifest's IgnoreRule (github.com/kubescape/storage) has no
-// fields for this provenance; see buildSuppressionAttributes for where it is captured.
+// matched, its scope, and the stated reason/justification. Some of this (sourceKind, ruleId,
+// justification/impactStatement, actionStatement/response) is also durably written onto the
+// manifest's IgnoreRule by buildIgnoreRules, directly or repurposing a field with no dedicated
+// slot; normalizedTarget and the reason string are not, and live only here.
 //
 // When recorder is non-nil, the same suppression is also recorded as a K8s Event on the
 // SecurityException/ClusterSecurityException object that caused it, so it shows up in
@@ -454,6 +475,12 @@ func logSuppression(m v1beta1.Match, matched []armotypes.VulnerabilityExceptionP
 		}
 		if impact, ok := p.Attributes["impactStatement"].(string); ok && impact != "" {
 			fields = append(fields, helpers.String("impactStatement", impact))
+		}
+		if action, ok := p.Attributes["actionStatement"].(string); ok && action != "" {
+			fields = append(fields, helpers.String("actionStatement", action))
+		}
+		if responses, ok := p.Attributes["response"].([]string); ok && len(responses) > 0 {
+			fields = append(fields, helpers.String("response", strings.Join(responses, ",")))
 		}
 		if target, ok := p.Attributes["normalizedTarget"].(string); ok && target != "" {
 			fields = append(fields, helpers.String("normalizedTarget", target))

--- a/adapters/v1/securityexception_test.go
+++ b/adapters/v1/securityexception_test.go
@@ -336,6 +336,142 @@ func TestApplySecurityExceptions_PopulatesIgnoreRuleProvenance(t *testing.T) {
 	assert.Equal(t, "Vulnerable component is not loaded into the memory", rule.ImpactStatement)
 }
 
+// TestApplySecurityExceptions_PopulatesAffectedProvenance is the affected-status counterpart to
+// TestApplySecurityExceptions_PopulatesIgnoreRuleProvenance: an affected entry's actionStatement
+// and response never populate Justification/ImpactStatement directly, so without repurposing
+// those fields the way buildIgnoreRules does here, the real text an author wrote never reaches
+// the persisted IgnoreRule at all, and every affected suppression is indistinguishable on the
+// stored manifest (#866).
+func TestApplySecurityExceptions_PopulatesAffectedProvenance(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}},
+		},
+	}
+	exceptions := domain.CVEExceptions{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "risk-accepted-log4j",
+				Attributes: map[string]interface{}{
+					"sourceKind":      "SecurityException",
+					"ruleId":          "SecurityException/production/risk-accepted-log4j",
+					"sourceNamespace": "production",
+					"status":          "affected",
+					"actionStatement": "WAF mitigation in place, ticket SEC-1234",
+					"response":        []string{"will_not_fix"},
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-44228"}},
+		},
+	}
+
+	ApplySecurityExceptions(doc, exceptions, nil)
+
+	require.Len(t, doc.IgnoredMatches, 1)
+	require.Len(t, doc.IgnoredMatches[0].AppliedIgnoreRules, 1)
+	rule := doc.IgnoredMatches[0].AppliedIgnoreRules[0]
+
+	assert.Equal(t, "affected", rule.FixState)
+	assert.Equal(t, "WAF mitigation in place, ticket SEC-1234", rule.ImpactStatement,
+		"actionStatement must be recoverable from the persisted IgnoreRule, not only from the transient policy Attributes")
+	assert.Equal(t, "will_not_fix", rule.Justification,
+		"response must be recoverable from the persisted IgnoreRule, not only from the transient policy Attributes")
+}
+
+// TestApplySecurityExceptions_AffectedAndNotAffectedProvenanceAreDistinguishable is a direct
+// regression test for #866's reported symptom: two affected entries with different
+// author-written actionStatement/response must not collapse into indistinguishable provenance
+// on the stored manifest.
+func TestApplySecurityExceptions_AffectedAndNotAffectedProvenanceAreDistinguishable(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-A"}}},
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-B"}}},
+		},
+	}
+	exceptions := domain.CVEExceptions{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "policy-a",
+				Attributes: map[string]interface{}{
+					"sourceKind":      "SecurityException",
+					"status":          "affected",
+					"actionStatement": "vendor patch validated in staging, deploying next window",
+					"response":        []string{"update"},
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-A"}},
+		},
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "policy-b",
+				Attributes: map[string]interface{}{
+					"sourceKind":      "SecurityException",
+					"status":          "affected",
+					"actionStatement": "compensating control: network policy blocks the affected port",
+					"response":        []string{"can_not_fix"},
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-B"}},
+		},
+	}
+
+	ApplySecurityExceptions(doc, exceptions, nil)
+
+	require.Len(t, doc.IgnoredMatches, 2)
+	rules := map[string]v1beta1.IgnoreRule{}
+	for _, im := range doc.IgnoredMatches {
+		rules[im.Vulnerability.ID] = im.AppliedIgnoreRules[0]
+	}
+
+	require.Contains(t, rules, "CVE-A")
+	require.Contains(t, rules, "CVE-B")
+	assert.NotEqual(t, rules["CVE-A"].ImpactStatement, rules["CVE-B"].ImpactStatement,
+		"distinct actionStatements must not collapse into the same persisted provenance")
+	assert.Equal(t, "vendor patch validated in staging, deploying next window", rules["CVE-A"].ImpactStatement)
+	assert.Equal(t, "compensating control: network policy blocks the affected port", rules["CVE-B"].ImpactStatement)
+}
+
+// TestApplySecurityExceptions_NotAffectedUnaffectedByAffectedRepurposing pins that a
+// not_affected/fixed entry's Justification/ImpactStatement keep their ordinary meaning: the
+// repurposing buildIgnoreRules applies to affected entries must not leak into any other status.
+func TestApplySecurityExceptions_NotAffectedUnaffectedByAffectedRepurposing(t *testing.T) {
+	doc := &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{
+			{Vulnerability: v1beta1.Vulnerability{VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"}}},
+		},
+	}
+	exceptions := domain.CVEExceptions{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "not-affected-policy",
+				Attributes: map[string]interface{}{
+					"sourceKind":      "SecurityException",
+					"status":          "not_affected",
+					"justification":   "vulnerable_code_not_present",
+					"impactStatement": "Vulnerable component is not loaded into the memory",
+				},
+			},
+			PolicyType:            "vulnerabilityExceptionPolicy",
+			Actions:               []armotypes.VulnerabilityExceptionPolicyActions{armotypes.Ignore},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: "CVE-2021-44228"}},
+		},
+	}
+
+	ApplySecurityExceptions(doc, exceptions, nil)
+
+	require.Len(t, doc.IgnoredMatches, 1)
+	rule := doc.IgnoredMatches[0].AppliedIgnoreRules[0]
+	assert.Equal(t, "vulnerable_code_not_present", rule.Justification)
+	assert.Equal(t, "Vulnerable component is not loaded into the memory", rule.ImpactStatement)
+}
+
 // TestApplySecurityExceptions_MatchedCountDedupesPerFinding is a regression test: two
 // SecurityException policies suppressing the same finding (by ID and by alias, say) must
 // count as one match for that sourceKind, not two, since exactly one finding was removed.

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1224,8 +1224,8 @@ func ignoredMatchAssessment(m v1beta1.IgnoredMatch) ignoredVEXAssessment {
 		assessment.status = v1beta1.Status(vex.StatusAffected)
 		assessment.justification = ""
 		assessment.impactStatement = ""
-		assessment.actionStatement = securityExceptionAcceptedRiskAction
-		assessment.statusNotes = ignoredMatchStatusNotes(rule)
+		assessment.actionStatement = affectedActionStatement(rule)
+		assessment.statusNotes = affectedStatusNotes(rule)
 	default:
 		// Any unrecognized status (including "" and NotAffected) falls back to the safe
 		// not_affected-shaped assessment.
@@ -1274,6 +1274,30 @@ func ignoredMatchStatusNotes(rule v1beta1.IgnoreRule) string {
 		parts = append(parts, "impact: "+impact)
 	}
 	return strings.Join(parts, "; ")
+}
+
+// affectedActionStatement returns the actionStatement text a SecurityException author wrote
+// for an affected (risk-accepted) entry. adapters/v1.buildIgnoreRules repurposes
+// rule.ImpactStatement to carry it for a FixState=="affected" rule, since IgnoreRule has no
+// dedicated field and ImpactStatement is otherwise unused there (it's the not_affected field).
+// Falls back to the generic constant only for a rule with nothing in that field, which today
+// means a manifest cached from before this repurposing existed.
+func affectedActionStatement(rule v1beta1.IgnoreRule) string {
+	if action := strings.TrimSpace(rule.ImpactStatement); action != "" {
+		return action
+	}
+	return securityExceptionAcceptedRiskAction
+}
+
+// affectedStatusNotes renders the response[] a SecurityException author stated for an
+// affected entry. adapters/v1.buildIgnoreRules repurposes rule.Justification to carry the
+// comma-joined response values, for the same reason affectedActionStatement repurposes
+// ImpactStatement. Empty when the rule carries none, same as ignoredMatchStatusNotes.
+func affectedStatusNotes(rule v1beta1.IgnoreRule) string {
+	if response := strings.TrimSpace(rule.Justification); response != "" {
+		return "response: " + response
+	}
+	return ""
 }
 
 // newLocalStatement builds the VEX statement kubevuln writes for a match, in the baseline

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -754,8 +754,11 @@ func TestAPIServerStore_storeVEX_preservesSecurityExceptionSemantics(t *testing.
 				SourceName:      "SecurityException/default/affected",
 				SourceNamespace: "default",
 				FixState:        string(sev1beta1.VulnerabilityStatusAffected),
-				Justification:   "accepted risk",
-				ImpactStatement: "compensating controls limit exposure",
+				// For an affected entry, buildIgnoreRules repurposes Justification/ImpactStatement
+				// to carry response/actionStatement instead of their usual not_affected meaning
+				// (see adapters/v1/securityexception.go's buildIgnoreRules).
+				Justification:   "will_not_fix",
+				ImpactStatement: "Compensating controls limit exposure, reviewed by security lead",
 			}},
 		},
 	}
@@ -817,8 +820,68 @@ func TestAPIServerStore_storeVEX_preservesSecurityExceptionSemantics(t *testing.
 	assert.Equal(t, v1beta1.Status(vex.StatusAffected), got["CVE-AFFECTED"].Status)
 	assert.Empty(t, got["CVE-AFFECTED"].Justification)
 	assert.Empty(t, got["CVE-AFFECTED"].ImpactStatement)
-	assert.Equal(t, securityExceptionAcceptedRiskAction, got["CVE-AFFECTED"].ActionStatement)
-	assert.Equal(t, "justification: accepted risk; impact: compensating controls limit exposure", got["CVE-AFFECTED"].StatusNotes)
+	assert.Equal(t, "Compensating controls limit exposure, reviewed by security lead", got["CVE-AFFECTED"].ActionStatement,
+		"the author's own actionStatement must surface, not the generic securityExceptionAcceptedRiskAction fallback (#866)")
+	assert.Equal(t, "response: will_not_fix", got["CVE-AFFECTED"].StatusNotes)
+}
+
+// TestAPIServerStore_storeVEX_affectedFallsBackWithoutRepurposedProvenance guards the fallback
+// path in affectedActionStatement/affectedStatusNotes: a rule with FixState=="affected" but no
+// repurposed ImpactStatement/Justification (e.g. a manifest cached from before #866's fix, or a
+// rule some other future writer produces without populating them) must still get the generic,
+// always-valid action statement instead of an empty one.
+func TestAPIServerStore_storeVEX_affectedFallsBackWithoutRepurposedProvenance(t *testing.T) {
+	ignoredMatches := []v1beta1.IgnoredMatch{
+		{
+			Match: v1beta1.Match{
+				Vulnerability: v1beta1.Vulnerability{
+					VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-AFFECTED-LEGACY", DataSource: "https://example.test/CVE-AFFECTED-LEGACY"},
+				},
+				Artifact: v1beta1.GrypePackage{PURL: "pkg:deb/debian/affected-legacy@1.0"},
+			},
+			AppliedIgnoreRules: []v1beta1.IgnoreRule{{
+				Vulnerability:   "CVE-AFFECTED-LEGACY",
+				SourceKind:      "SecurityException",
+				SourceName:      "SecurityException/default/affected-legacy",
+				SourceNamespace: "default",
+				FixState:        string(sev1beta1.VulnerabilityStatusAffected),
+			}},
+		},
+	}
+
+	cveManifest := domain.CVEManifest{
+		Name: "legacy-affected-manifest",
+		Annotations: map[string]string{
+			helpersv1.ImageIDMetadataKey: "registry.k8s.io/coredns/coredns:v1.10.1",
+		},
+		Content: &v1beta1.GrypeDocument{IgnoredMatches: ignoredMatches},
+	}
+	cveManifestFiltered := cveManifest
+	cveManifestFiltered.Content = &v1beta1.GrypeDocument{
+		IgnoredMatches: append([]v1beta1.IgnoredMatch(nil), ignoredMatches...),
+	}
+
+	a := NewFakeAPIServerStorage("kubescape")
+	ctx := context.TODO()
+	workload := domain.ScanCommand{
+		ImageHash:     "sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228",
+		InstanceID:    "apiVersion-apps/v1/namespace-kubescape/kind-ReplicaSet/name-kubevuln-65bfbfdcdd/containerName-kubevuln",
+		Wlid:          "wlid://cluster-aaa/namespace-anyNamespaceJob/job-anyJob",
+		ImageTag:      "registry.k8s.io/coredns/coredns:v1.10.1",
+		ContainerName: "anyJobContName",
+	}
+	ctx = context.WithValue(ctx, domain.WorkloadKey{}, workload)
+
+	require.NoError(t, a.StoreVEX(ctx, cveManifest, cveManifestFiltered, false))
+
+	vexContainer, err := a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(context.Background(), cveManifest.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	require.Len(t, vexContainer.Spec.Statements, 1)
+	stmt := vexContainer.Spec.Statements[0]
+	assert.Equal(t, v1beta1.Status(vex.StatusAffected), stmt.Status)
+	assert.Equal(t, securityExceptionAcceptedRiskAction, stmt.ActionStatement)
+	assert.Empty(t, stmt.StatusNotes)
 }
 
 // TestAPIServerStore_storeVEX_updateRestoresNotAffected guards against a regression where


### PR DESCRIPTION
## Problem

A `SecurityException`/`ClusterSecurityException` entry with `status: affected` can carry an author-written `actionStatement` and a typed `response[]` (e.g. `will_not_fix`) — the fields RFC #453 added specifically so a risk-accepted finding could survive audit scrutiny instead of being expressed through a stretched `not_affected` claim.

They never survived past the in-memory suppression decision. Every `affected` suppression — regardless of what its author actually wrote — was logged, stored, and exported identically, with the real justification discarded at the first hop.

## Root Cause

`buildSuppressionAttributes` (`adapters/v1/securityexception.go`) captures `actionStatement`/`response` into the transient `policy.Attributes` map, but:

- `buildIgnoreRules` — which persists provenance onto the manifest's `IgnoreRule` — only copied `sourceKind`, `ruleId`, `sourceNamespace`, `status` (into `FixState`), `justification`, and `impactStatement`. `actionStatement`/`response` were dropped.
- `logSuppression` had the identical gap.
- Downstream, `ignoredMatchAssessment` (`repositories/apiserver.go`), which builds the actual exported OpenVEX statement, had nothing to read back from the persisted `IgnoreRule` and fell back to a single hardcoded `action_statement` (`securityExceptionAcceptedRiskAction`) for **every** affected suppression on the cluster.

`IgnoreRule` (`github.com/kubescape/storage`) has no dedicated fields for `actionStatement`/`response`, and adding them is a cross-repo schema change.

## Solution

`buildIgnoreRules` now repurposes `Justification`/`ImpactStatement` for a `FixState=="affected"` rule, the same way `FixState` itself is already repurposed to carry the SecurityException status vocabulary instead of Grype's native one (see the existing comment on that repurposing). This is safe: those two fields are otherwise unused on an `affected` entry — they're the `not_affected` fields, and `shouldSuppress` requires `actionStatement`, never `justification`, for an `affected` entry to suppress at all. `ImpactStatement` carries the action statement text; `Justification` carries the comma-joined `response` values.

`ignoredMatchAssessment` reads the real text back through two small helpers, `affectedActionStatement`/`affectedStatusNotes`, falling back to the generic constant only when the field is genuinely empty (e.g. a manifest cached before this fix).

`logSuppression` gets `actionStatement`/`response` added directly to its log fields, alongside the existing `justification`/`impactStatement` logging.

No API, schema, or CRD change. The fix is entirely internal to how `adapters/v1` and `repositories` already move data between each other.

## Testing

- `adapters/v1`: extended `TestApplySecurityExceptions_PopulatesIgnoreRuleProvenance`'s sibling coverage with three new tests — the repurposed fields land on the persisted `IgnoreRule`, two distinct `affected` entries produce distinct (not collapsed) provenance, and a `not_affected`/`fixed` entry's `Justification`/`ImpactStatement` are unaffected by the new repurposing branch.
- `repositories`: updated `TestAPIServerStore_storeVEX_preservesSecurityExceptionSemantics`'s `CVE-AFFECTED` fixture/assertions to the new contract (previously asserted the *old*, buggy behavior — the generic constant and a mislabeled `justification: ...; impact: ...` note built from ad hoc rule text), and added `TestAPIServerStore_storeVEX_affectedFallsBackWithoutRepurposedProvenance` for the fallback path.
- Ran the full `adapters/v1` and `repositories` test suites (`go test ./adapters/v1/... ./repositories/...`) — all pass, including the log output, which now visibly carries `actionStatement`/`response` for an affected suppression.
- `go build` and `go vet` on both packages: clean.
- Confirmed via `grep` that `buildIgnoreRules`, `logSuppression`, `ignoredMatchAssessment`, `ignoredMatchStatusNotes`, and the two new helpers are unexported and have no callers outside these two files/packages, so the change is contained.
- I was not able to complete a full repo-wide `go build ./...` / `go vet ./...` in my local environment (disk space and I/O constraints stalled linking the `cmd/*` binaries, which pull in the full grype/syft dependency tree) — the two touched packages are the only ones affected and are fully verified above.

## Impact

- Audit/compliance: the actual risk-acceptance rationale (why a real, present vulnerability was suppressed) now reaches the exported OpenVEX document, the persisted `VulnerabilityManifest`, and the logs — not a generic placeholder shared by every `affected` exception on the cluster.
- No behavior change for `not_affected`/`fixed` suppressions, or for any manifest already cached before this fix (falls back to the previous generic text).

Fixes #866.
