### PR TITLE
fix(registryauth): only fall back to anonymous on a repeated auth denial

### DIFF
--- a/internal/registryauth/resolve.go
+++ b/internal/registryauth/resolve.go
@@ -16,6 +16,16 @@ import (
 // which credentials to try, not about what comes back.
 type Getter[T any] func(ctx context.Context, ref string, opts *image.RegistryOptions) (T, error)
 
+// isAuthDenied reports whether err is a registry rejecting the request as unauthenticated or
+// unauthorized -- the two outcomes credentials (ours, or none at all) can actually change.
+// Matches the same bucket core/services/scan_failure_reasons.go's classifySBOMError already
+// uses for the identical distinction (401 vs. 403 both mean "the registry looked at who's
+// asking and said no", where a 429/5xx/timeout means something else went wrong that swapping
+// credentials cannot fix).
+func isAuthDenied(err error) bool {
+	return err != nil && (strings.Contains(err.Error(), "401 Unauthorized") || strings.Contains(err.Error(), "403 Forbidden"))
+}
+
 // ResolveSource pulls imageID, falling back in order when the pull fails:
 //
 //   - MANIFEST_UNKNOWN, which a registry returns for a digest it does not hold, is retried
@@ -67,8 +77,21 @@ func ResolveSource[T any](ctx context.Context, component string, get Getter[T], 
 			}
 		}
 		// If no provider matched, its credentials were unavailable, or it succeeded in auth
-		// but still got 401, fall back to anonymous access. err/src retain the last attempt.
-		if err != nil {
+		// but still got denied, fall back to anonymous access. err/src retain the last attempt.
+		//
+		// The isAuthDenied check matters: when a provider's credentials were used above, err
+		// may now hold whatever the credentialed retry actually failed with, not another
+		// auth rejection -- a 429, a 5xx, a timeout. None of those are fixed by dropping
+		// credentials and retrying anonymously (the registry was never rejecting the request
+		// for being unauthenticated), so without this check a persistently-429ing registry
+		// gets a second full attempt -- itself wrapped in its own retry-with-backoff by every
+		// caller -- doubling load on a registry that just asked to be backed off from, and the
+		// eventual error permanently mislabels whatever actually went wrong as "unauthorized"
+		// (via unauthorizedErr below). When no provider matched or its credentials were
+		// unavailable, err is untouched here and still holds the original auth-denied error
+		// from line 50 (or the MANIFEST_UNKNOWN retry above it), so this check doesn't change
+		// that path's existing behavior. See #921.
+		if isAuthDenied(err) {
 			logger.L().Debug("retrying without credentials",
 				helpers.String("imageID", imageID))
 			opts.Credentials = nil

--- a/internal/registryauth/resolve_test.go
+++ b/internal/registryauth/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/stretchr/testify/assert"
@@ -81,4 +82,66 @@ func TestResolveSource_PassesOtherErrorsStraightBack(t *testing.T) {
 
 	require.ErrorIs(t, err, boom)
 	assert.Equal(t, 1, attempts)
+}
+
+// TestResolveSource_DoesNotFallBackToAnonymousOnNonAuthErrorFromCredentialedRetry is a
+// regression test for #921: a credentialed retry that fails for a reason other than 401 (here,
+// a 429) must not trigger a further, doomed-to-fail anonymous retry. The registry was never
+// rejecting the request for being unauthenticated, so dropping credentials cannot fix it, and
+// the real error must be returned as-is rather than masked as an authorization failure.
+func TestResolveSource_DoesNotFallBackToAnonymousOnNonAuthErrorFromCredentialedRetry(t *testing.T) {
+	origGCPCredsFn := GCPCredsFn
+	defer func() { GCPCredsFn = origGCPCredsFn; ResetCaches() }()
+	GCPCredsFn = func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "tok"}, time.Now().Add(time.Hour), nil
+	}
+
+	rateLimited := errors.New("429 Too Many Requests")
+	var credentialsSeen []int
+	get := func(_ context.Context, _ string, opts *image.RegistryOptions) (fakeSource, error) {
+		credentialsSeen = append(credentialsSeen, len(opts.Credentials))
+		if len(opts.Credentials) == 0 {
+			return fakeSource{}, errors.New("401 Unauthorized")
+		}
+		return fakeSource{}, rateLimited
+	}
+
+	_, err := ResolveSource(context.Background(), "in_process", get,
+		"gcr.io/project/image:tag", "gcr.io/project/image:tag", image.RegistryOptions{})
+
+	require.ErrorIs(t, err, rateLimited, "the credentialed retry's real error must come back, not be masked as unauthorized")
+	assert.Equal(t, []int{0, 1}, credentialsSeen, "no third, anonymous attempt should follow a non-401 error from the credentialed retry")
+}
+
+// TestResolveSource_FallsBackToAnonymousWhenCredentialedRetryAlsoGets401 guards the behavior
+// the #921 fix must preserve: credentials that are outright refused (401 again, not some other
+// error) still fall back to anonymous access, exactly as ResolveSource's own doc comment
+// describes.
+func TestResolveSource_FallsBackToAnonymousWhenCredentialedRetryAlsoGets401(t *testing.T) {
+	origGCPCredsFn := GCPCredsFn
+	defer func() { GCPCredsFn = origGCPCredsFn; ResetCaches() }()
+	GCPCredsFn = func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+		return &image.RegistryCredentials{Username: "oauth2accesstoken", Password: "refused-token"}, time.Now().Add(time.Hour), nil
+	}
+
+	// Both the initial no-credentials attempt and the eventual anonymous retry pass zero
+	// credentials, so the fixture distinguishes them by call order rather than credential
+	// count: the first two attempts (no credentials, then the refused credentials) both fail
+	// with 401, and only the third (anonymous, after the credentialed retry is also refused)
+	// succeeds.
+	var credentialsSeen []int
+	get := func(_ context.Context, ref string, opts *image.RegistryOptions) (fakeSource, error) {
+		credentialsSeen = append(credentialsSeen, len(opts.Credentials))
+		if len(credentialsSeen) < 3 {
+			return fakeSource{}, errors.New("401 Unauthorized")
+		}
+		return fakeSource{ref: ref}, nil
+	}
+
+	src, err := ResolveSource(context.Background(), "in_process", get,
+		"gcr.io/project/image:tag", "gcr.io/project/image:tag", image.RegistryOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "gcr.io/project/image:tag", src.ref)
+	assert.Equal(t, []int{0, 1, 0}, credentialsSeen, "a credentialed retry refused again must still fall back to anonymous")
 }


