### PR TITLE
fix(repositories,adapters): deduplicate concurrent SecurityException/exceptions cache misses

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -56,9 +56,11 @@ type BackendAdapter struct {
 	// identical problem — see #916. Zero value is ready to use.
 	exceptionsGroup singleflight.Group
 	// exceptionsCacheMissHook, if set, is called synchronously by every cacheable caller that
-	// reaches an exceptionsCache miss, before it joins exceptionsGroup. Tests use it as a
-	// deterministic barrier to prove real concurrent contention on a miss, instead of a
-	// timing-based sleep — mirrors registryauth's credentialCache.onMiss.
+	// reaches an exceptionsCache miss, immediately after it registers with exceptionsGroup --
+	// not before, which would let a descheduled caller be counted as "joined" before it
+	// actually had. Tests use it as a deterministic barrier to prove real concurrent
+	// contention on a miss, instead of a timing-based sleep — mirrors registryauth's
+	// credentialCache.onMiss.
 	exceptionsCacheMissHook func()
 	httpClient              httputils.IHttpClient
 }
@@ -286,10 +288,6 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 			return cached.(domain.CVEExceptions), domain.ExceptionStats{}, nil
 		}
 	}
-	if a.exceptionsCacheMissHook != nil {
-		a.exceptionsCacheMissHook()
-	}
-
 	// Concurrent callers sharing cacheKey (e.g. the same container reached through both
 	// ScanCP and ScanCVE close together) are collapsed into a single fetch via
 	// exceptionsGroup, instead of each independently repeating the backend call and the CRD
@@ -302,6 +300,15 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 		ran = true
 		return a.fetchCVEExceptions(context.WithoutCancel(ctx), workload, namespace, cacheKey, cacheable)
 	})
