### PR TITLE
fix(adapters): don't let the docker.io/index.docker.io alias override a more specific entry

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -80,15 +80,25 @@ func rewriteImageRef(imageRef string, proxyMap map[string]string) string {
 		if strings.HasPrefix(imageRef, original+"/") {
 			return proxy + imageRef[len(original):]
 		}
-		// treat docker.io and index.docker.io as the same registry
-		if original == "docker.io" && strings.HasPrefix(imageRef, "index.docker.io/") {
+		// treat docker.io and index.docker.io as the same registry, but only when the
+		// spelling imageRef actually uses has no entry of its own: a configured entry for
+		// that exact spelling is a more specific match (the one "longest prefix wins"
+		// above already prefers) and must not be skipped in favor of the alias's proxy
+		// just because the alias happens to sort first by length (#883).
+		if original == "docker.io" && strings.HasPrefix(imageRef, "index.docker.io/") && !hasUsableProxy(proxyMap, "index.docker.io") {
 			return proxy + imageRef[len("index.docker.io"):]
 		}
-		if original == "index.docker.io" && strings.HasPrefix(imageRef, "docker.io/") {
+		if original == "index.docker.io" && strings.HasPrefix(imageRef, "docker.io/") && !hasUsableProxy(proxyMap, "docker.io") {
 			return proxy + imageRef[len("docker.io"):]
 		}
 	}
 	return imageRef
+}
+
+// hasUsableProxy reports whether proxyMap has a non-empty (after trimming any trailing
+// slash) proxy value configured for key.
+func hasUsableProxy(proxyMap map[string]string, key string) bool {
+	return strings.TrimRight(proxyMap[key], "/") != ""
 }
 
 func NormalizeImageID(imageID, imageTag string) string {

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -199,6 +199,38 @@ func TestRewriteImageRef(t *testing.T) {
 			},
 			want: "quay-mirror.example.com/kubescape/kubevuln:latest",
 		},
+		{
+			// #883: index.docker.io sorts before docker.io by length, so the alias
+			// fallback used to win even though docker.io/... is docker.io's own,
+			// more specific, direct match.
+			name:     "both docker.io and index.docker.io configured: docker.io ref uses its own entry",
+			imageRef: "docker.io/library/nginx:latest",
+			proxyMap: map[string]string{
+				"docker.io":       "mirror-a.example.com",
+				"index.docker.io": "mirror-b.example.com",
+			},
+			want: "mirror-a.example.com/library/nginx:latest",
+		},
+		{
+			name:     "both docker.io and index.docker.io configured: index.docker.io ref uses its own entry",
+			imageRef: "index.docker.io/library/nginx:latest",
+			proxyMap: map[string]string{
+				"docker.io":       "mirror-a.example.com",
+				"index.docker.io": "mirror-b.example.com",
+			},
+			want: "mirror-b.example.com/library/nginx:latest",
+		},
+		{
+			// The alias must still apply when only one of the pair has a usable value:
+			// an empty index.docker.io entry does not block docker.io's alias fallback.
+			name:     "index.docker.io entry present but empty does not block the docker.io alias fallback",
+			imageRef: "index.docker.io/library/alpine:latest",
+			proxyMap: map[string]string{
+				"docker.io":       "mirror.example.com",
+				"index.docker.io": "",
+			},
+			want: "mirror.example.com/library/alpine:latest",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

`rewriteImageRef` picks a `proxyRegistryMap` entry longest-key-first, so the most specific configured entry wins — `TestRewriteImageRef`'s own "longest prefix wins over shorter prefix" case establishes that as the function's contract. The `docker.io`/`index.docker.io` alias fallback breaks it: when both keys are configured with *different* proxy values, `index.docker.io` (16 chars) always sorts before `docker.io` (9 chars), so its alias branch matches a `docker.io/...` reference and returns before the loop ever reaches the `docker.io` key — the image's own, literal, more specific match.

## Root Cause

```go
sort.Slice(keys, func(i, j int) bool { return len(keys[i]) > len(keys[j]) })
for _, original := range keys {
    ...
    if original == "docker.io" && strings.HasPrefix(imageRef, "index.docker.io/") {
        return proxy + imageRef[len("index.docker.io"):]
    }
    if original == "index.docker.io" && strings.HasPrefix(imageRef, "docker.io/") {
        return proxy + imageRef[len("docker.io"):]
    }
}
```

With `proxyMap = {"docker.io": "mirror-a", "index.docker.io": "mirror-b"}` and `imageRef = "docker.io/library/nginx:latest"`, the loop visits `index.docker.io` first (longer key), its direct-prefix check fails, but the alias fallback (`original == "index.docker.io" && HasPrefix(imageRef, "docker.io/")`) succeeds and returns `mirror-b/...` — `docker.io`'s own explicitly configured `mirror-a` is never consulted. Confirmed by running the function directly:

```
rewritten: mirror-b.internal/library/nginx:latest
expected (docker.io's own explicit config): mirror-a.internal/library/nginx:latest
```

`TestRewriteImageRef` already covers `docker.io`-only and `index.docker.io`-only configurations separately, and separately covers longest-prefix-wins between two *unrelated* keys — but no case configures both `docker.io` and `index.docker.io` together, which is exactly the combination that breaks the "most specific match wins" guarantee.

## Fix

Added `hasUsableProxy`, and gated each alias branch on the *other* spelling not having a usable (non-empty) entry of its own:

```go
if original == "docker.io" && strings.HasPrefix(imageRef, "index.docker.io/") && !hasUsableProxy(proxyMap, "index.docker.io") {
    return proxy + imageRef[len("index.docker.io"):]
}
if original == "index.docker.io" && strings.HasPrefix(imageRef, "docker.io/") && !hasUsableProxy(proxyMap, "docker.io") {
    return proxy + imageRef[len("docker.io"):]
}
```

When only one of the two keys is configured, the alias fallback fires exactly as before (the other key's `hasUsableProxy` check is false, so the gate is a no-op). When both are configured, the loop now correctly continues past the alias's own iteration and reaches the directly-matching key on a later iteration.

## Testing

- `go build ./...` — passes
- `go vet ./adapters/v1/...` — passes
- `go test ./adapters/v1/...` — passes (confirmed clean on a sequential rerun; a `-p`-parallel run intermittently fails an unrelated timing test, `Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout`, due to Windows temp-file lock contention — reproduced the identical flake on a clean `upstream/main` checkout with no code changes, confirming it's pre-existing and unrelated to this change)
- `golangci-lint run --new-from-rev=upstream/main ./adapters/v1/...` — 0 issues

Added three cases to `TestRewriteImageRef`:
- both `docker.io` and `index.docker.io` configured with different proxies: a `docker.io/...` ref uses `docker.io`'s own entry (the bug's direct repro)
- the symmetric case: an `index.docker.io/...` ref uses `index.docker.io`'s own entry
- `index.docker.io` present but empty doesn't block the `docker.io` alias fallback, confirming the existing single-key behavior is preserved

All pre-existing cases pass unchanged.

## Impact

An operator configuring registry mirroring for both spellings of Docker Hub with different destinations no longer has `docker.io/...` references silently routed through the wrong mirror.

Fixes #883


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image proxy selection when both `docker.io` and `index.docker.io` configurations are present.
  * Exact registry configurations now take precedence over aliases.
  * Empty proxy entries no longer prevent valid alias-based proxy fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->