### PR TITLE
test(repositories): check our own VEX statements against go-vex's rules

### DIFF
--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
 	"github.com/akyoto/cache"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -5002,4 +5003,144 @@ func TestAPIServerStore_GetSecurityExceptions_ConversionFailureDegrades(t *testi
 	require.Error(t, err)
 	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls),
 		"an incomplete list must not be cached; the second call has to go back to the apiserver")
+}
+
+// asOpenVEXStatement round-trips a generated statement through JSON into go-vex's own
+// Statement type, so it can be checked with the library's rules rather than a local
+// restatement of them.
+func asOpenVEXStatement(t *testing.T, s v1beta1.Statement) vex.Statement {
+	t.Helper()
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+	var out vex.Statement
+	require.NoError(t, json.Unmarshal(b, &out))
+	return out
+}
+
+func ignoredMatchWithRule(rule v1beta1.IgnoreRule) v1beta1.IgnoredMatch {
+	return v1beta1.IgnoredMatch{
+		Match: v1beta1.Match{
+			Vulnerability: v1beta1.Vulnerability{
+				VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{ID: "CVE-2024-0001"},
+			},
+			Artifact: v1beta1.GrypePackage{Name: "pkg", Version: "1.0.0", PURL: "pkg:deb/pkg@1.0.0"},
+		},
+		AppliedIgnoreRules: []v1beta1.IgnoreRule{rule},
+	}
+}
+
+// TestGeneratedStatementsAreValidOpenVEX checks every statement shape kubevuln publishes
+// against go-vex's own Statement.Validate.
+//
+// internal/vexvalidate applies exactly these rules to documents kubevuln fetches (#878),
+// but nothing applied them to the documents it writes. The rules are easy to break from
+// here without noticing: they are mutual-exclusion rules, so adding an impact statement to
+// a fixed assessment, or an action statement to a not_affected one, produces a document
+// that decodes fine and that a strict consumer rejects.
+func TestGeneratedStatementsAreValidOpenVEX(t *testing.T) {
+	match := v1beta1.Match{
+		Vulnerability: v1beta1.Vulnerability{
+			VulnerabilityMetadata: v1beta1.VulnerabilityMetadata{
+				ID:         "CVE-2024-0001",
+				DataSource: "https://example.test/CVE-2024-0001",
+			},
+			Fix: v1beta1.Fix{State: "fixed", Versions: []string{"2.0.0"}},
+		},
+		Artifact: v1beta1.GrypePackage{Name: "pkg", Version: "1.0.0", PURL: "pkg:deb/pkg@1.0.0"},
+	}
+	const imagePullable = "docker://docker.io/library/nginx@sha256:abc"
+
+	baseline := func(t *testing.T) v1beta1.Statement {
+		t.Helper()
+		s, err := newLocalStatement(match, imagePullable)
+		require.NoError(t, err)
+		return s
+	}
+
+	tests := []struct {
+		name  string
+		build func(t *testing.T) v1beta1.Statement
+	}{
+		{
+			name:  "baseline not_affected",
+			build: baseline,
+		},
+		{
+			name: "relevant finding promoted to affected",
+			build: func(t *testing.T) v1beta1.Statement {
+				s := baseline(t)
+				idx := buildLocalVexStatementIndex([]v1beta1.Statement{s})
+				doc := v1beta1.VEX{Statements: []v1beta1.Statement{s}}
+				cvep := domain.CVEManifest{Content: &v1beta1.GrypeDocument{Matches: []v1beta1.Match{match}}}
+				require.NoError(t, markRelevantVulnerabilitiesAsAffectedInVex(&doc, &cvep, idx))
+				return doc.Statements[0]
+			},
+		},
+		{
+			name: "SecurityException, default not_affected",
+			build: func(t *testing.T) v1beta1.Statement {
+				s := baseline(t)
+				applyIgnoredMatchAssessment(&s, ignoredMatchAssessment(ignoredMatchWithRule(
+					v1beta1.IgnoreRule{SourceKind: "SecurityException"})))
+				return s
+			},
+		},
+		{
+			name: "SecurityException carrying justification and impact",
+			build: func(t *testing.T) v1beta1.Statement {
+				s := baseline(t)
+				applyIgnoredMatchAssessment(&s, ignoredMatchAssessment(ignoredMatchWithRule(
+					v1beta1.IgnoreRule{
+						SourceKind:      "SecurityException",
+						Justification:   "vulnerable_code_not_present",
+						ImpactStatement: "not reachable in this deployment",
+					})))
+				return s
+			},
+		},
+		{
+			name: "SecurityException with status fixed",
+			build: func(t *testing.T) v1beta1.Statement {
+				s := baseline(t)
+				applyIgnoredMatchAssessment(&s, ignoredMatchAssessment(ignoredMatchWithRule(
+					v1beta1.IgnoreRule{
+						SourceKind:    "SecurityException",
+						FixState:      string(sev1beta1.VulnerabilityStatusFixed),
+						Justification: "already patched",
+					})))
+				return s
+			},
+		},
+		{
+			name: "SecurityException accepting risk as affected",
+			build: func(t *testing.T) v1beta1.Statement {
+				s := baseline(t)
+				applyIgnoredMatchAssessment(&s, ignoredMatchAssessment(ignoredMatchWithRule(
+					v1beta1.IgnoreRule{
+						SourceKind: "SecurityException",
+						FixState:   string(sev1beta1.VulnerabilityStatusAffected),
+					})))
+				return s
+			},
+		},
+		{
+			name: "cloud exception policy, no CRD provenance",
+			build: func(t *testing.T) v1beta1.Statement {
+				s := baseline(t)
+				applyIgnoredMatchAssessment(&s, ignoredMatchAssessment(ignoredMatchWithRule(
+					v1beta1.IgnoreRule{Vulnerability: "CVE-2024-0001"})))
+				return s
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.build(t)
+			converted := asOpenVEXStatement(t, s)
+			err := converted.Validate()
+			assert.NoError(t, err, "status=%q justification=%q impact=%q action=%q",
+				s.Status, s.Justification, s.ImpactStatement, s.ActionStatement)
+		})
+	}
 }


