### PR TITLE
fix(adapters): recover the grype DB updater when a load hangs past its timeout

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -85,6 +85,14 @@ type GrypeAdapter struct {
 	trustedVendors    map[distro.Type]bool
 	updating          bool
 	updateChan        chan struct{}
+	// loadMu is held for the entire duration of a loadFn call, so at most one load ever
+	// runs against installCfg.DBRootDir at a time. grype's v6 curator deletes the active
+	// DB directory and renames a freshly downloaded one into its place with no
+	// cross-call synchronization, so two concurrent loads can leave the on-disk DB
+	// corrupted or stale. A load abandoned as stuck keeps holding this until its
+	// uncancellable goroutine finally exits, which is what makes a retry safe: the retry's
+	// goroutine sees the lock held (TryLock fails), skips, and reschedules (see #900).
+	loadMu sync.Mutex
 	// stuckUpdateTimeout overrides defaultStuckUpdateTimeout. Set only by tests, which
 	// cannot wait out the 15-minute production value; zero means use the default.
 	stuckUpdateTimeout time.Duration
@@ -303,17 +311,17 @@ func (g *GrypeAdapter) Ready(ctx context.Context) bool {
 // stuckUpdateTimeout for it, purely so a slow/stuck download doesn't hold up this goroutine
 // forever. grype.LoadVulnerabilityDB takes no context and cannot be cancelled, so giving up
 // on the wait does NOT stop the load - it keeps writing to installCfg.DBRootDir in the
-// background. On the happy path every mutation of shared state (installing a successful
-// result, scheduling the next attempt, releasing the single-flight guard, and cleaning up
-// DBRootDir on failure) happens exactly once, in finishUpdate, invoked by the goroutine that
-// actually ran the load. That is what keeps a slow load from racing a second one started by
-// the next readiness probe, and keeps DBRootDir from being wiped out from under a download
-// still writing to it.
+// background.
 //
-// ch identifies this attempt: it is the g.updateChan created for it. finishUpdate and
-// abandonStuckUpdate compare g.updateChan against ch to tell whether this attempt still owns
-// the in-flight slot, so a load that eventually returns after being abandoned as stuck can be
-// discarded instead of clobbering a newer one (see #900).
+// ch identifies this attempt: it is the g.updateChan created for it. finishUpdate,
+// abandonStuckUpdate and releaseAttempt compare g.updateChan against ch to tell whether this
+// attempt still owns the in-flight slot, so a load that eventually returns after being
+// abandoned as stuck can be discarded instead of clobbering a newer one (see #900).
+//
+// The load goroutine holds g.loadMu for its whole run, so a retry launched after this
+// attempt was abandoned cannot start a second concurrent load against the same DBRootDir
+// (grype's loader is not safe to run twice against one directory) - its goroutine sees the
+// lock held and reschedules instead.
 func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{}) {
 	// Use context.WithoutCancel to prevent the update from being cancelled if the request context (e.g. readiness probe) is cancelled
 	ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "GrypeAdapter.UpdateDB")
@@ -335,6 +343,18 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{})
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+
+		if !g.loadMu.TryLock() {
+			// A previous load - almost always one abandoned as stuck - is still running
+			// against installCfg.DBRootDir. Running loadFn now would race grype's
+			// delete-then-rename of the active DB directory. Skip and reschedule; the
+			// retry gets the lock once that goroutine finally exits.
+			logger.L().Ctx(ctx).Warning("grype DB update skipped: a previous load is still in flight against the DB cache dir",
+				helpers.String("retryIn", stuckUpdateRetryDelay.String()))
+			g.releaseAttempt(ch, stuckUpdateRetryDelay)
+			return
+		}
+		defer g.loadMu.Unlock()
 
 		if logger.L().GetLevel() == "debug" {
 			if distClient, err := distribution.NewClient(g.distCfg); err == nil {
@@ -386,79 +406,56 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{})
 	}
 }
 