### PR DESCRIPTION
## Overview

`ResolveSource` (`internal/registryauth/resolve.go`) is the shared pull-fallback ladder both
SBOM paths (`adapters/v1/syft.go`, `pkg/sbomscanner/v1/server.go`) use. When the initial,
credential-less pull fails with `401 Unauthorized`, it looks up a matching credential provider
(ECR/GCP), retries with those credentials, and — per its own doc comment — falls back to an
anonymous retry "if that provider has none or its credentials are refused too". The check that
decided whether to fall back to anonymous was a bare `err != nil`, not "refused too": any error
from the credentialed retry — a `429 Too Many Requests`, a `5xx`, a timeout — triggered the
anonymous fallback, not just another auth rejection.

**Why it matters:** each individual pull attempt (`get`) is itself wrapped in its own
`tools.RetryWithBackoff` with 429-handling by both real callers. So a credentialed retry that
hits a persistently-429ing registry already exhausts its own retry-with-backoff budget — and
this bug then triggered a *second* full retry-with-backoff cycle, anonymously, doubling request
volume against a registry that had just asked to be backed off from. The final error was also
always wrapped around the *original* pre-credentials 401/403, so a scan that actually failed
because of a transient 500 or a rate limit got permanently logged as "unauthorized" —
misleading for anyone diagnosing a real registry incident from kubevuln's logs.

## Root Cause

`internal/registryauth/resolve.go`'s fallback-to-anonymous guard checked only `err != nil`.

## Solution

Add `isAuthDenied(err)`, checking for `"401 Unauthorized"` or `"403 Forbidden"` — the same
bucket `core/services/scan_failure_reasons.go`'s `classifySBOMError` already uses for this exact
distinction (401 and 403 both mean "the registry looked at who's asking and said no"; a 429/5xx/
timeout means something else went wrong that swapping credentials can't fix) — and gate the
anonymous fallback on it instead of on any error at all.

I initially scoped this to 401 only, then found `pkg/sbomscanner/v1/server_test.go` already has
a passing test (`"GCP image, ADC succeeds but pull fails non-401, still anonymous..."`) that
depends on a `403 Forbidden` from the credentialed retry *also* triggering the anonymous
fallback. Widening to the same 401/403 bucket `classifySBOMError` already uses keeps that
existing, intentional behavior while fixing the actual bug (429/5xx/timeout wrongly triggering
it).

The outer gate that decides whether to enter the ladder at all (a 401 on the very first,
credential-less attempt) is unchanged — this is purely about the inner re-check after the
credentialed retry.

## How to Test

```
go test ./internal/registryauth/... -run ResolveSource -v
go test ./pkg/sbomscanner/... -run TestResolveSource -v
```

New tests in `internal/registryauth/resolve_test.go`:
- `TestResolveSource_DoesNotFallBackToAnonymousOnNonAuthErrorFromCredentialedRetry` — a
  credentialed retry that fails with `429 Too Many Requests` returns that error as-is, with no
  third (anonymous) attempt.
- `TestResolveSource_FallsBackToAnonymousWhenCredentialedRetryAlsoGets401` — guards the
  preserved behavior: credentials outright refused (401 again) still fall back to anonymous.

Both use `ResolveSource`'s existing `Getter[T]` parameter to exercise the ladder deterministically, no fake registry needed — following the pattern already established by this test file's other cases (and `GCPCredsFn`/`ResetCaches()`, already used elsewhere in this package for the same reason).

All pre-existing tests in both packages pass unchanged, including the `pkg/sbomscanner/v1`
table-driven `TestResolveSource` case that specifically exercises the 403-still-falls-back
path.

`go build ./...`, `go vet ./internal/registryauth/... ./adapters/v1/... ./pkg/sbomscanner/...`,
and the full `internal/registryauth`, `adapters/v1`, and `pkg/sbomscanner` suites all pass
locally.

## Impact

- Removes a retry-amplification bug that worked directly against this codebase's existing
  429-handling investment (`tools.RetryWithBackoff`, `ScanService.checkCreateSBOM`'s circuit
  breaker, per-component fallback metrics).
- Real, unrelated errors from a credentialed pull (5xx, timeout, DNS) are now returned as-is
  instead of being buried behind a misleading "anonymous fallback failed" wrapper around the
  original auth error.
- No change to the existing, intentional 401/403-triggers-anonymous-fallback behavior, and no
  change to the outer gate that decides whether to enter the ladder at all.

## Related issues/PRs:

Fixes #921

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Build and `go vet` pass locally; unit tests run in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry access handling when authentication fails.
  * Prevented unnecessary anonymous retries for rate limits, server errors, and timeouts.
  * Preserved anonymous fallback when access is explicitly denied.
  * Ensured non-authentication errors are returned accurately instead of being mislabeled as unauthorized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->