### PR TITLE
test(repositories): make the fake storage clientset honour ResourceVersion: metadata

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -74,6 +74,16 @@ const (
 	securityExceptionListCacheKeyPrefix        = "se/"
 )
 
+// resourceVersionMetadata mirrors kubescape/storage's
+// softwarecomposition.ResourceVersionMetadata. Passed as GetOptions.ResourceVersion, its
+// file-backed apiserver (pkg/registry/file/storage.go) honours it by reading only the
+// object's metadata blob from SQLite: the returned object carries its TypeMeta/ObjectMeta
+// but Spec and Status come back at their zero value. createOrUpdate's conflict-retry Get
+// uses it to avoid pulling a large payload just to read a resourceVersion, and updateVEX
+// deliberately does not (it merges into an existing Spec). The fake storage clientset used
+// in tests reproduces this behaviour, so both invariants stay under test (#910, #475).
+const resourceVersionMetadata = "metadata"
+
 // APIServerStore implements both CVERepository and SBOMRepository with in-cluster storage (apiserver) to be used for production
 type APIServerStore struct {
 	StorageClient spdxv1beta1.SpdxV1beta1Interface
@@ -249,6 +259,12 @@ func newFakeStorageClientset(objects ...runtime.Object) *fakeStorageClientset {
 	}
 
 	clientset := &fakeStorageClientset{tracker: tracker}
+	// Reproduce kubescape/storage's handling of GetOptions{ResourceVersion:
+	// resourceVersionMetadata}: return the object with only its metadata populated. The
+	// default ObjectReaction ignores GetOptions and always returns the full object, which
+	// leaves createOrUpdate's conflict-retry read-modify-write, and updateVEX's deliberate
+	// avoidance of that option, without test coverage (#910, #475).
+	clientset.PrependReactor("get", "*", metadataOnlyGetReactor(tracker))
 	clientset.AddReactor("*", "*", k8stesting.ObjectReaction(tracker))
 	clientset.AddWatchReactor("*", func(action k8stesting.Action) (bool, watch.Interface, error) {
 		var opts metav1.ListOptions
@@ -263,6 +279,44 @@ func newFakeStorageClientset(objects ...runtime.Object) *fakeStorageClientset {
 	})
 
 	return clientset
+}
+
+// metadataOnlyGetReactor handles a Get carrying
+// GetOptions{ResourceVersion: resourceVersionMetadata} by returning a copy of the tracked
+// object with every field other than TypeMeta/ObjectMeta zeroed, matching what
+// kubescape/storage's file-backed apiserver serves for that option. Any other Get returns
+// handled=false so the default ObjectReaction takes over.
+func metadataOnlyGetReactor(tracker k8stesting.ObjectTracker) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getAction, ok := action.(k8stesting.GetActionImpl)
+		if !ok || getAction.GetOptions.ResourceVersion != resourceVersionMetadata {
+			return false, nil, nil
+		}
+		obj, err := tracker.Get(getAction.GetResource(), getAction.GetNamespace(), getAction.GetName())
+		if err != nil {
+			return true, nil, err
+		}
+		return true, stripToMetadata(obj.DeepCopyObject()), nil
+	}
+}
+
+// stripToMetadata zeroes every field of obj except its embedded TypeMeta and ObjectMeta, so
+// what remains is only what a metadata-only read returns. obj is mutated in place and
+// returned for convenience; callers pass a copy.
+func stripToMetadata(obj runtime.Object) runtime.Object {
+	v := reflect.Indirect(reflect.ValueOf(obj))
+	if v.Kind() != reflect.Struct {
+		return obj
+	}
+	for i := range v.NumField() {
+		if name := v.Type().Field(i).Name; name == "TypeMeta" || name == "ObjectMeta" {
+			continue
+		}
+		if f := v.Field(i); f.CanSet() {
+			f.Set(reflect.Zero(f.Type()))
+		}
+	}
+	return obj
 }
 
 func newFakeAPIServerStore(namespace string, storageClient spdxv1beta1.SpdxV1beta1Interface) *APIServerStore {
@@ -1073,14 +1127,15 @@ func (a *APIServerStore) StoreVEX(ctx context.Context, cve domain.CVEManifest, c
 			// retrieve the latest version before attempting update
 			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
 			//
-			// NOTE: this must NOT use GetOptions{ResourceVersion: "metadata"} like the
-			// sibling Store* methods do. That option returns an ObjectMeta-only object
-			// with a zero Spec in kubescape/storage's apiserver, which is safe for the
-			// siblings because they overwrite Spec wholesale. updateVEX instead merges
+			// NOTE: this must NOT use GetOptions{ResourceVersion: resourceVersionMetadata}
+			// like the sibling Store* methods do. That option returns an ObjectMeta-only
+			// object with a zero Spec in kubescape/storage's apiserver, which is safe for
+			// the siblings because they overwrite Spec wholesale. updateVEX instead merges
 			// into vexContainer.Spec.Statements, so a metadata-only read would silently
 			// drop every previously stored statement and then fail when it tries to
-			// parse the zeroed Spec.Metadata.Timestamp. The fake clientset used in tests
-			// ignores GetOptions entirely, so no test can catch a regression here.
+			// parse the zeroed Spec.Metadata.Timestamp. The fake clientset reproduces the
+			// option's real behaviour (see newFakeStorageClientset), so switching this to
+			// it fails the storeVEX_* tests instead of shipping silently.
 			var getErr error
 			vexContainer, getErr = a.StorageClient.OpenVulnerabilityExchangeContainers(a.Namespace).Get(ctx, cvep.Name, metav1.GetOptions{})
 			if getErr != nil {
@@ -2109,7 +2164,7 @@ func createOrUpdate[T any](ctx context.Context, store objectStore[T], kind, name
 			}
 			// retrieve the latest version before attempting update
 			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-			existing, getErr := store.Get(ctx, name, metav1.GetOptions{ResourceVersion: "metadata"})
+			existing, getErr := store.Get(ctx, name, metav1.GetOptions{ResourceVersion: resourceVersionMetadata})
 			if getErr != nil {
 				return getErr
 			}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1862,6 +1862,116 @@ func TestAPIServerStore_StoreCVE_mergesMetadataOnUpdate(t *testing.T) {
 	assert.Equal(t, "v2", got.Labels["l1"])
 }
 
+// #910: the fake storage clientset must reproduce kubescape/storage's handling of
+// GetOptions{ResourceVersion: resourceVersionMetadata} -- an ObjectMeta-only object, Spec and
+// Status at their zero value. The default ObjectReaction ignores GetOptions, so without this
+// createOrUpdate's conflict-retry read-modify-write and updateVEX's deliberate avoidance of
+// the option have no coverage (the exact gap that let #475 ship a summary-erasing bug).
+func TestNewFakeStorageClientset_MetadataResourceVersionReturnsMetadataOnly(t *testing.T) {
+	sbom := &v1beta1.SBOMSyft{
+		TypeMeta: metav1.TypeMeta{Kind: "SBOMSyft", APIVersion: "spdx.softwarecomposition.kubescape.io/v1beta1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "kubescape",
+			Annotations: map[string]string{"a": "1"}, Labels: map[string]string{"l": "2"},
+		},
+		Spec: v1beta1.SBOMSyftSpec{Metadata: v1beta1.SPDXMeta{Tool: v1beta1.ToolMeta{Name: "syft", Version: "v1"}}},
+	}
+	vex := &v1beta1.OpenVulnerabilityExchangeContainer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "kubescape"},
+		Spec:       v1beta1.VEX{Statements: []v1beta1.Statement{{ID: "stmt-1"}}},
+	}
+	cs := newFakeStorageClientset(sbom, vex).SpdxV1beta1()
+	metaOpt := metav1.GetOptions{ResourceVersion: resourceVersionMetadata}
+
+	got, err := cs.SBOMSyfts("kubescape").Get(context.Background(), name, metaOpt)
+	require.NoError(t, err)
+	assert.Equal(t, name, got.Name, "metadata-only read keeps ObjectMeta")
+	assert.Equal(t, "1", got.Annotations["a"])
+	assert.Equal(t, "2", got.Labels["l"])
+	assert.Equal(t, "SBOMSyft", got.Kind, "metadata-only read keeps TypeMeta")
+	assert.Equal(t, sbom.APIVersion, got.APIVersion)
+	assert.Zero(t, got.Spec, "metadata-only read drops Spec")
+	// SBOMSyftStatus -- like every *Status type in this API -- is an empty struct today, so
+	// there is no non-zero value to seed; stripToMetadata zeroes it via the same field loop
+	// that zeroes Spec, and this assertion holds that line if the type ever gains fields.
+	assert.Zero(t, got.Status, "metadata-only read drops Status")
+
+	full, err := cs.SBOMSyfts("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "syft", full.Spec.Metadata.Tool.Name, "a normal Get is unaffected")
+
+	// The OVEC case is why updateVEX must NOT use this option: it would read back a document
+	// with no statements and then merge into it.
+	gotVex, err := cs.OpenVulnerabilityExchangeContainers("kubescape").Get(context.Background(), name, metaOpt)
+	require.NoError(t, err)
+	assert.Empty(t, gotVex.Spec.Statements, "metadata-only read drops VEX statements")
+}
+
+// createOrUpdate's conflict-retry path reads the existing object metadata-only (zero Spec)
+// then Updates. Each Store* is safe only because its merge overwrites Spec wholesale; this
+// locks that in against the metadata-aware fake -- a merge that started reading existing.Spec
+// would see zero here and silently lose data (#910, #475).
+func TestAPIServerStore_createOrUpdate_conflictRetryStoresFullSpec(t *testing.T) {
+	newCVE := tools.FileToCVEManifest("testdata/nginx-cve.json")
+	newCVE.Name = name
+	newCVE.CVEDBVersion = "new-db"
+	require.Positive(t, len(newCVE.Content.Matches))
+
+	t.Run("StoreCVE", func(t *testing.T) {
+		seeded := &v1beta1.VulnerabilityManifest{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "kubescape"},
+			Spec: v1beta1.VulnerabilityManifestSpec{
+				Metadata: v1beta1.VulnerabilityManifestMeta{Tool: v1beta1.VulnerabilityManifestToolMeta{DatabaseVersion: "old-db"}},
+				Payload:  v1beta1.GrypeDocument{Matches: make([]v1beta1.Match, 999)},
+			},
+		}
+		a := newFakeAPIServerStore("kubescape", newFakeStorageClientset(seeded).SpdxV1beta1())
+
+		require.NoError(t, a.StoreCVE(context.Background(), newCVE, false))
+
+		got, err := a.StorageClient.VulnerabilityManifests("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Len(t, got.Spec.Payload.Matches, len(newCVE.Content.Matches), "the conflict write must store the full new payload, not the stale seed")
+		assert.Equal(t, "new-db", got.Spec.Metadata.Tool.DatabaseVersion, "and the full new metadata")
+	})
+
+	t.Run("StoreSBOM", func(t *testing.T) {
+		seeded := &v1beta1.SBOMSyft{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "kubescape"},
+			Spec:       v1beta1.SBOMSyftSpec{Syft: v1beta1.SyftDocument{Artifacts: make([]v1beta1.SyftPackage, 999)}},
+		}
+		a := newFakeAPIServerStore("kubescape", newFakeStorageClientset(seeded).SpdxV1beta1())
+
+		sbom := domain.SBOM{Name: name, Content: &v1beta1.SyftDocument{Artifacts: make([]v1beta1.SyftPackage, 3)}}
+		require.NoError(t, a.StoreSBOM(context.Background(), sbom, false))
+
+		got, err := a.StorageClient.SBOMSyfts("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Len(t, got.Spec.Syft.Artifacts, 3, "the conflict write must store the full new SBOM payload, not the stale seed")
+	})
+
+	t.Run("StoreCVESummary", func(t *testing.T) {
+		workload := domain.ScanCommand{ImageTag: "nginx:latest", ImageSlug: name, ContainerName: "nginx"}
+		ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, workload)
+		ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+
+		seeded := &v1beta1.VulnerabilityManifestSummary{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "kubescape"},
+			Spec: v1beta1.VulnerabilityManifestSummarySpec{
+				Severities: v1beta1.SeveritySummary{Critical: v1beta1.VulnerabilityCounters{All: 987654}},
+			},
+		}
+		a := newFakeAPIServerStore("kubescape", newFakeStorageClientset(seeded).SpdxV1beta1())
+
+		require.NoError(t, a.StoreCVESummary(ctx, newCVE, domain.CVEManifest{}, false))
+
+		got, err := a.StorageClient.VulnerabilityManifestSummaries("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, parseSeverities(newCVE, domain.CVEManifest{}, false), got.Spec.Severities,
+			"the conflict write must store the full recomputed summary, not merge onto the zeroed metadata read")
+	})
+}
+
 func TestAPIServerStore_GetCVE_transientError(t *testing.T) {
 	clientset := newFakeStorageClientset()
 	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))