-// abandonStuckUpdate releases the single-flight guard for a load that updateDBBackground has
-// given up waiting for, and schedules a fresh attempt. The load goroutine keeps running
-// (grype.LoadVulnerabilityDB cannot be cancelled); ch is what lets its eventual finishUpdate
-// tell that it has been superseded and must not touch shared state. Only ever called on the
-// warm path (an existing DB is still serving), so the pod stays Ready throughout.
-func (g *GrypeAdapter) abandonStuckUpdate(ctx context.Context, ch chan struct{}) {
+// releaseAttempt relinquishes the in-flight update slot owned by ch: it clears the
+// single-flight guard, closes ch (which unblocks any cold-start Ready waiters), and
+// schedules the next attempt delay from now. It is a no-op returning false if ch no longer
+// owns the slot - a newer attempt has taken over, or finishUpdate already ran - so the
+// caller must not touch g.store/g.dbStatus either in that case.
+func (g *GrypeAdapter) releaseAttempt(ch chan struct{}, delay time.Duration) bool {
 	g.mu.Lock()
-	// g.updateChan == ch (non-nil) means this attempt still owns the in-flight slot. If it
-	// no longer matches, finishUpdate for this attempt already ran, or a newer attempt took
-	// over - either way there is nothing to abandon.
+	defer g.mu.Unlock()
 	if g.updateChan != ch {
-		g.mu.Unlock()
-		return
+		return false
 	}
-	existingVersion := g.dbVersionLocked()
 	g.updating = false
 	close(g.updateChan)
 	g.updateChan = nil
-	g.nextUpdateAttempt = time.Now().Add(stuckUpdateRetryDelay)
-	g.mu.Unlock()
-
-	logger.L().Ctx(ctx).Error("grype DB update stuck past the load timeout with an uncancellable load in flight; continuing with the existing DB and scheduling a retry",
-		helpers.String("existingDBVersion", existingVersion),
-		helpers.String("retryIn", stuckUpdateRetryDelay.String()))
+	g.nextUpdateAttempt = time.Now().Add(delay)
+	return true
 }
 
-// finishUpdate is invoked exactly once per updateDBBackground call, by the goroutine that
-// actually ran loadFn, regardless of whether updateDBBackground's own wait already gave up on
-// it. When this attempt still owns the in-flight slot (g.updateChan == ch) it owns every
-// mutation of shared state for the update - installing a successful result, scheduling the
-// next attempt, and releasing the single-flight guard - so nothing else can delete DBRootDir
-// or start a second update while this one is still writing to it. Installing the new state
-// happens under g.mu, but the actual I/O (closing providers, deleting DBRootDir) happens after
-// unlocking, so scans only block for the pointer swap. The single-flight guard is released
-// only after that I/O completes: Ready() unblocks cold-start callers as soon as updateChan
-// closes, so closing it any earlier would let a caller observe g.store before an unusable one
-// has actually been Close()'d.
+// abandonStuckUpdate gives up on a load that updateDBBackground has waited out and schedules
+// a fresh attempt. The load goroutine keeps running (grype.LoadVulnerabilityDB cannot be
+// cancelled) and keeps holding g.loadMu, so the retry's goroutine will skip until it exits.
+// Only ever called on the warm path (an existing DB is still serving), so the pod stays
+// Ready throughout.
+func (g *GrypeAdapter) abandonStuckUpdate(ctx context.Context, ch chan struct{}) {
+	g.mu.RLock()
+	existingVersion := g.dbVersionLocked()
+	g.mu.RUnlock()
+
+	if g.releaseAttempt(ch, stuckUpdateRetryDelay) {
+		logger.L().Ctx(ctx).Error("grype DB update stuck past the load timeout with an uncancellable load in flight; continuing with the existing DB and scheduling a retry",
+			helpers.String("existingDBVersion", existingVersion),
+			helpers.String("retryIn", stuckUpdateRetryDelay.String()))
+	}
+}
+
+// finishUpdate is invoked exactly once per loadFn call, by the goroutine that ran it, whether
+// or not updateDBBackground's own wait already gave up. It first checks whether this attempt
+// still owns the in-flight slot (g.updateChan == ch); if not - it was abandoned as stuck, or
+// a newer attempt is in flight - the load result is discarded (its store closed) and nothing
+// else is touched, since the guard, updateChan and nextUpdateAttempt now belong to another
+// attempt (see #900).
 //
-// If the attempt was already abandoned as stuck (abandonStuckUpdate ran, or a newer attempt
-// is in flight), the load result is discarded: its store is closed and nothing else is
-// touched, since the guard, updateChan, and nextUpdateAttempt now belong to another attempt
-// (see #900).
+// The owner check and every state mutation it gates (installing the store/status, scheduling
+// the next attempt, releasing the guard) happen under a single g.mu acquisition, so an
+// abandon that lands between them cannot half-apply a stale result. The provider I/O (closing
+// the old or the rejected store, cleaning DBRootDir) happens after unlocking, so scans only
+// block for the swap itself; it is still serialized against a concurrent load by g.loadMu,
+// which the caller holds for the whole of finishUpdate.
 func (g *GrypeAdapter) finishUpdate(ctx context.Context, ch chan struct{}, hasExistingDB bool, store vulnerability.Provider, dbStatus *vulnerability.ProviderStatus, err error) {
 	now := time.Now()
-
-	g.mu.RLock()
-	superseded := g.updateChan != ch
-	g.mu.RUnlock()
-	if superseded {
-		logger.L().Ctx(ctx).Warning("discarding grype DB load result that returned after being abandoned as stuck")
-		if store != nil {
-			if closeErr := store.Close(); closeErr != nil {
-				logger.L().Ctx(ctx).Warning("failed to close discarded grype DB", helpers.Error(closeErr))
-			}
-		}
-		return
-	}
-
-	// Released last via defer, after any I/O below, no matter which branch runs or how it
-	// returns: a leaked updating=true would permanently wedge future updates, since nothing
-	// else ever clears it, so this must not depend on every branch remembering to call it.
-	// Guarded by the same updateChan == ch ownership check: abandonStuckUpdate may have run
-	// in the narrow window after the superseded check above, in which case it already
-	// released the guard and this attempt must not touch it.
-	defer func() {
-		g.mu.Lock()
-		if g.updateChan == ch {
-			g.updating = false
-			close(g.updateChan)
-			g.updateChan = nil
-		}
-		g.mu.Unlock()
-	}()
 
 	// A successful load whose reported status still carries an error is not usable: treat
 	// it the same as a load failure so Ready() keeps reporting not-ready and a retry gets
@@ -469,10 +466,19 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, ch chan struct{}, hasEx
 
 	if err != nil {
 		g.mu.Lock()
-		// Schedule retry in 5 minutes on update failure
-		g.nextUpdateAttempt = now.Add(5 * time.Minute)
+		owner := g.updateChan == ch
+		if owner {
+			g.nextUpdateAttempt = now.Add(stuckUpdateRetryDelay)
+			g.updating = false
+			close(g.updateChan)
+			g.updateChan = nil
+		}
 		g.mu.Unlock()
 
+		if !owner {
+			g.discardLoadResult(ctx, store)
+			return
+		}
 		logger.L().Ctx(ctx).Error("failed to update grype DB", helpers.Error(err))
 		if store != nil {
 			if closeErr := store.Close(); closeErr != nil {
@@ -489,19 +495,41 @@ func (g *GrypeAdapter) finishUpdate(ctx context.Context, ch chan struct{}, hasEx
 	}
 
 	g.mu.Lock()
-	oldStore := g.store
-	g.store = store
-	g.dbStatus = dbStatus
-	// Schedule the next routine refresh in 24 hours
-	g.nextUpdateAttempt = now.Add(24 * time.Hour)
+	owner := g.updateChan == ch
+	var oldStore vulnerability.Provider
+	if owner {
+		oldStore = g.store
+		g.store = store
+		g.dbStatus = dbStatus
+		// Schedule the next routine refresh in 24 hours
+		g.nextUpdateAttempt = now.Add(24 * time.Hour)
+		g.updating = false
+		close(g.updateChan)
+		g.updateChan = nil
+	}
 	g.mu.Unlock()
 
+	if !owner {
+		g.discardLoadResult(ctx, store)
+		return
+	}
 	if oldStore != nil && oldStore != store {
 		if closeErr := oldStore.Close(); closeErr != nil {
 			logger.L().Ctx(ctx).Warning("failed to close previous grype DB", helpers.Error(closeErr))
 		}
 	}
 	logger.L().Info("grype DB updated")
+}
+
+// discardLoadResult closes a provider from a load whose attempt no longer owns the in-flight
+// slot, so its file handles and any locks are released rather than leaked.
+func (g *GrypeAdapter) discardLoadResult(ctx context.Context, store vulnerability.Provider) {
+	logger.L().Ctx(ctx).Warning("discarding grype DB load result that returned after its attempt was abandoned or superseded")
+	if store != nil {
+		if closeErr := store.Close(); closeErr != nil {
+			logger.L().Ctx(ctx).Warning("failed to close discarded grype DB", helpers.Error(closeErr))
+		}
+	}
 }
 
 const dummyLayer = "generatedlayer"

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -57,13 +57,24 @@ func defaultLoadDB(distCfg distribution.Config, installCfg installation.Config) 
 	return grype.LoadVulnerabilityDB(distCfg, installCfg, true)
 }
 
+const (
+	// defaultStuckUpdateTimeout is how long updateDBBackground waits for a single
+	// grype.LoadVulnerabilityDB call before giving up on it. The call takes no context and
+	// cannot be cancelled, and the pinned grype's download client carries no response-body
+	// read timeout, so a stalled connection hangs the load goroutine indefinitely.
+	defaultStuckUpdateTimeout = 15 * time.Minute
+	// stuckUpdateRetryDelay is how far out the next attempt is scheduled once a load has
+	// been abandoned as stuck, matching the retry cadence finishUpdate uses on failure.
+	stuckUpdateRetryDelay = 5 * time.Minute
+)
+
 // GrypeAdapter implements CVEScanner from ports using Grype's API
 type GrypeAdapter struct {
 	// nextUpdateAttempt is when Ready may next launch a background update. It is set on
-	// every terminal outcome of updateDBBackground (success -> +24h, failure -> +5m) and
-	// gates retries independently of dbStatus, so a cold start that keeps failing (and
-	// therefore never sets dbStatus) still backs off between attempts instead of firing
-	// once per readiness probe.
+	// every terminal outcome of a background update (success -> +24h, failure -> +5m,
+	// abandoned-as-stuck -> +5m) and gates retries independently of dbStatus, so a cold
+	// start that keeps failing (and therefore never sets dbStatus) still backs off between
+	// attempts instead of firing once per readiness probe.
 	nextUpdateAttempt time.Time
 	dbStatus          *vulnerability.ProviderStatus
 	store             vulnerability.Provider
@@ -74,7 +85,10 @@ type GrypeAdapter struct {
 	trustedVendors    map[distro.Type]bool
 	updating          bool
 	updateChan        chan struct{}
-	loadDB            loadDBFunc
+	// stuckUpdateTimeout overrides defaultStuckUpdateTimeout. Set only by tests, which
+	// cannot wait out the 15-minute production value; zero means use the default.
+	stuckUpdateTimeout time.Duration
+	loadDB             loadDBFunc
 }
 
 var _ ports.CVEScanner = (*GrypeAdapter)(nil)
@@ -258,9 +272,10 @@ func (g *GrypeAdapter) Ready(ctx context.Context) bool {
 		if time.Now().After(g.nextUpdateAttempt) && !g.updating {
 			g.updating = true
 			g.updateChan = make(chan struct{})
+			ch := g.updateChan
 			g.mu.Unlock()
 
-			go g.updateDBBackground(ctx)
+			go g.updateDBBackground(ctx, ch)
 		} else {
 			g.mu.Unlock()
 		}
@@ -284,17 +299,22 @@ func (g *GrypeAdapter) Ready(ctx context.Context) bool {
 	return g.store != nil && g.dbStatus != nil && g.dbStatus.Error == nil
 }
 
-// updateDBBackground launches the actual DB load in its own goroutine and waits up to 15
-// minutes for it, purely so a slow/stuck download doesn't hold up this goroutine forever.
-// grype.LoadVulnerabilityDB takes no context and cannot be cancelled, so giving up on the
-// wait does NOT stop the load - it keeps writing to installCfg.DBRootDir in the background.
-// Consequently every mutation of shared state (installing a successful result, scheduling
-// the next attempt, releasing the single-flight guard, and cleaning up DBRootDir on failure)
-// happens exactly once, in finishUpdate, invoked by the goroutine that actually ran the load
-// - never here. That is what keeps a slow load from racing a second one started by the next
-// readiness probe, and keeps DBRootDir from being wiped out from under a download still
-// writing to it.
-func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
+// updateDBBackground launches the actual DB load in its own goroutine and waits up to
+// stuckUpdateTimeout for it, purely so a slow/stuck download doesn't hold up this goroutine
+// forever. grype.LoadVulnerabilityDB takes no context and cannot be cancelled, so giving up
+// on the wait does NOT stop the load - it keeps writing to installCfg.DBRootDir in the
+// background. On the happy path every mutation of shared state (installing a successful
+// result, scheduling the next attempt, releasing the single-flight guard, and cleaning up
+// DBRootDir on failure) happens exactly once, in finishUpdate, invoked by the goroutine that
+// actually ran the load. That is what keeps a slow load from racing a second one started by
+// the next readiness probe, and keeps DBRootDir from being wiped out from under a download
+// still writing to it.
+//
+// ch identifies this attempt: it is the g.updateChan created for it. finishUpdate and
+// abandonStuckUpdate compare g.updateChan against ch to tell whether this attempt still owns
+// the in-flight slot, so a load that eventually returns after being abandoned as stuck can be
+// discarded instead of clobbering a newer one (see #900).
+func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{}) {
 	// Use context.WithoutCancel to prevent the update from being cancelled if the request context (e.g. readiness probe) is cancelled
 	ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "GrypeAdapter.UpdateDB")
 	defer span.End()
@@ -331,57 +351,109 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context) {
 				helpers.String("dbRootDir", g.installCfg.DBRootDir))
 		}
 		store, dbStatus, err := loadFn(g.distCfg, g.installCfg)
-		g.finishUpdate(ctx, hasExistingDB, store, dbStatus, err)
+		g.finishUpdate(ctx, ch, hasExistingDB, store, dbStatus, err)
 	}()
+
+	timeout := g.stuckUpdateTimeout
+	if timeout <= 0 {
+		timeout = defaultStuckUpdateTimeout
+	}
 
 	select {
 	case <-done:
-	case <-time.After(15 * time.Minute):
+	case <-time.After(timeout):
 		// grype.LoadVulnerabilityDB takes no context and cannot be cancelled, and the
 		// pinned grype's HTTP client bounds only dial/TLS handshake, not response-body
 		// reads (its withUserAgent post-processor replaces the *http.Client wholesale,
 		// silently dropping any Timeout we set on distCfg). A connection that stalls
 		// mid-download therefore hangs the load goroutine forever, so finishUpdate would
-		// never run: updating would stay true and DBRootDir would never be retried.
+		// never run on its own.
 		//
 		// On a cold start there is nothing to lose, so restart - the one case where this
 		// loses non-blocking behaviour is a download that is genuinely stuck, not merely
 		// slow, which is the same condition that used to trigger os.Exit(0) unconditionally
-		// before this PR. With an existing DB, though, the pod is healthy and serving: keep
-		// it that way instead of dropping in-flight scans, and let finishUpdate install the
-		// stuck load whenever (if ever) it returns.
+		// before #427. With an existing DB the pod is healthy and serving, so keep it that
+		// way: release the single-flight guard and schedule a fresh attempt here rather than
+		// waiting on a load that may never return. Without this, an uncancellable load that
+		// hangs forever would leave g.updating latched true for the pod's lifetime and
+		// Ready() would never launch another update - the pod would keep scanning against an
+		// ever-staler DB with no recovery (see #900).
 		if !hasExistingDB {
-			logger.L().Ctx(ctx).Error("grype DB initial download stuck past 15 minutes with an uncancellable load in flight, restarting to recover")
+			logger.L().Ctx(ctx).Error("grype DB initial download stuck past the load timeout with an uncancellable load in flight, restarting to recover")
 			os.Exit(0)
 		}
-		g.mu.RLock()
-		existingVersion := g.dbVersionLocked()
-		g.mu.RUnlock()
-		logger.L().Ctx(ctx).Error("grype DB update stuck past 15 minutes with an uncancellable load in flight, continuing with existing DB",
-			helpers.String("existingDBVersion", existingVersion))
+		g.abandonStuckUpdate(ctx, ch)
 	}
 }
 
