### PR TITLE
fix: thread context.Context through fetchCVEExceptions' backend call

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -41,7 +41,7 @@ type BackendAdapter struct {
 	eventReceiverRestURL  string
 	apiServerRestURL      string
 	clusterConfig         pkgcautils.ClusterConfig
-	getCVEExceptionsFunc  func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
+	getCVEExceptionsFunc  func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
 	httpPostFunc          func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error)
 	sendStatusFunc        func(*backendClientV1.BaseReportSender, string, bool)
 	accessKey             string
@@ -362,7 +362,7 @@ func (a *BackendAdapter) fetchCVEExceptions(ctx context.Context, workload domain
 		},
 	}
 
-	vulnExceptionList, err := a.getCVEExceptionsFunc(a.apiServerRestURL, a.clusterConfig.AccountID, &designator, a.getRequestHeaders())
+	vulnExceptionList, err := a.getCVEExceptionsFunc(ctx, a.apiServerRestURL, a.clusterConfig.AccountID, &designator, a.getRequestHeaders())
 	if err != nil {
 		return cveExceptionsFetchResult{}, err
 	}

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -79,7 +79,7 @@ func scanContext(wlid, containerName, image string) context.Context {
 
 func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 	type fields struct {
-		getCVEExceptionsFunc func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
+		getCVEExceptionsFunc func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
 		clusterConfig        armometadata.ClusterConfig
 	}
 	tests := []struct {
@@ -139,7 +139,7 @@ func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
 	calls := 0
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		calls++
 		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
 	}
@@ -208,7 +208,7 @@ func TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses(t *testing.T)
 			}}, nil, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		atomic.AddInt32(&backendCalls, 1)
 		<-allJoined
 		return nil, nil
@@ -261,7 +261,7 @@ func TestBackendAdapter_GetCVEExceptions_CallerCancellationDoesNotAbortSharedFet
 	fetchStarted := make(chan struct{})
 	releaseFetch := make(chan struct{})
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		close(fetchStarted)
 		<-releaseFetch
 		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
@@ -339,7 +339,7 @@ func TestBackendAdapter_GetCVEExceptions_CacheDoesNotOutliveCRDExpiry(t *testing
 			}}, nil, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		return nil, nil
 	}
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
@@ -367,7 +367,7 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheAlreadyExpiredPolicy(t *tes
 	calls := 0
 	past := time.Now().Add(-1 * time.Hour)
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		calls++
 		return []armotypes.VulnerabilityExceptionPolicy{{ExpirationDate: &past}}, nil
 	}
@@ -398,7 +398,7 @@ func TestBackendAdapter_GetCVEExceptions_ImageScopedCRDPoliciesUseDistinctCacheE
 			}}, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		return nil, nil
 	}
 
@@ -427,7 +427,7 @@ func TestBackendAdapter_GetCVEExceptions_RegistryScansDoNotShareExceptionResults
 			}}, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		return nil, nil
 	}
 
@@ -447,7 +447,7 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenCRDLookupFails(t *testi
 			return nil, nil, errors.New("boom")
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		calls++
 		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
 	}
@@ -478,7 +478,7 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenRealCRDListFails(t *tes
 
 	calls := 0
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", store)
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		calls++
 		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
 	}
@@ -512,7 +512,7 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheUnresolvedSelectorLabels(t 
 			return nil, errors.New("lookup failed")
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 		calls++
 		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
 	}
