### PR TITLE
fix(sbomscanner): return syftToDomain's error instead of a nil the caller dereferences

### DIFF
--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -315,7 +315,10 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	}
 
 	// Convert to SyftDocument and serialize
-	doc := syftToDomain(*syftSBOM)
+	doc, err := syftToDomain(*syftSBOM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert SBOM: %w", err)
+	}
 	docBytes, err := json.Marshal(doc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize SBOM: %w", err)
@@ -342,8 +345,9 @@ func (s *scannerServer) Health(_ context.Context, _ *pb.HealthRequest) (*pb.Heal
 }
 
 // syftToDomain converts a Syft SBOM to a v1beta1.SyftDocument.
-// This is the same logic as SyftAdapter.syftToDomain.
-func syftToDomain(sbomSBOM sbom.SBOM) *v1beta1.SyftDocument {
+// This is the same logic as SyftAdapter.syftToDomain, including its error return: this
+// used to swallow both errors and return nil, which the caller then dereferenced.
+func syftToDomain(sbomSBOM sbom.SBOM) (*v1beta1.SyftDocument, error) {
 	doc := syftjson.ToFormatModel(sbomSBOM, syftjson.EncoderConfig{
 		Pretty: false,
 		Legacy: false,
@@ -351,16 +355,16 @@ func syftToDomain(sbomSBOM sbom.SBOM) *v1beta1.SyftDocument {
 
 	b, err := json.Marshal(doc)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	var syftDoc *v1beta1.SyftDocument
 	if err := json.Unmarshal(b, &syftDoc); err != nil {
-		return nil
+		return nil, err
 	}
 	syftmeta.Reattach(syftDoc.Artifacts, doc.Artifacts)
 
-	return syftDoc
+	return syftDoc, nil
 }
 
 func packageVersion(name string) string {

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 	"github.com/gofrs/flock"
@@ -36,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"math"
 )
 
 // maxUnixSockPathLen is the largest sockaddr_un.sun_path length (including the
@@ -969,4 +972,32 @@ func TestCreateSBOM_Exhausted429RateLimitFromResolveSource(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, domain.ReasonTooManyRequests, resp.StatusReason)
+}
+
+func syftSBOMWithMetadata(meta interface{}) sbom.SBOM {
+	p := pkg.Package{Name: "example", Version: "1.0.0", Metadata: meta}
+	p.SetID()
+	return sbom.SBOM{
+		Artifacts:     sbom.Artifacts{Packages: pkg.NewCollection(p)},
+		Relationships: []artifact.Relationship{},
+	}
+}
+
+func TestSyftToDomain(t *testing.T) {
+	doc, err := syftToDomain(syftSBOMWithMetadata(nil))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Len(t, doc.Artifacts, 1)
+	assert.Equal(t, "example", doc.Artifacts[0].Name)
+	assert.Equal(t, "1.0.0", doc.Artifacts[0].Version)
+}
+
+// A document that cannot be serialised must be reported, not returned as a nil pointer for
+// the caller to dereference. The in-process adapter's copy of this function has always
+// returned the error; this one dropped it, and CreateSBOM then read doc.Artifacts.
+func TestSyftToDomain_ReportsMarshalFailure(t *testing.T) {
+	doc, err := syftToDomain(syftSBOMWithMetadata(map[string]interface{}{"score": math.NaN()}))
+	require.Error(t, err)
+	assert.Nil(t, doc)
+	assert.Contains(t, err.Error(), "NaN")
 }


### PR DESCRIPTION
## Overview

The sidecar's `syftToDomain` says it is "the same logic as `SyftAdapter.syftToDomain`". It was not: the in-process copy returns its error, this one dropped both and returned `nil`.

The caller does not expect nil, and `json.Marshal` of a nil pointer succeeds (producing `"null"`, no error), so the nil survived to `len(doc.Artifacts)` in the completion log and panicked there.

The gRPC server is built with no recovery interceptor, and grpc-go does not recover handler panics, so that takes the sidecar process down rather than failing the one scan.

## Reproduction

Against current main, a package whose metadata carries a NaN float is enough to make `json.Marshal` fail:

```
syftToDomain returned nil? true
call site does len(doc.Artifacts) at server.go:327 -> nil deref
PANIC reproduced: runtime error: invalid memory address or nil pointer dereference
```

Stated plainly so it is not overread: package metadata comes from cataloguing a scanned image, and I have not shown a specific real image that produces an unmarshalable value. What is demonstrated is the failure mode, that any marshal or unmarshal failure here crashes the sidecar rather than returning an error, while the in-process path returns one for the same input.

## The change

`syftToDomain` returns `(*v1beta1.SyftDocument, error)` like its in-process counterpart, and `CreateSBOM` surfaces it as a gRPC error.

No explicit `endActiveTempDirUse()` at the new return: the defer covering it lives inside the `dl.Run` closure, which has already returned by this point. The existing serialize-error return immediately below does the same, so this matches the surrounding code rather than adding a call that the `sync.Once` would swallow anyway.

## Testing

`go build ./... && go vet ./... && go test ./pkg/sbomscanner/v1/ -count=1`

`syftToDomain` had no test at all, which is presumably why the divergence survived. Both outcomes are now covered, and reverting the error return to `nil, nil` fails `TestSyftToDomain_ReportsMarshalFailure`.

Coverage for the package goes 71.3% to 75.3%; `syftToDomain` 0% to 88.9%. It was the largest single uncovered block in the package.

## Related issues/PRs:

* Resolved #893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SBOM creation now reports serialization and deserialization failures instead of silently returning an empty result.
  - Conversion errors are propagated with clearer error context.

- **Tests**
  - Added coverage for SBOM conversion error scenarios.
  - Simplified test server and mock response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->