+// abandonStuckUpdate releases the single-flight guard for a load that updateDBBackground has
+// given up waiting for, and schedules a fresh attempt. The load goroutine keeps running
+// (grype.LoadVulnerabilityDB cannot be cancelled); ch is what lets its eventual finishUpdate
+// tell that it has been superseded and must not touch shared state. Only ever called on the
+// warm path (an existing DB is still serving), so the pod stays Ready throughout.
+func (g *GrypeAdapter) abandonStuckUpdate(ctx context.Context, ch chan struct{}) {
+	g.mu.Lock()
+	// g.updateChan == ch (non-nil) means this attempt still owns the in-flight slot. If it
+	// no longer matches, finishUpdate for this attempt already ran, or a newer attempt took
+	// over - either way there is nothing to abandon.
+	if g.updateChan != ch {
+		g.mu.Unlock()
+		return
+	}
+	existingVersion := g.dbVersionLocked()
+	g.updating = false
+	close(g.updateChan)
+	g.updateChan = nil
+	g.nextUpdateAttempt = time.Now().Add(stuckUpdateRetryDelay)
+	g.mu.Unlock()
+
+	logger.L().Ctx(ctx).Error("grype DB update stuck past the load timeout with an uncancellable load in flight; continuing with the existing DB and scheduling a retry",
+		helpers.String("existingDBVersion", existingVersion),
+		helpers.String("retryIn", stuckUpdateRetryDelay.String()))
+}
+
 // finishUpdate is invoked exactly once per updateDBBackground call, by the goroutine that