@@ -624,7 +624,7 @@ func TestBackendAdapter_SubmitCVE(t *testing.T) {
 			}
 			a := &BackendAdapter{
 				clusterConfig: armometadata.ClusterConfig{},
-				getCVEExceptionsFunc: func(s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				getCVEExceptionsFunc: func(_ context.Context, s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 					return tt.exceptions, nil
 				},
 				httpPostFunc:          httpPostFunc,
@@ -688,7 +688,7 @@ func TestBackendAdapter_SubmitCVE_RelevancySubset(t *testing.T) {
 	}
 
 	a := &BackendAdapter{
-		getCVEExceptionsFunc: func(s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		getCVEExceptionsFunc: func(_ context.Context, s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
 		},
 		httpPostFunc:          httpPostFunc,
@@ -1197,7 +1197,7 @@ func TestGetCVEExceptions_MergesCRDExceptions(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
-		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return cloudPolicies, nil
 		},
 		securityExceptionRepo: mockRepo,
@@ -1248,7 +1248,7 @@ func TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
-		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return cloudPolicies, nil
 		},
 		securityExceptionRepo: mockRepo,
@@ -1396,7 +1396,7 @@ func TestGetCVEExceptions_ScopesCRDByMatch(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
-		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
 		},
 		securityExceptionRepo: mockRepo,
@@ -1603,7 +1603,7 @@ func TestBackendAdapter_SubmitCVE_SkipsChunksWhenSummaryFails(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{},
-		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
 		},
 		httpPostFunc:          httpPostFunc,
@@ -1645,7 +1645,7 @@ func TestSubmitCVE_NoPanicOnNonStringArgs(t *testing.T) {
 	backend := &BackendAdapter{
 		clusterConfig:         armometadata.ClusterConfig{},
 		securityExceptionRepo: &testSecurityExceptionRepo{},
-		getCVEExceptionsFunc: func(string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
 		},
 		sendStatusFunc: func(*beClientV1.BaseReportSender, string, bool) {},

--- a/go.mod
+++ b/go.mod
@@ -32,10 +32,10 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kinbiko/jsonassert v1.2.0
-	github.com/kubescape/backend v0.0.40
+	github.com/kubescape/backend v0.0.51
 	github.com/kubescape/go-logger v0.0.33
 	github.com/kubescape/k8s-interface v0.0.214
-	github.com/kubescape/storage v0.0.302
+	github.com/kubescape/storage v0.0.305
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/openvex/go-vex v0.2.7
 	github.com/package-url/packageurl-go v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -870,6 +870,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kubescape/backend v0.0.40 h1:nwQ74sbtuvwkzewS3axf6pIA6C6v+X4e4AzLuvVvoxI=
 github.com/kubescape/backend v0.0.40/go.mod h1:cMEGP8cXUZgY89YU4GRBGIla9HZW7grZsUtlCwvZgAE=
+github.com/kubescape/backend v0.0.51 h1:tmiKleQ9/IQs5LEipAGSvJq2JZspcs8f0cFlejmve+Y=
+github.com/kubescape/backend v0.0.51/go.mod h1:8MqQJ3h5vU6SjtOsNbGLFzY5Ay7QADtCPiq4mZEcBIc=
 github.com/kubescape/go-logger v0.0.33 h1:Gn+HhDsudPoyxW70e2zQehlg9wPrNchOuJrHFGWdDtc=
 github.com/kubescape/go-logger v0.0.33/go.mod h1:Alj7JBQ8/WCxbXe8Ura6ZheSRK45E0p21M3xeqedX90=
 github.com/kubescape/k8s-interface v0.0.214 h1:j7KP0/5VvYOoQdBGV2+gRM3qnR8PWLAGF8RM/k/DmJ0=
@@ -880,6 +882,8 @@ github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520 h1:SqlwF8G
 github.com/kubescape/rbac-utils v0.0.21-0.20230806101615-07e36f555520/go.mod h1:wuxMUSDzGUyWd25IJfBzEJ/Udmw2Vy7npj+MV3u3GrU=
 github.com/kubescape/storage v0.0.302 h1:iMWxoqo5Qz9WOLjOSGJanfxqdfI7jPoYmccyVT2pNTc=
 github.com/kubescape/storage v0.0.302/go.mod h1:d/1hqWPda2clsjx2wmQgysnB5dThIo3rDKP7RWx+v+M=
+github.com/kubescape/storage v0.0.305 h1:Ofuoi3V6OW/7CApr7yuzYlcBQP0flBDY2zRzXs3N3Ls=
+github.com/kubescape/storage v0.0.305/go.mod h1:d/1hqWPda2clsjx2wmQgysnB5dThIo3rDKP7RWx+v+M=
 github.com/kubescape/syft v1.32.0-ks.2 h1:xdUksUmKEyyVKsTfJDYW8Z5HawVJtelsUolPOsWtDx0=
 github.com/kubescape/syft v1.32.0-ks.2/go.mod h1:E6Kd4iBM2ljUOUQvSt7hVK6vBwaHkMXwcvBZmGMSY5o=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
## Summary
`kubescape/backend` v0.0.46+ changed `GetCVEExceptionByDesignator` to take a `ctx context.Context` as its first argument. `BackendAdapter.getCVEExceptionsFunc`'s field type, its one real call site in `fetchCVEExceptions` (which already has `ctx` in scope), and the test mocks are updated to match. Bumped `github.com/kubescape/backend` to v0.0.51 (pulls in `kubescape/storage` v0.0.305 transitively).

## Why
Found while consolidating ARMO's backend services into a Go workspace monorepo: one shared dependency graph means every module has to agree on one `kubescape/backend` version. kubevuln was the only consumer still calling the pre-context signature, which made it impossible to pick any single version that worked for everyone. This isn't a version-pin problem `replace` can solve — it's a real signature change, so the call site itself needs to thread the context through.

## Testing
`go build ./...` and `go test ./...` pass, except `TestCreateSBOM_PullHoldsTempDirGuard` (`pkg/sbomscanner/v1`), which fails identically on `main` on macOS — it's a `sun_path` (104-byte) Unix-socket-path-length limit hit by this machine's long `/var/folders/...` temp dir, unrelated to this change.

Docs-exempt: internal signature fix forced by upstream kubescape/backend API change, no behavioral or user-facing change.

AI-skills: armosec-shared-rules:agent-dispatch-policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context handling when retrieving cloud CVE exceptions.

* **Chores**
  * Updated backend and storage components to newer versions.
  * Updated related test coverage without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->