### PR DESCRIPTION
## Overview

**Current behaviour.** `APIServerStore`'s write path leans on one `GetOptions` field that the
test double does not model.

- `createOrUpdate` (`repositories/apiserver.go`) — the conflict-retry read-modify-write behind
  `StoreCVE`, `StoreCVESummary`, `StoreSBOM` (and the filtered variant) — does
  `Get(name, GetOptions{ResourceVersion: "metadata"})`, then `merge(existing)`, then `Update`.
- `kubescape/storage@v0.0.302`, `pkg/registry/file/storage.go`, honours that option by reading
  only the object's SQLite metadata blob: the returned object carries `TypeMeta`/`ObjectMeta`
  but **`Spec` and `Status` come back at their zero value**.
- Every `Store*` merge is correct only because it overwrites `Spec` wholesale
  (`existing.Spec = manifest.Spec`); `updateVEX` must *not* use the option because it merges
  into an existing `Spec.Statements`, and its inline comment says so.
- `newFakeStorageClientset` wires `k8stesting.ObjectReaction`, which **ignores `GetOptions`**
  and always returns the full object. So none of the above is under test — the exact gap that
  let **#475** (a metadata-only read defeating `StoreCVESummaryStub`'s data-preservation guard,
  silently erasing a real `VulnerabilityManifestSummary`) reach production. `updateVEX`'s
  comment already admits it: *"The fake clientset used in tests ignores GetOptions entirely, so
  no test can catch a regression here."*

