### PR TITLE
fix(tools): reject a Retry-After value that would overflow time.Duration

### DIFF
--- a/internal/tools/retry.go
+++ b/internal/tools/retry.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"errors"
+	"math"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -15,6 +16,15 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/metrics"
 )
+
+// maxRetryAfterSeconds is the largest number of seconds that can be multiplied by
+// time.Second without overflowing time.Duration's underlying int64 nanosecond count. A
+// numeric Retry-After value beyond this wraps around to a negative time.Duration -- which
+// RetryWithBackoff's ceiling check never catches (a negative delay is never ">" a positive
+// ceiling) and time.After fires immediately for, turning backoff into a hot retry loop
+// against whatever is rate-limiting it. Mirrors adapters/v1/backend.go's identical guard on
+// the report-posting retry path's own Retry-After parsing (see #754, #877).
+const maxRetryAfterSeconds = math.MaxInt64 / int64(time.Second)
 
 // RetryConfig specifies configuration for retrying operations.
 type RetryConfig struct {
@@ -95,7 +105,7 @@ func ParseRetryAfter(err error) (time.Duration, bool) {
 		fields := strings.Fields(sub)
 		if len(fields) > 0 {
 			token := strings.Trim(fields[0], ";,")
-			if seconds, parseErr := strconv.Atoi(token); parseErr == nil && seconds > 0 {
+			if seconds, parseErr := strconv.ParseInt(token, 10, 64); parseErr == nil && seconds > 0 && seconds <= maxRetryAfterSeconds {
 				return time.Duration(seconds) * time.Second, true
 			}
 		}

--- a/internal/tools/retry_test.go
+++ b/internal/tools/retry_test.go
@@ -84,6 +84,26 @@ func TestParseRetryAfter(t *testing.T) {
 	assert.Equal(t, time.Duration(0), nilErr)
 }
 
+// A numeric Retry-After large enough that seconds*time.Second overflows time.Duration's
+// int64 nanosecond range must be rejected, not silently wrapped into a negative duration
+// (#877). math.MaxInt64/int64(time.Second) is the largest value that does not overflow.
+func TestParseRetryAfter_RejectsOverflowingValue(t *testing.T) {
+	atBoundary := fmt.Sprintf("received status code 429 Retry-After: %d", maxRetryAfterSeconds)
+	dur, ok := ParseRetryAfter(errors.New(atBoundary))
+	assert.True(t, ok, "the largest non-overflowing value must still parse")
+	assert.Equal(t, time.Duration(maxRetryAfterSeconds)*time.Second, dur)
+
+	justOverBoundary := fmt.Sprintf("received status code 429 Retry-After: %d", maxRetryAfterSeconds+1)
+	dur, ok = ParseRetryAfter(errors.New(justOverBoundary))
+	assert.False(t, ok, "one past the boundary must be rejected, not wrapped")
+	assert.Equal(t, time.Duration(0), dur)
+
+	wayOverBoundary := errors.New("received status code 429 Retry-After: 10000000000")
+	dur, ok = ParseRetryAfter(wayOverBoundary)
+	assert.False(t, ok)
+	assert.Equal(t, time.Duration(0), dur)
+}
+
 func TestRetryWithBackoff_SuccessFirstAttempt(t *testing.T) {
 	calls := 0
 	config := RetryConfig{
@@ -278,6 +298,35 @@ func TestRetryWithBackoff_UnsetCeilingFallsBackToMaxWait(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Less(t, elapsed, 500*time.Millisecond, "took %s", elapsed)
+}
+
+// An overflowing Retry-After must not turn into a hot loop: ParseRetryAfter rejects it, so
+// RetryWithBackoff falls back to its normal jittered backoff instead of the wrapped negative
+// duration time.After would otherwise fire on immediately (#877).
+func TestRetryWithBackoff_OverflowingRetryAfterFallsBackToBackoff(t *testing.T) {
+	cfg := RetryConfig{
+		MaxAttempts: 3,
+		InitialWait: 20 * time.Millisecond,
+		MaxWait:     40 * time.Millisecond,
+		Backoff:     2.0,
+	}
+	rateLimited := errors.New("429 Too Many Requests, Retry-After: 10000000000")
+
+	attempts := 0
+	start := time.Now()
+	_, err := RetryWithBackoff(context.Background(), "source_resolution", cfg, IsRateLimitError,
+		func(context.Context) (int, error) {
+			attempts++
+			return 0, rateLimited
+		})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Equal(t, cfg.MaxAttempts, attempts)
+	// Two backoff waits (20ms then 40ms, ignoring jitter) rather than two immediate retries: a
+	// hot loop from the wrapped negative duration would complete in well under a millisecond.
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond,
+		"an overflowing Retry-After must fall back to backoff, not fire immediately (took %s)", elapsed)
 }
 
 func TestRetryWithBackoff_NonRetryableErrorNoRetry(t *testing.T) {


### PR DESCRIPTION
## Problem

`internal/tools.ParseRetryAfter` parses a numeric `Retry-After` value from error text and multiplies it by `time.Second`, with only a `> 0` check on the parsed value — no upper bound. A large-enough (but otherwise valid-looking) numeric value overflows `time.Duration`'s underlying `int64` nanosecond count and silently wraps around to a **negative** duration, with no error.

`RetryWithBackoff` (the only caller) hands that value straight to the ceiling check and then `time.After`. A negative delay is never `>` the positive ceiling, so the cap is skipped, and `time.After` with a negative duration fires immediately. Instead of backing off, the retry loop fires every attempt back-to-back with no delay — a hot loop against whatever is rate-limiting it.

## Root Cause

```go
if seconds, parseErr := strconv.Atoi(token); parseErr == nil && seconds > 0 {
	return time.Duration(seconds) * time.Second, true
}
```

This is the same failure class already fixed once, in #754 — but in a different function. That fix landed in `adapters/v1/backend.go`'s `parseRetryAfterSeconds`, used only by the report-posting retry path:

```go
const maxRetryAfterSeconds = math.MaxInt64 / int64(time.Second)
if seconds < 0 || seconds > maxRetryAfterSeconds {
	return 0, false
}
```

`ParseRetryAfter`, used by the registry-pull/SBOM-generation retry path, is an independent implementation and never received the equivalent guard.

I verified the overflow directly with `go run`:

```go
seconds, _ := strconv.Atoi("10000000000") // no error, seconds > 0
d := time.Duration(seconds) * time.Second
// d == -2346317h47m53.709551616s  (int64 ns: -8446744073709551616)
```

## Fix

`ParseRetryAfter` now rejects a value beyond `maxRetryAfterSeconds` (`math.MaxInt64/int64(time.Second)`), mirroring `backend.go`'s existing guard exactly, and switches from `strconv.Atoi` to `strconv.ParseInt(token, 10, 64)` so the comparison is between matching types. The change is confined to the one numeric branch of `ParseRetryAfter`.

## Testing

- `go build ./...` — passes
- `go vet ./internal/tools/...` — passes
- `go test ./internal/tools/... ./adapters/... ./core/services/... ./pkg/sbomscanner/...` (every package that calls `RetryWithBackoff`/`ParseRetryAfter`) — passes
- `golangci-lint run --new-from-rev=upstream/main ./internal/tools/...` — 0 issues

Added to `internal/tools/retry_test.go`:
- `TestParseRetryAfter_RejectsOverflowingValue` — the largest non-overflowing value still parses; one past the boundary and a large value (10000000000) are both rejected as `(0, false)` instead of wrapping.
- `TestRetryWithBackoff_OverflowingRetryAfterFallsBackToBackoff` — an end-to-end regression through `RetryWithBackoff`: an overflowing `Retry-After` now falls back to normal jittered backoff (asserted via elapsed time ≥ the configured backoff, which a hot loop from the wrapped negative duration would complete in well under a millisecond).

All pre-existing `TestParseRetryAfter`/`TestRetryWithBackoff_*` cases pass unchanged.

## Impact

`internal/tools.RetryWithBackoff` backs the retry logic for both SBOM-generation paths' registry interactions (`adapters/v1/syft.go`, `pkg/sbomscanner/v1/server.go`, `core/services/scan.go`). A malformed, misconfigured, or malicious `Retry-After` value can no longer turn a bounded backoff into an unbounded hot loop against whatever endpoint is rate-limiting the scan.

Fixes #877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented excessively large retry delays from causing immediate retry loops.
  * Invalid or overflowing retry-delay values now fall back to the standard backoff behavior.

* **Tests**
  * Added coverage for retry-delay boundary values and overflow handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->