### PR TITLE
fix(repositories): cache GetWorkloadLabels/GetNamespaceLabels results

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -74,6 +74,21 @@ const (
 	securityExceptionListCacheKeyPrefix        = "se/"
 )
 
+// labelsCacheCleaningInterval/TTL bound how stale the workload/namespace labels
+// GetWorkloadLabels/GetNamespaceLabels read can be. Unlike securityExceptionListCache, this data
+// has no informer behind it to invalidate on change (a label edit is rare and not otherwise
+// latency-sensitive here), so the TTL alone bounds staleness — same 30s value, for the same
+// reason: close enough to live, while still collapsing a burst of Get()s for the same object
+// into one. Without this cache, a single ScanCP call for an N-container workload issues N
+// identical Get()s for that one workload's labels (BuildExceptionTarget resolves them on every
+// exceptionsCache miss, and that cache is keyed per container, not per workload) — see #919.
+const (
+	labelsCacheCleaningInterval   = 30 * time.Second
+	labelsCacheTTL                = 30 * time.Second
+	workloadLabelsCacheKeyPrefix  = "wl/"
+	namespaceLabelsCacheKeyPrefix = "ns/"
+)
+
 // resourceVersionMetadata mirrors kubescape/storage's
 // softwarecomposition.ResourceVersionMetadata. Passed as GetOptions.ResourceVersion, its
 // file-backed apiserver (pkg/registry/file/storage.go) honours it by reading only the
@@ -94,6 +109,10 @@ type APIServerStore struct {
 	// nil is safe (falls back to always listing, e.g. in tests that construct APIServerStore
 	// literals directly instead of through the constructors below).
 	securityExceptionListCache *cache.Cache
+
+	// labelsCache caches GetWorkloadLabels'/GetNamespaceLabels' Get() results; nil is safe,
+	// same as securityExceptionListCache above.
+	labelsCache *cache.Cache
 
 	// securityExceptionCacheEntries backs the compare-and-swap that keeps a List() in flight
 	// when a CRD change invalidates its cache key from silently re-populating the cache with
@@ -222,6 +241,7 @@ func NewAPIServerStorage(namespace string) (*APIServerStore, error) {
 		DynamicClient:              dynClient,
 		Namespace:                  namespace,
 		securityExceptionListCache: cache.New(securityExceptionListCacheCleaningInterval),
+		labelsCache:                cache.New(labelsCacheCleaningInterval),
 	}
 	store.enableSecurityExceptionCacheInvalidation(context.Background())
 	return store, nil
@@ -332,6 +352,7 @@ func newFakeAPIServerStore(namespace string, storageClient spdxv1beta1.SpdxV1bet
 		}),
 		Namespace:                  namespace,
 		securityExceptionListCache: cache.New(securityExceptionListCacheCleaningInterval),
+		labelsCache:                cache.New(labelsCacheCleaningInterval),
 	}
 }
 
