### PR TITLE
fix(repositories): start security exception informer only when risk acceptance is enabled

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -107,6 +107,7 @@ func main() {
 	riskAcceptanceActive := isRiskAcceptanceActive(storage, c.RiskAcceptance)
 	if riskAcceptanceActive {
 		seRepo = storage
+		storage.EnableSecurityExceptionCacheInvalidation(ctx)
 		logger.L().Info("SecurityException CRD integration enabled")
 
 		// Event recording is best-effort: a confirmed suppression is always logged

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -136,6 +136,7 @@ type APIServerStore struct {
 	// miss, instead of a timing-based sleep — mirrors registryauth's credentialCache.onMiss.
 	securityExceptionCacheMissHook func()
 
+	securityExceptionInformerMu   sync.Mutex
 	securityExceptionInformerStop context.CancelFunc
 }
 
@@ -379,7 +380,14 @@ func NewFakeAPIServerStorage(namespace string, objects ...runtime.Object) *APISe
 // SecurityExceptions and ClusterSecurityExceptions when changes occur on the cluster.
 // It should only be called when riskAcceptance integration is actively enabled.
 func (a *APIServerStore) EnableSecurityExceptionCacheInvalidation(ctx context.Context) {
-	if a == nil || a.DynamicClient == nil || a.securityExceptionListCache == nil || a.securityExceptionInformerStop != nil {
+	if a == nil || a.DynamicClient == nil || a.securityExceptionListCache == nil {
+		return
+	}
+
+	a.securityExceptionInformerMu.Lock()
+	defer a.securityExceptionInformerMu.Unlock()
+
+	if a.securityExceptionInformerStop != nil {
 		return
 	}
 

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -259,7 +259,6 @@ func NewAPIServerStorage(namespace string) (*APIServerStore, error) {
 		securityExceptionListCache: cache.New(securityExceptionListCacheCleaningInterval),
 		labelsCache:                cache.New(labelsCacheCleaningInterval),
 	}
-	store.enableSecurityExceptionCacheInvalidation(context.Background())
 	return store, nil
 }
 
@@ -376,7 +375,10 @@ func NewFakeAPIServerStorage(namespace string, objects ...runtime.Object) *APISe
 	return newFakeAPIServerStore(namespace, newFakeStorageClientset(objects...).SpdxV1beta1())
 }
 
-func (a *APIServerStore) enableSecurityExceptionCacheInvalidation(ctx context.Context) {
+// EnableSecurityExceptionCacheInvalidation starts background informers to invalidate cached
+// SecurityExceptions and ClusterSecurityExceptions when changes occur on the cluster.
+// It should only be called when riskAcceptance integration is actively enabled.
+func (a *APIServerStore) EnableSecurityExceptionCacheInvalidation(ctx context.Context) {
 	if a == nil || a.DynamicClient == nil || a.securityExceptionListCache == nil || a.securityExceptionInformerStop != nil {
 		return
 	}

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -5645,10 +5644,44 @@ func TestAPIServerStore_EnableSecurityExceptionCacheInvalidation(t *testing.T) {
 	store.EnableSecurityExceptionCacheInvalidation(ctx)
 	assert.NotNil(t, store.securityExceptionInformerStop, "informer stop func must be set after enabling")
 
-	firstStop := store.securityExceptionInformerStop
+	// Replace the stop function with a sentinel to verify that subsequent calls do not overwrite it.
+	var sentinelCalled bool
+	store.securityExceptionInformerStop = func() {
+		sentinelCalled = true
+	}
 
 	// Enabling again should be a no-op and not overwrite the stop func
 	store.EnableSecurityExceptionCacheInvalidation(ctx)
-	assert.True(t, reflect.ValueOf(firstStop).Pointer() == reflect.ValueOf(store.securityExceptionInformerStop).Pointer(), "subsequent calls must be a no-op")
+	store.securityExceptionInformerStop()
+	assert.True(t, sentinelCalled, "subsequent calls must not overwrite existing stop func")
 }
+
+func TestAPIServerStore_EnableSecurityExceptionCacheInvalidation_Concurrent(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+
+	store := &APIServerStore{
+		DynamicClient:              dynClient,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			store.EnableSecurityExceptionCacheInvalidation(ctx)
+		}()
+	}
+	wg.Wait()
+
+	assert.NotNil(t, store.securityExceptionInformerStop, "informer stop func must be set after concurrent enable calls")
+}
+
 

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -5623,3 +5624,31 @@ func TestCalculateVexCanonicalHash_NilAndEmptyStatementsAgree(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, nilHash, emptyHash)
 }
+
+func TestAPIServerStore_EnableSecurityExceptionCacheInvalidation(t *testing.T) {
+	dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	})
+
+	store := &APIServerStore{
+		DynamicClient:              dynClient,
+		Namespace:                  "kubescape",
+		securityExceptionListCache: cache.New(time.Minute),
+	}
+
+	assert.Nil(t, store.securityExceptionInformerStop, "informer stop func must be nil before enabling")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store.EnableSecurityExceptionCacheInvalidation(ctx)
+	assert.NotNil(t, store.securityExceptionInformerStop, "informer stop func must be set after enabling")
+
+	firstStop := store.securityExceptionInformerStop
+
+	// Enabling again should be a no-op and not overwrite the stop func
+	store.EnableSecurityExceptionCacheInvalidation(ctx)
+	assert.True(t, reflect.ValueOf(firstStop).Pointer() == reflect.ValueOf(store.securityExceptionInformerStop).Pointer(), "subsequent calls must be a no-op")
+}
+


### PR DESCRIPTION
## Description
Previously, `NewAPIServerStorage` unconditionally started dynamic informers for `SecurityException` and `ClusterSecurityException` resources whenever `storage` was enabled, regardless of whether the `riskAcceptance` capability was active.

This caused continuous `403 Forbidden` errors in environments where `riskAcceptance` was disabled (the default setting in the Helm chart) and corresponding RBAC permissions were not granted to `kubevuln`.

This PR:
1. Exports `EnableSecurityExceptionCacheInvalidation` on `APIServerStore` and stops calling it unconditionally inside `NewAPIServerStorage`.
2. Calls `storage.EnableSecurityExceptionCacheInvalidation(ctx)` in `cmd/http/main.go` only when `riskAcceptanceActive` is true.
3. Adds a unit test verifying informer enablement behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security exception handling when risk acceptance is enabled, ensuring cached security exception data is refreshed after relevant configuration changes.
  * Prevented unnecessary cache-refresh processes from starting when risk acceptance integration is not active.
* **Reliability**
  * Improved stability by ensuring cache invalidation is initialized only once when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->