### PR TITLE
fix(repositories): emit an empty statements array, not null, for a clean image

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -1752,6 +1752,10 @@ func (a *APIServerStore) createVEX(ctx context.Context, cve domain.CVEManifest, 
 
 	// Calculate VEX
 	vexDoc := v1beta1.VEX{
+		// Explicitly empty rather than nil: Statements has no omitempty, so a scan that
+		// found nothing would otherwise serialise "statements": null. go-vex's own
+		// vex.New() emits [], and a consumer expecting an array should get one. See #923.
+		Statements: []v1beta1.Statement{},
 		Metadata: v1beta1.Metadata{
 			Context:     "https://openvex.dev/ns/v0.2.0",
 			Author:      "kubescape.io",
@@ -2228,9 +2232,9 @@ func (a *APIServerStore) GetSBOM(ctx context.Context, name, SBOMCreatorVersion s
 		return result, domain.ErrOutdatedSBOM
 	}
 	result := domain.SBOM{
-		Name:               name,
-		Annotations:        manifest.Annotations,
-		Labels:             manifest.Labels,
+		Name:        name,
+		Annotations: manifest.Annotations,
+		Labels:      manifest.Labels,
 		// The manifest's own recorded version, not the caller's requested SBOMCreatorVersion:
 		// semver.Compare treats build-metadata differences as equal, so the two can still
 		// differ as strings even when the check above passes.

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -5587,3 +5587,39 @@ func TestGeneratedStatementsAreValidOpenVEX(t *testing.T) {
 		})
 	}
 }
+
+// A scan that finds nothing still stores a VEX document. Statements has no omitempty, so a
+// nil slice serialises "statements": null, where go-vex's own vex.New() emits []. See #923.
+func TestAPIServerStore_StoreVEX_EmptyDocumentUsesAnArray(t *testing.T) {
+	clientset := newFakeStorageClientset()
+	a := newFakeAPIServerStore("kubescape", clientset.SpdxV1beta1())
+
+	clean := domain.CVEManifest{Name: name, Content: &v1beta1.GrypeDocument{}}
+	require.NoError(t, a.StoreVEX(context.TODO(), clean, clean, false))
+
+	stored, err := clientset.SpdxV1beta1().OpenVulnerabilityExchangeContainers("kubescape").
+		Get(context.TODO(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Empty(t, stored.Spec.Statements, "a clean image asserts nothing")
+	assert.NotNil(t, stored.Spec.Statements, "but the slice must be empty, not nil")
+
+	b, err := json.Marshal(stored.Spec)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"statements":[]`)
+	assert.NotContains(t, string(b), `"statements":null`)
+}
+
+// The canonical hash must not distinguish a nil slice from an empty one, or switching to an
+// empty one would re-hash every stored document and bump its version for no real change.
+func TestCalculateVexCanonicalHash_NilAndEmptyStatementsAgree(t *testing.T) {
+	md := v1beta1.Metadata{
+		Context:   "https://openvex.dev/ns/v0.2.0",
+		Author:    "kubescape.io",
+		Timestamp: "2026-01-01T00:00:00Z",
+	}
+	nilHash, err := calculateVexCanonicalHash(v1beta1.VEX{Metadata: md})
+	require.NoError(t, err)
+	emptyHash, err := calculateVexCanonicalHash(v1beta1.VEX{Metadata: md, Statements: []v1beta1.Statement{}})
+	require.NoError(t, err)
+	assert.Equal(t, nilHash, emptyHash)
+}


### PR DESCRIPTION
## Overview

A scan that finds nothing still publishes a VEX document, and it carried `"statements": null`:

```json
{"@context":"https://openvex.dev/ns/v0.2.0","@id":"14e85ecc…","author":"kubescape.io",
 "timestamp":"…","version":0,"tooling":"kubescape-vulnerability-analyzer","statements":null}
```

`createVEX` builds its statements by ranging over `Matches` and `IgnoredMatches`, so with no findings neither loop appends and `Statements` stays nil. The field has no `omitempty`, so nil serialises as `null`.

`go-vex`'s own `vex.New()` emits `[]`:

```
{"@context":"https://openvex.dev/ns/v0.2.0","@id":"","author":"Unknown Author","timestamp":"…","version":1,"statements":[]}
```

A consumer expecting an array should get one, which matters more once #387 means these documents are read back.

## Why this is safe

The canonical hash is unaffected. It sorts a copy of the statements and length-prefixes each, so nil and empty produce the same digest, verified and pinned by `TestCalculateVexCanonicalHash_NilAndEmptyStatementsAgree`. If they differed, this change would re-hash every stored document and bump its version for no real change.

Only the creation path is touched. `updateVEX` deep-copies the stored spec, so a document already carrying `null` keeps it rather than being rewritten on the next scan, which would otherwise be a one-time version bump across every clean image in the cluster. Existing documents are left alone; new ones get the array.

## Scope

This is the unambiguous half of #923. The other half, whether a document that asserts nothing should be published at all, or whether `vexvalidate` should accept one, is a design decision and stays open on the issue. `Refs` rather than `Resolved` for that reason.

Worth being explicit: this change alone does **not** make a clean-image document pass `vexvalidate`. `len()` is zero either way, so `ErrNoStatements` still applies. It fixes the shape, not the verdict.

## Testing

`go test ./repositories/ -count=1` passes. `golangci-lint run ./repositories/...` exits 0 locally.

Removing the initialiser fails `TestAPIServerStore_StoreVEX_EmptyDocumentUsesAnArray`, which asserts on the marshalled document rather than the in-memory slice, since `null` versus `[]` is only visible once serialised.

## Related issues/PRs:

* Refs #923
