### PR TITLE
services: classify UNAUTHORIZED and NAME_UNKNOWN registry error codes

### DIFF
--- a/core/services/scan_failure_reasons.go
+++ b/core/services/scan_failure_reasons.go
@@ -62,10 +62,17 @@ func classifySBOMError(err error) string {
 	switch {
 	case strings.Contains(errStr, "401 Unauthorized") || strings.Contains(errStr, "403 Forbidden"):
 		return scanfailure.ReasonImageAuthFailed
+	case strings.Contains(errStr, "UNAUTHORIZED"):
+		// uppercase code, same rationale as MANIFEST_UNKNOWN below: stable across registries
+		// even when the typed *transport.Error doesn't survive (e.g. crossing gRPC to the sidecar).
+		return scanfailure.ReasonImageAuthFailed
 	case strings.Contains(errStr, "404 Not Found") ||
 		strings.Contains(errStr, "MANIFEST_UNKNOWN") ||
 		strings.Contains(errStr, "NAME_UNKNOWN") ||
 		strings.Contains(errStr, "BLOB_UNKNOWN"):
+		// NAME_UNKNOWN: repository does not exist (distinct from MANIFEST_UNKNOWN: unknown
+		// tag/digest on an existing repo). Same "not found" bucket since armoapi-go has no
+		// dedicated reason.
 		return scanfailure.ReasonImageNotFound
 	// uppercase code is the stable token; lowercase phrase varies by registry. A typed
 	// *transport.Error (HTTP 400 + code) also lands here, as its Error() includes the code.

--- a/core/services/scan_failure_reasons_test.go
+++ b/core/services/scan_failure_reasons_test.go
@@ -102,12 +102,17 @@ func TestClassifySBOMError(t *testing.T) {
 			expected: scanfailure.ReasonImageNotFound,
 		},
 		{
+			name:     "string-based UNAUTHORIZED code",
+			err:      fmt.Errorf("GET https://registry.io/v2/app/manifests/latest: UNAUTHORIZED: authentication required"),
+			expected: scanfailure.ReasonImageAuthFailed,
+		},
+		{
 			name:     "MANIFEST_UNKNOWN",
 			err:      fmt.Errorf("GET https://registry.io/v2/app/manifests/latest: MANIFEST_UNKNOWN: not found"),
 			expected: scanfailure.ReasonImageNotFound,
 		},
 		{
-			name:     "NAME_UNKNOWN",
+			name:     "NAME_UNKNOWN repository not found",
 			err:      fmt.Errorf("GET https://registry.io/v2/nonexistent/manifests/latest: NAME_UNKNOWN: repository name not known to registry"),
 			expected: scanfailure.ReasonImageNotFound,
 		},


### PR DESCRIPTION
Adds recognition for two registry error codes (UNAUTHORIZED and NAME_UNKNOWN) that were not being classified correctly before.

## Overview

Before: when an error contains the code UNAUTHORIZED or NAME_UNKNOWN, it falls into the generic "SBOM generation failed" category instead of being classified correctly.

After:
- UNAUTHORIZED -> classified as an authentication error (same category as the already-handled 401/403 cases)
- NAME_UNKNOWN -> classified as "image not found" (same category as the already-handled MANIFEST_UNKNOWN, but for a repository that doesn't exist instead of a missing tag)

## Additional Information

No behavior change to existing cases. Only two new cases added.

## How to Test

Two unit tests added in scan_failure_reasons_test.go. All tests pass (21/21).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan failure reporting for registry authentication errors.
  * Improved detection and reporting when a referenced image repository or image layer cannot be found.
  * Preserved accurate handling of manifest-not-found errors across service boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->