**Future behaviour.** `newFakeStorageClientset` prepends a `get` reactor that reproduces the
real backend: for a Get carrying `resourceVersionMetadata` it returns a copy of the tracked
object with every field other than `TypeMeta`/`ObjectMeta` zeroed; any other Get falls through
to the default reaction unchanged. The `"metadata"` literal is now a shared
`resourceVersionMetadata` const so the fake and the production `createOrUpdate` call cannot
drift. No production behaviour changes.

## Additional Information

- `k8s.io/client-go@v0.35.0`'s `GetActionImpl` carries `GetOptions` (the generated fake calls
  `testing.NewGetActionWithOptions`), so the reactor can read `ResourceVersion` directly.
- `VulnerabilityManifestStatus` / `SBOMSyftStatus` are empty structs today, so zeroing `Status`
  is a no-op now and future-proofing.
- The four `Store*` merges stay as they are; this change makes their "overwrite wholesale"
  contract testable, it does not alter it.

## How to Test

```
go test ./repositories/ ./core/... -count=1
```

New tests:

- `TestNewFakeStorageClientset_MetadataResourceVersionReturnsMetadataOnly` — a metadata-only
  Get returns `ObjectMeta` intact and `Spec`/`Status` zeroed (and, for an OVEC, no statements —
  the reason `updateVEX` avoids the option); a normal Get is unaffected.
