### PR TITLE
test(tools): cover DeleteContents and the default retry config, drop two dead helpers

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -18,7 +18,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/gofrs/flock"
 	"github.com/kubescape/kubevuln/core/domain"
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -83,20 +82,6 @@ func LabelsFromImageID(imageID string) map[string]string {
 		}
 	}
 	return labels
-}
-
-func FileContent(path string) []byte {
-	b, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
-		return nil
-	}
-	return b
-}
-
-func FileToSBOM(path string) *v1beta1.SyftDocument {
-	sbom := v1beta1.SyftDocument{}
-	_ = json.Unmarshal(FileContent(path), &sbom)
-	return &sbom
 }
 
 func FileToCVEManifest(path string) domain.CVEManifest {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -564,3 +564,82 @@ func TestLabelsFromImageID_UppercaseTagIsKept(t *testing.T) {
 		assert.Empty(t, validation.IsDNS1123Label(value), "label %q has invalid value %q", key, value)
 	}
 }
+
+// TestDeleteContents covers the property its one caller depends on: adapters/v1/grype.go
+// clears a half-written DB cache with it and then expects to install into that same
+// directory, so emptying it must not remove it.
+func TestDeleteContents(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(path.Join(dir, "file.txt"), []byte("x"), 0o600))
+	require.NoError(t, os.Mkdir(path.Join(dir, "sub"), 0o750))
+	require.NoError(t, os.WriteFile(path.Join(dir, "sub", "nested.txt"), []byte("y"), 0o600))
+	require.NoError(t, os.Mkdir(path.Join(dir, "sub", "deeper"), 0o750))
+
+	require.NoError(t, DeleteContents(dir))
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err, "the directory itself must survive")
+	assert.True(t, info.IsDir())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "files and subdirectories alike should be gone")
+}
+
+func TestDeleteContents_EmptyDirIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, DeleteContents(dir))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestDeleteContents_MissingDirReportsAnError(t *testing.T) {
+	err := DeleteContents(path.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "should surface the read error rather than reporting success")
+}
+
+// TestDeleteContents_LeavesSiblingsAlone checks it stays inside the directory it was given.
+// The caller passes a configured DBRootDir, so anything it deletes above that is data it was
+// never asked to touch.
+func TestDeleteContents_LeavesSiblingsAlone(t *testing.T) {
+	parent := t.TempDir()
+	target := path.Join(parent, "target")
+	sibling := path.Join(parent, "sibling")
+	require.NoError(t, os.Mkdir(target, 0o750))
+	require.NoError(t, os.Mkdir(sibling, 0o750))
+	require.NoError(t, os.WriteFile(path.Join(target, "gone.txt"), []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(path.Join(sibling, "kept.txt"), []byte("y"), 0o600))
+
+	require.NoError(t, DeleteContents(target))
+
+	_, err := os.Stat(path.Join(sibling, "kept.txt"))
+	assert.NoError(t, err, "a sibling directory must be untouched")
+}
+
+// TestDefault429RetryConfig pins the values governing every registry-pull retry, in both SBOM
+// paths and the scan service. They bound how long a worker is held by one rate-limited pull,
+// so a change here is a change to that ceiling and should be deliberate.
+func TestDefault429RetryConfig(t *testing.T) {
+	c := Default429RetryConfig()
+
+	assert.Equal(t, 3, c.MaxAttempts, "one initial attempt plus two retries")
+	assert.Equal(t, 500*time.Millisecond, c.InitialWait)
+	assert.Equal(t, 2*time.Second, c.MaxWait)
+	assert.Equal(t, 2.0, c.Backoff)
+	assert.Equal(t, 30*time.Second, c.MaxRetryAfter)
+
+	// MaxRetryAfter is what bounds a registry-chosen delay. Without it the ceiling would fall
+	// back to MaxWait, so the two must not be confused.
+	assert.Equal(t, 30*time.Second, c.retryAfterCeiling())
+}
+
+// FastRetryConfig sets no MaxRetryAfter, so its ceiling falls back to MaxWait. That fallback
+// is the branch retryAfterCeiling exists for.
+func TestFastRetryConfig_CeilingFallsBackToMaxWait(t *testing.T) {
+	c := FastRetryConfig()
+	assert.Zero(t, c.MaxRetryAfter)
+	assert.Equal(t, c.MaxWait, c.retryAfterCeiling())
+}


### PR DESCRIPTION
## Overview

`internal/tools` was at 79.3%. Two of the uncovered functions are live and load-bearing, two are dead, and one only looks uncovered.

79.3% to 86.7%. `DeleteContents` 0% to 87.5%, `Default429RetryConfig` 0% to 100%.

## The two that were live

**`DeleteContents`** empties a directory. Its one caller is `adapters/v1/grype.go`, clearing a half-written Grype DB cache after a failed update:

```go
if !hasExistingDB {
	if delErr := tools.DeleteContents(g.installCfg.DBRootDir); delErr != nil {
```

The property that caller depends on is that the directory itself survives, since the next install goes back into the same `DBRootDir`. Nothing pinned it. `TestDeleteContents` covers that alongside nested subdirectories, and `TestDeleteContents_LeavesSiblingsAlone` pins that it stays inside the directory it was given, which matters because that path is configured rather than fixed.

**`Default429RetryConfig`** has five production callers, across both SBOM paths and the scan service, and had no test. Its values bound how long a worker is held by one rate-limited registry pull. `MaxRetryAfter` is specifically what caps a registry-chosen `Retry-After`; without it `retryAfterCeiling` falls back to `MaxWait`, which is 2s rather than 30s. The test asserts both, and `TestFastRetryConfig_CeilingFallsBackToMaxWait` covers the fallback branch deliberately, since `FastRetryConfig` is the config that uses it.

## The two that were dead

`FileToSBOM` has **zero references** in the repository, production or test. `FileContent` has exactly one, inside `FileToSBOM`, so the pair is dead together. Both are exported from an `internal` package, so there are no outside consumers to break. Removed, along with the `v1beta1` import that became unused.

## The one that only looks uncovered

`FileToCVEManifest` also reports 0.0% in this package. That is per-package measurement rather than a gap: it has 46 references from other packages' tests and none in production. Left alone, and called out here so the remaining 0% in the report is not mistaken for dead code.

## Testing

`go build ./... && go vet ./... && go test ./internal/tools/ -count=1`

Three mutations, each caught:

| mutation | fails |
| --- | --- |
| make `DeleteContents` remove the directory itself | `TestDeleteContents`, `..._EmptyDirIsANoOp` |
| change `MaxRetryAfter` to 90s | `TestDefault429RetryConfig` |
| make `retryAfterCeiling` always fall back to `MaxWait` | `TestDefault429RetryConfig` |

`golangci-lint run ./internal/tools/...` exits 0 locally.

## Related issues/PRs:

* Resolved #896


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when clearing directory contents, including nested files and folders.
  * Preserved directories and sibling folders during cleanup operations.
  * Added clearer handling for missing directories.

* **Tests**
  * Added coverage for directory cleanup behavior.
  * Added validation for default and fast retry configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->