### PR TITLE
docs: correct SecurityException CRD apiVersion to v1beta1

### DIFF
--- a/docs/security-exception-design.md
+++ b/docs/security-exception-design.md
@@ -11,7 +11,7 @@ Kubescape currently has **no in-cluster, declarative exception mechanism**. All 
 
 ## Solution
 
-Introduce a **SecurityException CRD** (`kubescape.io/v1`) that teams deploy via GitOps alongside their applications. It covers both vulnerability exceptions (OpenVEX-compatible) and posture/compliance exceptions in a single resource.
+Introduce a **SecurityException CRD** (`kubescape.io/v1beta1`) that teams deploy via GitOps alongside their applications. It covers both vulnerability exceptions (OpenVEX-compatible) and posture/compliance exceptions in a single resource.
 
 ## CRD Specification
 
@@ -20,7 +20,7 @@ Introduce a **SecurityException CRD** (`kubescape.io/v1`) that teams deploy via 
 | Field | Value |
 |-------|-------|
 | Group | `kubescape.io` |
-| Version | `v1` |
+| Version | `v1beta1` |
 | Kinds | `SecurityException` (namespaced), `ClusterSecurityException` (cluster-scoped) |
 | Short names | `se`, `cse` |
 
@@ -98,7 +98,7 @@ Guidance:
 #### Namespaced — target specific workloads by label and name
 
 ```yaml
-apiVersion: kubescape.io/v1
+apiVersion: kubescape.io/v1beta1
 kind: SecurityException
 metadata:
   name: nginx-exceptions
@@ -143,7 +143,7 @@ spec:
 #### Namespaced: risk-accepted finding (`affected`)
 
 ```yaml
-apiVersion: kubescape.io/v1
+apiVersion: kubescape.io/v1beta1
 kind: SecurityException
 metadata:
   name: risk-accepted-log4j
@@ -163,7 +163,7 @@ spec:
 #### Namespaced — apply to all workloads in namespace (no match selector)
 
 ```yaml
-apiVersion: kubescape.io/v1
+apiVersion: kubescape.io/v1beta1
 kind: SecurityException
 metadata:
   name: namespace-wide-log4j
@@ -181,7 +181,7 @@ spec:
 #### Cluster-scoped — target namespaces by label
 
 ```yaml
-apiVersion: kubescape.io/v1
+apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: staging-relaxed-posture
@@ -204,7 +204,7 @@ spec:
 #### Cluster-scoped — target by image pattern
 
 ```yaml
-apiVersion: kubescape.io/v1
+apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: nginx-http2-exception
@@ -227,7 +227,7 @@ spec:
 #### Cluster-scoped — target specific workloads across namespaces
 
 ```yaml
-apiVersion: kubescape.io/v1
+apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: infra-daemonset-exceptions


### PR DESCRIPTION
## Summary

The documentation examples for the `SecurityException` and `ClusterSecurityException` CRDs incorrectly listed the apiVersion as `kubescape.io/v1`, but the shipped CRDs use `v1beta1`. The Go types are defined at `pkg/securityexception/v1beta1/types.go`, the dynamic-client reader in `repositories/apiserver.go` uses `Version: "v1beta1"`, and the helm-charts CRD manifests declare `v1beta1` as the served version. This documentation fix aligns the examples with the actual implementation so users copying the manifests get resources that correctly match the cluster-served API version.

Docs-only change, no behavior modification.

AI-skills: armosec-shared-rules:agent-dispatch-policy | cmds: /update-repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SecurityException examples and design specifications to use API version `v1beta1`.
  * Included updates for both namespaced and cluster-scoped resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->