- `TestAPIServerStore_createOrUpdate_conflictRetryStoresFullSpec` — for `StoreCVE`,
  `StoreSBOM`, `StoreCVESummary`: seed a stale `Spec`, re-store so the path is
  `Create` → `AlreadyExists` → RMW, and assert the stored object ends with the complete new
  `Spec`. A merge that started reading `existing.Spec` would now see zero here and fail.
- The existing `storeVEX_*` tests now fail if `updateVEX` is switched to the metadata option
  (they append onto a previously-stored statement across an update).

`go build ./...`, `go vet ./repositories/`, `go test ./repositories/` (full), and
`go test ./core/...` pass locally.

## Impact

- Test-support only; no production code path changes.
- A whole class of silent data-loss regression — a `merge` that reads `existing.Spec` or
  `existing.Status`, a new `Store*` that merges rather than overwrites, or a `updateVEX`
  "simplification" — now fails CI instead of shipping. #475 would have been caught here.

## Related issues/PRs:

Resolved #910

Follows #475 / #476, which fixed one instance of this class narrowly and left the harness gap
that hid it.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conflict handling when saving vulnerability, SBOM, and summary data.
  * Ensured retries preserve the complete object content, including specifications and status details, instead of potentially saving incomplete records.
* **Tests**
  * Added coverage for metadata-only reads and conflict-retry scenarios to help prevent data loss during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->