### PR TITLE
services: mark hash.Hash.Write's error as intentionally ignored

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -120,7 +120,7 @@ func credentialsFingerprint(workload domain.ScanCommand) string {
 	h := sha256.New()
 	for _, cred := range workload.CredentialsList {
 		// codeql[go/weak-crypto, go/weak-password-hashing]
-		fmt.Fprintf(h, "%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s\n",
+		fmt.Fprintf(h, "%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s\n", //nolint:errcheck // hash.Hash.Write never returns an error
 			len(cred.Username), cred.Username,
 			len(cred.Password), cred.Password,
 			len(cred.Auth), cred.Auth,


### PR DESCRIPTION
Small lint cleanup: annotates an errcheck finding on `credentialsFingerprint`'s `fmt.Fprintf(h, ...)` call.

## Overview

Before: golangci-lint (errcheck) flags the return value of `fmt.Fprintf(h, ...)` in `credentialsFingerprint` as an unchecked error.

After: the error is explicitly marked as intentionally ignored, with a comment explaining why.

## Why this is safe

`h` here is a `sha256.Hash` (a `hash.Hash`). Per the `hash.Hash` interface contract in the Go standard library, `Write` never returns an error   so the value `Fprintf` would return is unreachable dead error handling. errcheck flags it anyway because it doesn't know this contract.

## Additional Information

Same pattern already used elsewhere in this repo: `crypto/rand.Read` in `internal/vexdoc`'s `randomFilename` has the identical `//nolint:errcheck` annotation with a similar justification comment.

No behavior change  this is a lint annotation only, not a logic change.

## How to Test

No new tests needed (not a behavior change). Confirmed the finding disappears:

golangci-lint run ./core/services/...

All existing tests in core/services still pass (verified locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis guidance for credential fingerprint processing.
  * No user-visible functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->