### PR TITLE
fix(adapters): give every manifest build step a unique order

### DIFF
--- a/adapters/v1/backend_test.go
+++ b/adapters/v1/backend_test.go
@@ -892,6 +892,10 @@ func TestParseImageManifest(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, imageManifest)
+				require.Len(t, imageManifest.Layers, 17)
+				for order, layer := range imageManifest.Layers {
+					assert.Equal(t, order, layer.LayerOrder)
+				}
 			}
 		})
 	}

--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -331,12 +331,14 @@ func parseLayersPayload(target source.ImageMetadata) (map[string]containerscan.E
 	}
 
 	listLayers := make([]containerscan.ESLayer, 0)
+	// Retain full build-step orders while pairing only physical layers with DiffIDs.
 	for i := range jsonConfig.History {
 
 		if !jsonConfig.History[i].EmptyLayer {
 			listLayers = append(listLayers, containerscan.ESLayer{LayerInfo: &containerscan.LayerInfo{
 				CreatedBy:   jsonConfig.History[i].CreatedBy,
 				CreatedTime: &jsonConfig.History[i].Created.Time,
+				LayerOrder:  i,
 			},
 			})
 		}
@@ -345,7 +347,6 @@ func parseLayersPayload(target source.ImageMetadata) (map[string]containerscan.E
 		listLayers[i].LayerHash = jsonConfig.RootFS.DiffIDs[i].String()
 		if i > 0 {
 			listLayers[i].ParentLayerHash = jsonConfig.RootFS.DiffIDs[i-1].String()
-			listLayers[i].LayerInfo.LayerOrder = i
 		}
 		layerMap[listLayers[i].LayerHash] = listLayers[i]
 	}
@@ -364,11 +365,6 @@ func syftCoordinatesToCoordinates(c []v1beta1.SyftCoordinates) []containerscan.C
 	return coordinates
 
 }