+	// Fired after DoChan, not before: this caller has now actually registered with
+	// exceptionsGroup for cacheKey (as leader or as a joiner of an already in-flight call).
+	// Firing any earlier would let a caller be descheduled between that earlier point and its
+	// real DoChan call, so a test barrier gated on it would only prove every caller had
+	// *reached* this function, not that every one of them had *joined* the same singleflight
+	// call.
+	if a.exceptionsCacheMissHook != nil {
+		a.exceptionsCacheMissHook()
+	}
 
 	select {
 	case res := <-ch:

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/core/ports"
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/singleflight"
 )
 
 type BackendAdapter struct {
@@ -46,7 +47,20 @@ type BackendAdapter struct {
 	accessKey             string
 	securityExceptionRepo ports.SecurityExceptionRepository
 	exceptionsCache       *cache.Cache
-	httpClient            httputils.IHttpClient
+	// exceptionsGroup deduplicates concurrent GetCVEExceptions callers that miss
+	// exceptionsCache for the same cacheKey (the same workload/container/image reached
+	// through more than one scan path close together): without it, each of them repeats the
+	// same backend HTTP call and CRD lookup instead of sharing the result of whichever one
+	// actually runs it. Same pattern registryauth's credentialCache (#569) and this
+	// package's GetSecurityExceptions layer (repositories/apiserver.go) already use for the
+	// identical problem — see #916. Zero value is ready to use.
+	exceptionsGroup singleflight.Group
+	// exceptionsCacheMissHook, if set, is called synchronously by every cacheable caller that
+	// reaches an exceptionsCache miss, before it joins exceptionsGroup. Tests use it as a
+	// deterministic barrier to prove real concurrent contention on a miss, instead of a
+	// timing-based sleep — mirrors registryauth's credentialCache.onMiss.
+	exceptionsCacheMissHook func()
+	httpClient              httputils.IHttpClient
 }
 
 var _ ports.Platform = (*BackendAdapter)(nil)
@@ -246,8 +260,9 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 	namespace := wlidpkg.GetNamespaceFromWlid(workload.Wlid)
 	// Registry scans carry no Wlid (registryScanCommandToScanCommand never sets
 	// it), which would otherwise collapse every scanned image onto the same
-	// cache key ("<accountID>/////"). Skip caching entirely for them rather than
-	// let unrelated images share exceptions.
+	// cache key ("<accountID>/////"). Skip caching -- and the deduplication below,
+	// which shares the same key -- entirely for them rather than let unrelated
+	// images share exceptions.
 	cacheable := workload.Wlid != ""
 	cacheKey := strings.Join([]string{
 		a.clusterConfig.AccountID,
@@ -259,14 +274,75 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 		workload.ImageTagNormalized,
 	}, "/")
 
-	if cacheable && a.exceptionsCache != nil {
+	if !cacheable {
+		result, err := a.fetchCVEExceptions(ctx, workload, namespace, cacheKey, cacheable)
+		return result.exceptions, result.stats, err
+	}
+
+	if a.exceptionsCache != nil {
 		if cached, ok := a.exceptionsCache.Get(cacheKey); ok {
 			// A cache hit skips CRD re-evaluation entirely, so there is nothing new to
 			// report this call; the zero value is correct, not a missing measurement.
 			return cached.(domain.CVEExceptions), domain.ExceptionStats{}, nil
 		}
 	}
+	if a.exceptionsCacheMissHook != nil {
+		a.exceptionsCacheMissHook()
+	}
 
+	// Concurrent callers sharing cacheKey (e.g. the same container reached through both
+	// ScanCP and ScanCVE close together) are collapsed into a single fetch via
+	// exceptionsGroup, instead of each independently repeating the backend call and the CRD
+	// lookup — see #916. The fetch runs detached from this particular caller's
+	// cancellation/deadline (context.WithoutCancel), the same reason
+	// repositories/apiserver.go's coalescedSecurityExceptionList does: it may end up serving
+	// callers other than this one, so it must not be tied to this one's ctx.
+	ran := false
+	ch := a.exceptionsGroup.DoChan(cacheKey, func() (interface{}, error) {
+		ran = true
+		return a.fetchCVEExceptions(context.WithoutCancel(ctx), workload, namespace, cacheKey, cacheable)
+	})
+
+	select {
+	case res := <-ch:
+		result := res.Val.(cveExceptionsFetchResult)
+		stats := result.stats
+		if !ran {
+			// This caller shared another goroutine's fetch and triggered no CRD
+			// re-evaluation of its own -- the same reason a cache hit above reports
+			// the zero value.
+			stats = domain.ExceptionStats{}
+		}
+		return result.exceptions, stats, res.Err
+	case <-ctx.Done():
+		return nil, domain.ExceptionStats{}, ctx.Err()
+	}
+}
+
+// cveExceptionsFetchResult is the outcome one un-deduplicated GetCVEExceptions cache miss
+// computes: the merged exception list plus the stats describing the CRD-based exceptions that
+// computation found (see ConvertToVulnerabilityExceptionPolicies' crdStats).
+type cveExceptionsFetchResult struct {
+	exceptions domain.CVEExceptions
+	stats      domain.ExceptionStats
+}
+
+// fetchCVEExceptions is GetCVEExceptions' cache-miss path: fetch cloud-side exceptions via
+// getCVEExceptionsFunc, merge in CRD-based SecurityException/ClusterSecurityException policies
+// via GetSecurityExceptions, and -- unless the result is uncacheable -- write it back to
+// exceptionsCache under cacheKey. When cacheable is true, this runs at most once per coalesced
+// burst of concurrent GetCVEExceptions callers sharing cacheKey (see GetCVEExceptions and
+// #916), which is why the cache write lives here rather than in every caller; when cacheable is
+// false (a registry scan, which has no per-workload identity to key on), GetCVEExceptions calls
+// this directly, uncoalesced, exactly as before this existed.
+//
+// A non-nil error with a zero-value result means the cloud exceptions fetch itself failed. A
+// degraded result (a CRD list error, or an unresolved object/namespace selector) is signalled
+// by returning domain.ErrExceptionsDegraded alongside a populated but deliberately uncached
+// result: GetCVEExceptions' caller (ScanService.applyExceptionsToManifest) still needs that
+// partial list, but a coalesced degraded result must not be read back from the cache during
+// exceptionsCacheTTL by a caller that didn't compute it.
+func (a *BackendAdapter) fetchCVEExceptions(ctx context.Context, workload domain.ScanCommand, namespace, cacheKey string, cacheable bool) (cveExceptionsFetchResult, error) {
 	designator := identifiers.PortalDesignator{
 		DesignatorType: identifiers.DesignatorAttribute,
 		Attributes: map[string]string{
@@ -281,7 +357,7 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 
 	vulnExceptionList, err := a.getCVEExceptionsFunc(a.apiServerRestURL, a.clusterConfig.AccountID, &designator, a.getRequestHeaders())
 	if err != nil {
-		return nil, domain.ExceptionStats{}, err
+		return cveExceptionsFetchResult{}, err
 	}
 
 	// Merge CRD-based exceptions
@@ -313,20 +389,22 @@ func (a *BackendAdapter) GetCVEExceptions(ctx context.Context) (domain.CVEExcept
 		}
 	}
 
+	result := cveExceptionsFetchResult{exceptions: domain.CVEExceptions(vulnExceptionList), stats: stats}
+
 	// A non-positive TTL means a policy has already expired by the time we're about to
 	// cache it (e.g. lost a race with its own expiresAt between conversion and this
 	// point). akyoto/cache only reaps entries on its cleaning-interval sweep, not the
 	// instant their TTL elapses, so a Set with ttl<=0 would still be readable as a cache
 	// hit until the next sweep -- skip the write entirely rather than rely on that.
 	if ttl := cacheTTLFor(vulnExceptionList, exceptionsCacheTTL); cacheable && a.exceptionsCache != nil && ttl > 0 {
-		a.exceptionsCache.Set(cacheKey, domain.CVEExceptions(vulnExceptionList), ttl)
+		a.exceptionsCache.Set(cacheKey, result.exceptions, ttl)
 	}
 
 	if degraded {
-		return vulnExceptionList, stats, domain.ErrExceptionsDegraded
+		return result, domain.ErrExceptionsDegraded
 	}
 
-	return vulnExceptionList, stats, nil
+	return result, nil
 }
 
 // excludeCloudCoveredPolicies drops CRD-derived policies that cover a CVE the cloud-fetched

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -178,14 +178,21 @@ func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
 // a cache hit already uses ("there is nothing new to report this call") -- this asserts exactly
 // one of the n callers sees the real (non-nil ExpiredBySource) stats.
 //
-// exceptionsCacheMissHook blocks every one of the n callers' cache misses until all of them
-// have arrived, so none can proceed into the singleflight group until every one of them is
-// genuinely contending for the same key -- a hard guarantee, not a timing-based approximation
-// of concurrency.
+// getCVEExceptionsFunc only ever runs inside the one goroutine singleflight picks as leader
+// for the cache key, so blocking it -- until every one of the n callers has passed the
+// (non-blocking) exceptionsCacheMissHook below -- is what actually forces genuine contention:
+// the leader cannot finish and release the singleflight call until every other caller has had
+// the chance to reach DoChan and join it. A hook that blocked callers itself, before any of
+// them could reach DoChan, would only prove they all *arrived*, not that they *overlapped* --
+// the scheduler is free to run each one to completion before waking the next, especially on a
+// CPU-constrained CI runner. Mirrors registryauth's credentialCache.onMiss + fetch split, used
+// the same way in #569's own test.
 func TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses(t *testing.T) {
 	expired := metav1.NewTime(time.Now().Add(-time.Hour))
 	const n = 20
 
+	var joined int32
+	allJoined := make(chan struct{})
 	var crdCalls, backendCalls int32
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &testSecurityExceptionRepo{
 		getSecurityExceptions: func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
@@ -203,16 +210,13 @@ func TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses(t *testing.T)
 	})
 	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		atomic.AddInt32(&backendCalls, 1)
+		<-allJoined
 		return nil, nil
 	}
-
-	var joined int32
-	allJoined := make(chan struct{})
 	a.exceptionsCacheMissHook = func() {
 		if atomic.AddInt32(&joined, 1) == n {
 			close(allJoined)
 		}
-		<-allJoined
 	}
 
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -168,6 +168,150 @@ func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
 	assert.Equal(t, 2, calls, "a different workload should not hit the cache")
 }
 
+// TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses is the regression test for
+// #916: concurrent callers sharing a cache key (the same workload/container/image reached
+// through more than one scan path close together, e.g. ScanCP and ScanCVE) must collapse into
+// a single backend fetch and CRD lookup instead of each independently repeating both.
+//
+// Only the caller whose own closure actually ran the fetch reports the real ExceptionStats;
+// every other caller sharing the coalesced result reports the zero value, the same convention
+// a cache hit already uses ("there is nothing new to report this call") -- this asserts exactly
+// one of the n callers sees the real (non-nil ExpiredBySource) stats.
+//
+// exceptionsCacheMissHook blocks every one of the n callers' cache misses until all of them
+// have arrived, so none can proceed into the singleflight group until every one of them is
+// genuinely contending for the same key -- a hard guarantee, not a timing-based approximation
+// of concurrency.
+func TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses(t *testing.T) {
+	expired := metav1.NewTime(time.Now().Add(-time.Hour))
+	const n = 20
+
+	var crdCalls, backendCalls int32
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &testSecurityExceptionRepo{
+		getSecurityExceptions: func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
+			atomic.AddInt32(&crdCalls, 1)
+			return []sev1beta1.SecurityException{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-ns"},
+				Spec: sev1beta1.SecurityExceptionSpec{
+					ExpiresAt: &expired,
+					Vulnerabilities: []sev1beta1.VulnerabilityException{
+						{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-EXPIRED"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
+					},
+				},
+			}}, nil, nil
+		},
+	})
+	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		atomic.AddInt32(&backendCalls, 1)
+		return nil, nil
+	}
+
+	var joined int32
+	allJoined := make(chan struct{})
+	a.exceptionsCacheMissHook = func() {
+		if atomic.AddInt32(&joined, 1) == n {
+			close(allJoined)
+		}
+		<-allJoined
+	}
+
+	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
+
+	var wg sync.WaitGroup
+	stats := make([]domain.ExceptionStats, n)
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, stats[i], errs[i] = a.GetCVEExceptions(ctx)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "call %d", i)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&backendCalls),
+		"N concurrent misses for the same cache key must share a single backend fetch")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&crdCalls),
+		"N concurrent misses for the same cache key must share a single CRD lookup")
+
+	realStats := 0
+	for i, s := range stats {
+		if s.ExpiredBySource != nil {
+			realStats++
+			assert.Equal(t, 1, s.ExpiredBySource["SecurityException"], "call %d", i)
+		}
+	}
+	assert.Equal(t, 1, realStats,
+		"only the caller whose own closure ran the fetch should report non-zero stats; every other caller shares the zero value, like a cache hit")
+}
+
+// TestBackendAdapter_GetCVEExceptions_CallerCancellationDoesNotAbortSharedFetch is a
+// regression test for #916: GetCVEExceptions' fetch is now shared across every concurrent
+// caller racing the same cache-miss key (see exceptionsGroup), so one caller's ctx canceling
+// while waiting on someone else's in-flight fetch must not abort that fetch or affect any other
+// waiter -- only that one caller's own wait ends early, with its own ctx error.
+func TestBackendAdapter_GetCVEExceptions_CallerCancellationDoesNotAbortSharedFetch(t *testing.T) {
+	fetchStarted := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
+	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		close(fetchStarted)
+		<-releaseFetch
+		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	}
+	baseCtx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
+		Wlid:          "wlid://cluster-c/namespace-ns/deployment-d",
+		ContainerName: "container",
+	})
+
+	// leader: starts the fetch and blocks in it until releaseFetch closes.
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_, _, err := a.GetCVEExceptions(baseCtx)
+		assert.NoError(t, err)
+	}()
+
+	select {
+	case <-fetchStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetch never reached the point where it should be in flight")
+	}
+
+	// follower: joins the same in-flight fetch, then has its own ctx canceled.
+	followerCtx, cancel := context.WithCancel(baseCtx)
+	followerDone := make(chan error, 1)
+	go func() {
+		_, _, err := a.GetCVEExceptions(followerCtx)
+		followerDone <- err
+	}()
+
+	cancel()
+
+	select {
+	case err := <-followerDone:
+		require.ErrorIs(t, err, context.Canceled, "a canceled follower must return promptly with its own ctx error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the canceled follower never returned")
+	}
+
+	select {
+	case <-leaderDone:
+		t.Fatal("the leader must not have completed yet -- it is still blocked in the fetch")
+	default:
+	}
+
+	close(releaseFetch)
+	select {
+	case <-leaderDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the leader never returned after the fetch was released")
+	}
+}
+
 // TestBackendAdapter_GetCVEExceptions_CacheDoesNotOutliveCRDExpiry is a regression test:
 // ConvertToVulnerabilityExceptionPolicies only checks an exception's expiresAt on a cache
 // miss, so a cache entry that outlives the CRD exception it was built from would keep

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -110,9 +110,11 @@ type APIServerStore struct {
 	securityExceptionGroup singleflight.Group
 
 	// securityExceptionCacheMissHook, if set, is called synchronously by every caller that
-	// reaches a securityExceptionListCache miss, before it joins securityExceptionGroup. Tests
-	// use it as a deterministic barrier to prove real concurrent contention on a miss, instead
-	// of a timing-based sleep — mirrors registryauth's credentialCache.onMiss.
+	// reaches a securityExceptionListCache miss, immediately after it registers with
+	// securityExceptionGroup (see coalescedSecurityExceptionList's onRegistered param) — not
+	// before, which would let a descheduled caller be counted as "joined" before it actually
+	// had. Tests use it as a deterministic barrier to prove real concurrent contention on a
+	// miss, instead of a timing-based sleep — mirrors registryauth's credentialCache.onMiss.
 	securityExceptionCacheMissHook func()
 
 	securityExceptionInformerStop context.CancelFunc
@@ -522,7 +524,17 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 // namespaced call alone consuming that whole budget -- without this check, the cluster-wide call
 // right after it would still start (and, absent another caller already racing that key, become
 // leader for) a List() nothing can use, against an apiserver that just demonstrated it's slow.
-func coalescedSecurityExceptionList[T any](ctx context.Context, group *singleflight.Group, cacheKey string, fetch func(context.Context) (T, error)) (T, error) {
+//
+// onRegistered, if non-nil, is called synchronously by every caller immediately after its own
+// DoChan call returns -- i.e. once it has actually registered with group for cacheKey, whether
+// as leader or as a joiner of an already in-flight call. It exists purely for tests: firing it
+// any earlier (e.g. before DoChan, at the outer cache-miss check) would let a caller be
+// descheduled between that earlier point and its actual DoChan call, so a test barrier gated on
+// it would only prove every caller had *reached* this function, not that every one of them had
+// *joined* the same singleflight call -- the leader could finish and be forgotten by group in
+// between, leaving a still-descheduled caller to start a fresh, ungrouped call once it finally
+// resumes.
+func coalescedSecurityExceptionList[T any](ctx context.Context, group *singleflight.Group, cacheKey string, onRegistered func(), fetch func(context.Context) (T, error)) (T, error) {
 	if err := ctx.Err(); err != nil {
 		var zero T
 		return zero, err
@@ -531,6 +543,9 @@ func coalescedSecurityExceptionList[T any](ctx context.Context, group *singlefli
 	ch := group.DoChan(cacheKey, func() (interface{}, error) {
 		return fetch(context.WithoutCancel(ctx))
 	})
+	if onRegistered != nil {
+		onRegistered()
+	}
 
 	select {
 	case res := <-ch:
@@ -552,10 +567,7 @@ func (a *APIServerStore) listSecurityExceptions(ctx context.Context, namespace s
 			return cached.([]sev1beta1.SecurityException), nil
 		}
 	}
-	if a.securityExceptionCacheMissHook != nil {
-		a.securityExceptionCacheMissHook()
-	}
-	return coalescedSecurityExceptionList(ctx, &a.securityExceptionGroup, cacheKey,
+	return coalescedSecurityExceptionList(ctx, &a.securityExceptionGroup, cacheKey, a.securityExceptionCacheMissHook,
 		func(fetchCtx context.Context) ([]sev1beta1.SecurityException, error) {
 			return a.fetchSecurityExceptions(fetchCtx, cacheKey, namespace)
 		})
@@ -636,11 +648,8 @@ func (a *APIServerStore) listClusterSecurityExceptions(ctx context.Context) ([]s
 			return cached.([]sev1beta1.ClusterSecurityException), nil
 		}
 	}
-	if a.securityExceptionCacheMissHook != nil {
-		a.securityExceptionCacheMissHook()
-	}
 	return coalescedSecurityExceptionList(ctx, &a.securityExceptionGroup, clusterSecurityExceptionListCacheKey,
-		a.fetchClusterSecurityExceptions)
+		a.securityExceptionCacheMissHook, a.fetchClusterSecurityExceptions)
 }
 
 // fetchClusterSecurityExceptions is listClusterSecurityExceptions' cache-miss path, run by

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -514,7 +514,20 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 // non-nil, incomplete items) or a hard failure is expected to be left uncached by fetch, and
 // that contract, including the (possibly non-nil) items returned alongside a non-nil error,
 // carries through unchanged to every caller sharing the coalesced result.
+//
+// ctx is checked before DoChan, not just raced against it afterward: fetch runs detached from
+// ctx, so once DoChan starts it as this key's leader it keeps running its own full 30s window
+// regardless of whether this particular caller could still use the result. GetSecurityExceptions
+// calls this twice sequentially against one shared listCtx, so the common way to hit this is the
+// namespaced call alone consuming that whole budget -- without this check, the cluster-wide call
+// right after it would still start (and, absent another caller already racing that key, become
+// leader for) a List() nothing can use, against an apiserver that just demonstrated it's slow.
 func coalescedSecurityExceptionList[T any](ctx context.Context, group *singleflight.Group, cacheKey string, fetch func(context.Context) (T, error)) (T, error) {
+	if err := ctx.Err(); err != nil {
+		var zero T
+		return zero, err
+	}
+
 	ch := group.DoChan(cacheKey, func() (interface{}, error) {
 		return fetch(context.WithoutCancel(ctx))
 	})

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -465,19 +465,28 @@ func unstructuredFromEvent(obj interface{}) *unstructured.Unstructured {
 // never cached, so a transient apiserver hiccup self-heals on the next call instead of being
 // pinned for the TTL.
 func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
+	// One shared deadline for both sequential calls below, not one each: fetchSecurityExceptions/
+	// fetchClusterSecurityExceptions each additionally bound the shared fetch they might end up
+	// running to its own 30s (see their doc comments) since that fetch can outlive this specific
+	// caller, but this caller's own wait for either one must not exceed 30s total -- otherwise a
+	// namespaced list that takes the full 30s would let the cluster-wide one that follows it take
+	// up to another 30s, doubling this call's worst case.
+	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	var listErrs []error
 
 	// Only list namespaced exceptions when namespace is provided
 	var exceptions []sev1beta1.SecurityException
 	if namespace != "" {
 		var err error
-		exceptions, err = a.listSecurityExceptions(ctx, namespace)
+		exceptions, err = a.listSecurityExceptions(listCtx, namespace)
 		if err != nil {
 			listErrs = append(listErrs, err)
 		}
 	}
 
-	clusterExceptions, err := a.listClusterSecurityExceptions(ctx)
+	clusterExceptions, err := a.listClusterSecurityExceptions(listCtx)
 	if err != nil {
 		listErrs = append(listErrs, err)
 	}

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openvex/go-vex/pkg/vex"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/mod/semver"
+	"golang.org/x/sync/singleflight"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -100,6 +101,19 @@ type APIServerStore struct {
 	// its now-stale result afterward — see securityExceptionCacheEntry's doc comment and #733.
 	// Zero value (empty sync.Map) is ready to use, so this needs no constructor initialization.
 	securityExceptionCacheEntries sync.Map // cacheKey (string) -> *securityExceptionCacheEntry
+
+	// securityExceptionGroup deduplicates concurrent callers that miss
+	// securityExceptionListCache for the same key: without it, every one of them repeats the
+	// same List() call instead of sharing the result of whichever one actually runs it. Same
+	// pattern registryauth's credentialCache (#569) and scan.go's SBOM creation (#642) already
+	// use for the identical problem — see #916. Zero value is ready to use.
+	securityExceptionGroup singleflight.Group
+
+	// securityExceptionCacheMissHook, if set, is called synchronously by every caller that
+	// reaches a securityExceptionListCache miss, before it joins securityExceptionGroup. Tests
+	// use it as a deterministic barrier to prove real concurrent contention on a miss, instead
+	// of a timing-based sleep — mirrors registryauth's credentialCache.onMiss.
+	securityExceptionCacheMissHook func()
 
 	securityExceptionInformerStop context.CancelFunc
 }
@@ -451,22 +465,19 @@ func unstructuredFromEvent(obj interface{}) *unstructured.Unstructured {
 // never cached, so a transient apiserver hiccup self-heals on the next call instead of being
 // pinned for the TTL.
 func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
-	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	var listErrs []error
 
 	// Only list namespaced exceptions when namespace is provided
 	var exceptions []sev1beta1.SecurityException
 	if namespace != "" {
 		var err error
-		exceptions, err = a.listSecurityExceptions(ctx, listCtx, namespace)
+		exceptions, err = a.listSecurityExceptions(ctx, namespace)
 		if err != nil {
 			listErrs = append(listErrs, err)
 		}
 	}
 
-	clusterExceptions, err := a.listClusterSecurityExceptions(ctx, listCtx)
+	clusterExceptions, err := a.listClusterSecurityExceptions(ctx)
 	if err != nil {
 		listErrs = append(listErrs, err)
 	}
@@ -474,21 +485,88 @@ func (a *APIServerStore) GetSecurityExceptions(ctx context.Context, namespace st
 	return exceptions, clusterExceptions, stderrors.Join(listErrs...)
 }
 
+// coalescedSecurityExceptionList runs fetch — a List()+convert step for one
+// SecurityException/ClusterSecurityException scope — deduplicated against every other
+// concurrent caller racing the same cacheKey via group, so only one of them actually calls
+// fetch; the rest share its result. Same pattern registryauth's credentialCache (#569) and
+// scan.go's SBOM creation (#642) already use for the identical duplicate-work problem — see
+// #916.
+//
+// fetch runs on a context detached from any one particular caller's cancellation/deadline
+// (context.WithoutCancel), mirroring credentialCache.get: one caller's ctx canceling must not
+// abort the shared fetch out from under every other caller racing the same key. Each caller
+// instead races the shared result against its own ctx in the select below, so a caller whose
+// own ctx is canceled while waiting on someone else's fetch returns promptly without affecting
+// that fetch or any other waiter.
+//
+// fetch owns writing a successful result back to its cache itself — it runs at most once per
+// coalesced burst, so that write can't race a sibling call's write for the same key the way it
+// would if every caller wrote its own copy back. A partial result (a non-nil error alongside
+// non-nil, incomplete items) or a hard failure is expected to be left uncached by fetch, and
+// that contract, including the (possibly non-nil) items returned alongside a non-nil error,
+// carries through unchanged to every caller sharing the coalesced result.
+func coalescedSecurityExceptionList[T any](ctx context.Context, group *singleflight.Group, cacheKey string, fetch func(context.Context) (T, error)) (T, error) {
+	ch := group.DoChan(cacheKey, func() (interface{}, error) {
+		return fetch(context.WithoutCancel(ctx))
+	})
+
+	select {
+	case res := <-ch:
+		return res.Val.(T), res.Err
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	}
+}
+
 // listSecurityExceptions returns the namespaced SecurityExceptions for namespace, from
-// securityExceptionListCache when a fresh entry exists. The write back to the cache after a
-// List() is conditional on no invalidation having raced it (see trySetSecurityExceptionCache) -
-// without that, a List() started just before a SecurityException change in namespace would
-// silently re-populate the cache with the pre-change result after the informer had already
-// evicted it — see #733.
-func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, namespace string) ([]sev1beta1.SecurityException, error) {
+// securityExceptionListCache when a fresh entry exists, otherwise via
+// coalescedSecurityExceptionList so concurrent callers racing the same cache-miss share one
+// List() instead of each repeating it (see #916).
+func (a *APIServerStore) listSecurityExceptions(ctx context.Context, namespace string) ([]sev1beta1.SecurityException, error) {
 	cacheKey := securityExceptionListCacheKeyPrefix + namespace
-	var seenGeneration uint64
 	if a.securityExceptionListCache != nil {
 		if cached, ok := a.securityExceptionListCache.Get(cacheKey); ok {
 			return cached.([]sev1beta1.SecurityException), nil
 		}
+	}
+	if a.securityExceptionCacheMissHook != nil {
+		a.securityExceptionCacheMissHook()
+	}
+	return coalescedSecurityExceptionList(ctx, &a.securityExceptionGroup, cacheKey,
+		func(fetchCtx context.Context) ([]sev1beta1.SecurityException, error) {
+			return a.fetchSecurityExceptions(fetchCtx, cacheKey, namespace)
+		})
+}
+
+// fetchSecurityExceptions is listSecurityExceptions' cache-miss path, run by
+// coalescedSecurityExceptionList at most once per coalesced burst of concurrent callers
+// sharing cacheKey: it re-checks the cache first (a sibling call for cacheKey, no longer
+// in flight by the time this one started, may have already populated it — mirroring
+// credentialCache.get's own re-check for the same reason), then List()s and converts
+// namespace's SecurityExceptions, and — on full success — writes the result back to
+// securityExceptionListCache, conditional on no invalidation having raced it (see
+// trySetSecurityExceptionCache) — without that, a List() started just before a
+// SecurityException change in namespace would silently re-populate the cache with the
+// pre-change result after the informer had already evicted it — see #733.
+//
+// ctx is already detached from any one particular caller (context.WithoutCancel, applied by
+// coalescedSecurityExceptionList); this bounds it with its own 30s timeout, matching
+// GetSecurityExceptions' previous shared listCtx.
+func (a *APIServerStore) fetchSecurityExceptions(ctx context.Context, cacheKey, namespace string) ([]sev1beta1.SecurityException, error) {
+	if a.securityExceptionListCache != nil {
+		if cached, ok := a.securityExceptionListCache.Get(cacheKey); ok {
+			return cached.([]sev1beta1.SecurityException), nil
+		}
+	}
+
+	var seenGeneration uint64
+	if a.securityExceptionListCache != nil {
 		seenGeneration = a.beginSecurityExceptionCacheRefresh(cacheKey)
 	}
+
+	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
 	seList, err := a.DynamicClient.Resource(securityExceptionGVR).Namespace(namespace).List(listCtx, metav1.ListOptions{})
 	if err != nil {
@@ -525,18 +603,41 @@ func (a *APIServerStore) listSecurityExceptions(ctx, listCtx context.Context, na
 }
 
 // listClusterSecurityExceptions returns every ClusterSecurityException in the cluster, from
-// securityExceptionListCache when a fresh entry exists. The result is the same regardless of
-// which workload/namespace triggered the call, so it is cached under a single cluster-wide key.
-// The write back to the cache after a List() is conditional on no invalidation having raced it -
-// see listSecurityExceptions' and trySetSecurityExceptionCache's doc comments, and #733.
-func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Context) ([]sev1beta1.ClusterSecurityException, error) {
-	var seenGeneration uint64
+// securityExceptionListCache when a fresh entry exists, otherwise via
+// coalescedSecurityExceptionList so concurrent callers racing the same cache-miss share one
+// List() instead of each repeating it (see #916). The result is the same regardless of which
+// workload/namespace triggered the call, so it is cached — and coalesced — under a single
+// cluster-wide key.
+func (a *APIServerStore) listClusterSecurityExceptions(ctx context.Context) ([]sev1beta1.ClusterSecurityException, error) {
 	if a.securityExceptionListCache != nil {
 		if cached, ok := a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey); ok {
 			return cached.([]sev1beta1.ClusterSecurityException), nil
 		}
+	}
+	if a.securityExceptionCacheMissHook != nil {
+		a.securityExceptionCacheMissHook()
+	}
+	return coalescedSecurityExceptionList(ctx, &a.securityExceptionGroup, clusterSecurityExceptionListCacheKey,
+		a.fetchClusterSecurityExceptions)
+}
+
+// fetchClusterSecurityExceptions is listClusterSecurityExceptions' cache-miss path, run by
+// coalescedSecurityExceptionList at most once per coalesced burst — see fetchSecurityExceptions
+// and #733, #916, which this mirrors for the cluster-wide scope.
+func (a *APIServerStore) fetchClusterSecurityExceptions(ctx context.Context) ([]sev1beta1.ClusterSecurityException, error) {
+	if a.securityExceptionListCache != nil {
+		if cached, ok := a.securityExceptionListCache.Get(clusterSecurityExceptionListCacheKey); ok {
+			return cached.([]sev1beta1.ClusterSecurityException), nil
+		}
+	}
+
+	var seenGeneration uint64
+	if a.securityExceptionListCache != nil {
 		seenGeneration = a.beginSecurityExceptionCacheRefresh(clusterSecurityExceptionListCacheKey)
 	}
+
+	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
 	cseList, err := a.DynamicClient.Resource(clusterSecurityExceptionGVR).List(listCtx, metav1.ListOptions{})
 	if err != nil {
@@ -557,7 +658,7 @@ func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Cont
 		clusterExceptions = append(clusterExceptions, cse)
 	}
 
-	// See listSecurityExceptions: a dropped exception is an incomplete set, reported and
+	// See fetchSecurityExceptions: a dropped exception is an incomplete set, reported and
 	// left uncached the same way a failed List() is.
 	if len(convErrs) > 0 {
 		return clusterExceptions, stderrors.Join(convErrs...)

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2871,6 +2872,183 @@ func TestAPIServerStore_GetSecurityExceptions_DoesNotCacheListFailures(t *testin
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
 }
 
+// TestAPIServerStore_ListSecurityExceptions_CoalescesConcurrentMisses is the regression test
+// for #916: concurrent callers racing the same namespaced cache-miss key must share a single
+// List() call instead of every one of them independently repeating it. #510's cache alone only
+// collapses List() calls spread out over time (repeated calls within the TTL); it does nothing
+// for N callers that all miss the same key at once, which scanConcurrency > 1 makes routine --
+// every securityExceptionListCacheTTL (30s) window, and on every real SecurityException CRD
+// change, since invalidation forces every in-flight scan into the same miss window together.
+//
+// This calls listSecurityExceptions directly (rather than through GetSecurityExceptions, which
+// also calls listClusterSecurityExceptions afterward) so securityExceptionCacheMissHook's
+// barrier -- every one of the n callers blocks in it until all n have arrived -- only has to
+// count one hook hit per caller: GetSecurityExceptions' two calls are sequential within one
+// goroutine, so a hook that blocks synchronously would only ever see the first of each
+// goroutine's two hits before that goroutine stalls, and could never reach a threshold sized
+// for both.
+func TestAPIServerStore_ListSecurityExceptions_CoalescesConcurrentMisses(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR: "SecurityExceptionList",
+	})
+
+	const n = 20
+	var listCalls int32
+	dynClient.PrependReactor("list", "securityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&listCalls, 1)
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient:              dynClient,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	var joined int32
+	allJoined := make(chan struct{})
+	// Blocking every caller here until all n have arrived is a hard guarantee that every one
+	// of them is genuinely contending for the same key once released, not a timing-based
+	// approximation -- mirrors registryauth's credentialCache.onMiss, used the same way for
+	// the identical problem in #569's own test.
+	a.securityExceptionCacheMissHook = func() {
+		if atomic.AddInt32(&joined, 1) == n {
+			close(allJoined)
+		}
+		<-allJoined
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = a.listSecurityExceptions(context.Background(), "ns-a")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "call %d", i)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&listCalls),
+		"N concurrent misses for the same namespace must share a single List() call")
+}
+
+// TestAPIServerStore_ListClusterSecurityExceptions_CoalescesConcurrentMisses is the
+// cluster-scoped counterpart of the test above. It matters more in practice than the
+// namespaced case: clusterSecurityExceptionListCacheKey is a single key shared by every
+// namespace's scans in the process, so a miss window here is contended by the whole process'
+// concurrent scan volume, not just one namespace's.
+func TestAPIServerStore_ListClusterSecurityExceptions_CoalescesConcurrentMisses(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+
+	const n = 20
+	var listCalls int32
+	dynClient.PrependReactor("list", "clustersecurityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&listCalls, 1)
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient:              dynClient,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	var joined int32
+	allJoined := make(chan struct{})
+	a.securityExceptionCacheMissHook = func() {
+		if atomic.AddInt32(&joined, 1) == n {
+			close(allJoined)
+		}
+		<-allJoined
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = a.listClusterSecurityExceptions(context.Background())
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "call %d", i)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&listCalls),
+		"N concurrent misses for the cluster-wide list must share a single List() call")
+}
+
+// TestAPIServerStore_GetSecurityExceptions_CallerCancellationDoesNotAbortSharedFetch is a
+// regression test for #916: GetSecurityExceptions' underlying List() calls are now shared
+// across every concurrent caller racing the same cache-miss key (see
+// coalescedSecurityExceptionList), so one caller's ctx canceling must not cancel the List()
+// call out from under every other caller sharing it -- only that one caller's own wait ends
+// early, with its own ctx error. Before #916 this asserted the opposite (that cancellation did
+// propagate to the List() call): with only one caller ever running "the" call, that was
+// correct; sharing a call across callers means it can no longer belong to any single one of
+// them.
+func TestAPIServerStore_GetSecurityExceptions_CallerCancellationDoesNotAbortSharedFetch(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+	wrapped := &ctxCapturingDynamicClient{Interface: dynClient}
+
+	listInFlight := make(chan struct{})
+	releaseList := make(chan struct{})
+	var listCtx context.Context
+	wrapped.resources = map[schema.GroupVersionResource]*ctxCapturingResource{
+		clusterSecurityExceptionGVR: {
+			ResourceInterface: dynClient.Resource(clusterSecurityExceptionGVR),
+			hook: func(ctx context.Context) {
+				listCtx = ctx
+				close(listInFlight)
+				<-releaseList
+			},
+		},
+	}
+
+	a := &APIServerStore{DynamicClient: wrapped, Namespace: "kubescape"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := a.GetSecurityExceptions(ctx, "kubescape")
+		done <- err
+	}()
+
+	select {
+	case <-listInFlight:
+	case <-time.After(5 * time.Second):
+		t.Fatal("List() never reached the point where it should be in flight")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled, "a caller whose own ctx is canceled must return promptly with its own ctx error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetSecurityExceptions never returned after its own ctx was canceled")
+	}
+
+	select {
+	case <-listCtx.Done():
+		t.Error("the shared List() call must not be canceled by one caller's ctx cancellation")
+	default:
+	}
+
+	close(releaseList) // let the still-running fetch finish so it doesn't leak past the test
+}
+
 // TestAPIServerStore_ListSecurityExceptions_DoesNotRepopulateAfterRacingInvalidation is a
 // regression test for #733: enableSecurityExceptionCacheInvalidation evicts a cache key as soon
 // as its CRD changes, but a List() already in flight for that key when the change lands used to
@@ -3135,26 +3313,6 @@ func requireHookObservesCancellation(t *testing.T, cancel func()) (hook func(ctx
 		cancel()
 		assert.ErrorIs(t, ctx.Err(), context.Canceled, "canceling the caller's ctx must cancel the ctx passed to the K8s API call")
 	}, &calledFlag
-}
-
-func TestAPIServerStore_GetSecurityExceptions_HonorsCallerCancellation(t *testing.T) {
-	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-		securityExceptionGVR:        "SecurityExceptionList",
-		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
-	})
-	wrapped := &ctxCapturingDynamicClient{Interface: dynClient}
-	a := &APIServerStore{DynamicClient: wrapped, Namespace: "kubescape"}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	hook, called := requireHookObservesCancellation(t, cancel)
-	wrapped.resources = map[schema.GroupVersionResource]*ctxCapturingResource{
-		clusterSecurityExceptionGVR: {ResourceInterface: dynClient.Resource(clusterSecurityExceptionGVR), hook: hook},
-	}
-
-	_, _, err := a.GetSecurityExceptions(ctx, "kubescape")
-	require.NoError(t, err)
-	require.True(t, *called, "the List call the hook was attached to must have run")
 }
 
 func TestAPIServerStore_GetWorkloadLabels_HonorsCallerCancellation(t *testing.T) {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2893,9 +2893,22 @@ func TestAPIServerStore_ListSecurityExceptions_CoalescesConcurrentMisses(t *test
 	})
 
 	const n = 20
+	var joined int32
+	allJoined := make(chan struct{})
 	var listCalls int32
+	// The reactor only ever runs inside the one goroutine singleflight picks as leader for
+	// cacheKey, so blocking it here -- until every one of the n callers has passed the
+	// (non-blocking) miss hook below -- is what actually forces genuine contention: the leader
+	// cannot finish and release the singleflight call until every other caller has had the
+	// chance to reach DoChan and join it. A hook that blocked callers itself, before any of
+	// them could reach DoChan, would only prove they all *arrived*, not that they *overlapped*
+	// -- the scheduler is free to run each one to completion before waking the next, especially
+	// on a CPU-constrained CI runner, which is exactly what let all n become their own leader
+	// despite such a hook faithfully unblocking at n. Mirrors registryauth's
+	// credentialCache.onMiss + fetch split, used the same way in #569's own test.
 	dynClient.PrependReactor("list", "securityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
 		atomic.AddInt32(&listCalls, 1)
+		<-allJoined
 		return false, nil, nil
 	})
 
@@ -2904,18 +2917,10 @@ func TestAPIServerStore_ListSecurityExceptions_CoalescesConcurrentMisses(t *test
 		Namespace:                  "kubescape",
 		securityExceptionListCache: cache.New(time.Minute),
 	}
-
-	var joined int32
-	allJoined := make(chan struct{})
-	// Blocking every caller here until all n have arrived is a hard guarantee that every one
-	// of them is genuinely contending for the same key once released, not a timing-based
-	// approximation -- mirrors registryauth's credentialCache.onMiss, used the same way for
-	// the identical problem in #569's own test.
 	a.securityExceptionCacheMissHook = func() {
 		if atomic.AddInt32(&joined, 1) == n {
 			close(allJoined)
 		}
-		<-allJoined
 	}
 
 	var wg sync.WaitGroup
@@ -2947,9 +2952,16 @@ func TestAPIServerStore_ListClusterSecurityExceptions_CoalescesConcurrentMisses(
 	})
 
 	const n = 20
