### PR TITLE
chore(ci): bump ossf/scorecard-action from v2.4.0 to v2.4.4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Overview
v2.4.4 bundles Scorecard v5.5.0 internally (up from v5.0.0 in v2.4.0), improving the accuracy of the security checks this workflow runs, plus assorted bug fixes across the intermediate patch releases.

## Additional Information
No input/output interface changes between v2.4.0 and v2.4.4 : results_file, results_format, and other workflow inputs are unchanged. Commit SHA pin verified against the official v2.4.4 

  github.com/ossf/scorecard-action/releases/tag/v2.4.4
  
## How to Test
CI-only change (workflow trigger, not app code) , no unit tests apply. Verified by re-running the Scorecard workflow after merge.