### PR TITLE
refactor(adapters): use VulnerabilityDBLoader interface instead of function pointer field

### DIFF
--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -109,13 +109,17 @@ func NewGrypeAdapter(listingURL string, matchingMode config.CVEMatchingMode, tru
 	return g
 }
 
-// WithDBLoader configures a custom VulnerabilityDBLoader.
+// WithDBLoader configures a custom VulnerabilityDBLoader. It should be called during initialization before background operations start.
 func (g *GrypeAdapter) WithDBLoader(loader VulnerabilityDBLoader) *GrypeAdapter {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	g.dbLoader = loader
 	return g
 }
 
 func (g *GrypeAdapter) getDBLoader() VulnerabilityDBLoader {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 	if g.dbLoader != nil {
 		return g.dbLoader
 	}
@@ -248,8 +252,6 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{})
 	hasExistingDB := g.store != nil
 	g.mu.RUnlock()
 
-	// dbLoader is set once at construction or via WithDBLoader and never reassigned afterwards, so reading it
-	// here without g.mu is safe even though every other field on GrypeAdapter is guarded.
 	loader := g.getDBLoader()
 
 	done := make(chan struct{})

--- a/adapters/v1/grype.go
+++ b/adapters/v1/grype.go
@@ -48,12 +48,6 @@ const (
 	VendorTrustedMatchMetadataKey = "kubescape.io/vendor-trusted-match"
 )
 
-type loadDBFunc func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error)
-
-func defaultLoadDB(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
-	return grype.LoadVulnerabilityDB(distCfg, installCfg, true)
-}
-
 const (
 	// defaultStuckUpdateTimeout is how long updateDBBackground waits for a single
 	// grype.LoadVulnerabilityDB call before giving up on it. The call takes no context and
@@ -93,7 +87,7 @@ type GrypeAdapter struct {
 	// stuckUpdateTimeout overrides defaultStuckUpdateTimeout. Set only by tests, which
 	// cannot wait out the 15-minute production value; zero means use the default.
 	stuckUpdateTimeout time.Duration
-	loadDB             loadDBFunc
+	dbLoader           VulnerabilityDBLoader
 }
 
 var _ ports.CVEScanner = (*GrypeAdapter)(nil)
@@ -110,9 +104,22 @@ func NewGrypeAdapter(listingURL string, matchingMode config.CVEMatchingMode, tru
 		},
 		matchingMode:   matchingMode,
 		trustedVendors: buildTrustedVendorSet(trustedVendors),
-		loadDB:         defaultLoadDB,
+		dbLoader:       DefaultVulnerabilityDBLoader{},
 	}
 	return g
+}
+
+// WithDBLoader configures a custom VulnerabilityDBLoader.
+func (g *GrypeAdapter) WithDBLoader(loader VulnerabilityDBLoader) *GrypeAdapter {
+	g.dbLoader = loader
+	return g
+}
+
+func (g *GrypeAdapter) getDBLoader() VulnerabilityDBLoader {
+	if g.dbLoader != nil {
+		return g.dbLoader
+	}
+	return DefaultVulnerabilityDBLoader{}
 }
 
 // buildTrustedVendorSet maps configured vendor slugs to Grype distro types.
@@ -241,12 +248,9 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{})
 	hasExistingDB := g.store != nil
 	g.mu.RUnlock()
 
-	// loadDB is set once at construction and never reassigned afterwards, so reading it
+	// dbLoader is set once at construction or via WithDBLoader and never reassigned afterwards, so reading it
 	// here without g.mu is safe even though every other field on GrypeAdapter is guarded.
-	loadFn := g.loadDB
-	if loadFn == nil {
-		loadFn = defaultLoadDB
-	}
+	loader := g.getDBLoader()
 
 	done := make(chan struct{})
 	go func() {
@@ -254,7 +258,7 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{})
 
 		if !g.loadMu.TryLock() {
 			// A previous load - almost always one abandoned as stuck - is still running
-			// against installCfg.DBRootDir. Running loadFn now would race grype's
+			// against installCfg.DBRootDir. Running loader.LoadDB now would race grype's
 			// delete-then-rename of the active DB directory. Skip and reschedule; the
 			// retry gets the lock once that goroutine finally exits.
 			logger.L().Ctx(ctx).Warning("grype DB update skipped: a previous load is still in flight against the DB cache dir",
@@ -278,7 +282,7 @@ func (g *GrypeAdapter) updateDBBackground(ctx context.Context, ch chan struct{})
 				helpers.Error(err),
 				helpers.String("dbRootDir", g.installCfg.DBRootDir))
 		}
