### PR TITLE
fix(services): classify HTTP 404, NAME_UNKNOWN, and BLOB_UNKNOWN registry errors as ImageNotFound (#908)

### DIFF
--- a/core/services/scan_failure_reasons.go
+++ b/core/services/scan_failure_reasons.go
@@ -42,6 +42,8 @@ func classifySBOMError(err error) string {
 		case transportErr.StatusCode == http.StatusUnauthorized ||
 			transportErr.StatusCode == http.StatusForbidden:
 			return scanfailure.ReasonImageAuthFailed
+		case transportErr.StatusCode == http.StatusNotFound:
+			return scanfailure.ReasonImageNotFound
 		}
 	}
 
@@ -60,7 +62,10 @@ func classifySBOMError(err error) string {
 	switch {
 	case strings.Contains(errStr, "401 Unauthorized") || strings.Contains(errStr, "403 Forbidden"):
 		return scanfailure.ReasonImageAuthFailed
-	case strings.Contains(errStr, "MANIFEST_UNKNOWN"):
+	case strings.Contains(errStr, "404 Not Found") ||
+		strings.Contains(errStr, "MANIFEST_UNKNOWN") ||
+		strings.Contains(errStr, "NAME_UNKNOWN") ||
+		strings.Contains(errStr, "BLOB_UNKNOWN"):
 		return scanfailure.ReasonImageNotFound
 	// uppercase code is the stable token; lowercase phrase varies by registry. A typed
 	// *transport.Error (HTTP 400 + code) also lands here, as its Error() includes the code.

--- a/core/services/scan_failure_reasons_test.go
+++ b/core/services/scan_failure_reasons_test.go
@@ -82,8 +82,37 @@ func TestClassifySBOMError(t *testing.T) {
 			expected: scanfailure.ReasonImageAuthFailed,
 		},
 		{
+			name: "transport 404 via errors.As",
+			err: &transport.Error{
+				StatusCode: http.StatusNotFound,
+			},
+			expected: scanfailure.ReasonImageNotFound,
+		},
+		{
+			name: "wrapped transport 404",
+			err: fmt.Errorf("fetching manifest: %w", &transport.Error{
+				StatusCode: http.StatusNotFound,
+			}),
+			expected: scanfailure.ReasonImageNotFound,
+		},
+		{
+			name:     "string-based 404 Not Found",
+			err:      fmt.Errorf("GET https://registry.io/v2/app/manifests/latest: 404 Not Found"),
+			expected: scanfailure.ReasonImageNotFound,
+		},
+		{
 			name:     "MANIFEST_UNKNOWN",
 			err:      fmt.Errorf("GET https://registry.io/v2/app/manifests/latest: MANIFEST_UNKNOWN: not found"),
+			expected: scanfailure.ReasonImageNotFound,
+		},
+		{
+			name:     "NAME_UNKNOWN",
+			err:      fmt.Errorf("GET https://registry.io/v2/nonexistent/manifests/latest: NAME_UNKNOWN: repository name not known to registry"),
+			expected: scanfailure.ReasonImageNotFound,
+		},
+		{
+			name:     "BLOB_UNKNOWN",
+			err:      fmt.Errorf("GET https://registry.io/v2/app/blobs/sha256:123: BLOB_UNKNOWN: blob unknown to registry"),
 			expected: scanfailure.ReasonImageNotFound,
 		},
 		{

--- a/core/services/scan_failure_reasons_test.go
+++ b/core/services/scan_failure_reasons_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestClassifySBOMError verifies that registry, scanner, and transport errors are classified into standard failure reason codes.
 func TestClassifySBOMError(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -175,6 +176,7 @@ func TestClassifySBOMError(t *testing.T) {
 	}
 }
 
+// TestClassifySBOMStatus verifies non-error SBOM status string mapping to failure reason codes.
 func TestClassifySBOMStatus(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -206,6 +208,7 @@ func TestClassifySBOMStatus(t *testing.T) {
 	}
 }
 
+// TestClassifySBOMStatusWithAnnotation verifies refined status classification using SBOM annotations.
 func TestClassifySBOMStatusWithAnnotation(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION

## Overview
In `core/services/scan_failure_reasons.go`, `classifySBOMError` inspects registry and scanner errors to resolve appropriate failure reasons for metrics and scan statuses.

Previously:
- `classifySBOMError` only checked `transport.Error` for `401` and `403` (`ReasonImageAuthFailed`), and string fallbacks for `"MANIFEST_UNKNOWN"`.
- When an image repository or tag is missing and the registry returns HTTP 404 (`transport.Error{StatusCode: 404}` or `"404 Not Found"`) or standard OCI errors like `NAME_UNKNOWN` / `BLOB_UNKNOWN`, it fell through to `ReasonSBOMGenerationFailed` instead of `ReasonImageNotFound`.

This PR:
- Adds `transportErr.StatusCode == http.StatusNotFound` to map typed 404 transport errors to `scanfailure.ReasonImageNotFound`.
- Adds string fallback checks for `"404 Not Found"`, `"NAME_UNKNOWN"`, and `"BLOB_UNKNOWN"` to map untyped / wrapped errors to `scanfailure.ReasonImageNotFound`.
- Adds table tests in `core/services/scan_failure_reasons_test.go` covering typed/wrapped 404 errors, `"404 Not Found"`, `"NAME_UNKNOWN"`, and `"BLOB_UNKNOWN"`.

## How to Test
Run unit tests:
```bash
go test -v ./core/services/ -run TestClassifySBOMError
```

## Related issues/PRs:
* Resolved #908

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-not-found detection for HTTP 404 responses and common container registry errors.
  * Scan failures now provide more accurate image-not-found classifications across additional error formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->