### PR TITLE
fix(adapters): check subcomponent scope before excluding a CRD exception for cloud precedence

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -340,9 +340,14 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 //
 // Reuses cveExceptionIndex's own name normalization (lower-cased CVE ID/alias) so a CRD
 // exception naming a CVE by an alias the cloud exception names by its canonical ID, or vice
-// versa, still counts as the same CVE. A CRD policy not covered by any cloud policy passes
-// through unchanged, matching the doc's separate "non-overlapping exceptions are merged"
-// clause.
+// versa, still counts as the same CVE. Coverage is then checked at the same package
+// (subcomponent) granularity scopedToSubcomponent applies at suppression time, not by CVE name
+// alone: both cloud- and CRD-derived policies can independently scope to specific packages via
+// the shared Attributes["subcomponents"] mechanism (subcomponent.go), so a cloud policy naming
+// the same CVE but scoped to a different package does not make a CRD policy redundant.
+// Excluding it anyway would silently drop suppression for the package the cloud exception never
+// covered (#875). A CRD policy not covered by any cloud policy passes through unchanged,
+// matching the doc's separate "non-overlapping exceptions are merged" clause.
 func excludeCloudCoveredPolicies(crdPolicies, cloudPolicies []armotypes.VulnerabilityExceptionPolicy) []armotypes.VulnerabilityExceptionPolicy {
 	if len(cloudPolicies) == 0 || len(crdPolicies) == 0 {
 		return crdPolicies
@@ -351,18 +356,48 @@ func excludeCloudCoveredPolicies(crdPolicies, cloudPolicies []armotypes.Vulnerab
 
 	var filtered []armotypes.VulnerabilityExceptionPolicy
 	for _, p := range crdPolicies {
-		coveredByCloud := false
-		for _, vp := range p.VulnerabilityPolicies {
-			if len(cloudIndex.byName[strings.ToLower(vp.Name)]) > 0 {
-				coveredByCloud = true
-				break
-			}
-		}
-		if !coveredByCloud {
+		if !cloudCoversPolicy(p, cloudIndex) {
 			filtered = append(filtered, p)
 		}
 	}
 	return filtered
+}
+
+// cloudCoversPolicy reports whether some cloud policy sharing one of p's CVE/alias names also
+// covers every package p's own scope names. An unscoped cloud policy applies product-wide, so
+// it covers p regardless of p's own scope; a scoped cloud policy covers p only when p's scope
+// is fully contained in it. p being unscoped itself (applying product-wide) is never covered by
+// a scoped cloud policy, since the cloud policy only accounts for part of what p suppresses.
+func cloudCoversPolicy(p armotypes.VulnerabilityExceptionPolicy, cloudIndex *cveExceptionIndex) bool {
+	pScope, pScoped := policySubcomponents(p)
+	for _, vp := range p.VulnerabilityPolicies {
+		for _, i := range cloudIndex.byName[strings.ToLower(vp.Name)] {
+			cloudScope, cloudScoped := policySubcomponents(cloudIndex.srcCVEList[i])
+			if !cloudScoped {
+				return true
+			}
+			if pScoped && purlsCoveredBy(pScope, cloudScope) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// purlsCoveredBy reports whether every purl in scope is matched by some purl in by, i.e.
+// scope's coverage is fully contained in by's. Reuses purlMatches with by's entries as the
+// pattern side and scope's as the instance side, the same direction scopedToSubcomponent
+// matches a finding's purl against an exception's stated scope.
+func purlsCoveredBy(scope, by []string) bool {
+	if len(scope) == 0 {
+		return false
+	}
+	for _, purl := range scope {
+		if !anyPURLMatches(by, purl) {
+			return false
+		}
+	}
+	return true
 }
 
 // ReportError reports the given error to the platform

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -1175,6 +1175,61 @@ func TestExcludeCloudCoveredPolicies(t *testing.T) {
 	}
 }
 
+// A cloud and a CRD policy can independently scope to specific packages via the
+// Attributes["subcomponents"] purl list, the same mechanism ConvertToVulnerabilityExceptionPolicies
+// uses for a CRD exception's own vuln.Subcomponents field. Naming the same CVE is not the same
+// as covering the same package, so exclusion must also account for scope (#875).
+func TestExcludeCloudCoveredPolicies_SubcomponentScope(t *testing.T) {
+	policy := func(ruleName, cve string, subcomponents interface{}) armotypes.VulnerabilityExceptionPolicy {
+		p := armotypes.VulnerabilityExceptionPolicy{
+			PortalBase:            armotypes.PortalBase{Name: ruleName},
+			VulnerabilityPolicies: []armotypes.VulnerabilityPolicy{{Name: cve}},
+		}
+		if subcomponents != nil {
+			p.Attributes = map[string]interface{}{attrSubcomponents: subcomponents}
+		}
+		return p
+	}
+
+	tests := []struct {
+		name        string
+		crdPolicies []armotypes.VulnerabilityExceptionPolicy
+		cloud       []armotypes.VulnerabilityExceptionPolicy
+		wantLen     int
+	}{
+		{
+			name:        "disjoint packages: CRD policy scoped to a different package than cloud's survives",
+			crdPolicies: []armotypes.VulnerabilityExceptionPolicy{policy("crd-rule", "CVE-1", []string{"pkg:npm/bar"})},
+			cloud:       []armotypes.VulnerabilityExceptionPolicy{policy("cloud-rule", "CVE-1", []interface{}{"pkg:npm/foo"})},
+			wantLen:     1,
+		},
+		{
+			name:        "same package: CRD policy is dropped, matching #812's fix",
+			crdPolicies: []armotypes.VulnerabilityExceptionPolicy{policy("crd-rule", "CVE-1", []string{"pkg:npm/bar"})},
+			cloud:       []armotypes.VulnerabilityExceptionPolicy{policy("cloud-rule", "CVE-1", []interface{}{"pkg:npm/bar"})},
+			wantLen:     0,
+		},
+		{
+			name:        "unscoped cloud policy covers a scoped CRD policy for any package",
+			crdPolicies: []armotypes.VulnerabilityExceptionPolicy{policy("crd-rule", "CVE-1", []string{"pkg:npm/bar"})},
+			cloud:       []armotypes.VulnerabilityExceptionPolicy{policy("cloud-rule", "CVE-1", nil)},
+			wantLen:     0,
+		},
+		{
+			name:        "scoped cloud policy does not cover an unscoped (product-wide) CRD policy",
+			crdPolicies: []armotypes.VulnerabilityExceptionPolicy{policy("crd-rule", "CVE-1", nil)},
+			cloud:       []armotypes.VulnerabilityExceptionPolicy{policy("cloud-rule", "CVE-1", []interface{}{"pkg:npm/foo"})},
+			wantLen:     1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := excludeCloudCoveredPolicies(tt.crdPolicies, tt.cloud)
+			assert.Len(t, got, tt.wantLen)
+		})
+	}
+}
+
 func TestGetCVEExceptions_ScopesCRDByMatch(t *testing.T) {
 	// A cluster exception scoped to redis images must NOT be applied to an
 	// nginx workload — this is the fail-open regression the match logic fixes.


### PR DESCRIPTION
## Problem

Both cloud-delivered and CRD-derived (`SecurityException`/`ClusterSecurityException`) exception policies can independently scope an exception to specific packages via the `subcomponents` purl list (`docs/security-exception-design.md`, "Identifier Bridging" section) — they're both instances of the same `armotypes.VulnerabilityExceptionPolicy` type, carrying that scope in the same `Attributes["subcomponents"]` bag either source can populate.

`excludeCloudCoveredPolicies` (added in #813 to implement the documented cloud-over-CRD precedence, #812) dropped a CRD policy whenever a cloud policy existed for the *same CVE ID*, without ever checking which package each one was scoped to. So a cloud exception for CVE-X scoped to package A silently excluded a CRD exception for the same CVE-X scoped to a *different* package B — even though the two don't actually overlap. The CVE-X finding on package B, which the CRD exception existed specifically to suppress, ended up suppressed by neither source: it reappears in scan results and the exported VEX document, with no error or log explaining why.

This contradicts `docs/security-exception-design.md`'s own "non-overlapping exceptions are merged" clause: two exceptions scoped to disjoint packages are non-overlapping, but the CVE-name-only comparison treated them as conflicting.

## Root Cause

`excludeCloudCoveredPolicies` (`adapters/v1/backend.go`) built a CVE-name index over the cloud policies and dropped any CRD policy sharing a name with one of them — full stop, no scope check:

```go
for _, p := range crdPolicies {
	coveredByCloud := false
	for _, vp := range p.VulnerabilityPolicies {
		if len(cloudIndex.byName[strings.ToLower(vp.Name)]) > 0 {
			coveredByCloud = true
			break
		}
	}
	if !coveredByCloud {
		filtered = append(filtered, p)
	}
}
```

`TestExcludeCloudCoveredPolicies` had zero coverage for a scoped policy on either side.

I verified the failure directly, running the exact sequence `GetCVEExceptions` runs (exclude, then `scopedToSubcomponent`) with a cloud policy scoped to `pkg:npm/foo` and a CRD policy scoped to a different package `pkg:npm/bar`, both for the same CVE: the CRD policy was dropped, and after merging, nothing in the result applied to package `bar` — the finding it was written to suppress went unsuppressed.

## Fix

`excludeCloudCoveredPolicies` now delegates the per-policy decision to a new `cloudCoversPolicy` helper that checks package scope, not just CVE name:

- An unscoped cloud policy still covers everything (preserves #812's fix for the workload-wide case that motivated it).
- A scoped cloud policy covers a CRD policy only when the CRD policy's own scope is fully contained in it (`purlsCoveredBy`, reusing the existing `purlMatches`/`anyPURLMatches` helpers from `subcomponent.go` rather than duplicating purl-matching logic).
- A scoped cloud policy never covers an *unscoped* CRD policy: the CRD policy also applies to packages the cloud policy never addressed, so dropping it would lose that coverage.

The change is confined to `excludeCloudCoveredPolicies` and its two new helpers in `adapters/v1/backend.go` — no changes to how scope is recorded or read elsewhere.

## Testing

- `go build ./...` — passes
- `go vet ./adapters/...` — passes
- `go test ./adapters/... ./repositories/...` — passes
- `golangci-lint run --new-from-rev=upstream/main ./adapters/...` — 0 issues

Added `TestExcludeCloudCoveredPolicies_SubcomponentScope` in `adapters/v1/backend_test.go`:
- disjoint packages (cloud scoped to `foo`, CRD scoped to `bar`) — CRD policy survives, the case that reproduces the original bug.
- same package on both sides — CRD policy is still dropped, preserving #812's fix.
- unscoped cloud policy, scoped CRD policy — dropped (cloud covers everything).
- scoped cloud policy, unscoped CRD policy — CRD policy survives (cloud doesn't cover the rest of what the CRD policy applies to).

All pre-existing `TestExcludeCloudCoveredPolicies` and `TestGetCVEExceptions_*` cases (unscoped policies throughout) pass unchanged, confirming the common single-scope case is unaffected.

## Impact

Restores suppression correctness for the "gradual migration" scenario `docs/security-exception-design.md` itself describes — cloud and CRD exceptions coexisting simultaneously. A CRD exception scoped to one package no longer silently stops applying just because an unrelated cloud exception exists for the same CVE ID on a different package.

Fixes #875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy filtering to account for package scope coverage when matching cloud and CRD policies.
  * Prevented policies from being incorrectly excluded when package coverage is partial, disjoint, or unscoped.
  * Ensured fully covered policies are excluded while preserving policies with distinct package scopes.

* **Tests**
  * Added coverage for scoped and unscoped policy combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->