-		store, dbStatus, err := loadFn(g.distCfg, g.installCfg)
+		store, dbStatus, err := loader.LoadDB(g.distCfg, g.installCfg)
 		g.finishUpdate(ctx, ch, hasExistingDB, store, dbStatus, err)
 	}()
 

--- a/adapters/v1/grype_db_loader.go
+++ b/adapters/v1/grype_db_loader.go
@@ -1,0 +1,33 @@
+package v1
+
+import (
+	"github.com/anchore/grype/grype"
+	"github.com/anchore/grype/grype/db/v6/distribution"
+	"github.com/anchore/grype/grype/db/v6/installation"
+	"github.com/anchore/grype/grype/vulnerability"
+)
+
+// VulnerabilityDBLoader abstracts loading the vulnerability database for GrypeAdapter.
+type VulnerabilityDBLoader interface {
+	LoadDB(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error)
+}
+
+// DefaultVulnerabilityDBLoader is the production implementation of VulnerabilityDBLoader using grype.LoadVulnerabilityDB.
+type DefaultVulnerabilityDBLoader struct{}
+
+var _ VulnerabilityDBLoader = DefaultVulnerabilityDBLoader{}
+
+// LoadDB calls grype.LoadVulnerabilityDB to load the vulnerability provider.
+func (DefaultVulnerabilityDBLoader) LoadDB(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+	return grype.LoadVulnerabilityDB(distCfg, installCfg, true)
+}
+
+// VulnerabilityDBLoaderFunc adapts a function to the VulnerabilityDBLoader interface.
+type VulnerabilityDBLoaderFunc func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error)
+
+var _ VulnerabilityDBLoader = VulnerabilityDBLoaderFunc(nil)
+
+// LoadDB calls the underlying function.
+func (f VulnerabilityDBLoaderFunc) LoadDB(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+	return f(distCfg, installCfg)
+}

--- a/adapters/v1/grype_docker_fixture.go
+++ b/adapters/v1/grype_docker_fixture.go
@@ -116,7 +116,7 @@ func NewGrypeAdapterFixedDBWithMatchers(matchingMode config.CVEMatchingMode, tru
 		},
 		matchingMode:   matchingMode,
 		trustedVendors: buildTrustedVendorSet(trustedVendors),
-		loadDB:         defaultLoadDB,
+		dbLoader:       DefaultVulnerabilityDBLoader{},
 	}
 	return g, terminate, nil
 }

--- a/adapters/v1/grype_test.go
+++ b/adapters/v1/grype_test.go
@@ -108,10 +108,10 @@ func Test_grypeAdapter_NonBlockingReady(t *testing.T) {
 		store:             oldStore,
 		dbStatus:          &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"},
 		nextUpdateAttempt: time.Now().Add(24 * time.Hour),
-		loadDB: func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		dbLoader: VulnerabilityDBLoaderFunc(func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			<-blockLoad
 			return newStore, &vulnerability.ProviderStatus{From: "schema:v6%3Anew-checksum"}, nil
-		},
+		}),
 	}
 
 	// Initial check with valid DB returns ready immediately
@@ -172,10 +172,10 @@ func Test_grypeAdapter_Ready_backsOffAfterFailedColdStart(t *testing.T) {
 	ctx := context.Background()
 	var calls int32
 	g := &GrypeAdapter{
-		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		dbLoader: VulnerabilityDBLoaderFunc(func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			atomic.AddInt32(&calls, 1)
 			return nil, nil, errors.New("network down")
-		},
+		}),
 	}
 
 	for i := 0; i < 5; i++ {
@@ -197,9 +197,9 @@ func Test_grypeAdapter_Ready_treatsStatusErrorAsFailure(t *testing.T) {
 	statusErr := errors.New("corrupt db")
 	badStore := &closeTrackingProvider{}
 	g := &GrypeAdapter{
-		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		dbLoader: VulnerabilityDBLoaderFunc(func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			return badStore, &vulnerability.ProviderStatus{Error: statusErr}, nil
-		},
+		}),
 	}
 
 	require.False(t, g.Ready(ctx))
@@ -227,11 +227,11 @@ func Test_grypeAdapter_Ready_singleFlightUnderConcurrency(t *testing.T) {
 		store:             &mockProvider{},
 		dbStatus:          &vulnerability.ProviderStatus{From: "schema:v6%3Atest-checksum"},
 		nextUpdateAttempt: time.Now().Add(-time.Minute),
-		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		dbLoader: VulnerabilityDBLoaderFunc(func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			atomic.AddInt32(&calls, 1)
 			<-blockLoad
 			return &mockProvider{}, &vulnerability.ProviderStatus{From: "schema:v6%3Anew"}, nil
-		},
+		}),
 	}
 
 	var wg sync.WaitGroup
