### PR TITLE
fix(vexvalidate): reject a statement with no vulnerability, and empty subcomponents

### DIFF
--- a/internal/vexvalidate/vexvalidate.go
+++ b/internal/vexvalidate/vexvalidate.go
@@ -51,6 +51,21 @@ var (
 	// only a product with none of the three says nothing about what it
 	// actually is.
 	ErrEmptyProduct = errors.New("vexvalidate: statement has a product that identifies nothing")
+
+	// ErrNoVulnerability is returned when a statement never says which
+	// vulnerability it is about. go-vex's Statement.Validate() checks the
+	// status and the fields each status may carry, but not this, so a
+	// statement carrying neither an @id nor a name passes every other check
+	// here. Matching keys on the vulnerability name, so an unnamed statement
+	// keys on the empty string and collides with every other unnamed one.
+	ErrNoVulnerability = errors.New("vexvalidate: statement does not identify a vulnerability")
+
+	// ErrEmptySubcomponent is returned when a product lists a subcomponent
+	// that identifies nothing, by the same ID/hashes/identifiers test
+	// ErrEmptyProduct applies one level up. Subcomponents are what scope a
+	// statement to a package, which is the granularity suppression matches
+	// on, so an empty one says as little as an empty product.
+	ErrEmptySubcomponent = errors.New("vexvalidate: statement has a subcomponent that identifies nothing")
 )
 
 // openVEXContextPrefix is the real OpenVEX namespace URI. The spec allows a
@@ -72,12 +87,21 @@ func hasValidContext(context string) bool {
 	return rest == "" || strings.HasPrefix(rest, "/")
 }
 
-// productIsEmpty reports whether p identifies nothing at all. A Product's ID
-// is optional in go-vex's own Component type, since a product can instead be
-// identified by Hashes or Identifiers - so ID alone being unset does not
-// make a product empty, but having none of the three does.
-func productIsEmpty(p vex.Product) bool {
-	return p.ID == "" && len(p.Hashes) == 0 && len(p.Identifiers) == 0
+// componentIsEmpty reports whether c identifies nothing at all. A Component's
+// ID is optional in go-vex, since it can instead be identified by Hashes or
+// Identifiers - so ID alone being unset does not make it empty, but having
+// none of the three does. Used for a product and for each of its
+// subcomponents, which are the same Component type.
+func componentIsEmpty(c vex.Component) bool {
+	return c.ID == "" && len(c.Hashes) == 0 && len(c.Identifiers) == 0
+}
+
+// vulnerabilityIsAnonymous reports whether v names no vulnerability. go-vex
+// makes both fields optional: @id is an IRI referencing it, name is the main
+// identifier. Either one identifies the statement's subject, so only having
+// neither leaves it about nothing in particular.
+func vulnerabilityIsAnonymous(v vex.Vulnerability) bool {
+	return strings.TrimSpace(v.ID) == "" && strings.TrimSpace(string(v.Name)) == ""
 }
 
 // Validate parses data as an OpenVEX document and checks it is genuinely
@@ -109,13 +133,23 @@ func Validate(data []byte) error {
 			return fmt.Errorf("%w: statement %d: %w", ErrInvalidStatement, i, err)
 		}
 
+		if vulnerabilityIsAnonymous(s.Vulnerability) {
+			return fmt.Errorf("%w: statement %d", ErrNoVulnerability, i)
+		}
+
 		if len(s.Products) == 0 {
 			return fmt.Errorf("%w: statement %d", ErrNoProducts, i)
 		}
 
 		for j, p := range s.Products {
-			if productIsEmpty(p) {
+			if componentIsEmpty(p.Component) {
 				return fmt.Errorf("%w: statement %d, product %d", ErrEmptyProduct, i, j)
+			}
+			for k, sub := range p.Subcomponents {
+				if componentIsEmpty(sub.Component) {
+					return fmt.Errorf("%w: statement %d, product %d, subcomponent %d",
+						ErrEmptySubcomponent, i, j, k)
+				}
 			}
 		}
 	}

--- a/internal/vexvalidate/vexvalidate_test.go
+++ b/internal/vexvalidate/vexvalidate_test.go
@@ -279,3 +279,65 @@ func TestValidate_AllOpenVEXStatuses_WithRequiredFields_Accepted(t *testing.T) {
 		})
 	}
 }
