### PR TITLE
fix(repositories): give an affected SecurityException precedence when multiple exceptions match

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1255,14 +1255,39 @@ func isOwnIgnoreRule(m v1beta1.IgnoredMatch) bool {
 	return m.AppliedIgnoreRules[0].Package == nil
 }
 
+// securityExceptionIgnoreRule can face more than one candidate: buildIgnoreRule
+// (adapters/v1) writes one IgnoreRule per suppressing policy, and it is normal for a match
+// to be suppressed by several exceptions at once -- e.g. a broad ClusterSecurityException
+// and a more specific namespaced SecurityException both matching the same CVE. Picking
+// whichever rule happens to be listed first would let an unattributed not_affected/fixed
+// rule silently outrank an affected rule's author-written actionStatement/response, purely
+// because of incidental ordering.
+//
+// An affected rule always wins when one is present: shouldSuppress requires an explicit
+// actionStatement before an affected entry can suppress at all, so it is always a deliberate,
+// specific risk acceptance -- never one this function should let a less specific rule
+// override. Among rules that agree on not being affected (or when none is), the first
+// SE/CSE rule is used, preserving prior behavior for the common single-exception case.
 func securityExceptionIgnoreRule(m v1beta1.IgnoredMatch) (v1beta1.IgnoreRule, bool) {
+	var (
+		first v1beta1.IgnoreRule
+		found bool
+	)
 	for _, rule := range m.AppliedIgnoreRules {
 		switch rule.SourceKind {
 		case "SecurityException", "ClusterSecurityException":
+		default:
+			continue
+		}
+		if !found {
+			first = rule
+			found = true
+		}
+		if strings.TrimSpace(rule.FixState) == string(sev1beta1.VulnerabilityStatusAffected) {
 			return rule, true
 		}
 	}
-	return v1beta1.IgnoreRule{}, false
+	return first, found
 }
 
 func ignoredMatchStatusNotes(rule v1beta1.IgnoreRule) string {

--- a/repositories/apiserver_external_test.go
+++ b/repositories/apiserver_external_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/tools"
+	sev1beta1 "github.com/kubescape/kubevuln/pkg/securityexception/v1beta1"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/openvex/go-vex/pkg/vex"
 )
@@ -555,4 +556,96 @@ func TestIgnoredMatchAssessment_AttributesBySource(t *testing.T) {
 				"all of these are suppressions, so the status is unchanged")
 		})
 	}
+}
+
+// A match can be suppressed by more than one SecurityException/ClusterSecurityException at
+// once -- buildIgnoreRule (adapters/v1) writes one IgnoreRule per suppressing policy. An
+// affected rule always requires an explicit, author-written actionStatement to suppress at
+// all (shouldSuppress), so it must never be silently outranked by an automatic
+// not_affected/fixed rule from a different, less specific exception -- whichever order they
+// happen to be listed in.
+func TestIgnoredMatchAssessment_MultipleExceptions_AffectedTakesPrecedence(t *testing.T) {
+	match := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"},
+		},
+	}
+	affected := v1beta1.IgnoreRule{
+		Vulnerability:   "CVE-2021-44228",
+		SourceKind:      "SecurityException",
+		SourceName:      "se/team-a/name",
+		FixState:        string(sev1beta1.VulnerabilityStatusAffected),
+		ImpactStatement: "WAF mitigation in place, ticket SEC-1234",
+		Justification:   "will_not_fix",
+	}
+	notAffected := v1beta1.IgnoreRule{
+		Vulnerability: "CVE-2021-44228",
+		SourceKind:    "ClusterSecurityException",
+		SourceName:    "cse/blanket-baseline",
+		FixState:      string(sev1beta1.VulnerabilityStatusNotAffected),
+		Justification: "vulnerable code not present",
+	}
+
+	tests := []struct {
+		name  string
+		rules []v1beta1.IgnoreRule
+	}{
+		{name: "affected listed first", rules: []v1beta1.IgnoreRule{affected, notAffected}},
+		{name: "affected listed last", rules: []v1beta1.IgnoreRule{notAffected, affected}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ignoredMatchAssessment(v1beta1.IgnoredMatch{Match: match, AppliedIgnoreRules: tt.rules})
+
+			assert.Equal(t, v1beta1.Status(vex.StatusAffected), got.status,
+				"the risk-accepted exception must win regardless of list order")
+			assert.Equal(t, "WAF mitigation in place, ticket SEC-1234", got.actionStatement,
+				"the affected exception's real actionStatement must reach the export, not the other exception's")
+			assert.Equal(t, "response: will_not_fix", got.statusNotes)
+		})
+	}
+}
+
+// Fixed also requires an explicit human decision (unlike the not_affected default), but it
+// is not itself a risk acceptance the way affected is, so affected still takes precedence
+// over it when both are present.
+func TestIgnoredMatchAssessment_MultipleExceptions_AffectedBeatsFixed(t *testing.T) {
+	match := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"},
+		},
+	}
+	rules := []v1beta1.IgnoreRule{
+		{Vulnerability: "CVE-2021-44228", SourceKind: "ClusterSecurityException", FixState: string(sev1beta1.VulnerabilityStatusFixed)},
+		{
+			Vulnerability:   "CVE-2021-44228",
+			SourceKind:      "SecurityException",
+			FixState:        string(sev1beta1.VulnerabilityStatusAffected),
+			ImpactStatement: "Compensating control documented in runbook",
+		},
+	}
+
+	got := ignoredMatchAssessment(v1beta1.IgnoredMatch{Match: match, AppliedIgnoreRules: rules})
+
+	assert.Equal(t, v1beta1.Status(vex.StatusAffected), got.status)
+	assert.Equal(t, "Compensating control documented in runbook", got.actionStatement)
+}
+
+// With no affected rule among several matching exceptions, the first SE/CSE rule is used --
+// the same behavior as before this fix, for the case that isn't a risk-acceptance conflict.
+func TestIgnoredMatchAssessment_MultipleExceptions_NoAffected_FirstRuleWins(t *testing.T) {
+	match := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2021-44228"},
+		},
+	}
+	rules := []v1beta1.IgnoreRule{
+		{Vulnerability: "CVE-2021-44228", SourceKind: "SecurityException", Justification: "first exception's reasoning"},
+		{Vulnerability: "CVE-2021-44228", SourceKind: "ClusterSecurityException", Justification: "second exception's reasoning"},
+	}
+
+	got := ignoredMatchAssessment(v1beta1.IgnoredMatch{Match: match, AppliedIgnoreRules: rules})
+
+	assert.Equal(t, v1beta1.Justification("first exception's reasoning"), got.justification)
 }


