### PR TITLE
fix(config): make accountID a real fallback and fail fast without any account identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ It [scans container images for vulnerabilities](https://www.armosec.io/blog/code
 To build kubevuln with its dependencies run: `make`
 
 ## Configuration
+
+See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for the current, complete configuration reference (environment variables, `clusterData.json` schema, and validation). The example below predates it and doesn't reflect current field names.
+
 1. Load config file using the `CONFIG` environment variable
 
    `export CONFIG=path/to/clusterData.json`

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -55,6 +56,9 @@ func main() {
 		logger.L().Info("credentials loaded",
 			helpers.Int("accessKeyLength", len(credentials.AccessKey)),
 			helpers.Int("accountLength", len(credentials.Account)))
+	}
+	if credentials.Account, err = resolveAccountID(credentials.Account, c.AccountID, c.KeepLocal); err != nil {
+		logger.L().Ctx(ctx).Fatal("account identifier error", helpers.Error(err))
 	}
 
 	// to enable otel, set OTEL_COLLECTOR_SVC=otel-collector:4317
@@ -279,4 +283,27 @@ func main() {
 // it seRepo falls back to NoOpSecurityExceptionRepository regardless of the flag.
 func isRiskAcceptanceActive(storage *repositories.APIServerStore, riskAcceptance bool) bool {
 	return storage != nil && riskAcceptance
+}
+
+// resolveAccountID picks the account identifier every backend report and CVE-exception
+// lookup is sent with, preferring credentialsAccount (from /etc/credentials/account,
+// normally a mounted Secret) and falling back to configAccountID (clusterData.json's
+// accountID field / ACCOUNTID env var) when that's empty. The fallback is what makes
+// that documented config field do anything at all: nothing else in this binary reads it
+// (see #957).
+//
+// It returns an error when keepLocal is false and neither source produced a value.
+// Without a real account identifier, every backend report would silently carry an
+// empty customerGUID instead of kubevuln failing to start the way
+// docs/CONFIGURATION.md's "required field" already promises. keepLocal mode never
+// talks to the backend, so it's the only case that doesn't need one.
+func resolveAccountID(credentialsAccount, configAccountID string, keepLocal bool) (string, error) {
+	accountID := credentialsAccount
+	if accountID == "" {
+		accountID = configAccountID
+	}
+	if accountID == "" && !keepLocal {
+		return "", fmt.Errorf("no account identifier configured: set /etc/credentials/account (normally mounted from a Secret), accountID in clusterData.json, or the ACCOUNTID environment variable -- or set keepLocal to run without reporting to the backend")
+	}
+	return accountID, nil
 }

--- a/cmd/http/main_test.go
+++ b/cmd/http/main_test.go
@@ -93,6 +93,53 @@ func TestIsRiskAcceptanceActive(t *testing.T) {
 	}
 }
 
+// TestResolveAccountID is the regression test for #957: clusterData.json's accountID
+// field used to be dead code (nothing read Config.AccountID), so setting it had no
+// effect, and a missing real account identifier (/etc/credentials/account) never
+// stopped startup despite docs/CONFIGURATION.md documenting both as required.
+func TestResolveAccountID(t *testing.T) {
+	tests := []struct {
+		name               string
+		credentialsAccount string
+		configAccountID    string
+		keepLocal          bool
+		want               string
+		wantErr            bool
+	}{
+		{
+			name:               "credentials file wins over the config fallback",
+			credentialsAccount: "from-credentials-file",
+			configAccountID:    "from-cluster-data",
+			want:               "from-credentials-file",
+		},
+		{
+			name:            "config fallback is used when the credentials file has none",
+			configAccountID: "from-cluster-data",
+			want:            "from-cluster-data",
+		},
+		{
+			name:      "keepLocal tolerates no account identifier at all",
+			keepLocal: true,
+			want:      "",
+		},
+		{
+			name:    "no account identifier and not keepLocal fails",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveAccountID(tt.credentialsAccount, tt.configAccountID, tt.keepLocal)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestScan(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -677,7 +677,8 @@ Some configuration is validated at runtime:
 | Error | Cause | Solution |
 |-------|-------|----------|
 | `load config error` | Missing or invalid `clusterData.json` | Check file exists and is valid JSON |
-| `missing required field` | Required field not set | Add `clusterName`, and either mount `/etc/credentials/account` or set `accountID` (unless `keepLocal` is `true`) |
+| `missing required field` | Required field not set | Add `clusterName` |
+| `account identifier error` | No usable account identifier and `keepLocal` is `false` | Mount `/etc/credentials/account`, or set `accountID`/`ACCOUNTID`, or set `keepLocal: true` |
 | `invalid duration` | Invalid `scanTimeout` format | Use format like `5m`, `1h`, `300s` |
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -160,8 +160,12 @@ The main configuration file. All options can be overridden via environment varia
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `accountID` | string | Account identifier for backend services |
 | `clusterName` | string | Name of the Kubernetes cluster |
+
+Unless `keepLocal` is `true`, kubevuln also needs an account identifier for the backend it
+reports to. Prefer `/etc/credentials/account` (see [Credentials Configuration](#credentials-configuration))
+over `accountID` here: `accountID` (and `ACCOUNTID`) is only a fallback, used when the
+credentials file has none. If neither source has one, startup fails.
 
 #### Scanning Options
 
@@ -215,11 +219,11 @@ The main configuration file. All options can be overridden via environment varia
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["accountID", "clusterName"],
+  "required": ["clusterName"],
   "properties": {
     "accountID": {
       "type": "string",
-      "description": "Account identifier"
+      "description": "Account identifier fallback, used only when /etc/credentials/account has none. Not required when that file supplies one, or when keepLocal is true."
     },
     "clusterName": {
       "type": "string",
@@ -404,6 +408,11 @@ Place credentials in `/etc/credentials/`:
 ├── account    # Account ID
 └── accessKey  # Access key for backend authentication
 ```
+
+`account` is the primary source of the account identifier kubevuln reports to the backend
+with; `accountID` in `clusterData.json` (or `ACCOUNTID` in the environment) is only used as
+a fallback when this file has none. Unless `keepLocal` is `true`, one of the two must
+resolve to a non-empty value or startup fails.
 
 ### Registry Credentials
 
@@ -653,8 +662,8 @@ SCANCONCURRENCY=8 CONFIG_DIR=/config ./kubevuln
 Kubevuln validates configuration at startup. Invalid configuration will prevent the service from starting.
 
 Required fields:
-- `accountID` (when `keepLocal` is `false`)
 - `clusterName`
+- an account identifier (when `keepLocal` is `false`): `/etc/credentials/account`, falling back to `accountID`/`ACCOUNTID`
 
 ### Runtime Validation
 
@@ -668,7 +677,7 @@ Some configuration is validated at runtime:
 | Error | Cause | Solution |
 |-------|-------|----------|
 | `load config error` | Missing or invalid `clusterData.json` | Check file exists and is valid JSON |
-| `missing required field` | Required field not set | Add `accountID` and `clusterName` |
+| `missing required field` | Required field not set | Add `clusterName`, and either mount `/etc/credentials/account` or set `accountID` (unless `keepLocal` is `true`) |
 | `invalid duration` | Invalid `scanTimeout` format | Use format like `5m`, `1h`, `300s` |
 
 ---


### PR DESCRIPTION
## Overview

`clusterData.json`'s `accountID` field (and its `ACCOUNTID` env override) is documented in `docs/CONFIGURATION.md` as a required field whose absence "will prevent the service from starting" — but nothing in `cmd/http/main.go` ever reads `Config.AccountID`. The account identifier actually used for every backend report and CVE-exception lookup comes from a completely separate source, `/etc/credentials/account`, and loading *that* is fail-open: `utils.LoadCredentialsFromFile` only errors when both the `accessKey` and `account` files are missing, so a missing/empty `account` file alone returns success with an empty account. kubevuln then starts normally and reports every scan to the backend with an empty `customerGUID`, discoverable only via an Info-level `accountLength=0` log line.

## Root Cause

A historical refactor (`e2b2c6f`, PR #154) moved the real account-identifier source from `clusterData.json` to the mounted credentials file, but left the old config field, its env binding, and its documentation behind as if it still worked. No fail-fast validation was ever added at the credentials-file path that actually matters, so the now-authoritative source degrades silently instead of failing the way the (stale) docs describe.

Notably, #639/#640 previously fixed the *environment-variable binding* for this same `accountID` field (`ACCOUNTID` wasn't reaching the `Config` struct at all), without anyone noticing the struct field is never consumed either way. This PR closes the deeper gap that fix didn't touch.

## Solution

`cmd/http/main.go` now resolves the account identifier through a small, testable function:

```go
func resolveAccountID(credentialsAccount, configAccountID string, keepLocal bool) (string, error)
```

- Prefers `credentialsAccount` (`/etc/credentials/account`).
- Falls back to `configAccountID` (`clusterData.json`'s `accountID` / `ACCOUNTID`) when that's empty — this is what makes the documented config field do something at all.
- Returns an error when `keepLocal` is `false` and neither source produced a value; `main.go` turns that into `logger.L().Ctx(ctx).Fatal(...)` instead of continuing with an empty account, matching the behavior the docs already promise.

`docs/CONFIGURATION.md` is updated to describe this precedence accurately: the required-fields list, the JSON schema (`accountID` is no longer marked `required`, with a description explaining it's a fallback), and the Credentials Configuration section. `README.md` gets a one-line pointer to the current reference doc next to its outdated example, without rewriting that already-stale, out-of-scope section (it predates `CONFIG_DIR` and other current field names).

## Testing

- `TestResolveAccountID` (new, in `cmd/http/main_test.go`, following the existing `TestIsRiskAcceptanceActive` pattern of extracting a small decision function out of `main()` for testability): covers the credentials-file taking precedence, the config-file fallback actually being used, `keepLocal` tolerating no account identifier, and the fail-fast error when neither source has one and `keepLocal` is false.
- `go build ./...` — passes.
- `go vet ./cmd/http/...` — passes.
- `gofmt` — clean.
- `go test -tags dockerfixture ./cmd/...` — passes (`cmd/http`, `cmd/sbom-scanner`), including all new and pre-existing tests.

## Impact

- An operator who sets `accountID`/`ACCOUNTID` (per the previously-inaccurate docs) now gets the behavior they expected: it's used whenever the credentials file doesn't supply one.
- A misconfigured or missing `/etc/credentials/account` on a non-`keepLocal` deployment now fails startup loudly instead of silently sending every backend report with an empty `customerGUID` for the life of the process.

Fixes #957


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Account identification now prioritizes the account value from backend credentials and uses the configured account ID as a fallback.
  - Startup reports an error when no account identifier is available, unless local-only mode is enabled.

- **Documentation**
  - Updated configuration guidance and validation details to reflect the account ID fallback behavior and current required fields.
  - Clarified credential sources, startup validation, and common configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->