@@ -274,13 +274,13 @@ func Test_grypeAdapter_Ready_recoversFromStuckWarmUpdate(t *testing.T) {
 		dbStatus:           &vulnerability.ProviderStatus{From: "schema:v6%3Aold"},
 		nextUpdateAttempt:  time.Now().Add(-time.Minute),
 		stuckUpdateTimeout: 20 * time.Millisecond,
-		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		dbLoader: VulnerabilityDBLoaderFunc(func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			if atomic.AddInt32(&loadCalls, 1) == 1 {
 				<-stuck // first load models an uncancellable download that never returns
 				return nil, nil, errors.New("unblocked later")
 			}
 			return newStore, &vulnerability.ProviderStatus{From: "schema:v6%3Anew"}, nil
-		},
+		}),
 	}
 
 	// 1. First probe launches the update; the load hangs; updateDBBackground abandons it.
@@ -345,10 +345,10 @@ func Test_grypeAdapter_Ready_slowLoadWithinTimeoutStillInstalls(t *testing.T) {
 		dbStatus:           &vulnerability.ProviderStatus{From: "schema:v6%3Aold"},
 		nextUpdateAttempt:  time.Now().Add(-time.Minute),
 		stuckUpdateTimeout: 500 * time.Millisecond,
-		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		dbLoader: VulnerabilityDBLoaderFunc(func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			time.Sleep(40 * time.Millisecond)
 			return newStore, &vulnerability.ProviderStatus{From: "schema:v6%3Anew"}, nil
-		},
+		}),
 	}
 
 	require.True(t, g.Ready(ctx))
@@ -378,10 +378,10 @@ func Test_grypeAdapter_finishUpdate_discardsAbandonedLoadResult(t *testing.T) {
 		dbStatus:           &vulnerability.ProviderStatus{From: "schema:v6%3Aold"},
 		nextUpdateAttempt:  time.Now().Add(-time.Minute),
 		stuckUpdateTimeout: 20 * time.Millisecond,
-		loadDB: func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		dbLoader: VulnerabilityDBLoaderFunc(func(distribution.Config, installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
 			<-release
 			return lateStore, &vulnerability.ProviderStatus{From: "schema:v6%3Alate"}, nil
-		},
+		}),
 	}
 
 	require.True(t, g.Ready(ctx))
@@ -561,4 +561,21 @@ func TestDefaultMatchers_CVEMatchingOnProducesCPEMatch(t *testing.T) {
 	}
 
 	assert.True(t, foundCPEMatch, "CVEMatchingOn must produce a CPE match for the expected CVE")
+}
+
+func Test_GrypeAdapter_WithDBLoader(t *testing.T) {
+	g := NewGrypeAdapter("https://example.com/listing.json", config.CVEMatchingOff, nil)
+	assert.IsType(t, DefaultVulnerabilityDBLoader{}, g.getDBLoader())
+
+	called := false
+	customLoader := VulnerabilityDBLoaderFunc(func(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error) {
+		called = true
+		return nil, nil, nil
+	})
+
+	g = g.WithDBLoader(customLoader)
+	assert.NotNil(t, g.getDBLoader())
+
+	_, _, _ = g.getDBLoader().LoadDB(distribution.Config{}, installation.Config{})
+	assert.True(t, called)
 }


### PR DESCRIPTION
## Description

Refactors `GrypeAdapter` to replace the ad-hoc `loadDB` function pointer field with a structured `VulnerabilityDBLoader` interface.

### Changes
- Defines `VulnerabilityDBLoader` interface in `adapters/v1/grype_db_loader.go` with method:
  - `LoadDB(distCfg distribution.Config, installCfg installation.Config) (vulnerability.Provider, *vulnerability.ProviderStatus, error)`
- Implements `DefaultVulnerabilityDBLoader` (production loader calling `grype.LoadVulnerabilityDB`).
- Implements `VulnerabilityDBLoaderFunc` adapter (allowing idiomatic function-based test injection).
- Adds `WithDBLoader(loader VulnerabilityDBLoader) *GrypeAdapter` method on `GrypeAdapter`.
- Updates unit tests in `adapters/v1/grype_test.go` and fixture in `adapters/v1/grype_docker_fixture.go`.

## Testing
- `make lint` passes cleanly (0 issues).
- `go test ./...` passes across the entire project.