-
-// metadataOnlyLayerOrder marks a history entry that produced no layer (ENV, LABEL, CMD and
-// the like). Real layers are numbered from zero, so there is no in-range value that means
-// "not a layer"; a negative one says so without colliding with any of them.
-const metadataOnlyLayerOrder = -1
 
 func ParseImageManifest(grypeDocument *v1beta1.GrypeDocument) (*containerscan.ImageManifest, error) {
 	if grypeDocument == nil || grypeDocument.Source == nil {
@@ -393,23 +389,10 @@ func ParseImageManifest(grypeDocument *v1beta1.GrypeDocument) (*containerscan.Im
 		Layers:       []containerscan.ESLayer{},
 	}
 
-	// LayerOrder counts real, layer-producing history entries only, matching
-	// parseLayersPayload's indexing (which builds the layerMap DomainToArmo attaches to
-	// each vulnerability). History also contains metadata-only entries (ENV, LABEL, CMD,
-	// etc.) that don't produce a layer; counting those too, as the raw loop index would,
-	// gives every real layer a different LayerOrder here than in the vulnerability report
-	// for the same layer hash, breaking any lookup that correlates the two by LayerOrder.
-	// A metadata-only entry has no layer, so it gets metadataOnlyLayerOrder rather than a
-	// real one. Stamping it with layerIndex, as this used to, handed it the order of the
-	// next real layer, which is the one thing LayerOrder must not do: on the nginx image
-	// six ENV/LABEL/CMD entries and the RUN layer they precede all came out as order 1, so
-	// the lookup this exists to serve returned seven entries for one layer.
+	// Every history entry has a unique chronological order, matching parseLayersPayload.
+	// Metadata-only steps consume an order but no physical layer hash or size.
 	layerIndex := 0
-	for _, historyLayer := range config.History {
-		order := metadataOnlyLayerOrder
-		if !historyLayer.EmptyLayer {
-			order = layerIndex
-		}
+	for order, historyLayer := range config.History {
 		layerInfo := containerscan.ESLayer{
 			LayerInfo: &containerscan.LayerInfo{
 				CreatedBy:   historyLayer.CreatedBy,
@@ -417,9 +400,11 @@ func ParseImageManifest(grypeDocument *v1beta1.GrypeDocument) (*containerscan.Im
 				LayerOrder:  order,
 			},
 		}
-		if !historyLayer.EmptyLayer && layerIndex < len(rawManifest.Layers) {
-			layerInfo.LayerHash = rawManifest.Layers[layerIndex].Digest
-			layerInfo.Size = rawManifest.Layers[layerIndex].Size
+		if !historyLayer.EmptyLayer {
+			if layerIndex < len(rawManifest.Layers) {
+				layerInfo.LayerHash = rawManifest.Layers[layerIndex].Digest
+				layerInfo.Size = rawManifest.Layers[layerIndex].Size
+			}
 			layerIndex++
 		}
 		imageManifest.Layers = append(imageManifest.Layers, layerInfo)

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -167,6 +167,15 @@ func Test_parseLayersPayload(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "missing config",
+			want: map[string]containerscan.ESLayer{},
+		},
+		{
+			name:    "malformed config",
+			target:  source.ImageMetadata{RawConfig: []byte(`{`)},
+			wantErr: true,
+		},
+		{
 			name: "Test parseLayersPayload",
 			target: source.ImageMetadata{
 				RawConfig: config,
@@ -209,6 +218,7 @@ func Test_parseLayersPayload(t *testing.T) {
 func Test_layerOrder_consistentBetweenManifestAndVulnerabilities(t *testing.T) {
 	config := containerRegistryV1.ConfigFile{
 		History: []containerRegistryV1.History{
+			{CreatedBy: "ENV BASE=1", EmptyLayer: true},
 			{CreatedBy: "FROM base", EmptyLayer: false},
 			{CreatedBy: "ENV FOO=bar", EmptyLayer: true},
 			{CreatedBy: "LABEL x=y", EmptyLayer: true},
@@ -243,6 +253,11 @@ func Test_layerOrder_consistentBetweenManifestAndVulnerabilities(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	require.Len(t, imageManifest.Layers, 6)
+	require.Len(t, layerMap, 2)
+	assert.Equal(t, 1, layerMap[imageMetadata.Layers[0].Digest].LayerOrder)
+	assert.Equal(t, 4, layerMap[imageMetadata.Layers[1].Digest].LayerOrder)
+	assert.Equal(t, imageMetadata.Layers[0].Digest, layerMap[imageMetadata.Layers[1].Digest].ParentLayerHash)
 	checked := 0
 	for _, layer := range imageManifest.Layers {
 		if layer.LayerHash == "" {
@@ -255,6 +270,100 @@ func Test_layerOrder_consistentBetweenManifestAndVulnerabilities(t *testing.T) {
 		checked++
 	}
 	assert.Equal(t, 2, checked, "expected to check both real layers")
+
+	document := layeredDocument(imageMetadata.Layers[1].Digest)
+	document.Source.Target = targetBytes
+	ctx := context.WithValue(t.Context(), domain.WorkloadKey{}, domain.ScanCommand{})
+	ctx = context.WithValue(ctx, domain.TimestampKey{}, int64(1734957372))
+	ctx = context.WithValue(ctx, domain.ScanIDKey{}, "scan-history-orders")
+	results, err := DomainToArmo(ctx, document, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Layers, 1)
+	assert.Equal(t, 4, results[0].Layers[0].LayerOrder)
+	assert.Equal(t, imageMetadata.Layers[1].Digest, results[0].IntroducedInLayer)
+}
+
+func TestParseImageManifest_IncompleteLayerMetadata(t *testing.T) {
+	history := []containerRegistryV1.History{
+		{CreatedBy: "ENV BASE=1", EmptyLayer: true},
+		{CreatedBy: "ADD base"},
+		{CreatedBy: "LABEL x=y", EmptyLayer: true},
+		{CreatedBy: "RUN install"},
+		{CreatedBy: "CMD app", EmptyLayer: true},
+	}
+	diffIDs := []containerRegistryV1.Hash{
+		{Algorithm: "sha256", Hex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{Algorithm: "sha256", Hex: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+	}
+	layers := []source.LayerMetadata{
+		{Digest: diffIDs[0].String(), Size: 100},
+		{Digest: diffIDs[1].String(), Size: 200},
+	}
+	for _, tt := range []struct {
+		name    string
+		history []containerRegistryV1.History
+		layers  []source.LayerMetadata
+		diffIDs []containerRegistryV1.Hash
+	}{
+		{"complete", history, layers, diffIDs},
+		{"missing raw layers", history, nil, diffIDs},
+		{"truncated raw layers", history, layers[:1], diffIDs},
+		{"truncated diff IDs", history, layers, diffIDs[:1]},
+		{"metadata only", []containerRegistryV1.History{history[0], history[2], history[4]}, nil, nil},
+		{"no history", nil, layers, diffIDs},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config := containerRegistryV1.ConfigFile{
+				History: tt.history,
+				RootFS:  containerRegistryV1.RootFS{DiffIDs: tt.diffIDs},
+			}
+			for i := range config.History {
+				config.History[i].Created = containerRegistryV1.Time{Time: time.Unix(int64(i), 0).UTC()}
+			}
+			rawConfig, err := json.Marshal(config)
+			require.NoError(t, err)
+			metadata := source.ImageMetadata{RawConfig: rawConfig, Layers: tt.layers}
+			target, err := json.Marshal(metadata)
+			require.NoError(t, err)
+			manifest, err := ParseImageManifest(&v1beta1.GrypeDocument{Source: &v1beta1.Source{Target: target}})
+			require.NoError(t, err)
+			require.Len(t, manifest.Layers, len(tt.history))
+			byOrder := make(map[int]containerscan.ESLayer)
+			for i, layer := range manifest.Layers {
+				byOrder[layer.LayerOrder] = layer
+				assert.Equal(t, i, layer.LayerOrder)
+				assert.Equal(t, config.History[i].CreatedBy, layer.CreatedBy)
+				assert.Equal(t, &config.History[i].Created.Time, layer.CreatedTime)
+			}
+			assert.Len(t, byOrder, len(tt.history), "order-keyed consumers retain the complete history")
+			payload, err := parseLayersPayload(metadata)
+			require.NoError(t, err)
+			if len(tt.history) == 0 || tt.history[1].EmptyLayer {
+				assert.Empty(t, payload)
+				for _, layer := range manifest.Layers {
+					assert.Empty(t, layer.LayerHash)
+					assert.Zero(t, layer.Size)
+				}
+				return
+			}
+			for physical, order := range []int{1, 3} {
+				if physical < len(tt.layers) {
+					assert.Equal(t, tt.layers[physical].Digest, manifest.Layers[order].LayerHash)
+					assert.EqualValues(t, tt.layers[physical].Size, manifest.Layers[order].Size)
+				} else {
+					assert.Empty(t, manifest.Layers[order].LayerHash)
+					assert.Zero(t, manifest.Layers[order].Size)
+				}
+				if physical < len(tt.diffIDs) {
+					layer, ok := payload[tt.diffIDs[physical].String()]
+					require.True(t, ok)
+					assert.Equal(t, order, layer.LayerOrder)
+				}
+			}
+			assert.Len(t, payload, len(tt.diffIDs))
+		})
+	}
 }
 
 func Test_suggestedVersion(t *testing.T) {
@@ -458,11 +567,7 @@ func Test_domainToArmo_introducedInLayer(t *testing.T) {
 	}
 }
 
-// LayerOrder is what correlates a vulnerability, which carries the order parseLayersPayload
-// assigned, with the layer in the manifest that produced it. That only works if one order
-// names one layer. Metadata-only history entries used to be stamped with layerIndex, which
-// is the order of the next real layer, so on nginx six ENV/LABEL/CMD entries and the RUN
-// layer after them all came out as order 1.
+// An order-keyed consumer must retain every build step, including metadata-only entries.
 func TestParseImageManifest_LayerOrderNamesOneLayer(t *testing.T) {
 	rawConfig := []byte(`{
 	  "architecture":"amd64","os":"linux",
@@ -489,16 +594,12 @@ func TestParseImageManifest_LayerOrderNamesOneLayer(t *testing.T) {
 	require.Len(t, im.Layers, 4, "every history entry is still reported")
 
 	seen := map[int]int{}
-	for _, l := range im.Layers {
-		if l.LayerHash == "" {
-			assert.Equal(t, metadataOnlyLayerOrder, l.LayerInfo.LayerOrder,
-				"a metadata-only entry must not claim a layer's order")
-			continue
-		}
+	for i, l := range im.Layers {
+		assert.Equal(t, i, l.LayerOrder)
 		seen[l.LayerInfo.LayerOrder]++
 	}
-	assert.Equal(t, map[int]int{0: 1, 1: 1}, seen,
-		"each real layer holds its own order, numbered from zero")
+	assert.Equal(t, map[int]int{0: 1, 1: 1, 2: 1, 3: 1}, seen,
+		"every history entry must have a distinct chronological order")
 }
 
 // TestDomainToArmo_IsFixedAgreesWithFixes pins the two "is there a fix?" answers a single

--- a/adapters/v1/testdata/nginx-image-manifest.json
+++ b/adapters/v1/testdata/nginx-image-manifest.json
@@ -15,49 +15,49 @@
       "parentLayerHash":"",
       "createdBy":"/bin/sh -c #(nop)  CMD [\"bash\"]",
       "createdTime":"2024-05-14T00:39:41.460424266Z",
-      "layerOrder":-1
+      "layerOrder":1
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"LABEL maintainer=NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":2
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NGINX_VERSION=1.27.0",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":3
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NJS_VERSION=0.8.4",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":4
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV NJS_RELEASE=2~bookworm",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":5
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"ENV PKG_RELEASE=2~bookworm",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":6
     },
     {
       "layerHash":"sha256:3a0cf035bbfcc7852c38d4d236673b6a0d9454e5f2621800814d1633e729ea20",
       "parentLayerHash":"",
       "createdBy":"RUN /bin/sh -c set -x     \u0026\u0026 groupadd --system --gid 101 nginx     \u0026\u0026 useradd --system --gid nginx --no-create-home --home /nonexistent --comment \"nginx user\" --shell /bin/false --uid 101 nginx     \u0026\u0026 apt-get update     \u0026\u0026 apt-get install --no-install-recommends --no-install-suggests -y gnupg1 ca-certificates     \u0026\u0026     NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62;     NGINX_GPGKEY_PATH=/etc/apt/keyrings/nginx-archive-keyring.gpg;     export GNUPGHOME=\"$(mktemp -d)\";     found='';     for server in         hkp://keyserver.ubuntu.com:80         pgp.mit.edu     ; do         echo \"Fetching GPG key $NGINX_GPGKEY from $server\";         gpg1 --keyserver \"$server\" --keyserver-options timeout=10 --recv-keys \"$NGINX_GPGKEY\" \u0026\u0026 found=yes \u0026\u0026 break;     done;     test -z \"$found\" \u0026\u0026 echo \u003e\u00262 \"error: failed to fetch GPG key $NGINX_GPGKEY\" \u0026\u0026 exit 1;     gpg1 --export \"$NGINX_GPGKEY\" \u003e \"$NGINX_GPGKEY_PATH\" ;     rm -rf \"$GNUPGHOME\";     apt-get remove --purge --auto-remove -y gnupg1 \u0026\u0026 rm -rf /var/lib/apt/lists/*     \u0026\u0026 dpkgArch=\"$(dpkg --print-architecture)\"     \u0026\u0026 nginxPackages=\"         nginx=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-xslt=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-geoip=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-image-filter=${NGINX_VERSION}-${PKG_RELEASE}         nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${NJS_RELEASE}     \"     \u0026\u0026 case \"$dpkgArch\" in         amd64|arm64)             echo \"deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx\" \u003e\u003e /etc/apt/sources.list.d/nginx.list             \u0026\u0026 apt-get update             ;;         *)             echo \"deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx\" \u003e\u003e /etc/apt/sources.list.d/nginx.list                         \u0026\u0026 tempDir=\"$(mktemp -d)\"             \u0026\u0026 chmod 777 \"$tempDir\"                         \u0026\u0026 savedAptMark=\"$(apt-mark showmanual)\"                         \u0026\u0026 apt-get update             \u0026\u0026 apt-get build-dep -y $nginxPackages             \u0026\u0026 (                 cd \"$tempDir\"                 \u0026\u0026 DEB_BUILD_OPTIONS=\"nocheck parallel=$(nproc)\"                     apt-get source --compile $nginxPackages             )                         \u0026\u0026 apt-mark showmanual | xargs apt-mark auto \u003e /dev/null             \u0026\u0026 { [ -z \"$savedAptMark\" ] || apt-mark manual $savedAptMark; }                         \u0026\u0026 ls -lAFh \"$tempDir\"             \u0026\u0026 ( cd \"$tempDir\" \u0026\u0026 dpkg-scanpackages . \u003e Packages )             \u0026\u0026 grep '^Package: ' \"$tempDir/Packages\"             \u0026\u0026 echo \"deb [ trusted=yes ] file://$tempDir ./\" \u003e /etc/apt/sources.list.d/temp.list             \u0026\u0026 apt-get -o Acquire::GzipIndexes=false update             ;;     esac         \u0026\u0026 apt-get install --no-install-recommends --no-install-suggests -y                         $nginxPackages                         gettext-base                         curl     \u0026\u0026 apt-get remove --purge --auto-remove -y \u0026\u0026 rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list         \u0026\u0026 if [ -n \"$tempDir\" ]; then         apt-get purge -y --auto-remove         \u0026\u0026 rm -rf \"$tempDir\" /etc/apt/sources.list.d/temp.list;     fi     \u0026\u0026 ln -sf /dev/stdout /var/log/nginx/access.log     \u0026\u0026 ln -sf /dev/stderr /var/log/nginx/error.log     \u0026\u0026 mkdir /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":1,
+      "layerOrder":7,
       "size":95802212
     },
     {
@@ -65,7 +65,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY docker-entrypoint.sh / # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":2,
+      "layerOrder":8,
       "size":1620
     },
     {
@@ -73,7 +73,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":3,
+      "layerOrder":9,
       "size":2125
     },
     {
@@ -81,7 +81,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 15-local-resolvers.envsh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":4,
+      "layerOrder":10,
       "size":336
     },
     {
@@ -89,7 +89,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 20-envsubst-on-templates.sh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":5,
+      "layerOrder":11,
       "size":3018
     },
     {
@@ -97,7 +97,7 @@
       "parentLayerHash":"",
       "createdBy":"COPY 30-tune-worker-processes.sh /docker-entrypoint.d # buildkit",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":6,
+      "layerOrder":12,
       "size":4619
     },
     {
@@ -105,28 +105,28 @@
       "parentLayerHash":"",
       "createdBy":"ENTRYPOINT [\"/docker-entrypoint.sh\"]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":13
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"EXPOSE map[80/tcp:{}]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":14
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"STOPSIGNAL SIGQUIT",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":15
     },
     {
       "layerHash":"",
       "parentLayerHash":"",
       "createdBy":"CMD [\"nginx\" \"-g\" \"daemon off;\"]",
       "createdTime":"2024-05-29T23:55:01Z",
-      "layerOrder":-1
+      "layerOrder":16
     }
   ]
 }


### PR DESCRIPTION
## Overview

Follow up #752: assigning every metadata-only history entry `layerOrder: -1` leaves those entries sharing one key. Use each entry's position in the full build history instead, so order-keyed consumers can retain all metadata and filesystem steps in build order. The nginx fixture now has 17 distinct orders, `0..16`.

Update vulnerability layer enrichment to use the same history positions, preserving the order/hash correlation fixed by #617 and #752. Real-layer order values therefore include gaps where metadata steps occur. Physical hashes, sizes, parent hashes, and introduction-layer selection retain their existing associations.

Regression coverage includes metadata before/between/after physical layers, an order-keyed consumer, the final vulnerability enrichment output, missing/truncated layer metadata and DiffIDs, metadata-only/empty histories, and the nginx golden. Confirmed the new ordering assertions fail before the fix. The nginx fixture changes only `layerOrder` values.

## How to Test

- `make verify` — build, Docker-enabled tests, vet, and lint passed (zero lint issues).
- `go test ./... -count=1` — passed.
- Focused manifest, layer-payload, and vulnerability-enrichment regressions — passed after cleanup.
- `git diff --check` — passed.
- Independent code and architecture reviews — approved, no findings.

## Related issues/PRs

Follow-up to #752 (which addressed #751). Downstream list truncation was reported by the requester; repository tests verify complete, uniquely ordered output and vulnerability correlation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected image layer ordering so all image history entries, including metadata-only steps, retain their chronological position.
  * Improved consistency between image layers and vulnerability mappings.
  * Fixed handling of incomplete layer metadata and vulnerabilities without a valid upgrade, which now use an unknown fix version.
* **Tests**
  * Expanded coverage for malformed manifests, layer ordering, introduced layers, and vulnerability count calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->