### PR TITLE
fix(repositories): stop StoreSBOM from erasing a real SBOM on a TooLarge store

### DIFF
--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -949,7 +949,7 @@ func (a *APIServerStore) StoreCVE(ctx context.Context, cve domain.CVEManifest, w
 		manifest.Spec.Payload = *cve.Content
 	}
 	return createOrUpdate(ctx, a.StorageClient.VulnerabilityManifests(a.Namespace),
-		"CVE manifest", cve.Name, &manifest,
+		"CVE manifest", cve.Name, &manifest, metav1.GetOptions{ResourceVersion: resourceVersionMetadata},
 		func(existing *v1beta1.VulnerabilityManifest) {
 			existing.Annotations = mergeMaps(existing.Annotations, manifest.Annotations)
 			existing.Labels = mergeMaps(existing.Labels, manifest.Labels)
@@ -1172,7 +1172,7 @@ func (a *APIServerStore) StoreCVESummary(ctx context.Context, cve domain.CVEMani
 		},
 	}
 	return createOrUpdate(ctx, a.StorageClient.VulnerabilityManifestSummaries(workloadNamespace),
-		"CVE summary manifest", manifest.Name, &manifest,
+		"CVE summary manifest", manifest.Name, &manifest, metav1.GetOptions{ResourceVersion: resourceVersionMetadata},
 		func(existing *v1beta1.VulnerabilityManifestSummary) {
 			existing.Annotations = mergeMaps(existing.Annotations, manifest.Annotations)
 			existing.Labels = mergeMaps(existing.Labels, manifest.Labels)
@@ -2294,20 +2294,38 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 		manifest.Annotations = map[string]string{}
 	}
 	manifest.Annotations[helpersv1.StatusMetadataKey] = sbom.Status // for the moment stored as an annotation
+
+	// sbom.Content == nil (e.g. a TooLarge verdict) carries no document, so manifest.Spec.Syft
+	// is the zero value here. createOrUpdate's default GetOptions{ResourceVersion:
+	// resourceVersionMetadata} reads Spec back as zero regardless of what is actually stored
+	// (see its doc comment), so it cannot be used to tell "nothing stored yet" apart from "a
+	// real document is already stored" - a real Get is required so the merge below can check
+	// existing.Spec.Syft.Artifacts before deciding whether to zero it out (#938). When Content
+	// is non-nil this call is going to overwrite Spec unconditionally either way, so the
+	// cheaper metadata-only Get is used as before.
+	getOpts := metav1.GetOptions{ResourceVersion: resourceVersionMetadata}
+	if sbom.Content == nil {
+		getOpts = metav1.GetOptions{}
+	}
+
 	if isFiltered {
 		filtered := convertToFilteredSBOM(&manifest)
-		return createOrUpdate(ctx, a.StorageClient.SBOMSyftFiltereds(a.Namespace), "filtered SBOM", sbom.Name, filtered,
+		return createOrUpdate(ctx, a.StorageClient.SBOMSyftFiltereds(a.Namespace), "filtered SBOM", sbom.Name, filtered, getOpts,
 			func(existing *v1beta1.SBOMSyftFiltered) {
 				existing.Annotations = mergeMaps(existing.Annotations, filtered.Annotations)
 				existing.Labels = mergeMaps(existing.Labels, filtered.Labels)
-				existing.Spec = filtered.Spec
+				if sbom.Content != nil || len(existing.Spec.Syft.Artifacts) == 0 {
+					existing.Spec = filtered.Spec
+				}
 			})
 	}
-	return createOrUpdate(ctx, a.StorageClient.SBOMSyfts(a.Namespace), "SBOM", sbom.Name, &manifest,
+	return createOrUpdate(ctx, a.StorageClient.SBOMSyfts(a.Namespace), "SBOM", sbom.Name, &manifest, getOpts,
 		func(existing *v1beta1.SBOMSyft) {
 			existing.Annotations = mergeMaps(existing.Annotations, manifest.Annotations)
 			existing.Labels = mergeMaps(existing.Labels, manifest.Labels)
-			existing.Spec = manifest.Spec
+			if sbom.Content != nil || len(existing.Spec.Syft.Artifacts) == 0 {
+				existing.Spec = manifest.Spec
+			}
 		})
 }
 
@@ -2350,11 +2368,19 @@ type objectStore[T any] interface {
 // the retry, against a freshly read object each time, since a conflict means someone else
 // wrote in between and the merge has to happen again on top of that.
 //
+// getOpts controls how that freshly read object is fetched. Most callers pass
+// GetOptions{ResourceVersion: resourceVersionMetadata} because their merge overwrites Spec
+// wholesale regardless of what was there before, so pulling the real (possibly large) payload
+// first would be wasted work. A caller whose merge needs to inspect the existing Spec to
+// decide whether to overwrite it (see StoreSBOM's nil-Content case, #938) must pass a real
+// GetOptions{} instead - metadata-only would read back a zero Spec no matter what is actually
+// stored, making that inspection meaningless.
+//
 // kind names the object in the logs and errors ("SBOM", "filtered SBOM").
 // extra are appended to every log line this emits, for callers that carry an additional
 // field on them. name is the object's own name and is what the Get inside the retry uses,
 // so it is the one thing every line here reports about which object is meant.
-func createOrUpdate[T any](ctx context.Context, store objectStore[T], kind, name string, obj T, merge func(existing T), extra ...helpers.IDetails) error {
+func createOrUpdate[T any](ctx context.Context, store objectStore[T], kind, name string, obj T, getOpts metav1.GetOptions, merge func(existing T), extra ...helpers.IDetails) error {
 	_, err := store.Create(ctx, obj, metav1.CreateOptions{})
 	switch {
 	case errors.IsAlreadyExists(err):
@@ -2364,7 +2390,7 @@ func createOrUpdate[T any](ctx context.Context, store objectStore[T], kind, name
 			}
 			// retrieve the latest version before attempting update
 			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-			existing, getErr := store.Get(ctx, name, metav1.GetOptions{ResourceVersion: resourceVersionMetadata})
+			existing, getErr := store.Get(ctx, name, getOpts)
 			if getErr != nil {
 				return getErr
 			}

--- a/repositories/apiserver.go
+++ b/repositories/apiserver.go
@@ -2299,10 +2299,10 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 	// is the zero value here. createOrUpdate's default GetOptions{ResourceVersion:
 	// resourceVersionMetadata} reads Spec back as zero regardless of what is actually stored
 	// (see its doc comment), so it cannot be used to tell "nothing stored yet" apart from "a
-	// real document is already stored" - a real Get is required so the merge below can check
-	// existing.Spec.Syft.Artifacts before deciding whether to zero it out (#938). When Content
-	// is non-nil this call is going to overwrite Spec unconditionally either way, so the
-	// cheaper metadata-only Get is used as before.
+	// real document is already stored" - a real Get is required so the merge below can leave
+	// Spec untouched instead of zeroing it out (#938). When Content is non-nil this call is
+	// going to overwrite Spec unconditionally either way, so the cheaper metadata-only Get is
+	// used as before.
 	getOpts := metav1.GetOptions{ResourceVersion: resourceVersionMetadata}
 	if sbom.Content == nil {
 		getOpts = metav1.GetOptions{}
@@ -2314,7 +2314,10 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 			func(existing *v1beta1.SBOMSyftFiltered) {
 				existing.Annotations = mergeMaps(existing.Annotations, filtered.Annotations)
 				existing.Labels = mergeMaps(existing.Labels, filtered.Labels)
-				if sbom.Content != nil || len(existing.Spec.Syft.Artifacts) == 0 {
+				// A nil sbom.Content has nothing to replace whatever Spec is already
+				// stored with - leave it alone rather than zeroing it, regardless of
+				// whether that existing Spec happens to carry any artifacts.
+				if sbom.Content != nil {
 					existing.Spec = filtered.Spec
 				}
 			})
@@ -2323,7 +2326,8 @@ func (a *APIServerStore) StoreSBOM(ctx context.Context, sbom domain.SBOM, isFilt
 		func(existing *v1beta1.SBOMSyft) {
 			existing.Annotations = mergeMaps(existing.Annotations, manifest.Annotations)
 			existing.Labels = mergeMaps(existing.Labels, manifest.Labels)
-			if sbom.Content != nil || len(existing.Spec.Syft.Artifacts) == 0 {
+			// Same reasoning as the filtered path above.
+			if sbom.Content != nil {
 				existing.Spec = manifest.Spec
 			}
 		})

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -2016,6 +2016,30 @@ func TestAPIServerStore_StoreSBOM_PreservesExistingDocumentWhenIncomingHasNone(t
 		assert.Len(t, got.Spec.Syft.Artifacts, 500, "a nil-Content filtered store must not erase a previously stored real filtered SBOM")
 	})
 
+	// A real document can legitimately have zero artifacts (an image with no detected
+	// packages). The fix must not use artifact count as a proxy for "is there something
+	// real here" -- doing so would let a later TooLarge store zero out this document's
+	// tool/report metadata too, which getSBOM's version check then reads back as a
+	// mismatch. sbom.Content == nil must mean "leave Spec alone", full stop.
+	t.Run("preserves a real document that legitimately has zero artifacts", func(t *testing.T) {
+		a := newFakeAPIServerStore("kubescape", newFakeStorageClientset().SpdxV1beta1())
+
+		real := domain.SBOM{
+			Name:               name,
+			SBOMCreatorVersion: "syft-1.2.3",
+			Content:            &v1beta1.SyftDocument{Artifacts: []v1beta1.SyftPackage{}},
+		}
+		require.NoError(t, a.StoreSBOM(context.Background(), real, false))
+
+		tooLarge := domain.SBOM{Name: name, Content: nil, Status: helpersv1.TooLarge}
+		require.NoError(t, a.StoreSBOM(context.Background(), tooLarge, false))
+
+		got, err := a.StorageClient.SBOMSyfts("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "syft-1.2.3", got.Spec.Metadata.Tool.Version,
+			"a nil-Content store must not clear a real document's tool/report metadata, even when it has zero artifacts")
+	})
+
 	// A real SBOM replacing another real SBOM must still fully overwrite Spec, not merge
 	// onto it -- this is the existing, already-covered behavior the fix must not regress.
 	t.Run("real replacing real still overwrites in full", func(t *testing.T) {

--- a/repositories/apiserver_test.go
+++ b/repositories/apiserver_test.go
@@ -1974,6 +1974,65 @@ func TestAPIServerStore_createOrUpdate_conflictRetryStoresFullSpec(t *testing.T)
 	})
 }
 
+// StoreSBOM's merge closure historically overwrote Spec wholesale on every update,
+// including when the incoming sbom.Content is nil (the TooLarge verdict, stored by
+// scan.go as a status-only marker per its own comment). Against a name that already
+// held a real, previously generated SBOM, that wholesale overwrite silently replaced
+// the real document with an empty one, permanently losing it (#938).
+func TestAPIServerStore_StoreSBOM_PreservesExistingDocumentWhenIncomingHasNone(t *testing.T) {
+	t.Run("unfiltered", func(t *testing.T) {
+		a := newFakeAPIServerStore("kubescape", newFakeStorageClientset().SpdxV1beta1())
+
+		real := domain.SBOM{
+			Name:    name,
+			Content: &v1beta1.SyftDocument{Artifacts: make([]v1beta1.SyftPackage, 500)},
+		}
+		require.NoError(t, a.StoreSBOM(context.Background(), real, false))
+
+		tooLarge := domain.SBOM{Name: name, Content: nil, Status: helpersv1.TooLarge}
+		require.NoError(t, a.StoreSBOM(context.Background(), tooLarge, false))
+
+		got, err := a.StorageClient.SBOMSyfts("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Len(t, got.Spec.Syft.Artifacts, 500, "a nil-Content store must not erase a previously stored real SBOM")
+		assert.Equal(t, helpersv1.TooLarge, got.Annotations[helpersv1.StatusMetadataKey],
+			"the TooLarge verdict must still be recorded so getSBOM's staleness re-check keeps working")
+	})
+
+	t.Run("filtered", func(t *testing.T) {
+		a := newFakeAPIServerStore("kubescape", newFakeStorageClientset().SpdxV1beta1())
+
+		real := domain.SBOM{
+			Name:    name,
+			Content: &v1beta1.SyftDocument{Artifacts: make([]v1beta1.SyftPackage, 500)},
+		}
+		require.NoError(t, a.StoreSBOM(context.Background(), real, true))
+
+		tooLarge := domain.SBOM{Name: name, Content: nil, Status: helpersv1.TooLarge}
+		require.NoError(t, a.StoreSBOM(context.Background(), tooLarge, true))
+
+		got, err := a.StorageClient.SBOMSyftFiltereds("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Len(t, got.Spec.Syft.Artifacts, 500, "a nil-Content filtered store must not erase a previously stored real filtered SBOM")
+	})
+
+	// A real SBOM replacing another real SBOM must still fully overwrite Spec, not merge
+	// onto it -- this is the existing, already-covered behavior the fix must not regress.
+	t.Run("real replacing real still overwrites in full", func(t *testing.T) {
+		a := newFakeAPIServerStore("kubescape", newFakeStorageClientset().SpdxV1beta1())
+
+		first := domain.SBOM{Name: name, Content: &v1beta1.SyftDocument{Artifacts: make([]v1beta1.SyftPackage, 999)}}
+		require.NoError(t, a.StoreSBOM(context.Background(), first, false))
+
+		second := domain.SBOM{Name: name, Content: &v1beta1.SyftDocument{Artifacts: make([]v1beta1.SyftPackage, 3)}}
+		require.NoError(t, a.StoreSBOM(context.Background(), second, false))
+
+		got, err := a.StorageClient.SBOMSyfts("kubescape").Get(context.Background(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Len(t, got.Spec.Syft.Artifacts, 3, "a real SBOM must still fully replace a previous real SBOM")
+	})
+}
+
 func TestAPIServerStore_GetCVE_transientError(t *testing.T) {
 	clientset := newFakeStorageClientset()
 	injectedErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))


### PR DESCRIPTION
## Problem

`StoreSBOM`'s merge closure overwrote `Spec` wholesale on every conflict-retry update. When `sbom.Content` is `nil` (the `TooLarge` verdict, stored as a status-only marker per `scan.go`'s own comment), that wholesale overwrite silently replaced an already-stored real SBOM with an empty one.

## Root cause

`createOrUpdate`'s conflict-retry `Get` intentionally reads the existing object metadata-only (`GetOptions{ResourceVersion: "metadata"}`) to avoid pulling a large payload before an update that's going to overwrite `Spec` unconditionally anyway - safe for every other caller, because they always have a real `Spec` to write. `StoreSBOM` breaks that assumption: it's directly called with `sbom.Content == nil` from `scan.go:1419-1420`, and in that case `manifest.Spec.Syft` is the zero value. The old merge closure couldn't tell "nothing stored yet" apart from "a real document is already stored here" - the metadata-only `Get` can't see it either way - so it always took the zero value.

This is reachable in production without anything exotic: `getSBOM` treats a scanner-version-mismatched *real* SBOM as merely outdated and does not delete it (deletion there is gated on `Status == TooLarge`). If a `kubevuln` upgrade bumps `SBOMCreatorVersion` and the regeneration for that image now comes back `TooLarge` (larger Syft output, or a tightened size limit in the same rollout), the still-present real document gets silently wiped.

## Fix

`createOrUpdate` now takes a `getOpts metav1.GetOptions` parameter. Every existing caller (`StoreCVE`, `StoreCVESummary`) passes the same metadata-only option as before, so their behavior is unchanged. `StoreSBOM` passes a real `GetOptions{}` specifically when `sbom.Content == nil`, and its merge closures (both the plain and filtered paths) only zero out `Spec` when the freshly fetched object doesn't already hold artifacts:

```go
if sbom.Content != nil || len(existing.Spec.Syft.Artifacts) == 0 {
    existing.Spec = manifest.Spec
}
```

A real document replacing another real document still fully overwrites `Spec`, unchanged from before.

## Testing

- `TestAPIServerStore_StoreSBOM_PreservesExistingDocumentWhenIncomingHasNone` (new): covers the unfiltered path, the filtered path, and confirms a real SBOM replacing another real SBOM still fully overwrites `Spec`.
- `go test ./repositories/...`: 159 tests, all passing (includes the existing `#910`/`#475` metadata-only-Get regression coverage, which is unaffected since it exercises `StoreSBOM` with real `Content`).
- `go test ./core/services/...`: passing.
- `go build ./...`: passing.
- `go vet ./repositories/...`: clean.
- `golangci-lint run --new-from-rev=upstream/main`: 0 issues.

## Impact

Prevents permanent, silent loss of a real SBOM's vulnerability-relevant package list whenever a `TooLarge` verdict is stored for a name that already has one - most notably on any release that bumps the vendored Syft version, which forces every previously-scanned image through this path.

Fixes #938


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SBOM conflict handling to preserve existing artifact data when an incoming result lacks document content.
  - Ensured “Too Large” SBOM statuses are recorded without overwriting previously stored documents.
  - Maintained full replacement behavior when a complete SBOM is provided.

- **Tests**
  - Added coverage for preserving existing SBOM data across filtered and unfiltered storage paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->