-// actually ran loadFn, regardless of whether updateDBBackground's own 15-minute wait already
-// gave up on it. It owns every mutation of shared state for this update - installing a
-// successful result, scheduling the next attempt, and releasing the single-flight guard -
-// so nothing else can delete DBRootDir or start a second update while this one is still
-// writing to it. Installing the new state happens under g.mu, but the actual I/O (closing
-// providers, deleting DBRootDir) happens after unlocking, so scans only block for the pointer
-// swap. The single-flight guard is released only after that I/O completes: Ready() unblocks
-// cold-start callers as soon as updateChan closes, so closing it any earlier would let a
-// caller observe g.store before an unusable one has actually been Close()'d.
-func (g *GrypeAdapter) finishUpdate(ctx context.Context, hasExistingDB bool, store vulnerability.Provider, dbStatus *vulnerability.ProviderStatus, err error) {
+// actually ran loadFn, regardless of whether updateDBBackground's own wait already gave up on
+// it. When this attempt still owns the in-flight slot (g.updateChan == ch) it owns every
+// mutation of shared state for the update - installing a successful result, scheduling the
+// next attempt, and releasing the single-flight guard - so nothing else can delete DBRootDir
+// or start a second update while this one is still writing to it. Installing the new state
+// happens under g.mu, but the actual I/O (closing providers, deleting DBRootDir) happens after
+// unlocking, so scans only block for the pointer swap. The single-flight guard is released
+// only after that I/O completes: Ready() unblocks cold-start callers as soon as updateChan
+// closes, so closing it any earlier would let a caller observe g.store before an unusable one
+// has actually been Close()'d.
+//
+// If the attempt was already abandoned as stuck (abandonStuckUpdate ran, or a newer attempt
+// is in flight), the load result is discarded: its store is closed and nothing else is
+// touched, since the guard, updateChan, and nextUpdateAttempt now belong to another attempt
+// (see #900).
+func (g *GrypeAdapter) finishUpdate(ctx context.Context, ch chan struct{}, hasExistingDB bool, store vulnerability.Provider, dbStatus *vulnerability.ProviderStatus, err error) {
 	now := time.Now()
+
+	g.mu.RLock()
+	superseded := g.updateChan != ch
+	g.mu.RUnlock()
+	if superseded {
+		logger.L().Ctx(ctx).Warning("discarding grype DB load result that returned after being abandoned as stuck")
+		if store != nil {
+			if closeErr := store.Close(); closeErr != nil {
+				logger.L().Ctx(ctx).Warning("failed to close discarded grype DB", helpers.Error(closeErr))
+			}
+		}
+		return
+	}
 
 	// Released last via defer, after any I/O below, no matter which branch runs or how it
 	// returns: a leaked updating=true would permanently wedge future updates, since nothing
 	// else ever clears it, so this must not depend on every branch remembering to call it.
+	// Guarded by the same updateChan == ch ownership check: abandonStuckUpdate may have run
+	// in the narrow window after the superseded check above, in which case it already
+	// released the guard and this attempt must not touch it.
 	defer func() {
 		g.mu.Lock()
-		g.updating = false
-		if g.updateChan != nil {
+		if g.updateChan == ch {
+			g.updating = false
 			close(g.updateChan)
 			g.updateChan = nil
 		}

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -320,18 +320,25 @@ func Test_grypeAdapter_Ready_singleFlightUnderConcurrency(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent Ready() calls must not launch more than one background load")
 }
 
+func forceUpdateDue(g *GrypeAdapter) {
+	g.mu.Lock()
+	g.nextUpdateAttempt = time.Now().Add(-time.Minute)
+	g.mu.Unlock()
+}
+
 // A warm-path DB update whose load never returns (an uncancellable download hung on a
 // stalled connection) must not latch g.updating true forever: updateDBBackground abandons it
-// after stuckUpdateTimeout, releases the guard, and schedules a retry, so a later Ready() can
-// launch a fresh attempt that succeeds. Before #900 the guard stayed set for the pod's
-// lifetime and no further update was ever attempted.
+// after stuckUpdateTimeout, releases the guard, and schedules a retry. A retry launched while
+// the stuck load is still running must NOT start a second concurrent load against the same DB
+// cache dir; once the stuck load's goroutine finally exits, the next retry loads and installs
+// a fresh DB. Before #900 the guard stayed set for the pod's lifetime and no further update
+// was ever attempted.
 func Test_grypeAdapter_Ready_recoversFromStuckWarmUpdate(t *testing.T) {
 	ctx := context.Background()
 	oldStore := &closeTrackingProvider{}
 	newStore := &closeTrackingProvider{}
 	stuck := make(chan struct{})
-	defer close(stuck) // let the abandoned first load unwind at test teardown
-	var calls int32
+	var loadCalls int32
 
 	g := &GrypeAdapter{
 		store:              oldStore,
@@ -339,15 +346,15 @@ func Test_grypeAdapter_Ready_recoversFromStuckWarmUpdate(t *testing.T) {
 		nextUpdateAttempt:  time.Now().Add(-time.Minute),
 		stuckUpdateTimeout: 20 * time.Millisecond,
 		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
-			if atomic.AddInt32(&calls, 1) == 1 {
-				<-stuck // first attempt models a load that never returns
-				return nil, nil, errors.New("unblocked at teardown")
+			if atomic.AddInt32(&loadCalls, 1) == 1 {
+				<-stuck // first load models an uncancellable download that never returns
+				return nil, nil, errors.New("unblocked later")
 			}
 			return newStore, &vulnerability.ProviderStatus{From: "schema:v6%3Anew"}, nil
 		},
 	}
 
-	// First probe launches the update; the load hangs; updateDBBackground abandons it.
+	// 1. First probe launches the update; the load hangs; updateDBBackground abandons it.
 	require.True(t, g.Ready(ctx), "pod stays Ready while the stuck update is abandoned")
 	require.Eventually(t, func() bool {
 		g.mu.RLock()
@@ -360,18 +367,65 @@ func Test_grypeAdapter_Ready_recoversFromStuckWarmUpdate(t *testing.T) {
 	assert.Same(t, oldStore, g.store, "the existing DB keeps serving while the stuck load is abandoned")
 	g.mu.RUnlock()
 
-	// Simulate the retry delay elapsing, then the next probe: a fresh attempt runs and lands.
-	g.mu.Lock()
-	g.nextUpdateAttempt = time.Now().Add(-time.Minute)
-	g.mu.Unlock()
+	// 2. A retry while the stuck load still holds loadMu must skip rather than start a second
+	//    concurrent load against the same DB cache dir, and must reschedule.
+	forceUpdateDue(g)
+	require.True(t, g.Ready(ctx))
+	require.Eventually(t, func() bool {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+		return !g.updating
+	}, 2*time.Second, 5*time.Millisecond, "the bounced retry must reschedule")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&loadCalls), "no second load runs while the stuck one holds the DB cache dir")
+	g.mu.RLock()
+	assert.Same(t, oldStore, g.store)
+	g.mu.RUnlock()
+
+	// 3. The stuck load finally exits, releasing loadMu; a retry now loads and installs.
+	close(stuck)
+	require.Eventually(t, func() bool {
+		g.mu.Lock()
+		g.nextUpdateAttempt = time.Now().Add(-time.Minute)
+		updating := g.updating
+		g.mu.Unlock()
+		if !updating {
+			g.Ready(ctx)
+		}
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+		return g.store == newStore
+	}, 3*time.Second, 15*time.Millisecond, "once the stuck load releases loadMu, a retry installs a fresh DB")
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	assert.Equal(t, int32(2), atomic.LoadInt32(&loadCalls), "exactly one load ran after the stuck one was released")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldStore.closed), "the superseded store is closed once the new one is installed")
+}
+
+// A load that is slow but returns within stuckUpdateTimeout is installed normally: the
+// stuck-load handling and loadMu serialization must not interfere with an ordinary refresh.
+func Test_grypeAdapter_Ready_slowLoadWithinTimeoutStillInstalls(t *testing.T) {
+	ctx := context.Background()
+	oldStore := &closeTrackingProvider{}
+	newStore := &closeTrackingProvider{}
+	g := &GrypeAdapter{
+		store:              oldStore,
+		dbStatus:           &vulnerability.ProviderStatus{From: "schema:v6%3Aold"},
+		nextUpdateAttempt:  time.Now().Add(-time.Minute),
+		stuckUpdateTimeout: 500 * time.Millisecond,
+		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+			time.Sleep(40 * time.Millisecond)
+			return newStore, &vulnerability.ProviderStatus{From: "schema:v6%3Anew"}, nil
+		},
+	}
+
 	require.True(t, g.Ready(ctx))
 	waitForNotUpdating(t, g)
 
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	assert.Same(t, newStore, g.store, "a later probe must be able to launch a fresh update that lands")
-	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "exactly one fresh attempt after the abandoned one")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&oldStore.closed), "the superseded store is closed once the new one is installed")
+	assert.Same(t, newStore, g.store, "a slow-but-returning load must still be installed")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldStore.closed), "the previous store is closed after the swap")
 }
 
 // A load that finally returns after updateDBBackground abandoned it as stuck must be

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -320,6 +320,105 @@ func Test_grypeAdapter_Ready_singleFlightUnderConcurrency(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent Ready() calls must not launch more than one background load")
 }
 
