### PR TITLE
refactor(adapters): use BackendClient interface instead of function pointer fields

### DIFF
--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -146,7 +146,7 @@ func (a *BackendAdapter) getHTTPClient() httputils.IHttpClient {
 	return http.DefaultClient
 }
 
-// httpPostWithContext is the default httpPostFunc. Unlike httputils.HttpPostWithRetry (which
+// httpPostWithContext is the default HttpPost implementation. Unlike httputils.HttpPostWithRetry (which
 // binds context.Background() to the request and retries on a plain, non-cancellable
 // backoff.Retry loop), it threads the caller's ctx through the request AND the retry loop, so
 // cancelling ctx aborts both an in-flight attempt and any further retries promptly instead of

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -41,9 +41,7 @@ type BackendAdapter struct {
 	eventReceiverRestURL  string
 	apiServerRestURL      string
 	clusterConfig         pkgcautils.ClusterConfig
-	getCVEExceptionsFunc  func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
-	httpPostFunc          func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error)
-	sendStatusFunc        func(*backendClientV1.BaseReportSender, string, bool)
+	backendClient         BackendClient
 	accessKey             string
 	securityExceptionRepo ports.SecurityExceptionRepository
 	exceptionsCache       *cache.Cache
@@ -111,13 +109,9 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 		clusterConfig: pkgcautils.ClusterConfig{
 			AccountID: accountID,
 		},
-		eventReceiverRestURL: eventReceiverRestURL,
-		apiServerRestURL:     apiServerRestURL,
-		getCVEExceptionsFunc: backendClientV1.GetCVEExceptionByDesignator,
-		httpPostFunc:         httpPostWithContext,
-		sendStatusFunc: func(sender *backendClientV1.BaseReportSender, status string, sendReport bool) {
-			sender.SendStatus(status, sendReport) // TODO - update this function to use from kubescape/backend
-		},
+		eventReceiverRestURL:  eventReceiverRestURL,
+		apiServerRestURL:      apiServerRestURL,
+		backendClient:         &defaultBackendClient{},
 		accessKey:             accessKey,
 		securityExceptionRepo: seRepo,
 		exceptionsCache:       cache.New(exceptionsCacheCleaningInterval),
@@ -131,6 +125,18 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 			},
 		},
 	}
+}
+
+func (a *BackendAdapter) getBackendClient() BackendClient {
+	if a.backendClient != nil {
+		return a.backendClient
+	}
+	return &defaultBackendClient{}
+}
+
+func (a *BackendAdapter) WithBackendClient(client BackendClient) *BackendAdapter {
+	a.backendClient = client
+	return a
 }
 
 func (a *BackendAdapter) getHTTPClient() httputils.IHttpClient {
@@ -362,7 +368,7 @@ func (a *BackendAdapter) fetchCVEExceptions(ctx context.Context, workload domain
 		},
 	}
 
-	vulnExceptionList, err := a.getCVEExceptionsFunc(ctx, a.apiServerRestURL, a.clusterConfig.AccountID, &designator, a.getRequestHeaders())
+	vulnExceptionList, err := a.getBackendClient().GetCVEExceptions(ctx, a.apiServerRestURL, a.clusterConfig.AccountID, &designator, a.getRequestHeaders())
 	if err != nil {
 		return cveExceptionsFetchResult{}, err
 	}
@@ -513,7 +519,7 @@ func (a *BackendAdapter) ReportError(ctx context.Context, err error) error {
 	// constructor upstream in kubescape/backend. Tracked separately (#450) rather than silently
 	// left unaddressed.
 	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, a.getHTTPClient(), a.getRequestHeaders(), report)
-	a.sendStatusFunc(sender, sysreport.JobFailed, true)
+	a.getBackendClient().SendStatus(sender, sysreport.JobFailed, true)
 	return nil
 }
 
@@ -565,7 +571,7 @@ func (a *BackendAdapter) ReportScanFailure(ctx context.Context, failureCase scan
 	}
 
 	url := fmt.Sprintf("%s/k8s/v2/scanFailure", a.eventReceiverRestURL)