### PR DESCRIPTION
## Problem

A CVE match can be suppressed by more than one `SecurityException`/`ClusterSecurityException` at once — e.g. a broad, cluster-scoped exception and a more specific namespaced override both matching the same CVE. `buildIgnoreRules` (adapters/v1) correctly records one `IgnoreRule` per suppressing policy in that case, but `securityExceptionIgnoreRule` (repositories/apiserver.go), which picks the rule that drives the exported OpenVEX assessment, returned whichever rule happened to be listed first and silently discarded the rest.

If an unattributed `not_affected`/`fixed` rule from one exception happened to sort before an `affected` (risk-accepted) rule from another, the exported VEX statement reported `not_affected` and dropped the second exception's real, author-written `actionStatement`/`response` entirely — with no error, log, or any signal that a conflicting exception was even involved.

## Root Cause

`securityExceptionIgnoreRule` (`repositories/apiserver.go`) looped over `m.AppliedIgnoreRules` and returned on the first `SecurityException`/`ClusterSecurityException`-sourced rule it found:

```go
func securityExceptionIgnoreRule(m v1beta1.IgnoredMatch) (v1beta1.IgnoreRule, bool) {
	for _, rule := range m.AppliedIgnoreRules {
		switch rule.SourceKind {
		case "SecurityException", "ClusterSecurityException":
			return rule, true
		}
	}
	return v1beta1.IgnoreRule{}, false
}
```

Rule order comes from `cveExceptionIndex.lookup` (`adapters/v1/backend_utils.go`), which returns exceptions in the order they appear in the source list — not by any precedence rule. `hasIgnoreAction` only requires *any* matched policy to carry the `Ignore` action, so a mix of `affected` and `not_affected`/`fixed` rules among the matched policies is a normal, reachable combination (see #871 for the full writeup and a concrete repro scenario).

No existing test exercised more than one `SecurityException`/`ClusterSecurityException` rule reaching this function — the table in `TestIgnoredMatchAssessment_AttributesBySource` only ever supplied a single rule per case.

## Fix

`securityExceptionIgnoreRule` now scans every SE/CSE-sourced rule and prefers one with `FixState == "affected"` if present, falling back to the first SE/CSE rule otherwise (identical to the previous behavior for the common single-exception case).

An `affected` rule always wins because it is never a default the way `not_affected`/`fixed` can be: `shouldSuppress` requires an explicit, author-written `actionStatement` before an `affected` entry is even allowed to suppress a finding, so its presence always represents a deliberate risk acceptance that a less specific exception's automatic `not_affected`/`fixed` should not be able to silently override.

The change is confined to the read side in `repositories/apiserver.go` — no schema change, no change to how `buildIgnoreRules` records provenance.

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./repositories/... ./adapters/...` — passes
- `golangci-lint run --new-from-rev=upstream/main ./repositories/...` — 0 issues

Added regression coverage in `repositories/apiserver_external_test.go`:
- `TestIgnoredMatchAssessment_MultipleExceptions_AffectedTakesPrecedence` — an `affected` rule and a `not_affected` rule both present, asserted both orderings (`affected` listed first and listed last) produce the same, correct `affected` status with the real `actionStatement`/response preserved. The "listed last" case is the one that reproduces the original bug — it would have failed against the old first-match code.
- `TestIgnoredMatchAssessment_MultipleExceptions_AffectedBeatsFixed` — `affected` also takes precedence over `fixed`, not just `not_affected`.
- `TestIgnoredMatchAssessment_MultipleExceptions_NoAffected_FirstRuleWins` — with no `affected` rule present, the first SE/CSE rule is still used, confirming the common single/no-conflict case is unchanged.

## Impact

Restores correctness of the exported OpenVEX document — the audit-grade record of vulnerability disposition — whenever two or more `SecurityException`/`ClusterSecurityException` resources apply to the same finding, which is a normal configuration (org-wide baseline exceptions plus team-specific overrides). A deliberate, documented risk acceptance can no longer be silently overridden by an unrelated blanket suppression purely due to list order.

Fixes #871


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Security exception handling now consistently prioritizes rules explicitly marked as affected.
  - Preserves the correct action and status details from the applicable rule.
  - Retains expected first-match behavior when no affected rule is present.

- **Tests**
  - Added regression coverage for rule ordering, affected status, actions, and status notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->