+	var joined int32
+	allJoined := make(chan struct{})
 	var listCalls int32
+	// See TestAPIServerStore_ListSecurityExceptions_CoalescesConcurrentMisses for why the
+	// blocking lives in the reactor (which only the singleflight leader ever reaches), not in
+	// the miss hook (which every caller reaches, and must not block, or none of them can ever
+	// race each other into DoChan).
 	dynClient.PrependReactor("list", "clustersecurityexceptions", func(k8stesting.Action) (bool, runtime.Object, error) {
 		atomic.AddInt32(&listCalls, 1)
+		<-allJoined
 		return false, nil, nil
 	})
 
@@ -2958,14 +2970,10 @@ func TestAPIServerStore_ListClusterSecurityExceptions_CoalescesConcurrentMisses(
 		Namespace:                  "kubescape",
 		securityExceptionListCache: cache.New(time.Minute),
 	}
-
-	var joined int32
-	allJoined := make(chan struct{})
 	a.securityExceptionCacheMissHook = func() {
 		if atomic.AddInt32(&joined, 1) == n {
 			close(allJoined)
 		}
-		<-allJoined
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Overview

**Problem:** `securityExceptionListCache` (`repositories/apiserver.go`) and `exceptionsCache`
(`adapters/v1/backend.go`) are read-through TTL caches, but neither deduplicates concurrent
callers that miss the same key at the same time -- each independently repeats the full fetch
instead of sharing whichever one actually runs it.

`securityExceptionListCacheTTL` is a hard-coded 30s, and one of its two keys
(`clusterSecurityExceptionListCacheKey`) is a single key shared by every namespace's scans in
the process. So this isn't a rare edge case: every 30 seconds, and on every real
`ClusterSecurityException`/`SecurityException` CRD change (which invalidates the cache and
forces every in-flight scan into the same miss window together), any concurrently running scans
(`scanConcurrency` > 1, the normal reason the HTTP controller runs a worker pool at all) each
independently call `List()` against a `dynamic.Interface` client already rate-limited to
`QPS: 50, Burst: 100` (see #510). `adapters/v1/backend.go`'s `exceptionsCache` has the identical
shape one layer up, for the backend HTTP exceptions call plus the same CRD lookup.

**Root cause:** both caches are plain "check cache, on miss do the expensive thing, write it
back" -- there is nothing to coalesce two goroutines that both observe a miss for the same key
at the same moment. This is the same class of bug `internal/registryauth/cache.go`'s
`credentialCache` was built to fix (#569), and `core/services/scan.go`'s SBOM creation already
solved with `singleflight` (#642) -- the exceptions caches just never got the same treatment.

**Solution:** wrap the miss path of both caches in `golang.org/x/sync/singleflight`, reusing the
exact pattern `credentialCache.get` already established in this codebase:

- `repositories/apiserver.go`: `listSecurityExceptions`/`listClusterSecurityExceptions` now
  share a `List()` via a new `coalescedSecurityExceptionList[T]` helper and
  `securityExceptionGroup`. The existing generation-based invalidation guard (#733) is preserved
  unchanged -- the cache write moves into the coalesced fetch (`fetchSecurityExceptions`/
  `fetchClusterSecurityExceptions`) rather than living in every caller, since that fetch now
  runs at most once per coalesced burst.
- `adapters/v1/backend.go`: `GetCVEExceptions`' cache-miss path is split into
  `fetchCVEExceptions` and shared via a new `exceptionsGroup`, for the cacheable case only --
  registry scans have no per-workload identity to key on and keep going straight to
  `fetchCVEExceptions` uncoalesced, exactly as before this existed.
- The shared fetch in both places runs on a context detached from any one particular caller's
  cancellation/deadline (`context.WithoutCancel`), mirroring `credentialCache.get`: one caller's
  ctx canceling must not abort the fetch for every other caller sharing it. Each caller instead
  races the shared result against its own ctx, so a canceled caller still returns promptly with
  its own ctx error.
- A caller that shares a coalesced `GetCVEExceptions` result reports the zero `ExceptionStats`,
  the same convention a cache hit already used ("there is nothing new to report this call"),
  since it triggered no CRD re-evaluation of its own.

## How to Test

```
go test ./repositories/... -run 'CoalescesConcurrentMisses|CallerCancellationDoesNotAbortSharedFetch|GetSecurityExceptions' -v
go test ./adapters/v1/... -run 'GetCVEExceptions' -v
```

New tests:
- `TestAPIServerStore_ListSecurityExceptions_CoalescesConcurrentMisses` /
  `TestAPIServerStore_ListClusterSecurityExceptions_CoalescesConcurrentMisses`: N concurrent
  cache misses for the same namespaced/cluster-wide key collapse into exactly one `List()` call.
- `TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses`: N concurrent misses for the
  same workload/container/image collapse into exactly one backend fetch and one CRD lookup, and
  only the caller that actually ran the fetch gets non-zero `ExceptionStats`.
- `TestAPIServerStore_GetSecurityExceptions_CallerCancellationDoesNotAbortSharedFetch` /
  `TestBackendAdapter_GetCVEExceptions_CallerCancellationDoesNotAbortSharedFetch`: a caller whose
  own ctx is canceled while waiting on someone else's in-flight fetch returns promptly with its
  own ctx error, without affecting that fetch or any other waiter.

Each concurrency test uses a synchronous "cache miss" hook as a hard barrier (every goroutine
blocks in it until all of them have arrived, mirroring `credentialCache.onMiss`) rather than a
timing-based sleep, so the assertions are deterministic, not flaky-by-luck.

I also updated `TestAPIServerStore_GetSecurityExceptions_HonorsCallerCancellation`, which
previously asserted the *opposite* of the new, correct behavior (that cancellation *did*
propagate into the `List()` call) -- that was correct when each caller ran its own independent
call, but no longer holds once a call can be shared across callers. It's replaced by
`..._CallerCancellationDoesNotAbortSharedFetch` above.

`go build ./...`, `go vet ./repositories/... ./adapters/v1/...`, and the full test suite for
both changed packages all pass locally. (`-race` isn't runnable in my environment --
`CGO_ENABLED=0` -- but the fix reuses `credentialCache`'s already-race-tested `DoChan` pattern
verbatim rather than introducing new synchronization primitives.)

## Impact

- Removes a redundant-List()-call multiplier that scales with `scanConcurrency`, on both the
  per-namespace and (worse) the cluster-wide `dynamic.Interface` traffic, exactly at the moments
  (TTL expiry, real CRD changes) that already concentrate load.
- No behavior change on the correctness/semantics side: cached values, TTLs, the
  generation-based invalidation guard (#733), degraded/partial-result handling, and registry
  scans' cache isolation are all unchanged -- this only removes the duplicate work on a
  concurrent miss.

## Related issues/PRs:

Fixes #916

Follows the pattern established by #569 (`registryauth.credentialCache`) and #642
(`scan.go`'s SBOM singleflight), applied to the two remaining un-deduplicated caches in the
exception-resolution path.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Build and `go vet` pass locally; unit tests run in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent security and CVE exception lookups by sharing a single backend request when multiple requests miss the cache simultaneously.
  - Prevented one canceled request from interrupting an in-progress shared fetch needed by other requests.
  - Preserved prompt cancellation responses for individual callers, while allowing shared lookups to complete for other requests.
  - Improved handling of registry scans by retrieving exception data directly when appropriate.
- **Tests**
  - Added regression coverage for concurrent requests, cache misses, and caller cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->