### PR TITLE
fix(vex): handle mixed VEX formats

### DIFF
--- a/internal/vexbatch/testdata/csaf.json
+++ b/internal/vexbatch/testdata/csaf.json
@@ -1,0 +1,59 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "title": "Mixed format regression test",
+    "publisher": {
+      "category": "vendor",
+      "name": "kubevuln",
+      "namespace": "example.com"
+    },
+    "tracking": {
+      "current_release_date": "2026-01-01T00:00:00Z",
+      "id": "https://example.com/csaf/mixed-format-test",
+      "initial_release_date": "2026-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2026-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial release"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "product_name",
+        "name": "libcrypto3",
+        "product": {
+          "product_id": "LIBCRYPTO3-3.0.8-r3",
+          "name": "libcrypto3",
+          "product_identification_helper": {
+            "purl": "pkg:apk/alpine/libcrypto3@3.0.8-r3"
+          }
+        }
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-3817",
+      "flags": [
+        {
+          "label": "vulnerable_code_not_present",
+          "product_ids": [
+            "LIBCRYPTO3-3.0.8-r3"
+          ]
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "LIBCRYPTO3-3.0.8-r3"
+        ]
+      }
+    }
+  ]
+}

--- a/internal/vexbatch/testdata/openvex.json
+++ b/internal/vexbatch/testdata/openvex.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://example.com/vex/openvex-mixed-format-test",
+  "author": "kubevuln",
+  "timestamp": "2026-01-01T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2023-1255"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/alpine@sha256%3A124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/libcrypto3@3.0.8-r3"
+            }
+          ]
+        }
+      ],
+      "status": "fixed"
+    }
+  ]
+}

--- a/internal/vexbatch/vexbatch.go
+++ b/internal/vexbatch/vexbatch.go
@@ -1,0 +1,89 @@
+package vexbatch
+
+import (
+	"fmt"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vex"
+)
+
+type Format string
+
+const (
+	FormatOpenVEX Format = "openvex"
+	FormatCSAF    Format = "csaf"
+)
+
+type Document struct {
+	Format Format
+	Path   string
+}
+
+func Apply(
+	documents []Document,
+	pkgContext *pkg.Context,
+	matches *match.Matches,
+	ignoredMatches []match.IgnoredMatch,
+	ignoreRules []match.IgnoreRule,
+) (*match.Matches, []match.IgnoredMatch, error) {
+	if len(documents) == 0 {
+		return matches, ignoredMatches, nil
+	}
+
+	groups := make(map[Format][]Document)
+	var order []Format
+
+	for _, document := range documents {
+		switch document.Format {
+		case FormatOpenVEX, FormatCSAF:
+		default:
+			return matches, ignoredMatches, fmt.Errorf(
+				"unsupported VEX format %q",
+				document.Format,
+			)
+		}
+
+		if _, exists := groups[document.Format]; !exists {
+			order = append(order, document.Format)
+		}
+
+		groups[document.Format] = append(groups[document.Format], document)
+	}
+
+	for _, format := range order {
+		group := groups[format]
+
+		paths := make([]string, 0, len(group))
+		for _, document := range group {
+			paths = append(paths, document.Path)
+		}
+
+		processor, err := vex.NewProcessor(vex.ProcessorOptions{
+			Documents:   paths,
+			IgnoreRules: ignoreRules,
+		})
+		if err != nil {
+			return matches, ignoredMatches, fmt.Errorf(
+				"creating VEX processor for format %q: %w",
+				format,
+				err,
+			)
+		}
+
+		matches, ignoredMatches, err = processor.ApplyVEX(
+			pkgContext,
+			matches,
+			ignoredMatches,
+		)
+		if err != nil {
+			return matches, ignoredMatches, fmt.Errorf(
+				"applying VEX documents for format %q: %w",
+				format,
+				err,
+			)
+		}
+	}
+
+	return matches, ignoredMatches, nil
+}

