### PR TITLE
refactor(sbom): use SBOMCataloger interface instead of createSBOMFn global

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -35,10 +35,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-// createSBOMFn is an indirection over syft.CreateSBOM so the deadline handling in
-// CreateSBOM can be unit-tested without cataloguing a real image.
-var createSBOMFn = syft.CreateSBOM
-
 // SyftAdapter implements SBOMCreator from ports using Syft's API
 type SyftAdapter struct {
 	maxImageSize     int64
@@ -51,6 +47,7 @@ type SyftAdapter struct {
 	pullSem           chan struct{}
 	scanTimeout       time.Duration
 	scanEmbeddedSBOMs bool
+	cataloger         syftsource.SBOMCataloger
 }
 
 const digestDelim = "@"
@@ -66,7 +63,21 @@ func NewSyftAdapter(scanTimeout time.Duration, maxImageSize int64, maxSBOMSize i
 		pullSem:           make(chan struct{}, 1),
 		scanTimeout:       scanTimeout,
 		scanEmbeddedSBOMs: scanEmbeddedSBOMs,
+		cataloger:         syftsource.DefaultSBOMCataloger{},
 	}
+}
+
+// WithCataloger sets a custom SBOMCataloger for SyftAdapter.
+func (s *SyftAdapter) WithCataloger(cataloger syftsource.SBOMCataloger) *SyftAdapter {
+	s.cataloger = cataloger
+	return s
+}
+
+func (s *SyftAdapter) getCataloger() syftsource.SBOMCataloger {
+	if s.cataloger != nil {
+		return s.cataloger
+	}
+	return syftsource.DefaultSBOMCataloger{}
 }
 
 func rewriteImageRef(imageRef string, proxyMap map[string]string) string {
@@ -419,7 +430,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		// therefore not touch any variable the caller reads. Keep the result local and publish
 		// it on the channel, which is only received from once dl.Run reports success.
 		created, createErr := tools.RetryWithBackoff(ctxWithSize, "sbom_generation", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (*sbom.SBOM, error) {
-			return createSBOMFn(retryCtx, src, cfg)
+			return s.getCataloger().CreateSBOM(retryCtx, src, cfg)
 		})
 		if createErr != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", createErr)

--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -69,15 +69,10 @@ func NewSyftAdapter(scanTimeout time.Duration, maxImageSize int64, maxSBOMSize i
 
 // WithCataloger sets a custom SBOMCataloger for SyftAdapter.
 func (s *SyftAdapter) WithCataloger(cataloger syftsource.SBOMCataloger) *SyftAdapter {
-	s.cataloger = cataloger
-	return s
-}
-
-func (s *SyftAdapter) getCataloger() syftsource.SBOMCataloger {
-	if s.cataloger != nil {
-		return s.cataloger
+	if cataloger != nil {
+		s.cataloger = cataloger
 	}
-	return syftsource.DefaultSBOMCataloger{}
+	return s
 }
 
 func rewriteImageRef(imageRef string, proxyMap map[string]string) string {
@@ -430,7 +425,7 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		// therefore not touch any variable the caller reads. Keep the result local and publish
 		// it on the channel, which is only received from once dl.Run reports success.
 		created, createErr := tools.RetryWithBackoff(ctxWithSize, "sbom_generation", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (*sbom.SBOM, error) {
-			return s.getCataloger().CreateSBOM(retryCtx, src, cfg)
+			return s.cataloger.CreateSBOM(retryCtx, src, cfg)
 		})
 		if createErr != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", createErr)

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -566,7 +566,7 @@ func Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout(t 
 	require.NoError(t, firstRes.err)
 	assert.Equal(t, helpersv1.Incomplete, firstRes.domainSBOM.Status)
 	// CreateSBOM has returned Incomplete, but its abandoned goroutine is still blocked in
-	// createSBOMFn, holding pullMutex.
+	// the cataloger, holding pullMutex.
 
 	secondReturned := make(chan struct{})
 	secondResult := make(chan createSBOMResult, 1)
@@ -645,7 +645,7 @@ func Test_syftAdapter_CreateSBOM_GivesUpWaitingForPermanentlyStuckPullSem(t *tes
 
 	// scanTimeout is deliberately a few seconds, not sub-second: it must comfortably cover the
 	// first call's real (if local) HTTP source resolution against mockRegistryImage, so that
-	// call reaches createSBOMFn - and therefore firstStarted - instead of timing out during
+	// call reaches the cataloger - and therefore firstStarted - instead of timing out during
 	// resolution itself on a loaded machine, before ever holding pullSem.
 	adapter := NewSyftAdapter(2*time.Second, 1<<30, 1<<30, false, nil).WithCataloger(cataloger)
 
@@ -674,7 +674,7 @@ func Test_syftAdapter_CreateSBOM_GivesUpWaitingForPermanentlyStuckPullSem(t *tes
 	}
 	require.NoError(t, firstRes.err)
 	assert.Equal(t, helpersv1.Incomplete, firstRes.domainSBOM.Status)
-	// The first call's abandoned goroutine is now permanently blocked in createSBOMFn - it will
+	// The first call's abandoned goroutine is now permanently blocked in the cataloger - it will
 	// never close blockForever - so it holds pullSem forever.
 
 	start := time.Now()

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/metrics"
 	"github.com/kubescape/kubevuln/internal/syftmeta"
+	"github.com/kubescape/kubevuln/internal/syftsource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -488,15 +489,13 @@ func Test_syftAdapter_CreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft(t *testing.
 	host := mockRegistryImage(t)
 
 	finished := make(chan struct{})
-	orig := createSBOMFn
-	defer func() { createSBOMFn = orig }()
-	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
 		time.Sleep(1500 * time.Millisecond)
 		defer close(finished)
 		return &sbom.SBOM{}, nil
-	}
+	})
 
-	adapter := NewSyftAdapter(1*time.Second, 1<<30, 1<<30, false, nil)
+	adapter := NewSyftAdapter(1*time.Second, 1<<30, 1<<30, false, nil).WithCataloger(cataloger)
 	domainSBOM, err := adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
 
 	require.NoError(t, err)
@@ -526,10 +525,8 @@ func Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout(t 
 	firstAbandonedGoroutineFinished := make(chan struct{})
 	secondStarted := make(chan struct{})
 
-	orig := createSBOMFn
-	defer func() { createSBOMFn = orig }()
 	var calls atomic.Int32
-	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
 		if calls.Add(1) == 1 {
 			close(firstStarted)
 			<-releaseFirst
@@ -538,9 +535,9 @@ func Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout(t 
 		}
 		close(secondStarted)
 		return &sbom.SBOM{}, nil
-	}
+	})
 
-	adapter := NewSyftAdapter(1*time.Second, 1<<30, 1<<30, false, nil)
+	adapter := NewSyftAdapter(1*time.Second, 1<<30, 1<<30, false, nil).WithCataloger(cataloger)
 
 	type createSBOMResult struct {
 		domainSBOM domain.SBOM
@@ -635,10 +632,8 @@ func Test_syftAdapter_CreateSBOM_GivesUpWaitingForPermanentlyStuckPullSem(t *tes
 	blockForever := make(chan struct{}) // deliberately never closed
 	secondStarted := make(chan struct{})
 
-	orig := createSBOMFn
-	defer func() { createSBOMFn = orig }()
 	var calls atomic.Int32
-	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
 		if calls.Add(1) == 1 {
 			close(firstStarted)
 			<-blockForever
@@ -646,13 +641,13 @@ func Test_syftAdapter_CreateSBOM_GivesUpWaitingForPermanentlyStuckPullSem(t *tes
 		}
 		close(secondStarted)
 		return &sbom.SBOM{}, nil
-	}
+	})
 
 	// scanTimeout is deliberately a few seconds, not sub-second: it must comfortably cover the
 	// first call's real (if local) HTTP source resolution against mockRegistryImage, so that
 	// call reaches createSBOMFn - and therefore firstStarted - instead of timing out during
 	// resolution itself on a loaded machine, before ever holding pullSem.
-	adapter := NewSyftAdapter(2*time.Second, 1<<30, 1<<30, false, nil)
+	adapter := NewSyftAdapter(2*time.Second, 1<<30, 1<<30, false, nil).WithCataloger(cataloger)
 
 	type createSBOMResult struct {
 		domainSBOM domain.SBOM
@@ -720,21 +715,19 @@ func Test_syftAdapter_CreateSBOM_CanceledWhileWaitingForStuckPullSem(t *testing.
 	firstStarted := make(chan struct{})
 	blockForever := make(chan struct{}) // deliberately never closed
 
-	orig := createSBOMFn
-	defer func() { createSBOMFn = orig }()
 	var calls atomic.Int32
-	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
 		if calls.Add(1) == 1 {
 			close(firstStarted)
 			<-blockForever
 			return &sbom.SBOM{}, nil // unreachable
 		}
 		return &sbom.SBOM{}, nil
-	}
+	})
 
 	// A scanTimeout much longer than the cancellation below proves cancellation is honored on
 	// its own, not merely because scanTimeout happened to also elapse.
-	adapter := NewSyftAdapter(10*time.Second, 1<<30, 1<<30, false, nil)
+	adapter := NewSyftAdapter(10*time.Second, 1<<30, 1<<30, false, nil).WithCataloger(cataloger)
 
 	go func() {
 		_, _ = adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest", domain.RegistryOptions{InsecureUseHTTP: true})
@@ -1010,4 +1003,21 @@ func Test_syftAdapter_CreateSBOM_Retry429RateLimit(t *testing.T) {
 	mu.Lock()
 	assert.GreaterOrEqual(t, attempts, 2, "expected at least 2 manifest request attempts due to 429 retry")
 	mu.Unlock()
+}
+
+func Test_SyftAdapter_WithCataloger(t *testing.T) {
+	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
+	assert.IsType(t, syftsource.DefaultSBOMCataloger{}, adapter.getCataloger())
+
+	called := false
+	custom := syftsource.SBOMCatalogerFunc(func(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		called = true
+		return &sbom.SBOM{}, nil
+	})
+
+	adapter = adapter.WithCataloger(custom)
+	assert.NotNil(t, adapter.getCataloger())
+
+	_, _ = adapter.getCataloger().CreateSBOM(context.Background(), nil, nil)
+	assert.True(t, called)
 }

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -1007,7 +1007,11 @@ func Test_syftAdapter_CreateSBOM_Retry429RateLimit(t *testing.T) {
 
 func Test_SyftAdapter_WithCataloger(t *testing.T) {
 	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
-	assert.IsType(t, syftsource.DefaultSBOMCataloger{}, adapter.getCataloger())
+	assert.IsType(t, syftsource.DefaultSBOMCataloger{}, adapter.cataloger)
+
+	// Passing nil does not overwrite existing cataloger
+	adapter = adapter.WithCataloger(nil)
+	assert.IsType(t, syftsource.DefaultSBOMCataloger{}, adapter.cataloger)
 
 	called := false
 	custom := syftsource.SBOMCatalogerFunc(func(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
@@ -1016,8 +1020,8 @@ func Test_SyftAdapter_WithCataloger(t *testing.T) {
 	})
 
 	adapter = adapter.WithCataloger(custom)
-	assert.NotNil(t, adapter.getCataloger())
+	assert.NotNil(t, adapter.cataloger)
 
-	_, _ = adapter.getCataloger().CreateSBOM(context.Background(), nil, nil)
+	_, _ = adapter.cataloger.CreateSBOM(context.Background(), nil, nil)
 	assert.True(t, called)
 }

--- a/internal/syftsource/cataloger.go
+++ b/internal/syftsource/cataloger.go
@@ -1,0 +1,34 @@
+package syftsource
+
+import (
+	"context"
+
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+)
+
+// SBOMCataloger abstracts creating an SBOM from a source.
+type SBOMCataloger interface {
+	CreateSBOM(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error)
+}
+
+// DefaultSBOMCataloger is the production implementation that calls syft.CreateSBOM.
+type DefaultSBOMCataloger struct{}
+
+var _ SBOMCataloger = DefaultSBOMCataloger{}
+
+// CreateSBOM calls syft.CreateSBOM.
+func (DefaultSBOMCataloger) CreateSBOM(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	return syft.CreateSBOM(ctx, src, cfg)
+}
+
+// SBOMCatalogerFunc adapts a function to the SBOMCataloger interface.
+type SBOMCatalogerFunc func(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error)
+
+var _ SBOMCataloger = SBOMCatalogerFunc(nil)
+
+// CreateSBOM calls the underlying function.
+func (f SBOMCatalogerFunc) CreateSBOM(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	return f(ctx, src, cfg)
+}

--- a/internal/syftsource/cataloger_test.go
+++ b/internal/syftsource/cataloger_test.go
@@ -1,0 +1,24 @@
+package syftsource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSBOMCatalogerFunc(t *testing.T) {
+	called := false
+	fn := SBOMCatalogerFunc(func(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		called = true
+		return &sbom.SBOM{}, nil
+	})
+
+	res, err := fn.CreateSBOM(context.Background(), nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.True(t, called)
+}

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -55,15 +55,10 @@ type ServerOption func(*scannerServer)
 // WithCataloger configures a custom SBOMCataloger for the scanner server.
 func WithCataloger(cataloger syftsource.SBOMCataloger) ServerOption {
 	return func(s *scannerServer) {
-		s.cataloger = cataloger
+		if cataloger != nil {
+			s.cataloger = cataloger
+		}
 	}
-}
-
-func (s *scannerServer) getCataloger() syftsource.SBOMCataloger {
-	if s.cataloger != nil {
-		return s.cataloger
-	}
-	return syftsource.DefaultSBOMCataloger{}
 }
 
 // NewScannerServer creates a new gRPC scanner server.
@@ -272,7 +267,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		// the handler reads. It keeps its result local and publishes it on a channel,
 		// which the handler only receives from once dl.Run has reported success.
 		created, createErr := tools.RetryWithBackoff(context.Background(), "sbom_generation", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (*sbom.SBOM, error) {
-			return s.getCataloger().CreateSBOM(retryCtx, src, cfg)
+			return s.cataloger.CreateSBOM(retryCtx, src, cfg)
 		})
 		if createErr != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", createErr)

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -31,10 +31,6 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
 
-// createSBOMFn is an indirection over syft.CreateSBOM so the deadline handling in
-// CreateSBOM can be unit-tested without cataloguing a real image.
-var createSBOMFn = syft.CreateSBOM
-
 // sourceGetter abstracts the syft.GetSource call so the fallback ordering in
 // resolveSource is testable with a scripted implementation.
 type sourceGetter func(ctx context.Context, ref string, opts *image.RegistryOptions) (source.Source, error)
@@ -49,14 +45,37 @@ func resolveSource(ctx context.Context, get sourceGetter, imageID, imageTag stri
 
 type scannerServer struct {
 	pb.UnimplementedSBOMScannerServer
-	version string
+	version   string
+	cataloger syftsource.SBOMCataloger
+}
+
+// ServerOption configures a scannerServer.
+type ServerOption func(*scannerServer)
+
+// WithCataloger configures a custom SBOMCataloger for the scanner server.
+func WithCataloger(cataloger syftsource.SBOMCataloger) ServerOption {
+	return func(s *scannerServer) {
+		s.cataloger = cataloger
+	}
+}
+
+func (s *scannerServer) getCataloger() syftsource.SBOMCataloger {
+	if s.cataloger != nil {
+		return s.cataloger
+	}
+	return syftsource.DefaultSBOMCataloger{}
 }
 
 // NewScannerServer creates a new gRPC scanner server.
-func NewScannerServer() pb.SBOMScannerServer {
-	return &scannerServer{
-		version: tools.PackageVersion("github.com/anchore/syft"),
+func NewScannerServer(opts ...ServerOption) pb.SBOMScannerServer {
+	s := &scannerServer{
+		version:   tools.PackageVersion("github.com/anchore/syft"),
+		cataloger: syftsource.DefaultSBOMCataloger{},
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // CreateSBOM handles one scan per call, with no state shared across concurrent calls: each
@@ -253,7 +272,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		// the handler reads. It keeps its result local and publishes it on a channel,
 		// which the handler only receives from once dl.Run has reported success.
 		created, createErr := tools.RetryWithBackoff(context.Background(), "sbom_generation", tools.Default429RetryConfig(), tools.IsRateLimitError, func(retryCtx context.Context) (*sbom.SBOM, error) {
-			return createSBOMFn(retryCtx, src, cfg)
+			return s.getCataloger().CreateSBOM(retryCtx, src, cfg)
 		})
 		if createErr != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", createErr)

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -886,7 +886,7 @@ func TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft(t *testing.T) {
 	assert.Equal(t, helpersv1.Incomplete, resp.Status, "the late write must not affect the response")
 }
 
-func TestCreateSBOM_Exhausted429RateLimitFromCreateSBOMFn(t *testing.T) {
+func TestCreateSBOM_Exhausted429RateLimitFromCataloger(t *testing.T) {
 	layerBytes, layerHash, diffId, err := makeDummyTarGz(64)
 	require.NoError(t, err)
 

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubescape/kubevuln/core/domain"
 	"github.com/kubescape/kubevuln/internal/metrics"
 	"github.com/kubescape/kubevuln/internal/registryauth"
+	"github.com/kubescape/kubevuln/internal/syftsource"
 	"github.com/kubescape/kubevuln/internal/tools"
 	pb "github.com/kubescape/kubevuln/pkg/sbomscanner/v1/proto"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func newTestSocketPath(t *testing.T) string {
 	return sock
 }
 
-func startTestServer(t *testing.T) (pb.SBOMScannerClient, func()) {
+func startTestServer(t *testing.T, opts ...ServerOption) (pb.SBOMScannerClient, func()) {
 	t.Helper()
 	sock := newTestSocketPath(t)
 
@@ -75,7 +76,7 @@ func startTestServer(t *testing.T) (pb.SBOMScannerClient, func()) {
 		grpc.MaxRecvMsgSize(MaxgRPCMessageSize),
 		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
 	)
-	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
+	pb.RegisterSBOMScannerServer(srv, NewScannerServer(opts...))
 	go func() {
 		// Serve returns ErrServerStopped on the graceful Stop below; nothing else to do
 		// with it here, but ignoring it silently is what errcheck flags.
@@ -853,15 +854,13 @@ func TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft(t *testing.T) {
 	// Stand in for Syft: outlive the deadline, then return a result exactly as the real
 	// cataloguer would once it finishes naturally.
 	finished := make(chan struct{})
-	orig := createSBOMFn
-	defer func() { createSBOMFn = orig }()
-	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
 		time.Sleep(1500 * time.Millisecond)
 		defer close(finished)
 		return &sbom.SBOM{}, nil
-	}
+	})
 
-	client, cleanup := startTestServer(t)
+	client, cleanup := startTestServer(t, WithCataloger(cataloger))
 	defer cleanup()
 
 	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
@@ -921,13 +920,11 @@ func TestCreateSBOM_Exhausted429RateLimitFromCreateSBOMFn(t *testing.T) {
 	u, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
-	orig := createSBOMFn
-	defer func() { createSBOMFn = orig }()
-	createSBOMFn = func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, _ *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
 		return nil, &transport.Error{StatusCode: http.StatusTooManyRequests}
-	}
+	})
 
-	client, cleanup := startTestServer(t)
+	client, cleanup := startTestServer(t, WithCataloger(cataloger))
 	defer cleanup()
 
 	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -967,3 +967,22 @@ func TestCreateSBOM_Exhausted429RateLimitFromResolveSource(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, domain.ReasonTooManyRequests, resp.StatusReason)
 }
+
+func Test_WithCataloger(t *testing.T) {
+	srv := NewScannerServer().(*scannerServer)
+	assert.IsType(t, syftsource.DefaultSBOMCataloger{}, srv.cataloger)
+
+	// Passing nil does not overwrite existing cataloger
+	WithCataloger(nil)(srv)
+	assert.IsType(t, syftsource.DefaultSBOMCataloger{}, srv.cataloger)
+
+	called := false
+	custom := syftsource.SBOMCatalogerFunc(func(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		called = true
+		return &sbom.SBOM{}, nil
+	})
+	WithCataloger(custom)(srv)
+	assert.NotNil(t, srv.cataloger)
+	_, _ = srv.cataloger.CreateSBOM(context.Background(), nil, nil)
+	assert.True(t, called)
+}


### PR DESCRIPTION
## Description

Refactors `SyftAdapter` and `pkg/sbomscanner/v1` to replace mutable package-level `createSBOMFn` global variables with a shared `SBOMCataloger` interface in `internal/syftsource`.

### Changes
- Defines `SBOMCataloger` interface in `internal/syftsource/cataloger.go` with method:
  - `CreateSBOM(ctx context.Context, src source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error)`
- Implements `DefaultSBOMCataloger` (production implementation calling `syft.CreateSBOM`).
- Implements `SBOMCatalogerFunc` adapter (allowing idiomatic function-based test injection).
- Adds `WithCataloger(cataloger syftsource.SBOMCataloger) *SyftAdapter` method on `SyftAdapter`.
- Adds `WithCataloger(cataloger syftsource.SBOMCataloger) ServerOption` functional option on `NewScannerServer`.
- Eliminates mutable package-level global variables (`var createSBOMFn = syft.CreateSBOM`) in both `adapters/v1` and `pkg/sbomscanner/v1`.
- Updates unit tests in `adapters/v1/syft_test.go` and `pkg/sbomscanner/v1/server_test.go` to inject catalogers directly rather than monkey-patching package globals.

## Testing
- `make lint` passes cleanly (0 issues).
- `go test ./...` passes across the entire project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable SBOM catalogers for the Syft adapter and scanner server.
  * Added options for supplying custom cataloging behavior while retaining the default cataloger.
  * Preserved existing SBOM creation retry, deadline, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->