### PR TITLE
fix(scan): rewrite CVE summary on cache hit so image upgrades re-point the manifest ref

### DIFF
--- a/core/services/scan.go
+++ b/core/services/scan.go
@@ -726,6 +726,11 @@ func (s *ScanService) storeVEX(ctx context.Context, cve, cvep domain.CVEManifest
 // document — subject to the removal-safety rule below. publishVEX lets ScanCP opt
 // out: it republishes VEX later itself, once relevancy-filtered results are also
 // available, using the exceptionsComplete this call returns.
+//
+// The CVE summary is rewritten on every call under the same safety rule,
+// even when suppressions are unchanged: the summary is keyed by workload,
+// not by image, so a workload image upgrade must re-point it at the new
+// manifest rather than dangle at the old one (see #944).
 func (s *ScanService) reconcileCachedCVE(ctx context.Context, cve domain.CVEManifest, imageSlug string, publishVEX bool) (restoredCve, filteredCve domain.CVEManifest, exceptionsComplete bool) {
 	prevIgnored := v1.IgnoredMatchKeys(cve.Content)
 	cve.Content = v1.RestoreSuppressedMatches(cve.Content)
@@ -733,25 +738,21 @@ func (s *ScanService) reconcileCachedCVE(ctx context.Context, cve domain.CVEMani
 
 	if s.storage {
 		curIgnored := v1.IgnoredMatchKeys(filteredCve.Content)
-		if !maps.Equal(prevIgnored, curIgnored) {
-			// Persist additions freely, but never persist removals when the
-			// exception set is incomplete: a transient SecurityException CRD
-			// list failure must not look like a deletion and wipe suppression
-			// from the stored manifest.
-			hasRemovals := false
-			for k := range prevIgnored {
-				if _, ok := curIgnored[k]; !ok {
-					hasRemovals = true
-					break
-				}
+		// Persist additions freely, but never persist removals when the
+		// exception set is incomplete: a transient SecurityException CRD
+		// list failure must not look like a deletion and wipe suppression
+		// from the stored manifest.
+		hasRemovals := false
+		for k := range prevIgnored {
+			if _, ok := curIgnored[k]; !ok {
+				hasRemovals = true
+				break
 			}
-			if exceptionsComplete || !hasRemovals {
+		}
+		if exceptionsComplete || !hasRemovals {
+			if !maps.Equal(prevIgnored, curIgnored) {
 				if err := s.cveRepository.StoreCVE(ctx, filteredCve, false); err != nil {
 					logger.L().Ctx(ctx).Warning("storing CVE with exceptions", helpers.Error(err),
-						helpers.String("imageSlug", imageSlug))
-				}
-				if err := s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false); err != nil {
-					logger.L().Ctx(ctx).Warning("storing CVE summary with exceptions", helpers.Error(err),
 						helpers.String("imageSlug", imageSlug))
 				}
 				// The stored manifest just changed, so the VEX document describing it is
@@ -768,6 +769,16 @@ func (s *ScanService) reconcileCachedCVE(ctx context.Context, cve domain.CVEMani
 				if publishVEX && exceptionsComplete {
 					s.storeVEX(ctx, filteredCve, filteredCve, false, imageSlug)
 				}
+			}
+			// The summary is keyed by workload, not by image: always rewrite
+			// it from the cached manifest so a workload image upgrade
+			// re-points the summary at the new manifest instead of dangling
+			// at the old one. This stays inside the removal-safety gate
+			// above so a degraded exception fetch never persists a weakened
+			// summary.
+			if err := s.cveRepository.StoreCVESummary(ctx, filteredCve, domain.CVEManifest{}, false); err != nil {
+				logger.L().Ctx(ctx).Warning("storing CVE summary", helpers.Error(err),
+					helpers.String("imageSlug", imageSlug))
 			}
 		}
 	}

--- a/core/services/scan_test.go
+++ b/core/services/scan_test.go
@@ -2082,14 +2082,22 @@ func (p *recordingPlatform) SendStatus(context.Context, int) error { return nil 
 
 // countingCVERepository wraps a CVERepository and counts StoreCVE calls, so tests can assert a
 // cached manifest was (or wasn't) rewritten without depending on the stored content alone.
+// It also records every StoreCVESummary call's manifest name, so tests can observe summary
+// rewrites that the in-memory store itself does not persist as objects.
 type countingCVERepository struct {
 	ports.CVERepository
-	storeCVECalls int
+	storeCVECalls        int
+	storeCVESummaryNames []string
 }
 
 func (c *countingCVERepository) StoreCVE(ctx context.Context, cve domain.CVEManifest, withRelevancy bool) error {
 	c.storeCVECalls++
 	return c.CVERepository.StoreCVE(ctx, cve, withRelevancy)
+}
+
+func (c *countingCVERepository) StoreCVESummary(ctx context.Context, cve domain.CVEManifest, cvep domain.CVEManifest, withRelevancy bool) error {
+	c.storeCVESummaryNames = append(c.storeCVESummaryNames, cve.Name)
+	return c.CVERepository.StoreCVESummary(ctx, cve, cvep, withRelevancy)
 }
 
 // fakeCVEScanner is a CVEScanner whose ScanSBOM output is fully controlled, used to exercise the
@@ -2234,6 +2242,42 @@ func TestScanService_ScanCVE_CacheHit_UnchangedExceptionSkipsRewrite(t *testing.
 	require.NoError(t, err)
 	require.Len(t, stored.Content.IgnoredMatches, 1)
 	assert.Equal(t, "CVE-A", stored.Content.IgnoredMatches[0].Match.Vulnerability.ID)
+}
+
+// TestScanService_ScanCVE_CacheHitRewritesSummaryRef is the reproducer for
+// issue #944: one workload upgrades its image A -> B while B's CVE manifest
+// is already cached (e.g. another workload scanned B first) and no security
+// exceptions changed. The workload's summary (keyed by kind-name-container,
+// not by image) must be rewritten to reference manifest B; before the fix
+// the summary write is skipped entirely on this path, leaving the summary
+// dangling at the deleted manifest A.
+func TestScanService_ScanCVE_CacheHitRewritesSummaryRef(t *testing.T) {
+	platform := &recordingPlatform{}
+	inner := repositories.NewMemoryStorage(false, false)
+	counting := &countingCVERepository{CVERepository: inner}
+	s, sbomVer, cveVer, cveDBVer, _ := newScanCVETestService(t, platform, counting, nil)
+	// Warm the cache with B's manifest, as if another workload already
+	// scanned the upgraded image. No summary is written for our workload.
+	seedCachedCVEManifest(t, inner, "imageSlugB", sbomVer, cveVer, cveDBVer, context.TODO(), &v1beta1.GrypeDocument{
+		Matches: []v1beta1.Match{matchForTest("CVE-B")},
+	})
+
+	// Now scan our workload after its image upgrade to B; exceptions unchanged.
+	workload := domain.ScanCommand{
+		ImageSlug:     "imageSlugB",
+		ContainerName: "kube-proxy",
+		ImageHash:     "k8s.gcr.io/kube-proxy@sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
+		Wlid:          "wlid://cluster-minikube/namespace-kube-system/daemonset-kube-proxy",
+	}
+	ctx, err := s.ValidateScanCVE(context.TODO(), workload)
+	require.NoError(t, err)
+	require.NoError(t, s.ScanCVE(ctx))
+
+	assert.Zero(t, counting.storeCVECalls, "an unchanged exception set must not rewrite the cached manifest")
+	require.NotEmpty(t, counting.storeCVESummaryNames,
+		"a cache hit must still rewrite the summary ref to the scanned manifest")
+	assert.Equal(t, "imageSlugB", counting.storeCVESummaryNames[len(counting.storeCVESummaryNames)-1],
+		"summary must reference the new manifest after an image upgrade")
 }
 
 func TestScanService_ScanCVE_CacheHit_ExceptionFetchFailureDoesNotWipe(t *testing.T) {


### PR DESCRIPTION
## Overview

When a workload upgrades its image (A → B) while B's CVE manifest is already cached — e.g. another workload scanned B first — and no security exceptions changed, neither `StoreCVE` nor `StoreCVESummary` runs on the cache-hit path. The workload's summary object is keyed `<kind>-<name>-<container>` (image-independent), so it keeps pointing at manifest A after A is garbage-collected — a dangling `vulnerabilitiesRef` for every downstream consumer (CLI, Headlamp plugin, Prometheus exporter).

Closes #944 

## Reproducer (before the fix)

`TestScanService_ScanCVE_CacheHitRewritesSummaryRef`: same Wlid+container, B's manifest pre-stored (warm cache), exceptions unchanged, scan with `ImageSlug=B`, assert `StoreCVESummary` is called with manifest B. Before this fix it fails — the summary write never happens:

```
Error: Should NOT be empty, but was []
```

## What this PR does

- Hoists `StoreCVESummary` out of the `IgnoredMatches` gate on both cache-hit branches — `ScanCVE` (`core/services/scan.go:505-520`) and the `ScanCP` image-level branch (`:298-313`) — so every scan rewrites the summary ref from the cached manifest. The write is idempotent Create-or-Update and the severity counts recompute from cached in-memory content.
- Keeps `StoreCVE` gated as before, since manifest content itself is unchanged — no redundant full-manifest rewrites.
- Deliberately untouched: the `cve.Content == nil` full-scan paths, the relevancy `StoreCVESummary(..., true)` path, the schema-unsupported stub paths, `SubmitCVE`, and anything outside kubevuln (the manifest GC and the podwatcher trigger live elsewhere; the `vulnerabilitiesRef.namespace` observation is out of scope for this fix).

## Confirm (after the fix)

- The identical reproducer now passes — summary rewritten with manifest B.
- Full verification: `go test ./core/... ./repositories/... -count=1 -race` → 142 tests pass (including the existing `"second scan"` case, which an extra idempotent summary write doesn't affect); `gofmt`, `go vet` (on touched packages), `go build ./...` clean.
- Note: 3 `adapters/v1` syft golden-file tests fail identically on the pristine tree (environment-dependent live-syft output vs golden files) — pre-existing, unrelated, verified by re-running them with this change stashed.

## Related issue(s)

- #944 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CVE summaries are now refreshed when a workload image is upgraded, ensuring they reference the current image manifest.
  * Cached scans consistently update stored CVE summary information when storage is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->