### PR TITLE
fix(ci): pin actions/checkout and actions/setup-go to commit SHA in govulncheck.yaml

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: true


### PR DESCRIPTION
## Overview
`govulncheck.yaml` was the last workflow in this repo still using floating tags (`actions/checkout@v4`, `actions/setup-go@v5`) instead of pinned commit SHAs. Every other workflow (`lint.yaml`, `pr-image.yaml`, `scorecard.yml`, `security-insights.yaml`) already pins by SHA to mitigate supply-chain risk from a compromised or re-tagged release.

## Change
Pinned both actions to the same SHAs already trusted elsewhere in this repo , no new version introduced, just consistency:
- `actions/checkout` → `11d5960a326750d5838078e36cf38b85af677262` (v4.4.0)
- `actions/setup-go` → `40f1582b2485089dde7abd97c1529aa768e1baff` (v5.6.0)

## How to Test
CI-only change (workflow trigger, not app code). Verifiable by checking that `govulncheck` runs successfully post-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated vulnerability-checking workflow to use fixed, verified versions of its setup tools.
  - This improves the consistency and security of automated checks without changing the application’s behavior or user-facing functionality.
  - Existing Go version settings, caching behavior, and vulnerability scan steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->