### PR TITLE
   fix(registryauth): retry structured auth denials with provider credentials

### DIFF
--- a/internal/registryauth/resolve.go
+++ b/internal/registryauth/resolve.go
@@ -2,10 +2,13 @@ package registryauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/kubevuln/internal/metrics"
@@ -18,19 +21,33 @@ type Getter[T any] func(ctx context.Context, ref string, opts *image.RegistryOpt
 
 // isAuthDenied reports whether err is a registry rejecting the request as unauthenticated or
 // unauthorized -- the two outcomes credentials (ours, or none at all) can actually change.
-// Matches the same bucket core/services/scan_failure_reasons.go's classifySBOMError already
-// uses for the identical distinction (401 vs. 403 both mean "the registry looked at who's
-// asking and said no", where a 429/5xx/timeout means something else went wrong that swapping
-// credentials cannot fix).
 func isAuthDenied(err error) bool {
-	return err != nil && (strings.Contains(err.Error(), "401 Unauthorized") || strings.Contains(err.Error(), "403 Forbidden"))
+	if err == nil {
+		return false
+	}
+	var terr *transport.Error
+	if errors.As(err, &terr) {
+		return terr.StatusCode == http.StatusUnauthorized || terr.StatusCode == http.StatusForbidden
+	}
+	// The pinned stereoscope formats registry errors with %+v, losing their type.
+	// Structured OCI diagnostics omit HTTP status text, so recognize their codes too.
+	message := err.Error()
+	if strings.Contains(message, "401 Unauthorized") || strings.Contains(message, "403 Forbidden") {
+		return true
+	}
+	for _, code := range []string{"DENIED:", "UNAUTHORIZED:"} {
+		if strings.HasPrefix(message, code) || strings.Contains(message, ": "+code) || strings.Contains(message, "; "+code) {
+			return true
+		}
+	}
+	return false
 }
 
 // ResolveSource pulls imageID, falling back in order when the pull fails:
 //
 //   - MANIFEST_UNKNOWN, which a registry returns for a digest it does not hold, is retried
 //     against imageTag.
-//   - 401 Unauthorized is retried with credentials from the provider matching the reference
+//   - Authentication rejection is retried with credentials from the provider matching the reference
 //     (ECR, GCP), and then, if that provider has none or its credentials are refused too,
 //     without credentials at all. A registry that rejects our credentials may still serve
 //     the image anonymously.
@@ -57,7 +74,7 @@ func ResolveSource[T any](ctx context.Context, component string, get Getter[T], 
 		src, err = get(ctx, pullRef, &opts)
 	}
 
-	if err != nil && strings.Contains(err.Error(), "401 Unauthorized") {
+	if isAuthDenied(err) {
 		usedFallback = true
 		unauthorizedErr := err
 		if provider, ok := For(pullRef); ok {
@@ -89,7 +106,7 @@ func ResolveSource[T any](ctx context.Context, component string, get Getter[T], 
 		// eventual error permanently mislabels whatever actually went wrong as "unauthorized"
 		// (via unauthorizedErr below). When no provider matched or its credentials were
 		// unavailable, err is untouched here and still holds the original auth-denied error
-		// from line 50 (or the MANIFEST_UNKNOWN retry above it), so this check doesn't change
+		// from the initial pull (or the MANIFEST_UNKNOWN retry above it), so this check doesn't change
 		// that path's existing behavior. See #921.
 		if isAuthDenied(err) {
 			logger.L().Debug("retrying without credentials",

--- a/internal/registryauth/resolve_test.go
+++ b/internal/registryauth/resolve_test.go
@@ -3,10 +3,14 @@ package registryauth
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,6 +18,143 @@ import (
 // ResolveSource is generic over what a pull returns, so the ladder can be exercised without
 // Syft. The sidecar and the in-process adapter both reach it with their own source type.
 type fakeSource struct{ ref string }
+
+func registryAuthError(t *testing.T, status int, code transport.ErrorCode) *transport.Error {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, "https://europe-west1-docker.pkg.dev/v2/token?scope=repository:project/repo/image:pull", nil)
+	require.NoError(t, err)
+	return &transport.Error{
+		StatusCode: status,
+		Request:    req,
+		Errors:     []transport.Diagnostic{{Code: code, Message: "Unauthenticated request."}},
+	}
+}
+
+func flattenedRegistryAuthError(t *testing.T, code transport.ErrorCode) error {
+	t.Helper()
+	// Match stereoscope's formatting: the transport error's type is lost here.
+	err := fmt.Errorf("oci-registry: failed to get image descriptor from registry: %+v",
+		registryAuthError(t, http.StatusForbidden, code))
+	var terr *transport.Error
+	require.False(t, errors.As(err, &terr))
+	require.NotContains(t, err.Error(), "401 Unauthorized")
+	require.NotContains(t, err.Error(), "403 Forbidden")
+	return err
+}
+
+func TestIsAuthDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"typed 401", registryAuthError(t, http.StatusUnauthorized, transport.DeniedErrorCode), true},
+		{"wrapped typed 401", fmt.Errorf("pull failed: %w", registryAuthError(t, http.StatusUnauthorized, transport.DeniedErrorCode)), true},
+		{"typed 403", registryAuthError(t, http.StatusForbidden, transport.DeniedErrorCode), true},
+		{"wrapped typed 403", fmt.Errorf("pull failed: %w", registryAuthError(t, http.StatusForbidden, transport.UnauthorizedErrorCode)), true},
+		{"flattened DENIED", flattenedRegistryAuthError(t, transport.DeniedErrorCode), true},
+		{"flattened UNAUTHORIZED", flattenedRegistryAuthError(t, transport.UnauthorizedErrorCode), true},
+		{"bare DENIED", errors.New("DENIED: Unauthenticated request."), true},
+		{"bare UNAUTHORIZED", errors.New("UNAUTHORIZED: authentication required"), true},
+		{"multiple diagnostics", errors.New("multiple errors returned: UNKNOWN: other error; DENIED: Unauthenticated request."), true},
+		{"legacy 401", errors.New("pull failed: 401 Unauthorized"), true},
+		{"legacy 403", errors.New("pull failed: 403 Forbidden"), true},
+		{"typed 404 overrides diagnostic", registryAuthError(t, http.StatusNotFound, transport.DeniedErrorCode), false},
+		{"typed 429 overrides diagnostic", registryAuthError(t, http.StatusTooManyRequests, transport.DeniedErrorCode), false},
+		{"typed 500 overrides diagnostic", registryAuthError(t, http.StatusInternalServerError, transport.UnauthorizedErrorCode), false},
+		{"wrapped 429 overrides text", fmt.Errorf("401 Unauthorized: %w", registryAuthError(t, http.StatusTooManyRequests, transport.DeniedErrorCode)), false},
+		{"404", errors.New("404 Not Found"), false},
+		{"429", errors.New("429 Too Many Requests"), false},
+		{"500", errors.New("500 Internal Server Error"), false},
+		{"timeout", context.DeadlineExceeded, false},
+		{"filesystem permission", &os.PathError{Op: "open", Path: "/image", Err: os.ErrPermission}, false},
+		{"embedded DENIED", errors.New("unexpected text DENIED: unrelated failure"), false},
+		{"embedded UNAUTHORIZED", errors.New("unexpected text UNAUTHORIZED: unrelated failure"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAuthDenied(tt.err))
+		})
+	}
+}
+
+func TestResolveSource_StructuredAuthFallback(t *testing.T) {
+	denied := flattenedRegistryAuthError(t, transport.DeniedErrorCode)
+	unauthorized := flattenedRegistryAuthError(t, transport.UnauthorizedErrorCode)
+	rateLimited := &transport.Error{StatusCode: http.StatusTooManyRequests}
+	serverError := &transport.Error{StatusCode: http.StatusInternalServerError}
+	const artifactRef = "europe-west1-docker.pkg.dev/project/repo/image:tag"
+	tests := []struct {
+		name      string
+		imageID   string
+		imageTag  string
+		results   []error
+		wantCreds []int
+		wantRefs  []string
+		wantErr   error
+	}{
+		{name: "Artifact Registry DENIED", imageID: artifactRef, results: []error{denied, nil}, wantCreds: []int{0, 1}},
+		{name: "regional GCR DENIED", imageID: "eu.gcr.io/project/image:tag", results: []error{denied, nil}, wantCreds: []int{0, 1}},
+		{name: "Artifact Registry UNAUTHORIZED", imageID: artifactRef, results: []error{unauthorized, nil}, wantCreds: []int{0, 1}},
+		{name: "typed 403", imageID: artifactRef, results: []error{registryAuthError(t, http.StatusForbidden, transport.DeniedErrorCode), nil}, wantCreds: []int{0, 1}},
+		{name: "credentials denied", imageID: artifactRef, results: []error{denied, denied, nil}, wantCreds: []int{0, 1, 0}},
+		{name: "credentials unauthorized", imageID: artifactRef, results: []error{denied, unauthorized, nil}, wantCreds: []int{0, 1, 0}},
+		{name: "credentialed 429", imageID: artifactRef, results: []error{denied, rateLimited}, wantCreds: []int{0, 1}, wantErr: rateLimited},
+		{name: "credentialed 500", imageID: artifactRef, results: []error{denied, serverError}, wantCreds: []int{0, 1}, wantErr: serverError},
+		{name: "credentialed timeout", imageID: artifactRef, results: []error{denied, context.DeadlineExceeded}, wantCreds: []int{0, 1}, wantErr: context.DeadlineExceeded},
+		{
+			name: "tag before authentication", imageID: "europe-west1-docker.pkg.dev/project/repo/image@sha256:deadbeef", imageTag: artifactRef,
+			results: []error{errors.New("MANIFEST_UNKNOWN: manifest unknown"), denied, nil}, wantCreds: []int{0, 0, 1},
+			wantRefs: []string{"europe-west1-docker.pkg.dev/project/repo/image@sha256:deadbeef", artifactRef, artifactRef},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := GCPCredsFn
+			t.Cleanup(func() { GCPCredsFn = orig; ResetCaches() })
+			ResetCaches()
+			creds := image.RegistryCredentials{Username: "oauth2accesstoken", Password: "test-adc-token"}
+			credentialCalls := 0
+			GCPCredsFn = func(context.Context) (*image.RegistryCredentials, time.Time, error) {
+				credentialCalls++
+				return &creds, time.Now().Add(time.Hour), nil
+			}
+			var refs []string
+			var credentialsSeen []int
+			get := func(_ context.Context, ref string, opts *image.RegistryOptions) (fakeSource, error) {
+				attempt := len(refs)
+				require.Less(t, attempt, len(tt.results), "unexpected extra pull")
+				refs = append(refs, ref)
+				credentialsSeen = append(credentialsSeen, len(opts.Credentials))
+				if len(opts.Credentials) > 0 {
+					assert.Equal(t, []image.RegistryCredentials{creds}, opts.Credentials)
+				}
+				return fakeSource{ref: ref}, tt.results[attempt]
+			}
+			src, err := ResolveSource(context.Background(), "in_process", get, tt.imageID, tt.imageTag, image.RegistryOptions{})
+			if tt.wantErr != nil {
+				assert.True(t, err == tt.wantErr, "non-auth errors must be returned unchanged: got %v", err)
+			} else {
+				assert.NoError(t, err)
+				wantRef := tt.imageID
+				if tt.imageTag != "" {
+					wantRef = tt.imageTag
+				}
+				assert.Equal(t, wantRef, src.ref)
+			}
+			assert.Equal(t, 1, credentialCalls)
+			assert.Equal(t, tt.wantCreds, credentialsSeen)
+			if tt.wantRefs != nil {
+				assert.Equal(t, tt.wantRefs, refs)
+			} else {
+				for _, ref := range refs {
+					assert.Equal(t, tt.imageID, ref)
+				}
+			}
+		})
+	}
+}
 
 func TestResolveSource_RetriesTagOnManifestUnknown(t *testing.T) {
 	var tried []string


### PR DESCRIPTION

  ## Overview

  Private Google Artifact Registry and GCR pulls can return structured OCI errors such as `DENIED: Unauthenticated request` without the HTTP status text.
  `ResolveSource` previously entered the registry-auth fallback only when the rendered error contained `401 Unauthorized`, so GCP Application Default Credentials were never requested.

  This change:

  - Detects typed registry transport errors using their HTTP status code.
  - Recognizes flattened `DENIED` and `UNAUTHORIZED` OCI diagnostics when the underlying error type has been lost.
  - Retries supported private registries with provider credentials, enabling GCP ADC and Workload Identity authentication.
  - Preserves the existing behavior that 429, 5xx, timeout, and other non-authentication failures do not trigger an anonymous retry.
  - Adds regression coverage for Artifact Registry, regional GCR, typed and flattened errors, credential rejection, and the `MANIFEST_UNKNOWN` tag fallback sequence.

  No dependency or public API changes are included.

  ## How to Test

  ```bash
  export TMPDIR=/tmp
  export GOCACHE=/tmp/kubevuln-943-go-cache

  go test -mod=readonly -p=1 ./internal/registryauth -count=1

  go test -mod=readonly -p=1 ./pkg/sbomscanner/v1 \
    -run '^TestResolveSource' -count=1

  go test -mod=readonly -p=1 ./adapters/v1 -count=1

  go vet -mod=readonly -p=1 \
    ./internal/registryauth/... ./adapters/v1/... ./pkg/sbomscanner/...

  go build -mod=readonly -p=1 ./...
```

  All commands pass locally. The regression tests deterministically reproduce the reported fallback path; live GKE Workload Identity integration was not exercised locally.

  ## Related issues/PRs

  - Resolved #943

  ## Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have commented on hard-to-understand behavior
  - [x] I have performed a self-review of my code
  - [x] I have added focused regression tests
  - [x] New and existing relevant unit tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of container registry authentication failures, including structured and wrapped error responses.
  * Credentialed fallback now works reliably for recognized unauthorized and denied responses.
  * Non-authentication errors continue to be surfaced without triggering credential fallback.
  * Digest references that return `MANIFEST_UNKNOWN` now retry using the associated tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->