### PR TITLE
docs,test: apply the two review nits from #913 and #903

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -235,6 +235,7 @@ The main configuration file. All options can be overridden via environment varia
     },
     "maxImageSize": {
       "type": "integer",
+      "minimum": 1,
       "default": 536870912
     },
     "maxQueueDepth": {
@@ -243,6 +244,7 @@ The main configuration file. All options can be overridden via environment varia
     },
     "maxSBOMSize": {
       "type": "integer",
+      "minimum": 1,
       "default": 20971520
     },
     "namespace": {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2,13 +2,13 @@ package repositories
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"encoding/json"
 	"github.com/akyoto/cache"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"


### PR DESCRIPTION
## Overview

The two non-blocking points raised in review of #913 and #903, both mine.

**Schema, from #913.** That PR added the positive-value guard for `maxImageSize` and `maxSBOMSize` and documented it in the config table, but left the Complete Schema block in the same file untouched:

```json
"maxImageSize": {
  "type": "integer",
  "default": 536870912
},
```

So a schema validator still accepts values `LoadConfig` now rejects at startup. Both properties get `minimum: 1`.

Worth admitting: my own issue text on #912 said "the JSON schema for both size limits carries only `type` and a default, no `minimum`", so I identified the gap and then did not close it. CodeRabbit caught it.

**Import group, from #903.** `encoding/json` was appended to the third-party group instead of the stdlib one, where `goimports` sorts it. Moved.

## Testing

`go vet ./repositories/ && go test ./repositories/ -count=1` pass, `golangci-lint run ./repositories/...` exits 0 locally.

The schema block still parses as valid JSON, checked by loading it and reading both properties back rather than eyeballing the diff.

No behaviour change: the runtime guard was already in #913, this only makes the published schema agree with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the configuration schema to require positive values for maximum image and SBOM sizes.

- **Style**
  - Standardized import ordering in the API server test code without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->