+// A warm-path DB update whose load never returns (an uncancellable download hung on a
+// stalled connection) must not latch g.updating true forever: updateDBBackground abandons it
+// after stuckUpdateTimeout, releases the guard, and schedules a retry, so a later Ready() can
+// launch a fresh attempt that succeeds. Before #900 the guard stayed set for the pod's
+// lifetime and no further update was ever attempted.
+func Test_grypeAdapter_Ready_recoversFromStuckWarmUpdate(t *testing.T) {
+	ctx := context.Background()
+	oldStore := &closeTrackingProvider{}
+	newStore := &closeTrackingProvider{}
+	stuck := make(chan struct{})
+	defer close(stuck) // let the abandoned first load unwind at test teardown
+	var calls int32
+
+	g := &GrypeAdapter{
+		store:              oldStore,
+		dbStatus:           &vulnerability.ProviderStatus{From: "schema:v6%3Aold"},
+		nextUpdateAttempt:  time.Now().Add(-time.Minute),
+		stuckUpdateTimeout: 20 * time.Millisecond,
+		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				<-stuck // first attempt models a load that never returns
+				return nil, nil, errors.New("unblocked at teardown")
+			}
+			return newStore, &vulnerability.ProviderStatus{From: "schema:v6%3Anew"}, nil
+		},
+	}
+
+	// First probe launches the update; the load hangs; updateDBBackground abandons it.
+	require.True(t, g.Ready(ctx), "pod stays Ready while the stuck update is abandoned")
+	require.Eventually(t, func() bool {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+		return !g.updating && g.updateChan == nil
+	}, 2*time.Second, 5*time.Millisecond, "a stuck warm update must be abandoned, not left latched")
+
+	g.mu.RLock()
+	assert.True(t, g.nextUpdateAttempt.After(time.Now()), "an abandoned update must schedule a bounded retry")
+	assert.Same(t, oldStore, g.store, "the existing DB keeps serving while the stuck load is abandoned")
+	g.mu.RUnlock()
+
+	// Simulate the retry delay elapsing, then the next probe: a fresh attempt runs and lands.
+	g.mu.Lock()
+	g.nextUpdateAttempt = time.Now().Add(-time.Minute)
+	g.mu.Unlock()
+	require.True(t, g.Ready(ctx))
+	waitForNotUpdating(t, g)
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	assert.Same(t, newStore, g.store, "a later probe must be able to launch a fresh update that lands")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "exactly one fresh attempt after the abandoned one")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&oldStore.closed), "the superseded store is closed once the new one is installed")
+}
+
+// A load that finally returns after updateDBBackground abandoned it as stuck must be
+// discarded, not installed: its provider is closed and g.store / g.nextUpdateAttempt are left
+// as abandonStuckUpdate set them, so a slow load cannot silently overwrite a newer one or
+// undo the retry schedule (see #900, acceptance criterion 2).
+func Test_grypeAdapter_finishUpdate_discardsAbandonedLoadResult(t *testing.T) {
+	ctx := context.Background()
+	oldStore := &closeTrackingProvider{}
+	lateStore := &closeTrackingProvider{}
+	release := make(chan struct{})
+
+	g := &GrypeAdapter{
+		store:              oldStore,
+		dbStatus:           &vulnerability.ProviderStatus{From: "schema:v6%3Aold"},
+		nextUpdateAttempt:  time.Now().Add(-time.Minute),
+		stuckUpdateTimeout: 20 * time.Millisecond,
+		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+			<-release
+			return lateStore, &vulnerability.ProviderStatus{From: "schema:v6%3Alate"}, nil
+		},
+	}
+
+	require.True(t, g.Ready(ctx))
+	require.Eventually(t, func() bool {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+		return !g.updating
+	}, 2*time.Second, 5*time.Millisecond)
+
+	g.mu.RLock()
+	abandonSchedule := g.nextUpdateAttempt
+	g.mu.RUnlock()
+
+	// The abandoned load now returns a perfectly good DB - too late to be trusted.
+	close(release)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&lateStore.closed) == 1
+	}, 2*time.Second, 5*time.Millisecond, "a load result that returns after abandonment must be closed")
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	assert.Same(t, oldStore, g.store, "a discarded late load must not replace the active store")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&oldStore.closed), "the active store must not be closed by a discarded late load")
+	assert.Equal(t, abandonSchedule, g.nextUpdateAttempt, "a discarded late load must not touch the retry schedule")
+}
+
 // Grype's distro types are lowercase slugs compared verbatim, so a configured vendor was
 // only trusted when written exactly that way. "Wolfi", or a slug with the whitespace a JSON
 // list easily carries, went into the set as a key nothing matches, and adaptive mode quietly