-	resp, err := a.httpPostFunc(ctx, a.getHTTPClient(), url, a.getRequestHeaders(), payload, 30*time.Second)
+	resp, err := a.getBackendClient().HttpPost(ctx, a.getHTTPClient(), url, a.getRequestHeaders(), payload, 30*time.Second)
 	if err != nil {
 		logger.L().Ctx(ctx).Warning("failed to send scan failure report",
 			helpers.Error(err),
@@ -602,7 +608,7 @@ func (a *BackendAdapter) SendStatus(ctx context.Context, step int) error {
 	// NOTE: see the same comment on ReportError above — this call has the same ctx-cancellation
 	// gap for the same reason.
 	sender := backendClientV1.NewBaseReportSender(a.eventReceiverRestURL, a.getHTTPClient(), a.getRequestHeaders(), report)
-	a.sendStatusFunc(sender, statuses[step], true)
+	a.getBackendClient().SendStatus(sender, statuses[step], true)
 	return nil
 }
 

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -128,7 +128,10 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 }
 
 func (a *BackendAdapter) getBackendClient() BackendClient {
-	return a.backendClient
+	if a.backendClient != nil {
+		return a.backendClient
+	}
+	return &defaultBackendClient{}
 }
 
 func (a *BackendAdapter) WithBackendClient(client BackendClient) *BackendAdapter {

--- a/adapters/v1/backend.go
+++ b/adapters/v1/backend.go
@@ -128,10 +128,7 @@ func NewBackendAdapter(accountID, apiServerRestURL, eventReceiverRestURL, access
 }
 
 func (a *BackendAdapter) getBackendClient() BackendClient {
-	if a.backendClient != nil {
-		return a.backendClient
-	}
-	return &defaultBackendClient{}
+	return a.backendClient
 }
 
 func (a *BackendAdapter) WithBackendClient(client BackendClient) *BackendAdapter {
@@ -341,7 +338,7 @@ type cveExceptionsFetchResult struct {
 }
 
 // fetchCVEExceptions is GetCVEExceptions' cache-miss path: fetch cloud-side exceptions via
-// getCVEExceptionsFunc, merge in CRD-based SecurityException/ClusterSecurityException policies
+// BackendClient.GetCVEExceptions, merge in CRD-based SecurityException/ClusterSecurityException policies
 // via GetSecurityExceptions, and -- unless the result is uncacheable -- write it back to
 // exceptionsCache under cacheKey. When cacheable is true, this runs at most once per coalesced
 // burst of concurrent GetCVEExceptions callers sharing cacheKey (see GetCVEExceptions and

--- a/adapters/v1/backend_client.go
+++ b/adapters/v1/backend_client.go
@@ -1,0 +1,68 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
+	"github.com/armosec/utils-go/httputils"
+	backendClientV1 "github.com/kubescape/backend/pkg/client/v1"
+)
+
+// BackendClient defines the interface for interacting with upstream Kubescape/ARMO backend services.
+type BackendClient interface {
+	GetCVEExceptions(ctx context.Context, apiServerRestURL, accountID string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
+	HttpPost(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, maxElapsedTime time.Duration) (*http.Response, error)
+	SendStatus(sender *backendClientV1.BaseReportSender, status string, sendReport bool)
+}
+
+// defaultBackendClient is the production implementation of BackendClient delegating to kubescape/backend and HTTP endpoints.
+type defaultBackendClient struct{}
+
+func (c *defaultBackendClient) GetCVEExceptions(ctx context.Context, apiServerRestURL, accountID string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	return backendClientV1.GetCVEExceptionByDesignator(ctx, apiServerRestURL, accountID, designator, headers)
+}
+
+func (c *defaultBackendClient) HttpPost(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, maxElapsedTime time.Duration) (*http.Response, error) {
+	return httpPostWithContext(ctx, httpClient, fullURL, headers, body, maxElapsedTime)
+}
+
+func (c *defaultBackendClient) SendStatus(sender *backendClientV1.BaseReportSender, status string, sendReport bool) {
+	sender.SendStatus(status, sendReport)
+}
+
+// MockBackendClient provides a mockable implementation of BackendClient for testing.
+type MockBackendClient struct {
+	GetCVEExceptionsFunc func(ctx context.Context, apiServerRestURL, accountID string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
+	HttpPostFunc         func(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, maxElapsedTime time.Duration) (*http.Response, error)
+	SendStatusFunc       func(sender *backendClientV1.BaseReportSender, status string, sendReport bool)
+}
+
+var _ BackendClient = (*MockBackendClient)(nil)
+
+func (m *MockBackendClient) GetCVEExceptions(ctx context.Context, apiServerRestURL, accountID string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+	if m.GetCVEExceptionsFunc != nil {
+		return m.GetCVEExceptionsFunc(ctx, apiServerRestURL, accountID, designator, headers)
+	}
+	return nil, nil
+}
+
+func (m *MockBackendClient) HttpPost(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, maxElapsedTime time.Duration) (*http.Response, error) {
+	if m.HttpPostFunc != nil {
+		return m.HttpPostFunc(ctx, httpClient, fullURL, headers, body, maxElapsedTime)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+	}, nil
+}
+
+func (m *MockBackendClient) SendStatus(sender *backendClientV1.BaseReportSender, status string, sendReport bool) {
+	if m.SendStatusFunc != nil {
+		m.SendStatusFunc(sender, status, sendReport)
+	}
+}

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -79,8 +79,8 @@ func scanContext(wlid, containerName, image string) context.Context {
 
 func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 	type fields struct {
-		getCVEExceptionsFunc func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)
-		clusterConfig        armometadata.ClusterConfig
+		backendClient BackendClient
+		clusterConfig armometadata.ClusterConfig
 	}
 	tests := []struct {
 		fields   fields
@@ -94,32 +94,12 @@ func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 			workload: false,
 			wantErr:  true,
 		},
-		/*{
-			name:     "error get exceptions",
-			workload: true,
-			fields: fields{
-				getCVEExceptionsFunc: func(s string, designator *identifiers.PortalDesignator) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-					return nil, fmt.Errorf("error")
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name:     "no exception",
-			workload: true,
-			fields: fields{
-				getCVEExceptionsFunc: func(s string, designator *identifiers.PortalDesignator) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-					return []armotypes.VulnerabilityExceptionPolicy{}, nil
-				},
-			},
-			want: []armotypes.VulnerabilityExceptionPolicy{},
-		},*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &BackendAdapter{
 				clusterConfig:         tt.fields.clusterConfig,
-				getCVEExceptionsFunc:  tt.fields.getCVEExceptionsFunc,
+				backendClient:         tt.fields.backendClient,
 				securityExceptionRepo: &repositories.NoOpSecurityExceptionRepository{},
 			}
 			ctx := context.TODO()
@@ -139,9 +119,11 @@ func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
 	calls := 0
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		calls++
-		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			calls++
+			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+		},
 	}
 	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
 		Wlid:          "wlid://cluster-c/namespace-ns/deployment-d",
@@ -208,10 +190,12 @@ func TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses(t *testing.T)
 			}}, nil, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		atomic.AddInt32(&backendCalls, 1)
-		<-allJoined
-		return nil, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			atomic.AddInt32(&backendCalls, 1)
+			<-allJoined
+			return nil, nil
+		},
 	}
 	a.exceptionsCacheMissHook = func() {
 		if atomic.AddInt32(&joined, 1) == n {
@@ -261,10 +245,12 @@ func TestBackendAdapter_GetCVEExceptions_CallerCancellationDoesNotAbortSharedFet
 	fetchStarted := make(chan struct{})
 	releaseFetch := make(chan struct{})
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		close(fetchStarted)
-		<-releaseFetch
-		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			close(fetchStarted)
+			<-releaseFetch
+			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+		},
 	}
 	baseCtx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
 		Wlid:          "wlid://cluster-c/namespace-ns/deployment-d",
@@ -339,8 +325,10 @@ func TestBackendAdapter_GetCVEExceptions_CacheDoesNotOutliveCRDExpiry(t *testing
 			}}, nil, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		return nil, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
 	}
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
@@ -367,9 +355,11 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheAlreadyExpiredPolicy(t *tes
 	calls := 0
 	past := time.Now().Add(-1 * time.Hour)
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		calls++
-		return []armotypes.VulnerabilityExceptionPolicy{{ExpirationDate: &past}}, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			calls++
+			return []armotypes.VulnerabilityExceptionPolicy{{ExpirationDate: &past}}, nil
+		},
 	}
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
@@ -398,8 +388,10 @@ func TestBackendAdapter_GetCVEExceptions_ImageScopedCRDPoliciesUseDistinctCacheE
 			}}, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		return nil, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
 	}
 
 	nginx, _, err := a.GetCVEExceptions(scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25"))
@@ -427,8 +419,10 @@ func TestBackendAdapter_GetCVEExceptions_RegistryScansDoNotShareExceptionResults
 			}}, nil
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		return nil, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			return nil, nil
+		},
 	}
 
 	nginx, _, err := a.GetCVEExceptions(scanContext("", "", "docker.io/library/nginx:1.25"))
@@ -447,9 +441,11 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenCRDLookupFails(t *testi
 			return nil, nil, errors.New("boom")
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		calls++
-		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			calls++
+			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+		},
 	}
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
@@ -478,9 +474,11 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenRealCRDListFails(t *tes
 
 	calls := 0
 	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", store)
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		calls++
-		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			calls++
+			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+		},
 	}
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
@@ -512,9 +510,11 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheUnresolvedSelectorLabels(t 
 			return nil, errors.New("lookup failed")
 		},
 	})
-	a.getCVEExceptionsFunc = func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-		calls++
-		return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+	a.backendClient = &MockBackendClient{
+		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+			calls++
+			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+		},
 	}
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
@@ -624,10 +624,12 @@ func TestBackendAdapter_SubmitCVE(t *testing.T) {
 			}
 			a := &BackendAdapter{
 				clusterConfig: armometadata.ClusterConfig{},
-				getCVEExceptionsFunc: func(_ context.Context, s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-					return tt.exceptions, nil
+				backendClient: &MockBackendClient{
+					GetCVEExceptionsFunc: func(_ context.Context, s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+						return tt.exceptions, nil
+					},
+					HttpPostFunc: httpPostFunc,
 				},
-				httpPostFunc:          httpPostFunc,
 				securityExceptionRepo: &repositories.NoOpSecurityExceptionRepository{},
 			}
 			ctx := context.TODO()
@@ -688,10 +690,12 @@ func TestBackendAdapter_SubmitCVE_RelevancySubset(t *testing.T) {
 	}
 
 	a := &BackendAdapter{
-		getCVEExceptionsFunc: func(_ context.Context, s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			return nil, nil
+		backendClient: &MockBackendClient{
+			GetCVEExceptionsFunc: func(_ context.Context, s, a string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				return nil, nil
+			},
+			HttpPostFunc: httpPostFunc,
 		},
-		httpPostFunc:          httpPostFunc,
 		securityExceptionRepo: &repositories.NoOpSecurityExceptionRepository{},
 	}
 	ctx := context.TODO()
@@ -918,9 +922,7 @@ func TestNewBackendAdapter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBackendAdapter(tt.args.accountID, tt.args.apiServerRestURL, tt.args.eventReceiverRestURL, "", &repositories.NoOpSecurityExceptionRepository{})
-			// need to nil functions to compare
-			got.httpPostFunc = nil
-			got.getCVEExceptionsFunc = nil
+			got.backendClient = nil
 			got.securityExceptionRepo = nil
 			assert.NotEqual(t, got, tt.want)
 		})
@@ -959,9 +961,11 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var called bool
 			a := &BackendAdapter{
-				sendStatusFunc: func(sender *beClientV1.BaseReportSender, s string, b bool) {
-					called = true
-					assert.Equal(t, tt.wantStatus, s)
+				backendClient: &MockBackendClient{
+					SendStatusFunc: func(sender *beClientV1.BaseReportSender, s string, b bool) {
+						called = true
+						assert.Equal(t, tt.wantStatus, s)
+					},
 				},
 			}
 			ctx := context.TODO()
@@ -997,7 +1001,7 @@ func TestBackendAdapter_ReportScanFailure_WorkloadScan(t *testing.T) {
 	a := &BackendAdapter{
 		eventReceiverRestURL: "http://localhost:8080",
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
-		httpPostFunc:         mockHTTP,
+		backendClient:        &MockBackendClient{HttpPostFunc: mockHTTP},
 		accessKey:            "test-key",
 	}
 
@@ -1044,7 +1048,7 @@ func TestBackendAdapter_ReportScanFailure_RegistryScan(t *testing.T) {
 	a := &BackendAdapter{
 		eventReceiverRestURL: "http://localhost:8080",
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
-		httpPostFunc:         mockHTTP,
+		backendClient:        &MockBackendClient{HttpPostFunc: mockHTTP},
 	}
 
 	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
@@ -1085,7 +1089,7 @@ func TestBackendAdapter_ReportScanFailure_HTTPError(t *testing.T) {
 	a := &BackendAdapter{
 		eventReceiverRestURL: "http://localhost:8080",
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
-		httpPostFunc:         mockHTTP,
+		backendClient:        &MockBackendClient{HttpPostFunc: mockHTTP},
 	}
 
 	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
@@ -1109,7 +1113,7 @@ func TestBackendAdapter_ReportScanFailure_HTTPNon2xx(t *testing.T) {
 	a := &BackendAdapter{
 		eventReceiverRestURL: "http://localhost:8080",
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
-		httpPostFunc:         mockHTTP,
+		backendClient:        &MockBackendClient{HttpPostFunc: mockHTTP},
 	}
 
 	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
@@ -1137,7 +1141,7 @@ func TestBackendAdapter_ReportScanFailure_NilError(t *testing.T) {
 	a := &BackendAdapter{
 		eventReceiverRestURL: "http://localhost:8080",
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
-		httpPostFunc:         mockHTTP,
+		backendClient:        &MockBackendClient{HttpPostFunc: mockHTTP},
 	}
 
 	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
@@ -1197,8 +1201,10 @@ func TestGetCVEExceptions_MergesCRDExceptions(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
-		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			return cloudPolicies, nil
+		backendClient: &MockBackendClient{
+			GetCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				return cloudPolicies, nil
+			},
 		},
 		securityExceptionRepo: mockRepo,
 	}
@@ -1215,12 +1221,6 @@ func TestGetCVEExceptions_MergesCRDExceptions(t *testing.T) {
 	assert.Empty(t, stats.ExpiredBySource, "nothing expired in this scenario")
 }
 
-// TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD is the regression test for #812:
-// docs/security-exception-design.md documents that when both a cloud and a CRD exception
-// cover the same CVE on the same workload, the cloud exception's status/metadata are used and
-// the conflicting CRD exception is ignored. GetCVEExceptions used to append CRD policies
-// unconditionally, so a CVE covered by both sources reached the caller (and, downstream, the
-// manifest's IgnoreRule provenance and the exceptions_matched_total metric) twice.
 func TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD(t *testing.T) {
 	cloudPolicies := []armotypes.VulnerabilityExceptionPolicy{
 		{
@@ -1236,9 +1236,7 @@ func TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "crd-rule", Namespace: "default"},
 				Spec: sev1beta1.SecurityExceptionSpec{
 					Vulnerabilities: []sev1beta1.VulnerabilityException{
-						// Same CVE the cloud already covers.
 						{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2024-0001"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
-						// Not covered by cloud: must still come through.
 						{Vulnerability: sev1beta1.VulnerabilityRef{ID: "CVE-2024-0002"}, Status: sev1beta1.VulnerabilityStatusNotAffected},
 					},
 				},
@@ -1248,8 +1246,10 @@ func TestGetCVEExceptions_CloudExceptionTakesPrecedenceOverCRD(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
-		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			return cloudPolicies, nil
+		backendClient: &MockBackendClient{
+			GetCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				return cloudPolicies, nil
+			},
 		},
 		securityExceptionRepo: mockRepo,
 	}
@@ -1396,8 +1396,10 @@ func TestGetCVEExceptions_ScopesCRDByMatch(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{AccountID: "test-account"},
-		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			return nil, nil
+		backendClient: &MockBackendClient{
+			GetCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				return nil, nil
+			},
 		},
 		securityExceptionRepo: mockRepo,
 	}
@@ -1439,10 +1441,6 @@ func TestBackendAdapter_HTTPClientReuse(t *testing.T) {
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
 		eventReceiverRestURL: "http://example.invalid",
 		httpClient:           stub,
-		httpPostFunc:         httpPostWithContext,
-		sendStatusFunc: func(sender *beClientV1.BaseReportSender, status string, sendReport bool) {
-			sender.SendStatus(status, sendReport)
-		},
 	}
 
 	ctx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
@@ -1535,7 +1533,6 @@ func TestBackendAdapter_PostResultsAbortsPromptlyOnCtxCancellation(t *testing.T)
 	a := &BackendAdapter{
 		eventReceiverRestURL: "http://example.invalid",
 		httpClient:           client,
-		httpPostFunc:         httpPostWithContext,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -1562,7 +1559,6 @@ func TestBackendAdapter_ReportScanFailureAbortsPromptlyOnCtxCancellation(t *test
 		eventReceiverRestURL: "http://example.invalid",
 		clusterConfig:        armometadata.ClusterConfig{AccountID: "test-account"},
 		httpClient:           client,
-		httpPostFunc:         httpPostWithContext,
 	}
 	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
 		Wlid:               "wlid://cluster-prod/namespace-default/deployment-nginx",
@@ -1603,10 +1599,12 @@ func TestBackendAdapter_SubmitCVE_SkipsChunksWhenSummaryFails(t *testing.T) {
 
 	a := &BackendAdapter{
 		clusterConfig: armometadata.ClusterConfig{},
-		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			return nil, nil
+		backendClient: &MockBackendClient{
+			GetCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				return nil, nil
+			},
+			HttpPostFunc: httpPostFunc,
 		},
-		httpPostFunc:          httpPostFunc,
 		securityExceptionRepo: &repositories.NoOpSecurityExceptionRepository{},
 	}
 	ctx := context.TODO()
@@ -1645,12 +1643,14 @@ func TestSubmitCVE_NoPanicOnNonStringArgs(t *testing.T) {
 	backend := &BackendAdapter{
 		clusterConfig:         armometadata.ClusterConfig{},
 		securityExceptionRepo: &testSecurityExceptionRepo{},
-		getCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			return nil, nil
-		},
-		sendStatusFunc: func(*beClientV1.BaseReportSender, string, bool) {},
-		httpPostFunc: func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error) {
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil
+		backendClient: &MockBackendClient{
+			GetCVEExceptionsFunc: func(context.Context, string, string, *identifiers.PortalDesignator, map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				return nil, nil
+			},
+			SendStatusFunc: func(*beClientV1.BaseReportSender, string, bool) {},
+			HttpPostFunc: func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error) {
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil
+			},
 		},
 	}
 	ctx := context.WithValue(context.Background(), domain.TimestampKey{}, int64(123456))
@@ -1739,8 +1739,10 @@ func TestHttpPostWithContext_EmptyResponseBody(t *testing.T) {
 // TestBackendAdapter_PostResults_429RateLimitLogging verifies that postResults detects 429 rate-limiting errors and logs vendor guidance.
 func TestBackendAdapter_PostResults_429RateLimitLogging(t *testing.T) {
 	backend := &BackendAdapter{
-		httpPostFunc: func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error) {
-			return nil, fmt.Errorf("received status code: 429, body: quota exceeded")
+		backendClient: &MockBackendClient{
+			HttpPostFunc: func(context.Context, httputils.IHttpClient, string, map[string]string, []byte, time.Duration) (*http.Response, error) {
+				return nil, fmt.Errorf("received status code: 429, body: quota exceeded")
+			},
 		},
 	}
 

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -160,7 +160,7 @@ func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
 // a cache hit already uses ("there is nothing new to report this call") -- this asserts exactly
 // one of the n callers sees the real (non-nil ExpiredBySource) stats.
 //
-// getCVEExceptionsFunc only ever runs inside the one goroutine singleflight picks as leader
+// BackendClient.GetCVEExceptions only ever runs inside the one goroutine singleflight picks as leader
 // for the cache key, so blocking it -- until every one of the n callers has passed the
 // (non-blocking) exceptionsCacheMissHook below -- is what actually forces genuine contention:
 // the leader cannot finish and release the singleflight call until every other caller has had
@@ -974,7 +974,7 @@ func TestBackendAdapter_SendStatus(t *testing.T) {
 			if err := a.SendStatus(ctx, tt.step); (err != nil) != tt.wantErr {
 				t.Errorf("SendStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			assert.True(t, called, "sendStatusFunc was never invoked")
+			assert.True(t, called, "SendStatus was never invoked")
 		})
 	}
 }

--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -118,13 +118,13 @@ func TestBackendAdapter_GetCVEExceptions(t *testing.T) {
 
 func TestBackendAdapter_GetCVEExceptions_Caches(t *testing.T) {
 	calls := 0
-	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.backendClient = &MockBackendClient{
-		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			calls++
-			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
-		},
-	}
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{}).
+		WithBackendClient(&MockBackendClient{
+			GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				calls++
+				return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+			},
+		})
 	ctx := context.WithValue(context.TODO(), domain.WorkloadKey{}, domain.ScanCommand{
 		Wlid:          "wlid://cluster-c/namespace-ns/deployment-d",
 		ContainerName: "container",
@@ -189,14 +189,13 @@ func TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses(t *testing.T)
 				},
 			}}, nil, nil
 		},
-	})
-	a.backendClient = &MockBackendClient{
+	}).WithBackendClient(&MockBackendClient{
 		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			atomic.AddInt32(&backendCalls, 1)
 			<-allJoined
 			return nil, nil
 		},
-	}
+	})
 	a.exceptionsCacheMissHook = func() {
 		if atomic.AddInt32(&joined, 1) == n {
 			close(allJoined)
@@ -244,14 +243,14 @@ func TestBackendAdapter_GetCVEExceptions_CoalescesConcurrentMisses(t *testing.T)
 func TestBackendAdapter_GetCVEExceptions_CallerCancellationDoesNotAbortSharedFetch(t *testing.T) {
 	fetchStarted := make(chan struct{})
 	releaseFetch := make(chan struct{})
-	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.backendClient = &MockBackendClient{
-		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			close(fetchStarted)
-			<-releaseFetch
-			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
-		},
-	}
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{}).
+		WithBackendClient(&MockBackendClient{
+			GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				close(fetchStarted)
+				<-releaseFetch
+				return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+			},
+		})
 	baseCtx := context.WithValue(context.Background(), domain.WorkloadKey{}, domain.ScanCommand{
 		Wlid:          "wlid://cluster-c/namespace-ns/deployment-d",
 		ContainerName: "container",
@@ -324,12 +323,11 @@ func TestBackendAdapter_GetCVEExceptions_CacheDoesNotOutliveCRDExpiry(t *testing
 				},
 			}}, nil, nil
 		},
-	})
-	a.backendClient = &MockBackendClient{
+	}).WithBackendClient(&MockBackendClient{
 		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
 		},
-	}
+	})
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
 	exceptions, _, err := a.GetCVEExceptions(ctx)
@@ -354,13 +352,13 @@ func TestBackendAdapter_GetCVEExceptions_CacheDoesNotOutliveCRDExpiry(t *testing
 func TestBackendAdapter_GetCVEExceptions_DoesNotCacheAlreadyExpiredPolicy(t *testing.T) {
 	calls := 0
 	past := time.Now().Add(-1 * time.Hour)
-	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{})
-	a.backendClient = &MockBackendClient{
-		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			calls++
-			return []armotypes.VulnerabilityExceptionPolicy{{ExpirationDate: &past}}, nil
-		},
-	}
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", &repositories.NoOpSecurityExceptionRepository{}).
+		WithBackendClient(&MockBackendClient{
+			GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				calls++
+				return []armotypes.VulnerabilityExceptionPolicy{{ExpirationDate: &past}}, nil
+			},
+		})
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
 	_, _, err := a.GetCVEExceptions(ctx)
@@ -387,12 +385,11 @@ func TestBackendAdapter_GetCVEExceptions_ImageScopedCRDPoliciesUseDistinctCacheE
 				},
 			}}, nil
 		},
-	})
-	a.backendClient = &MockBackendClient{
+	}).WithBackendClient(&MockBackendClient{
 		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
 		},
-	}
+	})
 
 	nginx, _, err := a.GetCVEExceptions(scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25"))
 	assert.NoError(t, err)
@@ -418,12 +415,11 @@ func TestBackendAdapter_GetCVEExceptions_RegistryScansDoNotShareExceptionResults
 				},
 			}}, nil
 		},
-	})
-	a.backendClient = &MockBackendClient{
+	}).WithBackendClient(&MockBackendClient{
 		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			return nil, nil
 		},
-	}
+	})
 
 	nginx, _, err := a.GetCVEExceptions(scanContext("", "", "docker.io/library/nginx:1.25"))
 	assert.NoError(t, err)
@@ -440,13 +436,12 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenCRDLookupFails(t *testi
 		getSecurityExceptions: func(context.Context, string) ([]sev1beta1.SecurityException, []sev1beta1.ClusterSecurityException, error) {
 			return nil, nil, errors.New("boom")
 		},
-	})
-	a.backendClient = &MockBackendClient{
+	}).WithBackendClient(&MockBackendClient{
 		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			calls++
 			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
 		},
-	}
+	})
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
 	_, _, err := a.GetCVEExceptions(ctx)
@@ -473,13 +468,13 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheWhenRealCRDListFails(t *tes
 	})
 
 	calls := 0
-	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", store)
-	a.backendClient = &MockBackendClient{
-		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
-			calls++
-			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
-		},
-	}
+	a := NewBackendAdapter("account", "apiServer", "eventReceiver", "", store).
+		WithBackendClient(&MockBackendClient{
+			GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
+				calls++
+				return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
+			},
+		})
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
 	_, _, err := a.GetCVEExceptions(ctx)
@@ -509,13 +504,12 @@ func TestBackendAdapter_GetCVEExceptions_DoesNotCacheUnresolvedSelectorLabels(t 
 		getWorkloadLabels: func(context.Context, string, string, string) (map[string]string, error) {
 			return nil, errors.New("lookup failed")
 		},
-	})
-	a.backendClient = &MockBackendClient{
+	}).WithBackendClient(&MockBackendClient{
 		GetCVEExceptionsFunc: func(_ context.Context, _ string, _ string, _ *identifiers.PortalDesignator, _ map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error) {
 			calls++
 			return []armotypes.VulnerabilityExceptionPolicy{{}}, nil
 		},
-	}
+	})
 	ctx := scanContext("wlid://cluster-c/namespace-ns/deployment-d", "container", "docker.io/library/nginx:1.25")
 
 	_, _, err := a.GetCVEExceptions(ctx)

--- a/adapters/v1/backend_utils.go
+++ b/adapters/v1/backend_utils.go
@@ -131,7 +131,7 @@ func (a *BackendAdapter) postResults(
 		return err
 	}
 
-	resp, err := a.httpPostFunc(ctx, a.getHTTPClient(), urlBase.String(), a.getRequestHeaders(), payload, 60*time.Second)
+	resp, err := a.getBackendClient().HttpPost(ctx, a.getHTTPClient(), urlBase.String(), a.getRequestHeaders(), payload, 60*time.Second)
 	if err != nil {
 		errStr := err.Error()
 		if strings.Contains(errStr, "429") || strings.Contains(errStr, "Too Many Requests") {

--- a/adapters/v1/backend_utils_test.go
+++ b/adapters/v1/backend_utils_test.go
@@ -787,7 +787,9 @@ func Test_sendSummaryAndVulnerabilities(t *testing.T) {
 			}
 			a := &BackendAdapter{
 				clusterConfig: armometadata.ClusterConfig{},
-				httpPostFunc:  httpPostFunc,
+				backendClient: &MockBackendClient{
+					HttpPostFunc: httpPostFunc,
+				},
 			}
 			report.Vulnerabilities = []containerscan.CommonContainerVulnerabilityResult{}
 			actualNextPartNum, err := a.sendSummaryAndVulnerabilities(ctx, report, "", tc.totalVulnerabilities, "1234", tc.firstVulnerabilitiesChunk, errChan, sendWG)


### PR DESCRIPTION
## Summary
Introduces a dedicated `BackendClient` interface to handle interactions with the Kubescape/ARMO backend service, replacing the ad-hoc unexported function pointer fields (`getCVEExceptionsFunc`, `httpPostFunc`, `sendStatusFunc`) on `BackendAdapter`.

- Defines `BackendClient` in `adapters/v1/backend_client.go` with methods:
  - `GetCVEExceptions(ctx context.Context, apiServerRestURL, accountID string, designator *identifiers.PortalDesignator, headers map[string]string) ([]armotypes.VulnerabilityExceptionPolicy, error)`
  - `HttpPost(ctx context.Context, httpClient httputils.IHttpClient, fullURL string, headers map[string]string, body []byte, maxElapsedTime time.Duration) (*http.Response, error)`
  - `SendStatus(sender *backendClientV1.BaseReportSender, status string, sendReport bool)`
- Implements `defaultBackendClient` (used by default in production) delegating to `backendClientV1` and HTTP helper methods.
- Implements `MockBackendClient` for tests, allowing clean unit tests without mutating private function fields.
- Adds `WithBackendClient(client BackendClient)` builder on `BackendAdapter`.
- Updates all unit tests in `adapters/v1/backend_test.go` and `adapters/v1/backend_utils_test.go`.

Fixes #948
Follow-up to #947

## Testing
- `make lint` passes cleanly (0 issues).
- `go test ./...` passes across the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable backend client support for retrieving CVE exceptions, reporting status, posting scan results, and handling scan failures.
  - Added a client override option for customized backend integrations.

- **Refactor**
  - Consolidated backend operations behind a single client interface while preserving existing request handling and timeout behavior.

- **Tests**
  - Updated backend integration tests to use configurable client implementations, including cancellation and HTTP client reuse scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->