@@ -575,10 +596,25 @@ func (a *APIServerStore) listClusterSecurityExceptions(ctx, listCtx context.Cont
 // workload is not found, nil labels are returned (the selector then matches
 // nothing, i.e. the exception is not applied — the safe default for a
 // suppression feature).
+//
+// Served from labelsCache when a fresh entry exists: the labels are the same for every
+// container of the same workload, but BuildExceptionTarget resolves them on every
+// exceptionsCache miss (BackendAdapter.exceptionsCache is keyed per container, not per
+// workload), so without this a single ScanCP call for an N-container workload issues N
+// identical Get()s for one object's labels — see #919. A failed lookup (including NotFound)
+// is never cached, so it self-heals on the next call instead of pinning "unresolved" (and
+// therefore fail-closed/not-applied) for the TTL.
 func (a *APIServerStore) GetWorkloadLabels(ctx context.Context, namespace, kind, name string) (map[string]string, error) {
 	if namespace == "" || kind == "" || name == "" {
 		return nil, nil
 	}
+	cacheKey := workloadLabelsCacheKeyPrefix + namespace + "/" + kind + "/" + name
+	if a.labelsCache != nil {
+		if cached, ok := a.labelsCache.Get(cacheKey); ok {
+			return cached.(map[string]string), nil
+		}
+	}
+
 	gvr, err := k8sinterface.GetGroupVersionResource(kind)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve GroupVersionResource for kind %q: %w", kind, err)
@@ -592,15 +628,29 @@ func (a *APIServerStore) GetWorkloadLabels(ctx context.Context, namespace, kind,
 		// could not be resolved.
 		return nil, err
 	}
-	return obj.GetLabels(), nil
+	labels := obj.GetLabels()
+	if a.labelsCache != nil {
+		a.labelsCache.Set(cacheKey, labels, labelsCacheTTL)
+	}
+	return labels, nil
 }
 
 // GetNamespaceLabels resolves the labels of a namespace so that a
 // ClusterSecurityException's match.namespaceSelector can be evaluated.
+//
+// Served from labelsCache when a fresh entry exists, and a failed lookup is never cached —
+// see GetWorkloadLabels, which this mirrors.
 func (a *APIServerStore) GetNamespaceLabels(ctx context.Context, name string) (map[string]string, error) {
 	if name == "" {
 		return nil, nil
 	}
+	cacheKey := namespaceLabelsCacheKeyPrefix + name
+	if a.labelsCache != nil {
+		if cached, ok := a.labelsCache.Get(cacheKey); ok {
+			return cached.(map[string]string), nil
+		}
+	}
+
 	getCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	obj, err := a.DynamicClient.Resource(namespaceGVR).Get(getCtx, name, metav1.GetOptions{})
@@ -609,7 +659,11 @@ func (a *APIServerStore) GetNamespaceLabels(ctx context.Context, name string) (m
 		// GetWorkloadLabels).
 		return nil, err
 	}
-	return obj.GetLabels(), nil
+	labels := obj.GetLabels()
+	if a.labelsCache != nil {
+		a.labelsCache.Set(cacheKey, labels, labelsCacheTTL)
+	}
+	return labels, nil
 }
 
 func (a *APIServerStore) GetContainerProfile(ctx context.Context, namespace string, name string) (v1beta1.ContainerProfile, error) {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -3192,6 +3192,173 @@ func TestAPIServerStore_GetNamespaceLabels_HonorsCallerCancellation(t *testing.T
 	require.True(t, *called, "the Get call the hook was attached to must have run")
 }
 
+// TestAPIServerStore_GetWorkloadLabels_Caches is a regression test for #919:
+// GetWorkloadLabels used to issue a fresh Get() call on every invocation, even though the
+// labels are identical for every container of the same workload -- BuildExceptionTarget
+// resolves them on every BackendAdapter.exceptionsCache miss, and that cache is keyed per
+// container, so a single ScanCP call for an N-container workload used to fan this out into N
+// Get()s for one object. A Get() call counter proves the cache collapses repeated calls for
+// the same workload into a single Get(), and that a genuinely different workload still gets
+// its own fresh lookup.
+func TestAPIServerStore_GetWorkloadLabels_Caches(t *testing.T) {
+	pod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "mypod",
+			"namespace": "kubescape",
+			"labels":    map[string]interface{}{"app": "nginx"},
+		},
+	}}
+	dynClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), pod)
+
+	var getCalls int32
+	dynClient.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&getCalls, 1)
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient: dynClient,
+		Namespace:     "kubescape",
+		labelsCache:   cache.New(time.Minute),
+	}
+
+	labels1, err := a.GetWorkloadLabels(context.TODO(), "kubescape", "Pod", "mypod")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "nginx"}, labels1)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&getCalls))
+
+	labels2, err := a.GetWorkloadLabels(context.TODO(), "kubescape", "Pod", "mypod")
+	require.NoError(t, err)
+	assert.Equal(t, labels1, labels2)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&getCalls),
+		"a second call for the same workload should be served from cache")
+
+	_, err = a.GetWorkloadLabels(context.TODO(), "kubescape", "Pod", "other-pod")
+	require.Error(t, err, "a different, nonexistent workload is a genuine cache miss and must still be looked up")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&getCalls))
+}
+
+// TestAPIServerStore_GetWorkloadLabels_DoesNotCacheFailures guards the self-healing property
+// GetSecurityExceptions' own List() cache already relies on: a failed lookup must never
+// populate the cache, or a transient apiserver hiccup (or a workload not existing yet) would
+// be pinned as "unresolved" -- and therefore fail-closed, not applied -- for the full TTL
+// instead of self-healing on the next scan.
+func TestAPIServerStore_GetWorkloadLabels_DoesNotCacheFailures(t *testing.T) {
+	pod := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "mypod",
+			"namespace": "kubescape",
+			"labels":    map[string]interface{}{"app": "nginx"},
+		},
+	}}
+	dynClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), pod)
+
+	var calls int32
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	dynClient.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return true, nil, injectedErr
+		}
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient: dynClient,
+		Namespace:     "kubescape",
+		labelsCache:   cache.New(time.Minute),
+	}
+
+	_, err := a.GetWorkloadLabels(context.TODO(), "kubescape", "Pod", "mypod")
+	require.Error(t, err)
+
+	labels, err := a.GetWorkloadLabels(context.TODO(), "kubescape", "Pod", "mypod")
+	require.NoError(t, err, "a failed lookup must not be cached, so the next call retries instead of replaying the failure")
+	assert.Equal(t, map[string]string{"app": "nginx"}, labels)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+// TestAPIServerStore_GetNamespaceLabels_Caches is the namespace-scoped counterpart of
+// TestAPIServerStore_GetWorkloadLabels_Caches -- see #919.
+func TestAPIServerStore_GetNamespaceLabels_Caches(t *testing.T) {
+	ns := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name":   "myns",
+			"labels": map[string]interface{}{"team": "platform"},
+		},
+	}}
+	dynClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), ns)
+
+	var getCalls int32
+	dynClient.PrependReactor("get", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&getCalls, 1)
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient: dynClient,
+		Namespace:     "kubescape",
+		labelsCache:   cache.New(time.Minute),
+	}
+
+	labels1, err := a.GetNamespaceLabels(context.TODO(), "myns")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"team": "platform"}, labels1)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&getCalls))
+
+	labels2, err := a.GetNamespaceLabels(context.TODO(), "myns")
+	require.NoError(t, err)
+	assert.Equal(t, labels1, labels2)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&getCalls),
+		"a second call for the same namespace should be served from cache")
+
+	_, err = a.GetNamespaceLabels(context.TODO(), "other-ns")
+	require.Error(t, err, "a different, nonexistent namespace is a genuine cache miss and must still be looked up")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&getCalls))
+}
+
+// TestAPIServerStore_GetNamespaceLabels_DoesNotCacheFailures is the namespace-scoped
+// counterpart of TestAPIServerStore_GetWorkloadLabels_DoesNotCacheFailures.
+func TestAPIServerStore_GetNamespaceLabels_DoesNotCacheFailures(t *testing.T) {
+	ns := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name":   "myns",
+			"labels": map[string]interface{}{"team": "platform"},
+		},
+	}}
+	dynClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), ns)
+
+	var calls int32
+	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+	dynClient.PrependReactor("get", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return true, nil, injectedErr
+		}
+		return false, nil, nil
+	})
+
+	a := &APIServerStore{
+		DynamicClient: dynClient,
+		Namespace:     "kubescape",
+		labelsCache:   cache.New(time.Minute),
+	}
+
+	_, err := a.GetNamespaceLabels(context.TODO(), "myns")
+	require.Error(t, err)
+
+	labels, err := a.GetNamespaceLabels(context.TODO(), "myns")
+	require.NoError(t, err, "a failed lookup must not be cached, so the next call retries instead of replaying the failure")
+	assert.Equal(t, map[string]string{"team": "platform"}, labels)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
 func TestAPIServerStore_GetContainerProfile_ctxPropagated(t *testing.T) {
 	clientset := newFakeStorageClientset()
 	wrapped := &ctxCapturingClient{SpdxV1beta1Interface: clientset.SpdxV1beta1()}


### PR DESCRIPTION
## Overview

`GetWorkloadLabels` and `GetNamespaceLabels` (`repositories/apiserver.go`) resolve a scanned
workload's/namespace's labels so a `SecurityException`'s `objectSelector`/`namespaceSelector`
can be evaluated. Both issued a fresh, uncached `Get()` against the same rate-limited
(`QPS: 50, Burst: 100`) `dynamic.Interface` client `GetSecurityExceptions`' own `List()` calls
share — but unlike those `List()` calls, which #510/#511 gave a shared cache, these two `Get()`s
had none at all.

**Why it matters more than "one extra API call":** `BackendAdapter.exceptionsCache` is keyed
per **container**, not per workload (`accountID/cluster/namespace/kind/name/containerName/imageTag`),
and `BuildExceptionTarget` resolves the workload's/namespace's labels on every miss of that
cache. So for a workload with N containers, `ScanCP`'s per-container loop drives N separate
`exceptionsCache` misses for what is, from `GetWorkloadLabels`'s point of view, the identical
`(namespace, kind, name)` — N redundant `Get()`s for the same object's labels, all within one
`ScanCP` call, whenever an `objectSelector`/`namespaceSelector`-based exception is in use (an
ordinary, documented way to scope a suppression by label rather than by name).

**Root cause / relation to #510:** #510's own "Additional context" named these two `Get()`
calls as part of the same rate-limiter-exhaustion problem it filed. The PR that closed #510
(#511, "cache SecurityException/ClusterSecurityException List() results") is scoped, by its
own title and diff, purely to the `List()` calls — it never touched `GetWorkloadLabels`/
`GetNamespaceLabels`. This is that other half.

## Solution

Add `labelsCache` to `APIServerStore`, mirroring `securityExceptionListCache`'s
already-established pattern in the same file, field for field:

- Same 30s TTL (`labelsCacheTTL`) — close enough to live, while collapsing a burst of `Get()`s
  for the same object into one.
- Nil-safe, exactly like `securityExceptionListCache`: several existing tests construct
  `APIServerStore{}` literals directly instead of through the constructors, and those keep
  working uncached rather than panicking.
- A failed lookup (including `NotFound`) is never cached, so it self-heals on the next call
  instead of pinning "unresolved" — and therefore fail-closed/not-applied, per
  `matchExceptionTarget`'s existing semantics — for the full TTL.
- No informer-based invalidation (unlike `securityExceptionListCache`, which #733 gave one):
  a label edit is rare and not otherwise latency-sensitive on this path, so the TTL alone
  bounding staleness is the right amount of machinery here, not a corner cut.

`matchExceptionTarget`'s matching semantics are unchanged — this is a caching/fetch-path
change only, the same boundary #511 held itself to.

## How to Test

```
go test ./repositories/... -run 'GetWorkloadLabels|GetNamespaceLabels' -v
```

New tests:
- `TestAPIServerStore_GetWorkloadLabels_Caches` / `TestAPIServerStore_GetNamespaceLabels_Caches`
  — two calls for the same workload/namespace collapse into a single `Get()`; a different,
  nonexistent one still gets its own fresh lookup.
- `TestAPIServerStore_GetWorkloadLabels_DoesNotCacheFailures` /
  `..._GetNamespaceLabels_DoesNotCacheFailures` — a failed `Get()` is never cached, so the next
  call retries instead of replaying the failure.

The two pre-existing `..._HonorsCallerCancellation` tests (which construct `APIServerStore{}`
literals with no `labelsCache` set) still pass unchanged, confirming the nil-safe fallback.

`go build ./...`, `go vet ./repositories/...`, and the full `repositories` suite all pass
locally.

## Impact

- Removes a `Get()`-call multiplier that scales with container count, on the same rate-limited
  client `GetSecurityExceptions`' `List()` calls already depend on — so this also reduces
  pressure on those, not just on itself.
- No behavior change on the correctness/semantics side: fail-closed handling for an unresolved
  selector, `NotFound` propagation, and the empty-namespace/kind/name early return are all
  unchanged.

## Related issues/PRs:

Fixes #919

Completes the scope #510 originally described but #511 didn't cover.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Build and `go vet` pass locally; unit tests run in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved workload and namespace label lookups by caching successful results for a short period.
  - Repeated requests can now be served without additional backend lookups.

- **Reliability**
  - Failed or unavailable lookups are not cached, allowing subsequent requests to retry automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->