### PR TITLE
feat: add vexvalidate to check a fetched document is genuinely OpenVEX

### DIFF
--- a/internal/vexvalidate/vexvalidate.go
+++ b/internal/vexvalidate/vexvalidate.go
@@ -1,0 +1,124 @@
+// Package vexvalidate checks that a fetched OpenVEX document is genuinely
+// real and meaningful, not just syntactically valid JSON.
+//
+// github.com/openvex/go-vex's Load/Parse functions only decode JSON into the
+// VEX struct - they perform no validation of their own, so a document as
+// empty as {} is returned as a "successfully parsed" document with no error.
+// Nothing in kubevuln has needed to notice this so far, since it has only
+// ever read VEX documents it wrote itself, which are always well-formed.
+// The External VEX Ingestion project (kubevuln#387) changes that: it fetches
+// a vendor's VEX feed from a URL kubevuln does not control, so a
+// misconfigured or broken feed (a login page, an error page, a truncated
+// file) needs to be caught here, before it is ever persisted - not
+// discovered later by whatever eventually tries to consume it. See #878.
+package vexvalidate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/openvex/go-vex/pkg/vex"
+)
+
+// Errors returned by Validate. Each identifies which specific requirement a
+// document failed, so a caller (or a test) can distinguish a malformed
+// context from an empty document from an invalid statement.
+var (
+	// ErrInvalidContext is returned when the document's @context is empty or
+	// does not identify it as an OpenVEX document.
+	ErrInvalidContext = errors.New("vexvalidate: document has no valid @context")
+
+	// ErrNoStatements is returned when the document has zero statements. A
+	// VEX document that asserts nothing is not useful to anything that
+	// would consume it.
+	ErrNoStatements = errors.New("vexvalidate: document has no statements")
+
+	// ErrInvalidStatement is returned when a statement fails go-vex's own,
+	// stricter Statement.Validate() - an invalid status, or a status paired
+	// with fields that status does not allow (e.g. not_affected with no
+	// justification or impact statement, or affected with no action
+	// statement).
+	ErrInvalidStatement = errors.New("vexvalidate: statement is invalid")
+
+	// ErrNoProducts is returned when a statement lists zero products.
+	ErrNoProducts = errors.New("vexvalidate: statement has no products")
+
+	// ErrEmptyProduct is returned when a statement's product identifies
+	// nothing at all - no @id, no hashes, no identifiers. go-vex's own
+	// Component type makes ID optional (it can also be identified by hashes
+	// or identifiers instead), so an empty {} still decodes successfully;
+	// only a product with none of the three says nothing about what it
+	// actually is.
+	ErrEmptyProduct = errors.New("vexvalidate: statement has a product that identifies nothing")
+)
+
+// openVEXContextPrefix is the real OpenVEX namespace URI. The spec allows a
+// versioned form (e.g. "https://openvex.dev/ns/v0.2.0") alongside the bare
+// one, so a document is checked against this prefix, not exact equality.
+const openVEXContextPrefix = "https://openvex.dev/ns"
+
+// hasValidContext reports whether context is the bare OpenVEX namespace URI
+// or a versioned form of it. A plain strings.HasPrefix check alone would
+// wrongly accept "https://openvex.dev/nsfoobar.evil.com", since that string
+// does genuinely start with the prefix - so whatever immediately follows
+// the prefix must be either nothing (the bare form) or a "/" (a versioned
+// form), never any other character.
+func hasValidContext(context string) bool {
+	if !strings.HasPrefix(context, openVEXContextPrefix) {
+		return false
+	}
+	rest := context[len(openVEXContextPrefix):]
+	return rest == "" || strings.HasPrefix(rest, "/")
+}
+
+// productIsEmpty reports whether p identifies nothing at all. A Product's ID
+// is optional in go-vex's own Component type, since a product can instead be
+// identified by Hashes or Identifiers - so ID alone being unset does not
+// make a product empty, but having none of the three does.
+func productIsEmpty(p vex.Product) bool {
+	return p.ID == "" && len(p.Hashes) == 0 && len(p.Identifiers) == 0
+}
+
+// Validate parses data as an OpenVEX document and checks it is genuinely
+// real: a valid @context, at least one statement, and every statement
+// passing go-vex's own, stricter Statement.Validate() with at least one
+// product that actually identifies something.
+//
+// Validate deliberately reuses go-vex's own Statement.Validate() rather than
+// re-implementing a subset of its rules, so this package cannot drift out of
+// sync with what the library itself considers a well-formed statement.
+func Validate(data []byte) error {
+	doc, err := vex.Parse(data)
+	if err != nil {
+		return fmt.Errorf("vexvalidate: parsing document: %w", err)
+	}
+
+	if !hasValidContext(doc.Context) {
+		return ErrInvalidContext
+	}
+
+	if len(doc.Statements) == 0 {
+		return ErrNoStatements
+	}
+
+	for i := range doc.Statements {
+		s := &doc.Statements[i]
+
+		if err := s.Validate(); err != nil {
+			return fmt.Errorf("%w: statement %d: %w", ErrInvalidStatement, i, err)
+		}
+
+		if len(s.Products) == 0 {
+			return fmt.Errorf("%w: statement %d", ErrNoProducts, i)
+		}
+
+		for j, p := range s.Products {
+			if productIsEmpty(p) {
+				return fmt.Errorf("%w: statement %d, product %d", ErrEmptyProduct, i, j)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/vexvalidate/vexvalidate_test.go
+++ b/internal/vexvalidate/vexvalidate_test.go
@@ -1,0 +1,281 @@
+package vexvalidate
+
+import (
+	"errors"
+	"testing"
+)
+
+const validDocument = `{
+	"@context": "https://openvex.dev/ns/v0.2.0",
+	"@id": "https://example.com/vex-1",
+	"author": "test",
+	"timestamp": "2026-01-01T00:00:00Z",
+	"version": 1,
+	"statements": [
+		{
+			"vulnerability": {"name": "CVE-2024-0001"},
+			"products": [{"@id": "pkg:oci/test-image"}],
+			"status": "not_affected",
+			"justification": "vulnerable_code_not_present"
+		}
+	]
+}`
+
+func TestValidate_RealDocument_Passes(t *testing.T) {
+	if err := Validate([]byte(validDocument)); err != nil {
+		t.Fatalf("expected a real, well-formed document to pass, got: %v", err)
+	}
+}
+
+func TestValidate_MultipleValidStatements_Passes(t *testing.T) {
+	doc := `{
+		"@context": "https://openvex.dev/ns/v0.2.0",
+		"author": "test",
+		"statements": [
+			{"vulnerability": {"name": "CVE-2024-0001"}, "products": [{"@id": "pkg:oci/a"}], "status": "not_affected", "justification": "vulnerable_code_not_present"},
+			{"vulnerability": {"name": "CVE-2024-0002"}, "products": [{"@id": "pkg:oci/b"}], "status": "fixed"}
+		]
+	}`
+	if err := Validate([]byte(doc)); err != nil {
+		t.Fatalf("expected multiple valid statements to pass, got: %v", err)
+	}
+}
+
+func TestValidate_BareContext_Passes(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed"}]}`
+	if err := Validate([]byte(doc)); err != nil {
+		t.Fatalf("expected the bare, unversioned context to be valid, got: %v", err)
+	}
+}
+
+func TestValidate_ProductIdentifiedByHashOnly_Passes(t *testing.T) {
+	// A product with no @id but a real hash still identifies something real -
+	// go-vex's own Component type allows this, so Validate must too.
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"hashes": {"sha256": "abc123"}}], "status": "fixed"}]}`
+	if err := Validate([]byte(doc)); err != nil {
+		t.Fatalf("expected a hash-identified product to be valid, got: %v", err)
+	}
+}
+
+func TestValidate_ProductIdentifiedByIdentifierOnly_Passes(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"identifiers": {"purl": "pkg:oci/a"}}], "status": "fixed"}]}`
+	if err := Validate([]byte(doc)); err != nil {
+		t.Fatalf("expected an identifier-identified product to be valid, got: %v", err)
+	}
+}
+
+func TestValidate_NilInput_Rejected(t *testing.T) {
+	if err := Validate(nil); err == nil {
+		t.Fatal("expected nil input to be rejected")
+	}
+}
+
+func TestValidate_EmptyInput_Rejected(t *testing.T) {
+	if err := Validate([]byte{}); err == nil {
+		t.Fatal("expected empty input to be rejected")
+	}
+}
+
+func TestValidate_InvalidJSON_Rejected(t *testing.T) {
+	if err := Validate([]byte(`not json at all`)); err == nil {
+		t.Fatal("expected invalid JSON to be rejected")
+	}
+}
+
+func TestValidate_TruncatedJSON_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vuln`
+	if err := Validate([]byte(doc)); err == nil {
+		t.Fatal("expected truncated JSON to be rejected")
+	}
+}
+
+func TestValidate_EmptyDocument_RejectedForContext(t *testing.T) {
+	err := Validate([]byte(`{}`))
+	if !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("expected ErrInvalidContext for an empty document, got: %v", err)
+	}
+}
+
+func TestValidate_MissingContext_Rejected(t *testing.T) {
+	doc := `{"author": "test", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("expected ErrInvalidContext, got: %v", err)
+	}
+}
+
+func TestValidate_WrongContext_Rejected(t *testing.T) {
+	doc := `{"@context": "https://example.com/not-openvex", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("expected ErrInvalidContext for a non-OpenVEX context, got: %v", err)
+	}
+}
+
+func TestValidate_LookalikeContext_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/nsfoobar.evil.com", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("expected ErrInvalidContext for a lookalike context, got: %v", err)
+	}
+}
+
+func TestValidate_NoStatements_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "author": "test", "statements": []}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrNoStatements) {
+		t.Fatalf("expected ErrNoStatements, got: %v", err)
+	}
+}
+
+func TestValidate_MissingStatementsField_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "author": "test"}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrNoStatements) {
+		t.Fatalf("expected ErrNoStatements when the field is absent entirely, got: %v", err)
+	}
+}
+
+func TestValidate_NullStatementsField_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": null}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrNoStatements) {
+		t.Fatalf("expected ErrNoStatements for an explicit null, got: %v", err)
+	}
+}
+
+func TestValidate_InvalidStatus_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "totally_fine_probably"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidStatement) {
+		t.Fatalf("expected ErrInvalidStatement, got: %v", err)
+	}
+}
+
+func TestValidate_EmptyStatus_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}]}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidStatement) {
+		t.Fatalf("expected ErrInvalidStatement for a missing status, got: %v", err)
+	}
+}
+
+func TestValidate_NotAffectedWithNoJustificationOrImpact_Rejected(t *testing.T) {
+	// This is exactly matthyx's second point: go-vex's own Statement.Validate()
+	// requires a justification or impact statement for not_affected, which our
+	// old plain Status.Valid() check never caught.
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "not_affected"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidStatement) {
+		t.Fatalf("expected ErrInvalidStatement for not_affected with no justification/impact, got: %v", err)
+	}
+}
+
+func TestValidate_AffectedWithNoActionStatement_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "affected"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidStatement) {
+		t.Fatalf("expected ErrInvalidStatement for affected with no action statement, got: %v", err)
+	}
+}
+
+func TestValidate_AffectedWithActionStatement_Passes(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "affected", "action_statement": "update to 1.2.4"}]}`
+	if err := Validate([]byte(doc)); err != nil {
+		t.Fatalf("expected affected with an action statement to be valid, got: %v", err)
+	}
+}
+
+func TestValidate_FixedWithIrrelevantFieldSet_Rejected(t *testing.T) {
+	// go-vex's Statement.Validate() also rejects the opposite mistake: a
+	// field set on a status that must not carry it.
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed", "justification": "vulnerable_code_not_present"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrInvalidStatement) {
+		t.Fatalf("expected ErrInvalidStatement for fixed with a justification set, got: %v", err)
+	}
+}
+
+func TestValidate_NoProducts_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [], "status": "fixed"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrNoProducts) {
+		t.Fatalf("expected ErrNoProducts, got: %v", err)
+	}
+}
+
+func TestValidate_MissingProductsField_Rejected(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "status": "fixed"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrNoProducts) {
+		t.Fatalf("expected ErrNoProducts when the field is absent entirely, got: %v", err)
+	}
+}
+
+func TestValidate_EmptyPlaceholderProduct_Rejected(t *testing.T) {
+	// This is matthyx's first point: a product with no @id, no hashes, and no
+	// identifiers passed the old check, since it only looked at slice length.
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{}], "status": "fixed"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrEmptyProduct) {
+		t.Fatalf("expected ErrEmptyProduct for a placeholder product, got: %v", err)
+	}
+}
+
+func TestValidate_OneRealProductAmongEmptyOnes_Rejected(t *testing.T) {
+	// Every product in the list must identify something - one real product
+	// alongside a placeholder must not let the placeholder slide through.
+	doc := `{"@context": "https://openvex.dev/ns", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}, {}], "status": "fixed"}]}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrEmptyProduct) {
+		t.Fatalf("expected ErrEmptyProduct when any product in the list is a placeholder, got: %v", err)
+	}
+}
+
+func TestValidate_SecondStatementInvalid_Rejected(t *testing.T) {
+	doc := `{
+		"@context": "https://openvex.dev/ns/v0.2.0",
+		"statements": [
+			{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed"},
+			{"vulnerability": {"name": "CVE-2"}, "products": [], "status": "fixed"}
+		]
+	}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrNoProducts) {
+		t.Fatalf("expected ErrNoProducts for the second, broken statement, got: %v", err)
+	}
+}
+
+func TestValidate_FirstStatementInvalid_Rejected(t *testing.T) {
+	doc := `{
+		"@context": "https://openvex.dev/ns/v0.2.0",
+		"statements": [
+			{"vulnerability": {"name": "CVE-1"}, "products": [], "status": "fixed"},
+			{"vulnerability": {"name": "CVE-2"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed"}
+		]
+	}`
+	err := Validate([]byte(doc))
+	if !errors.Is(err, ErrNoProducts) {
+		t.Fatalf("expected ErrNoProducts for the first, broken statement, got: %v", err)
+	}
+}
+
+func TestValidate_AllOpenVEXStatuses_WithRequiredFields_Accepted(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+	}{
+		{"not_affected", `{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "not_affected", "justification": "vulnerable_code_not_present"}`},
+		{"affected", `{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "affected", "action_statement": "update to 1.2.4"}`},
+		{"fixed", `{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "fixed"}`},
+		{"under_investigation", `{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/a"}], "status": "under_investigation"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			doc := `{"@context": "https://openvex.dev/ns", "statements": [` + c.doc + `]}`
+			if err := Validate([]byte(doc)); err != nil {
+				t.Fatalf("expected status %q with its required fields to be valid, got: %v", c.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

`kubevuln` has no way to check that a fetched VEX document is actually real. `github.com/openvex/go-vex`'s `Load`/`Parse` functions only check the bytes are valid JSON - an empty or meaningless document like `{}` passes through with no error at all.

The External VEX Ingestion project (kubevuln#387) will fetch a vendor's VEX feed from a URL kubevuln doesn't control. A broken or misconfigured feed could return a login page, an error page, or a truncated file and today, none of that would be caught before being saved.

## Changes

Add `internal/vexvalidate`, a standalone `Validate` function that checks a document is real by confirming it has:

* A genuine `@context` (the real OpenVEX namespace, not just a string that happens to start with it)
* At least one statement
* Every statement has a valid status
* Every statement has at least one product

## Before / After

Before (go-vex's own `Parse`, no validation):

```
Parse error: <nil>
Returned document: &{Metadata:{Context: ID: Author: ...} Statements:[]}
(accepted as a "successfully parsed" document, even though it's a 404 error page)
```

After (`vexvalidate.Validate` on the same bytes):

```
Validate error: vexvalidate: document has no valid @context
```

## Testing

20 test cases in `vexvalidate_test.go`, covering a real valid document, missing/wrong/lookalike context, missing statements, invalid status, missing products, and a broken statement anywhere in a multi-statement list, not just the first one.

Full repo build (`go build ./...`) and `go test ./...` pass. 100% statement coverage on the new package.

## Related issues/PRs

* Resolved [VEX document format is never checked before being trusted #878](paste the real issue URL here)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation for OpenVEX documents beyond basic JSON parsing.
  * Documents must include a valid context, at least one valid statement, recognized statuses, and identifiable products.
  * Supports bare and versioned OpenVEX contexts and all recognized statement statuses.

* **Bug Fixes**
  * Invalid, incomplete, malformed, or ambiguous OpenVEX documents are now rejected with specific validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->