+
+// A statement that never says which vulnerability it is about passes every other check:
+// go-vex's Statement.Validate checks the status and the fields each status may carry, but
+// not this. Matching keys on the vulnerability name, so an unnamed statement keys on the
+// empty string and collides with every other unnamed one.
+func TestValidate_StatementWithoutVulnerability_Fails(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"status": "fixed", "products": [{"@id": "pkg:oci/x"}]}]}`
+	if err := Validate([]byte(doc)); !errors.Is(err, ErrNoVulnerability) {
+		t.Fatalf("expected ErrNoVulnerability, got: %v", err)
+	}
+}
+
+func TestValidate_VulnerabilityIdentifiedByEitherField(t *testing.T) {
+	byName := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-2024-0001"}, "products": [{"@id": "pkg:oci/x"}], "status": "fixed"}]}`
+	if err := Validate([]byte(byName)); err != nil {
+		t.Fatalf("a name identifies the vulnerability, got: %v", err)
+	}
+
+	byID := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"@id": "https://example.test/CVE-2024-0001"}, "products": [{"@id": "pkg:oci/x"}], "status": "fixed"}]}`
+	if err := Validate([]byte(byID)); err != nil {
+		t.Fatalf("an @id alone identifies the vulnerability, got: %v", err)
+	}
+
+	whitespace := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "   "}, "products": [{"@id": "pkg:oci/x"}], "status": "fixed"}]}`
+	if err := Validate([]byte(whitespace)); !errors.Is(err, ErrNoVulnerability) {
+		t.Fatalf("expected ErrNoVulnerability for a whitespace-only name, got: %v", err)
+	}
+}
+
+// The same emptiness test a product already gets, one level down. Subcomponents are what
+// scope a statement to a package, which is the granularity suppression matches on.
+func TestValidate_EmptySubcomponent_Fails(t *testing.T) {
+	only := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/x", "subcomponents": [{}]}], "status": "fixed"}]}`
+	if err := Validate([]byte(only)); !errors.Is(err, ErrEmptySubcomponent) {
+		t.Fatalf("expected ErrEmptySubcomponent, got: %v", err)
+	}
+
+	second := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/x", "subcomponents": [{"@id": "pkg:deb/a"}, {}]}], "status": "fixed"}]}`
+	if err := Validate([]byte(second)); !errors.Is(err, ErrEmptySubcomponent) {
+		t.Fatalf("a later empty subcomponent counts too, got: %v", err)
+	}
+}
+
+func TestValidate_PopulatedSubcomponents_Pass(t *testing.T) {
+	byID := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/x", "subcomponents": [{"@id": "pkg:deb/a"}, {"@id": "pkg:deb/b"}]}], "status": "fixed"}]}`
+	if err := Validate([]byte(byID)); err != nil {
+		t.Fatalf("populated subcomponents should pass, got: %v", err)
+	}
+
+	byHash := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/x", "subcomponents": [{"hashes": {"sha256": "abc"}}]}], "status": "fixed"}]}`
+	if err := Validate([]byte(byHash)); err != nil {
+		t.Fatalf("hashes identify a subcomponent, same as a product, got: %v", err)
+	}
+}
+
+// No subcomponents at all is product scope, which is legitimate and must stay so.
+func TestValidate_NoSubcomponents_Passes(t *testing.T) {
+	doc := `{"@context": "https://openvex.dev/ns/v0.2.0", "statements": [{"vulnerability": {"name": "CVE-1"}, "products": [{"@id": "pkg:oci/x"}], "status": "fixed"}]}`
+	if err := Validate([]byte(doc)); err != nil {
+		t.Fatalf("product-scope statements must still pass, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Overview

Two shapes got past `vexvalidate`, whose job is catching a fetched document that is valid JSON but not a meaningful VEX document.

**A statement that never says which vulnerability it is about.**

```json
{"@context":"https://openvex.dev/ns/v0.2.0",
 "statements":[{"status":"fixed","products":[{"@id":"pkg:oci/x"}]}]}
```

`go-vex`'s `Statement.Validate()` checks the status and the fields each status may carry, but not this, so nothing in the chain did. It matters for #387 because matching keys on the vulnerability name (`vexStatementKey{name, purl}`): an unnamed statement keys on the empty string and collides with every other unnamed one.

Either field identifies it, `@id` or `name`, so only having neither is rejected. A whitespace-only name counts as neither.

**A product whose subcomponents identify nothing.** `productIsEmpty` applied the ID/hashes/identifiers test to the product but not one level down, so `"subcomponents":[{}]` passed while `"products":[{}]` was caught. Subcomponents are what scope a statement to a package, the granularity `scopedToSubcomponent` matches on, so an empty one says as little as an empty product.

It is now `componentIsEmpty` running against both, since go-vex uses the same `Component` type for a product and a subcomponent.

Having no subcomponents at all is product scope, which is legitimate and stays valid, pinned by its own test.

## Testing

`go test ./internal/vexvalidate/ -count=1 -cover` — passes, coverage stays at 100%.

Tests follow the package's existing `errors.Is` style rather than introducing testify.

Both mutations caught:

| mutation | fails |
| --- | --- |
| drop the vulnerability-identity check | `..._StatementWithoutVulnerability_Fails`, `..._VulnerabilityIdentifiedByEitherField` |
| drop the subcomponent check | `..._EmptySubcomponent_Fails` |

`golangci-lint run ./internal/vexvalidate/...` exits 0 locally.

## Note

This is @Shreya2005-2005's package from #880, and I said on the issue she should have first refusal. Opening this so it is ready rather than to pre-empt her: happy to close it if she would rather take it, and no offence taken either way.

## Related issues/PRs:

* Resolved #924


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now rejects vulnerability statements without an identified vulnerability.
  * Empty subcomponents and blank identity values are rejected during validation.
  * Vulnerabilities and subcomponents can be identified by name, ID, or hash.
  * Product-level statements without subcomponents remain valid.

* **Tests**
  * Added coverage for missing and whitespace-only identifiers, empty subcomponents, supported identity fields, blank values, and valid product-level statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->