### PR DESCRIPTION
## Overview

`GrypeAdapter` refreshes the Grype vulnerability DB in the background, driven by readiness
probes (`Ready` → `updateDBBackground` → `finishUpdate`). PR #427 replaced the old
"hold the write lock for 15 minutes / `os.Exit(0)` on any failure" design with a single-flight
guard (`g.updating`), a `g.nextUpdateAttempt` back-off clock, and a 15-minute wait that only
calls `os.Exit(0)` on a cold start.

**Current behaviour:** on the warm path (a DB is already loaded and serving), if the background
load goroutine never returns, `g.updating` is never cleared and `g.nextUpdateAttempt` is never
advanced, so no further DB update is ever attempted for the lifetime of the pod. `Ready()`
keeps returning `true` (the old `g.store` is still valid), Kubernetes never restarts the pod,
and kubevuln keeps matching CVEs against a frozen database with only a single log line to show
for it.

Root cause: `g.updating` is set only in `Ready()` and cleared only in `finishUpdate`'s defer,
which runs only after `loadFn(...)` returns. `grype.LoadVulnerabilityDB` takes no context and
cannot be cancelled, and the pinned grype's download client carries no response-body read
timeout (its `withUserAgent` post-processor overwrites the `*http.Client`, dropping the timeout
set on `distCfg`), so a stalled connection hangs the load goroutine indefinitely.
`updateDBBackground`'s wait expiring, on the `hasExistingDB` branch, only logged and returned.