--- a/internal/vexbatch/vexbatch_test.go
+++ b/internal/vexbatch/vexbatch_test.go
@@ -1,0 +1,137 @@
+package vexbatch
+
+import (
+	"testing"
+
+	"github.com/anchore/grype/grype/match"
+	"github.com/anchore/grype/grype/pkg"
+	"github.com/anchore/grype/grype/vex"
+	"github.com/anchore/grype/grype/vex/status"
+	"github.com/anchore/grype/grype/vulnerability"
+	"github.com/anchore/syft/syft/source"
+	"github.com/stretchr/testify/require"
+)
+
+const testPURL = "pkg:apk/alpine/libcrypto3@3.0.8-r3"
+
+func TestApply_MixedFormats(t *testing.T) {
+	openvexPath := "testdata/openvex.json"
+	csafPath := "testdata/csaf.json"
+
+	pkgContext := &pkg.Context{
+		Source: &source.Description{
+			Name:    "alpine",
+			Version: "3.17",
+			Metadata: source.ImageMetadata{
+				RepoDigests: []string{
+					"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+				},
+			},
+		},
+	}
+
+	libCryptoPackage := pkg.Package{
+		ID:      "cc8f90662d91481d",
+		Name:    "libcrypto3",
+		Version: "3.0.8-r3",
+		Type:    "apk",
+		PURL:    testPURL,
+		Upstreams: []pkg.UpstreamPackage{
+			{Name: "openssl"},
+		},
+	}
+
+	newMatches := func() match.Matches {
+		return match.NewMatches(
+			match.Match{
+				Vulnerability: vulnerability.Vulnerability{
+					Reference: vulnerability.Reference{
+						ID:        "CVE-2023-1255",
+						Namespace: "alpine:distro:alpine:3.17",
+					},
+				},
+				Package: libCryptoPackage,
+			},
+			match.Match{
+				Vulnerability: vulnerability.Vulnerability{
+					Reference: vulnerability.Reference{
+						ID:        "CVE-2023-3817",
+						Namespace: "alpine:distro:alpine:3.17",
+					},
+				},
+				Package: libCryptoPackage,
+			},
+		)
+	}
+
+	ignoreRules := []match.IgnoreRule{
+		{
+			VexStatus: string(status.Fixed),
+		},
+		{
+			VexStatus:        string(status.NotAffected),
+			VexJustification: "vulnerable_code_not_present",
+		},
+	}
+
+	t.Run("old single processor", func(t *testing.T) {
+		matches := newMatches()
+
+		processor, err := vex.NewProcessor(vex.ProcessorOptions{
+			Documents:   []string{openvexPath, csafPath},
+			IgnoreRules: ignoreRules,
+		})
+		require.NoError(t, err)
+
+		remaining, ignored, err := processor.ApplyVEX(
+			pkgContext,
+			&matches,
+			nil,
+		)
+		require.NoError(t, err)
+
+		// A single Grype processor selects its parser from the first
+		// document, so the CSAF document is not applied when OpenVEX
+		// is first in the mixed batch.
+		require.Len(t, remaining.GetByPkgID(libCryptoPackage.ID), 1)
+		require.Len(t, ignored, 1)
+		require.Equal(
+			t,
+			"CVE-2023-1255",
+			ignored[0].Match.Vulnerability.Reference.ID,
+		)
+	})
+
+	t.Run("grouped processors", func(t *testing.T) {
+		matches := newMatches()
+
+		remaining, ignored, err := Apply(
+			[]Document{
+				{
+					Format: FormatOpenVEX,
+					Path:   openvexPath,
+				},
+				{
+					Format: FormatCSAF,
+					Path:   csafPath,
+				},
+			},
+			pkgContext,
+			&matches,
+			nil,
+			ignoreRules,
+		)
+		require.NoError(t, err)
+
+		require.Empty(t, remaining.GetByPkgID(libCryptoPackage.ID))
+		require.Len(t, ignored, 2)
+
+		ignoredIDs := make(map[string]struct{}, len(ignored))
+		for _, m := range ignored {
+			ignoredIDs[m.Match.Vulnerability.Reference.ID] = struct{}{}
+		}
+
+		require.Contains(t, ignoredIDs, "CVE-2023-1255")
+		require.Contains(t, ignoredIDs, "CVE-2023-3817")
+	})
+}


### PR DESCRIPTION
Fixes : : #892

## Overview 

Fixes VEX processing for batches containing mixed VEX formats (OpenVEX and CSAF).

### Changes

* Added `internal/vexbatch` to group VEX documents by their declared format.
* Creates a separate Grype VEX processor for each format group.
* Sequentially carries remaining and ignored matches between processors.
* Added regression fixtures and tests demonstrating the failure of mixed-format processing with a single processor.

This ensures VEX statements from both OpenVEX and CSAF sources are applied correctly when they are provided together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for processing VEX documents in both OpenVEX and CSAF formats.
  - Mixed-format VEX inputs can now be processed together while preserving document order.
  - Vulnerability statuses from supported VEX documents are applied to package findings and ignored matches.
  - Added handling for unsupported formats and processing failures with contextual error reporting.

- **Tests**
  - Added regression coverage for mixed OpenVEX and CSAF documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->