### PR TITLE
fix(adapters): normalize underscore delimiters in CleanDigestAlgorith…

### DIFF
--- a/adapters/v1/syft_utils.go
+++ b/adapters/v1/syft_utils.go
@@ -36,5 +36,6 @@ func Hashers(names ...string) ([]crypto.Hash, error) {
 
 func CleanDigestAlgorithmName(name string) string {
 	lower := strings.ToLower(name)
-	return strings.ReplaceAll(lower, "-", "")
+	r := strings.NewReplacer("-", "", "_", "")
+	return r.Replace(lower)
 }

--- a/adapters/v1/syft_utils.go
+++ b/adapters/v1/syft_utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// supportedHashAlgorithms returns the list of hash algorithms supported by Syft.
 func supportedHashAlgorithms() []crypto.Hash {
 	return []crypto.Hash{
 		crypto.MD5,
@@ -17,6 +18,7 @@ func supportedHashAlgorithms() []crypto.Hash {
 	}
 }
 
+// Hashers converts algorithm name strings into their corresponding crypto.Hash objects.
 func Hashers(names ...string) ([]crypto.Hash, error) {
 	hashByName := make(map[string]crypto.Hash)
 	for _, h := range supportedHashAlgorithms() {
@@ -34,6 +36,7 @@ func Hashers(names ...string) ([]crypto.Hash, error) {
 	return hashers, nil
 }
 
+// CleanDigestAlgorithmName normalizes a hash algorithm name by lowercasing and stripping hyphens and underscores.
 func CleanDigestAlgorithmName(name string) string {
 	lower := strings.ToLower(name)
 	r := strings.NewReplacer("-", "", "_", "")

--- a/adapters/v1/syft_utils_test.go
+++ b/adapters/v1/syft_utils_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestCleanDigestAlgorithmName tests the normalization of various hash algorithm names including hyphens and underscores.
 func TestCleanDigestAlgorithmName(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -31,6 +32,7 @@ func TestCleanDigestAlgorithmName(t *testing.T) {
 	}
 }
 
+// TestHashers tests resolving hash algorithm names to their crypto.Hash types.
 func TestHashers(t *testing.T) {
 	t.Run("supported algorithms are resolved correctly", func(t *testing.T) {
 		got, err := Hashers("sha-256", "MD5", "Sha-1")

--- a/adapters/v1/syft_utils_test.go
+++ b/adapters/v1/syft_utils_test.go
@@ -17,6 +17,9 @@ func TestCleanDigestAlgorithmName(t *testing.T) {
 		{name: "already lowercase, no hyphen", input: "md5", want: "md5"},
 		{name: "mixed case with hyphen", input: "Sha-1", want: "sha1"},
 		{name: "multiple hyphens", input: "SHA-512-256", want: "sha512256"},
+		{name: "lowercase with underscore", input: "sha_256", want: "sha256"},
+		{name: "uppercase with underscore", input: "SHA_512", want: "sha512"},
+		{name: "mixed hyphens and underscores", input: "Sha_512-256", want: "sha512256"},
 		{name: "empty string", input: "", want: ""},
 	}
 
@@ -33,6 +36,12 @@ func TestHashers(t *testing.T) {
 		got, err := Hashers("sha-256", "MD5", "Sha-1")
 		assert.NoError(t, err)
 		assert.Equal(t, []crypto.Hash{crypto.SHA256, crypto.MD5, crypto.SHA1}, got)
+	})
+
+	t.Run("underscore delimited algorithms are resolved correctly", func(t *testing.T) {
+		got, err := Hashers("sha_256", "SHA_512", "sha_384", "sha_224", "sha_1")
+		assert.NoError(t, err)
+		assert.Equal(t, []crypto.Hash{crypto.SHA256, crypto.SHA512, crypto.SHA384, crypto.SHA224, crypto.SHA1}, got)
 	})
 
 	t.Run("no names returns empty result", func(t *testing.T) {


### PR DESCRIPTION

## Overview
`adapters/v1/syft_utils.go` defines `CleanDigestAlgorithmName` to normalize hash algorithm strings before looking them up in `supportedHashAlgorithms`.

Previously, `CleanDigestAlgorithmName` only stripped hyphen delimiters (`-`), causing underscore-formatted algorithm names (such as `sha_256`, `sha_512`, `sha_384`, `sha_224`, `sha_1`) to fail with `unsupported hash algorithm: sha_256`.

This PR:
- Updates `CleanDigestAlgorithmName` to strip both hyphens and underscores (`-`, `_`).
- Adds unit tests in `adapters/v1/syft_utils_test.go` verifying normalization and hash resolution for snake_case and mixed-delimiter algorithm names.

## How to Test
Run unit tests:
```bash
go test -v ./adapters/v1/ -run "Test(CleanDigestAlgorithmName|Hashers)"
```

## Related issues/PRs:
* Resolved #898

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved digest algorithm name handling to recognize names containing underscores, including mixed capitalization and hyphenated formats.
  * Hash-based operations now correctly resolve underscore-delimited algorithm names.

* **Tests**
  * Added coverage for underscore-delimited digest names and hash resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->