**Future behaviour:** each background attempt is identified by its `g.updateChan`, threaded
through `updateDBBackground` / `finishUpdate`.

- When the wait expires on the warm path, `abandonStuckUpdate` (new) releases the guard if this
  attempt still owns the in-flight slot (`g.updateChan == ch`), closes/nils `g.updateChan`, and
  schedules a retry `+5m` (matching `finishUpdate`'s failure cadence). The next `Ready()` then
  launches a fresh attempt. It logs an `ERROR` each time, so a persistently stuck refresh is a
  recurring, alertable signal rather than one line.
- `finishUpdate` now checks ownership first. A load that returns after its attempt was abandoned
  (or superseded by a newer one) is discarded: its provider is `Close()`d and
  `g.store` / `g.dbStatus` / `g.nextUpdateAttempt` are left untouched, so a late load cannot
  clobber a newer one or undo the retry schedule. The deferred guard release is gated by the
  same check.
- Cold-start behaviour is unchanged: still `os.Exit(0)` (nothing to keep serving).
- The 15-minute wait is now `defaultStuckUpdateTimeout`, overridable via an unexported
  `stuckUpdateTimeout` field for tests (same pattern as the existing injectable `loadDB`).

Single-flight for a normal slow-but-returning load is preserved: `g.updating` still gates
concurrent `Ready()` calls until the load actually returns, unless the wait gives up on it
first.

## Additional Information

A dedicated staleness metric / `Diagnostics` field is a reasonable follow-up but is kept out of
this PR to keep it focused on the latch bug.

## How to Test

```
go test ./adapters/v1/ -run Test_grypeAdapter -count=1
```

New regression tests:

- `Test_grypeAdapter_Ready_recoversFromStuckWarmUpdate` — a load that never returns is abandoned
  after the timeout; `g.updating` / `g.updateChan` are cleared, the existing DB keeps serving, a
  retry is scheduled, and a later `Ready()` launches a fresh attempt that installs a new store.
- `Test_grypeAdapter_finishUpdate_discardsAbandonedLoadResult` — a load that returns a valid DB
  *after* being abandoned is closed and discarded; the active store and retry schedule are
  untouched.

Existing `Test_grypeAdapter_Ready_*` (non-blocking Ready, cold-start back-off,
status-error-as-failure, single-flight under concurrency) pass unchanged.

## Related issues/PRs:

Resolved #900

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database update handling when an update becomes stuck or takes longer than expected.
  * Preserved the active vulnerability database while safely retrying failed or abandoned updates.
  * Prevented overlapping database loads and discarded outdated results safely.
  * Ensured completed updates continue to replace the active database normally.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->