### PR DESCRIPTION
## Overview

#880 added `internal/vexvalidate`, which checks a *fetched* OpenVEX document with go-vex's own `Statement.Validate()`. Nothing applied those rules to the documents kubevuln *writes*.

This adds that as a regression test. Test-only, no production changes.

## Why it is worth pinning

The rules are mutual-exclusion ones, and the assessment code sets these fields individually:

| status | requires | must not carry |
| --- | --- | --- |
| `not_affected` | justification or impact statement | action statement |
| `affected` | action statement | justification, impact statement |
| `fixed`, `under_investigation` | nothing | all three |

So adding an impact statement to a `fixed` assessment, or leaving one in place when promoting a finding to `affected`, produces a document that decodes fine, stores fine, and is rejected by anything applying the spec, including kubevuln's own new validator.

## Current output is already compliant

I checked before writing the test, so this is a regression test rather than a fix. All seven shapes kubevuln can emit pass:

- the baseline `not_affected` from `newLocalStatement`
- a finding promoted to `affected` by relevancy
- a `SecurityException` suppression, default and carrying its own justification and impact
- a `SecurityException` with status `fixed`
- a `SecurityException` accepting risk as `affected`
- a cloud exception policy with no CRD provenance

Statements are round-tripped through JSON into go-vex's own `Statement` type and checked with the library rather than a local restatement of its rules, so the test cannot drift from what the library enforces. `repositories` already imports go-vex for the status constants, so there is no new dependency.

## Testing

`go test ./repositories/ -run TestGeneratedStatementsAreValidOpenVEX -count=1`

Three mutations, each caught:

| mutation | fails |
| --- | --- |
| keep a justification on a `fixed` assessment | `SecurityException_with_status_fixed` |
| make an `affected` assessment produce no action statement | `SecurityException_accepting_risk_as_affected` |
| leave the impact statement in place when promoting to `affected` | `relevant_finding_promoted_to_affected` |

`golangci-lint run ./repositories/...` exits 0 locally.

## One observation, not addressed here

A scan of a clean image produces a document with zero statements, which `vexvalidate` would reject as `ErrNoStatements`. That is consistent for a validator aimed at fetched feeds, since an image with no findings has nothing to assert, but it does mean kubevuln can publish a document its own validator would refuse. Flagging it for a maintainer's view rather than changing it.

## Related issues/PRs:

* Resolved #902


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation coverage for multiple OpenVEX statement variants.
  * Verified that statements remain valid after JSON serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->