### PR TITLE
feat(diagnostics): report worker pool queue depth

### DIFF
--- a/controllers/http.go
+++ b/controllers/http.go
@@ -221,11 +221,14 @@ func (h HTTPController) Ready(c *gin.Context) {
 // operators can query the running configuration directly instead of inferring it
 // from logs. See domain.Diagnostics for the excluded (credential) fields.
 func (h *HTTPController) Diagnostics(c *gin.Context) {
-	if h.diagnostics == nil {
-		c.JSON(http.StatusOK, domain.Diagnostics{})
-		return
+	var d domain.Diagnostics
+	if h.diagnostics != nil {
+		d = h.diagnostics(c.Request.Context())
 	}
-	c.JSON(http.StatusOK, h.diagnostics(c.Request.Context()))
+	if h.workerPool != nil {
+		d.QueueDepth = h.workerPool.WaitingQueueSize()
+	}
+	c.JSON(http.StatusOK, d)
 }
 
 // ScanStatus reports the current lifecycle state for a previously accepted scan job.

--- a/controllers/http_test.go
+++ b/controllers/http_test.go
@@ -133,7 +133,7 @@ func TestHTTPController_Diagnostics(t *testing.T) {
 		{
 			name:         "not configured",
 			diagnostics:  nil,
-			expectedBody: `{"scanMode":"","sbomCreatorVersion":"","cveScannerVersion":"","cveDBVersion":"","scanTimeout":"","scannerReadinessTimeout":"","storageEnabled":false,"riskAcceptanceEnabled":false}`,
+			expectedBody: `{"scanMode":"","sbomCreatorVersion":"","cveScannerVersion":"","cveDBVersion":"","scanTimeout":"","scannerReadinessTimeout":"","storageEnabled":false,"riskAcceptanceEnabled":false,"queueDepth":0}`,
 		},
 		{
 			name: "sidecar mode with storage and risk acceptance enabled",
@@ -149,12 +149,14 @@ func TestHTTPController_Diagnostics(t *testing.T) {
 					RiskAcceptanceEnabled:   true,
 				}
 			},
-			expectedBody: `{"scanMode":"sidecar","sbomCreatorVersion":"syft-1.2.3","cveScannerVersion":"grype-4.5.6-matching-adaptive","cveDBVersion":"db-2026-08-11","scanTimeout":"5m0s","scannerReadinessTimeout":"1m0s","storageEnabled":true,"riskAcceptanceEnabled":true}`,
+			expectedBody: `{"scanMode":"sidecar","sbomCreatorVersion":"syft-1.2.3","cveScannerVersion":"grype-4.5.6-matching-adaptive","cveDBVersion":"db-2026-08-11","scanTimeout":"5m0s","scannerReadinessTimeout":"1m0s","storageEnabled":true,"riskAcceptanceEnabled":true,"queueDepth":0}`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := HTTPController{diagnostics: tt.diagnostics}
+			pool := workerpool.New(1)
+			t.Cleanup(pool.Stop)
+			c := HTTPController{diagnostics: tt.diagnostics, workerPool: pool}
 			router := gin.Default()
 			path := "/v1/diagnostics"
 			router.GET(path, c.Diagnostics)
@@ -165,6 +167,38 @@ func TestHTTPController_Diagnostics(t *testing.T) {
 			assert.JSONEq(t, tt.expectedBody, w.Body.String(), w.Body.String())
 		})
 	}
+}
+
+func TestHTTPController_Diagnostics_QueueDepth(t *testing.T) {
+	pool := workerpool.New(1)
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		close(release)
+		pool.StopWait()
+	})
+
+	pool.Submit(func() {
+		<-release // occupy the pool's single worker
+	})
+	pool.Submit(func() {
+		<-release // sits in the waiting queue behind the task above
+	})
+
+	// Give the pool a moment to actually dequeue the first task before asserting.
+	require.Eventually(t, func() bool {
+		return pool.WaitingQueueSize() > 0
+	}, time.Second, time.Millisecond)
+
+	c := HTTPController{workerPool: pool}
+	router := gin.Default()
+	router.GET("/v1/diagnostics", c.Diagnostics)
+	req, _ := http.NewRequest("GET", "/v1/diagnostics", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var got domain.Diagnostics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, 1, got.QueueDepth)
 }
 
 func TestHTTPController_ScanCVE(t *testing.T) {

--- a/core/domain/diagnostics.go
+++ b/core/domain/diagnostics.go
@@ -13,6 +13,11 @@ type Diagnostics struct {
 	ScannerReadinessTimeout string `json:"scannerReadinessTimeout"`
 	StorageEnabled          bool   `json:"storageEnabled"`
 	RiskAcceptanceEnabled   bool   `json:"riskAcceptanceEnabled"`
+	// QueueDepth is the number of scan jobs currently waiting in the HTTP controller's
+	// worker pool, the same value backing the kubevuln_worker_pool_queue_depth metric
+	// (see controllers.HTTPController.WithMetrics). Surfacing it here lets operators read
+	// current backlog directly instead of having to query Prometheus.
+	QueueDepth int `json:"queueDepth"`
 }
 
 const (


### PR DESCRIPTION
## Overview
Right now, checking backlog on a kubevuln pod means going to Prometheus for `kubevuln_worker_pool_queue_depth`, then separately hitting `/v1/diagnostics` for scan mode and backend versions. This PR adds a `queueDepth` field to the diagnostics response, sourced from the same worker pool value already backing that metric, so both signals show up in one place.

## Additional Information
The value comes straight from `h.workerPool.WaitingQueueSize()`, the same call `WithMetrics` already uses for the Prometheus gauge. No new state, timers, or I/O were added, so the endpoint stays purely in-memory and its response time is unaffected.

## How to Test
```
go test ./controllers/... -run Diagnostics -v
```
Or hit `GET /v1/diagnostics` on a running instance and confirm the response now includes `queueDepth`.

## Related issues/PRs:
Resolved #881

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added worker queue depth to the diagnostics response.
  * Diagnostics now report the number of scan jobs waiting for processing.
  * The queue depth is available directly through the `queueDepth` field in the diagnostics JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->