### PR TITLE
fix(adapters): detect fix-version format from syft package type, not name

### DIFF
--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -486,13 +486,13 @@ var rpmAlnumSegment = regexp.MustCompile(`[a-zA-Z]+|[0-9]+|~`)
 
 // rpmVersionsDifferOnlyByTrailingZeros reports whether a and b tokenize (by
 // rpmAlnumSegment) to a common prefix followed by one side having extra segments that are
-// all literally "0" -- the shape Grype's compareRpmVersions treats as "equal" instead of
-// "the side with the extra segment is newer." The common prefix is compared as plain
-// strings rather than replicating Grype's own numeric-aware segment comparison (which
-// trims leading zeros before comparing digit runs); a prefix pair that Grype would judge
-// equal but that differs as raw strings (e.g. "01" and "1") is therefore reported as not
-// matching this shape, which only makes this function's caller more conservative, never
-// less -- consistent with rpmSafeToCompare's "skip when unsure" contract.
+// all zero-valued -- the shape Grype's compareRpmVersions treats as "equal" instead of
+// "the side with the extra segment is newer." Both the prefix comparison and the
+// all-zero check are numeric-aware (leading zeros trimmed before comparing digit runs),
+// matching Grype's own segment comparison: a prefix pair Grype would judge numerically
+// equal (e.g. "01" and "1") must be recognized as equal here too, or this shape slips
+// past rpmSafeToCompare's guard as a false negative -- the opposite of "skip when
+// unsure" (#961).
 func rpmVersionsDifferOnlyByTrailingZeros(a, b string) bool {
 	segsA := rpmAlnumSegment.FindAllString(a, -1)
 	segsB := rpmAlnumSegment.FindAllString(b, -1)
@@ -504,16 +504,52 @@ func rpmVersionsDifferOnlyByTrailingZeros(a, b string) bool {
 		shorter, longer = longer, shorter
 	}
 	for i := range shorter {
-		if shorter[i] != longer[i] {
+		if !rpmSegmentsEqual(shorter[i], longer[i]) {
 			return false
 		}
 	}
 	for _, seg := range longer[len(shorter):] {
-		if seg != "0" {
+		if !rpmSegmentIsZero(seg) {
 			return false
 		}
 	}
 	return true
+}
+
+// rpmSegmentsEqual reports whether a and b are the same rpmAlnumSegment token. Digit
+// runs are compared numerically (leading zeros trimmed), since Grype's own tokenizer
+// does the same; a letter run or "~" has no notion of a leading zero and is compared as
+// a plain string.
+func rpmSegmentsEqual(a, b string) bool {
+	na, aIsDigits := trimLeadingZeros(a)
+	nb, bIsDigits := trimLeadingZeros(b)
+	if aIsDigits && bIsDigits {
+		return na == nb
+	}
+	return a == b
+}
+
+// rpmSegmentIsZero reports whether seg is a digit run whose numeric value is zero (e.g.
+// "0" or "00"). A letter run or "~" is never zero-valued.
+func rpmSegmentIsZero(seg string) bool {
+	trimmed, isDigits := trimLeadingZeros(seg)
+	return isDigits && trimmed == "0"
+}
+
+// trimLeadingZeros reports s with its leading zeros stripped (leaving a single "0" for
+// an all-zero run), along with whether s is a run of digits at all. A non-digit s (a
+// letter run, or "~") is returned unchanged with ok false.
+func trimLeadingZeros(s string) (trimmed string, ok bool) {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return s, false
+		}
+	}
+	trimmed = strings.TrimLeft(s, "0")
+	if trimmed == "" {
+		trimmed = "0"
+	}
+	return trimmed, true
 }
 
 func parseLayersPayload(target source.ImageMetadata) (map[string]containerscan.ESLayer, error) {

--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	grypeversion "github.com/anchore/grype/grype/version"
+	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/containerscan"
@@ -289,20 +290,22 @@ func linkToVuln(id string) string {
 // for several maintained branches in any order), so the whole slice must be scanned
 // rather than trusting the first qualifying entry.
 //
-// artifactType selects how versions are compared: apk, deb and rpm package versions
-// (e.g. an epoch-prefixed "1:2.3.4-1", or an Alpine "-r10" release revision) are not
-// semver and are compared with Grype's own format-aware comparator instead - the same
-// one Grype's own presenter uses to sort fix versions (models.NewVulnerability, via
-// sortVersions). Generic semver comparison below is otherwise unchanged for every other
-// ecosystem.
+// artifactType selects how versions are compared: for every ecosystem where Grype
+// itself defines a format-aware comparator distinct from semver - apk, deb, rpm (e.g.
+// an epoch-prefixed "1:2.3.4-1", or an Alpine "-r10" release revision), Maven, Python
+// (PEP 440), RubyGems, Portage, Go modules, Windows KB and Bitnami - versions are
+// compared with that same comparator instead, the one Grype's own presenter uses to
+// sort fix versions (models.NewVulnerability, via sortVersions). Generic semver
+// comparison below is otherwise unchanged for every other ecosystem (npm, NuGet, and
+// the other ecosystems that are already semver or close enough to it).
 //
 // If current is not a version in the chosen comparator, the first entry is returned,
 // since there is nothing to compare against. If current is a version but no entry in
 // versions is greater than it, "" is returned rather than falling back to versions[0];
 // versions[0] could be older than current, which would suggest a downgrade (#844).
 //
-// For a recognized distro ecosystem, current failing to parse under its own comparator
-// never falls through to the semver path below: semver was never meant to parse that
+// For a recognized ecosystem, current failing to parse under its own comparator never
+// falls through to the semver path below: semver was never meant to parse that
 // ecosystem's versions either, and guessing versions[0] through it would reintroduce
 // the same unproven-remediation problem this function exists to avoid, just one layer
 // removed.
@@ -311,7 +314,7 @@ func suggestedVersion(current string, versions []string, artifactType v1beta1.Sy
 		return ""
 	}
 
-	if format, ok := distroPackageVersionFormat(artifactType); ok {
+	if format, ok := versionFormatForArtifact(artifactType); ok {
 		return nearestDistroFix(current, versions, format)
 	}
 
@@ -338,16 +341,47 @@ func suggestedVersion(current string, versions []string, artifactType v1beta1.Sy
 	return nearestStr
 }
 
-// distroPackageVersionFormat reports the Grype version format matching artifactType's
-// own (non-semver) version scheme, for the OS package ecosystems where that scheme is
-// known to disagree with generic semver: an apk/deb/rpm version can carry an epoch
-// prefix that plain semver rejects outright, or a release revision (e.g. "-r10") that
-// semver's prerelease-identifier rules order lexically rather than numerically. Every
-// other ecosystem returns false and keeps using suggestedVersion's semver comparison.
-func distroPackageVersionFormat(artifactType v1beta1.SyftType) (grypeversion.Format, bool) {
-	switch format := grypeversion.ParseFormat(string(artifactType)); format {
-	case grypeversion.ApkFormat, grypeversion.DebFormat, grypeversion.RpmFormat:
-		return format, true
+// versionFormatForArtifact reports the Grype version format matching the ecosystem of
+// the artifact a match was found in, for every ecosystem where Grype defines a
+// format-aware comparator distinct from generic semver. Every other ecosystem returns
+// false and keeps using suggestedVersion's semver comparison.
+//
+// This maps directly from the syft package type on the artifact (see
+// github.com/anchore/syft/syft/pkg.Type), mirroring how Grype's own
+// grype/pkg.VersionFormat resolves a match's comparator, rather than routing
+// artifactType through grypeversion.ParseFormat. ParseFormat matches format *names*
+// ("maven", "go", "kb"), but several syft package types are spelled differently from
+// Grype's own format name for that ecosystem - "java-archive", "go-module", "msrc-kb" -
+// so a name-based lookup silently misses them and falls through to the unguarded
+// semver comparison this function exists to avoid (#960).
+//
+// JVM installations (Grype's JVMFormat) are a metadata-based sub-case of the same
+// java-archive syft type used for ordinary Java library dependencies, distinguished by
+// package metadata that isn't carried on v1beta1.GrypePackage; java-archive is mapped
+// to MavenFormat unconditionally here, which is Grype's own format for the vast
+// majority of java-archive matches.
+func versionFormatForArtifact(artifactType v1beta1.SyftType) (grypeversion.Format, bool) {
+	switch syftPkg.Type(artifactType) {
+	case syftPkg.ApkPkg:
+		return grypeversion.ApkFormat, true
+	case syftPkg.DebPkg:
+		return grypeversion.DebFormat, true
+	case syftPkg.RpmPkg:
+		return grypeversion.RpmFormat, true
+	case syftPkg.JavaPkg:
+		return grypeversion.MavenFormat, true
+	case syftPkg.PythonPkg:
+		return grypeversion.PythonFormat, true
+	case syftPkg.GemPkg:
+		return grypeversion.GemFormat, true
+	case syftPkg.PortagePkg:
+		return grypeversion.PortageFormat, true
+	case syftPkg.GoModulePkg:
+		return grypeversion.GolangFormat, true
+	case syftPkg.KbPkg:
+		return grypeversion.KBFormat, true
+	case syftPkg.BitnamiPkg:
+		return grypeversion.BitnamiFormat, true
 	default:
 		return grypeversion.UnknownFormat, false
 	}

--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -391,8 +392,7 @@ func nearestDistroFix(current string, versions []string, format grypeversion.For
 // rpmSafeToCompare reports whether a and b can be safely ordered by Grype's RPM
 // comparator (github.com/anchore/grype/grype/version, rpmVersion.compare). That
 // comparator is a deliberately pragmatic vulnerability-matching tool, not a spec-compliant
-// one, and two of its shortcuts can turn "not proven to be an upgrade" into "accepted as
-// one":
+// one, and its shortcuts can turn "not proven to be an upgrade" into "accepted as one":
 //
 //  1. It only compares epochs when both sides carry one explicitly, skipping the
 //     comparison entirely otherwise -- rather than treating a missing epoch as 0, which is
@@ -403,17 +403,27 @@ func nearestDistroFix(current string, versions []string, format grypeversion.For
 //     caret is silently dropped and the digits around it are compared as an ordinary
 //     numeric segment, which can rank a caret-tagged snapshot above the release that
 //     actually supersedes it (e.g. "1.0^20250611" over "1.0.1").
+//  3. When one version string tokenizes into strictly more alphanumeric segments than the
+//     other and every extra segment is literally "0", it treats the two versions as equal
+//     and falls through to comparing releases alone -- rather than what real RPM/librpm
+//     does, which is to treat the version with the extra segment as newer regardless of
+//     release. "1.0-1" therefore outranks "1-2" under real RPM (the release never even
+//     gets compared), but Grype calls "1-2" the upgrade.
 //
 // Reimplementing spec-compliant RPM version comparison here would trade one hazard for
 // another -- a hand-rolled comparator error would be just as capable of shipping a wrong
 // remediation. Since suggestedVersion's contract is "never suggest an unproven upgrade,"
-// the conservative answer for either shape is to treat the pair as impossible to order
-// safely, so the caller skips that candidate rather than trusting Grype's relaxed result.
+// the conservative answer for any of these shapes is to treat the pair as impossible to
+// order safely, so the caller skips that candidate rather than trusting Grype's relaxed
+// result.
 func rpmSafeToCompare(a, b string) bool {
 	if strings.Contains(a, "^") || strings.Contains(b, "^") {
 		return false
 	}
-	return rpmHasExplicitEpoch(a) == rpmHasExplicitEpoch(b)
+	if rpmHasExplicitEpoch(a) != rpmHasExplicitEpoch(b) {
+		return false
+	}
+	return !rpmVersionsDifferOnlyByTrailingZeros(rpmVersionPart(a), rpmVersionPart(b))
 }
 
 // rpmHasExplicitEpoch reports whether raw carries an "epoch:" prefix, mirroring how
@@ -421,6 +431,55 @@ func rpmSafeToCompare(a, b string) bool {
 // and treat a first field present as the epoch.
 func rpmHasExplicitEpoch(raw string) bool {
 	return strings.Contains(raw, ":")
+}
+
+// rpmVersionPart returns raw's version component alone -- without any epoch prefix or
+// release suffix -- mirroring how Grype's own rpmVersion parser (newRpmVersion) splits
+// one: strip "epoch:" if present, then take everything before the first "-".
+func rpmVersionPart(raw string) string {
+	if _, after, ok := strings.Cut(raw, ":"); ok {
+		raw = after
+	}
+	version, _, _ := strings.Cut(raw, "-")
+	return version
+}
+
+// rpmAlnumSegment matches the same three token kinds Grype's own RPM version comparator
+// tokenizes a version string into (github.com/anchore/grype/grype/version, alphanumPattern):
+// a run of letters, a run of digits, or a literal "~". Everything else (".", "+", etc.) is a
+// separator and is dropped, exactly as Grype's own FindAllString-based tokenizing drops it.
+var rpmAlnumSegment = regexp.MustCompile(`[a-zA-Z]+|[0-9]+|~`)
+
+// rpmVersionsDifferOnlyByTrailingZeros reports whether a and b tokenize (by
+// rpmAlnumSegment) to a common prefix followed by one side having extra segments that are
+// all literally "0" -- the shape Grype's compareRpmVersions treats as "equal" instead of
+// "the side with the extra segment is newer." The common prefix is compared as plain
+// strings rather than replicating Grype's own numeric-aware segment comparison (which
+// trims leading zeros before comparing digit runs); a prefix pair that Grype would judge
+// equal but that differs as raw strings (e.g. "01" and "1") is therefore reported as not
+// matching this shape, which only makes this function's caller more conservative, never
+// less -- consistent with rpmSafeToCompare's "skip when unsure" contract.
+func rpmVersionsDifferOnlyByTrailingZeros(a, b string) bool {
+	segsA := rpmAlnumSegment.FindAllString(a, -1)
+	segsB := rpmAlnumSegment.FindAllString(b, -1)
+	if len(segsA) == len(segsB) {
+		return false
+	}
+	shorter, longer := segsA, segsB
+	if len(shorter) > len(longer) {
+		shorter, longer = longer, shorter
+	}
+	for i := range shorter {
+		if shorter[i] != longer[i] {
+			return false
+		}
+	}
+	for _, seg := range longer[len(shorter):] {
+		if seg != "0" {
+			return false
+		}
+	}
+	return true
 }
 
 func parseLayersPayload(target source.ImageMetadata) (map[string]containerscan.ESLayer, error) {

--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	grypeversion "github.com/anchore/grype/grype/version"
 	"github.com/anchore/syft/syft/source"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/containerscan"
@@ -287,14 +288,31 @@ func linkToVuln(id string) string {
 // for several maintained branches in any order), so the whole slice must be scanned
 // rather than trusting the first qualifying entry.
 //
-// If current is not a version, the first entry is returned, since there is nothing to
-// compare against. If current is a version but no entry in versions is greater than it,
-// "" is returned rather than falling back to versions[0]; versions[0] could be older
-// than current, which would suggest a downgrade.
-func suggestedVersion(current string, versions []string) string {
+// artifactType selects how versions are compared: apk, deb and rpm package versions
+// (e.g. an epoch-prefixed "1:2.3.4-1", or an Alpine "-r10" release revision) are not
+// semver and are compared with Grype's own format-aware comparator instead - the same
+// one Grype's own presenter uses to sort fix versions (models.NewVulnerability, via
+// sortVersions). Generic semver comparison below is otherwise unchanged for every other
+// ecosystem.
+//
+// If current is not a version in the chosen comparator, the first entry is returned,
+// since there is nothing to compare against. If current is a version but no entry in
+// versions is greater than it, "" is returned rather than falling back to versions[0];
+// versions[0] could be older than current, which would suggest a downgrade (#844).
+func suggestedVersion(current string, versions []string, artifactType v1beta1.SyftType) string {
 	if len(versions) == 0 {
 		return ""
 	}
+
+	if format, ok := distroPackageVersionFormat(artifactType); ok {
+		if v, resolved := nearestDistroFix(current, versions, format); resolved {
+			return v
+		}
+		// current doesn't parse even as its own ecosystem's version, so there is
+		// nothing distro-aware to compare against either; fall through to the
+		// same "nothing to compare against" behaviour as any other unparseable case.
+	}
+
 	c, err := semver.NewVersion(current)
 	if err != nil {
 		return versions[0]
@@ -316,6 +334,51 @@ func suggestedVersion(current string, versions []string) string {
 		}
 	}
 	return nearestStr
+}
+
+// distroPackageVersionFormat reports the Grype version format matching artifactType's
+// own (non-semver) version scheme, for the OS package ecosystems where that scheme is
+// known to disagree with generic semver: an apk/deb/rpm version can carry an epoch
+// prefix that plain semver rejects outright, or a release revision (e.g. "-r10") that
+// semver's prerelease-identifier rules order lexically rather than numerically. Every
+// other ecosystem returns false and keeps using suggestedVersion's semver comparison.
+func distroPackageVersionFormat(artifactType v1beta1.SyftType) (grypeversion.Format, bool) {
+	switch format := grypeversion.ParseFormat(string(artifactType)); format {
+	case grypeversion.ApkFormat, grypeversion.DebFormat, grypeversion.RpmFormat:
+		return format, true
+	default:
+		return grypeversion.UnknownFormat, false
+	}
+}
+
+// nearestDistroFix returns the smallest version in versions that is strictly greater
+// than current, comparing both under format instead of generic semver. The second
+// return value is false only when current itself fails to parse under format, meaning
+// there is nothing to compare against at all; a candidate that fails to parse is simply
+// skipped, same as the semver path.
+func nearestDistroFix(current string, versions []string, format grypeversion.Format) (string, bool) {
+	c := grypeversion.New(current, format)
+	if err := c.Validate(); err != nil {
+		return "", false
+	}
+
+	var nearest *grypeversion.Version
+	var nearestStr string
+	for _, raw := range versions {
+		v := grypeversion.New(raw, format)
+		cmp, err := c.Compare(v)
+		if err != nil || cmp >= 0 {
+			continue
+		}
+		if nearest == nil {
+			nearest, nearestStr = v, raw
+			continue
+		}
+		if nc, err := nearest.Compare(v); err == nil && nc > 0 {
+			nearest, nearestStr = v, raw
+		}
+	}
+	return nearestStr, true
 }
 
 func parseLayersPayload(target source.ImageMetadata) (map[string]containerscan.ESLayer, error) {

--- a/adapters/v1/domain_to_armo.go
+++ b/adapters/v1/domain_to_armo.go
@@ -299,18 +299,19 @@ func linkToVuln(id string) string {
 // since there is nothing to compare against. If current is a version but no entry in
 // versions is greater than it, "" is returned rather than falling back to versions[0];
 // versions[0] could be older than current, which would suggest a downgrade (#844).
+//
+// For a recognized distro ecosystem, current failing to parse under its own comparator
+// never falls through to the semver path below: semver was never meant to parse that
+// ecosystem's versions either, and guessing versions[0] through it would reintroduce
+// the same unproven-remediation problem this function exists to avoid, just one layer
+// removed.
 func suggestedVersion(current string, versions []string, artifactType v1beta1.SyftType) string {
 	if len(versions) == 0 {
 		return ""
 	}
 
 	if format, ok := distroPackageVersionFormat(artifactType); ok {
-		if v, resolved := nearestDistroFix(current, versions, format); resolved {
-			return v
-		}
-		// current doesn't parse even as its own ecosystem's version, so there is
-		// nothing distro-aware to compare against either; fall through to the
-		// same "nothing to compare against" behaviour as any other unparseable case.
+		return nearestDistroFix(current, versions, format)
 	}
 
 	c, err := semver.NewVersion(current)
@@ -352,19 +353,22 @@ func distroPackageVersionFormat(artifactType v1beta1.SyftType) (grypeversion.For
 }
 
 // nearestDistroFix returns the smallest version in versions that is strictly greater
-// than current, comparing both under format instead of generic semver. The second
-// return value is false only when current itself fails to parse under format, meaning
-// there is nothing to compare against at all; a candidate that fails to parse is simply
-// skipped, same as the semver path.
-func nearestDistroFix(current string, versions []string, format grypeversion.Format) (string, bool) {
+// than current, comparing both under format instead of generic semver. "" is returned
+// both when current itself fails to parse under format (nothing to compare against) and
+// when no candidate qualifies; a candidate that fails to parse, or that rpmSafeToCompare
+// rejects, is simply skipped rather than treated as disqualifying the whole result.
+func nearestDistroFix(current string, versions []string, format grypeversion.Format) string {
 	c := grypeversion.New(current, format)
 	if err := c.Validate(); err != nil {
-		return "", false
+		return ""
 	}
 
 	var nearest *grypeversion.Version
 	var nearestStr string
 	for _, raw := range versions {
+		if format == grypeversion.RpmFormat && !rpmSafeToCompare(current, raw) {
+			continue
+		}
 		v := grypeversion.New(raw, format)
 		cmp, err := c.Compare(v)
 		if err != nil || cmp >= 0 {
@@ -374,11 +378,49 @@ func nearestDistroFix(current string, versions []string, format grypeversion.For
 			nearest, nearestStr = v, raw
 			continue
 		}
+		if format == grypeversion.RpmFormat && !rpmSafeToCompare(nearestStr, raw) {
+			continue
+		}
 		if nc, err := nearest.Compare(v); err == nil && nc > 0 {
 			nearest, nearestStr = v, raw
 		}
 	}
-	return nearestStr, true
+	return nearestStr
+}
+
+// rpmSafeToCompare reports whether a and b can be safely ordered by Grype's RPM
+// comparator (github.com/anchore/grype/grype/version, rpmVersion.compare). That
+// comparator is a deliberately pragmatic vulnerability-matching tool, not a spec-compliant
+// one, and two of its shortcuts can turn "not proven to be an upgrade" into "accepted as
+// one":
+//
+//  1. It only compares epochs when both sides carry one explicitly, skipping the
+//     comparison entirely otherwise -- rather than treating a missing epoch as 0, which is
+//     what RPM itself specifies. A current version with an explicit higher epoch (e.g.
+//     "1:0") can therefore be judged older than a candidate that merely omits its epoch
+//     (e.g. "1"), when the candidate is actually the same release or older.
+//  2. Its tokenizer has no notion of "^" (RPM's post-release/snapshot marker) at all: the
+//     caret is silently dropped and the digits around it are compared as an ordinary
+//     numeric segment, which can rank a caret-tagged snapshot above the release that
+//     actually supersedes it (e.g. "1.0^20250611" over "1.0.1").
+//
+// Reimplementing spec-compliant RPM version comparison here would trade one hazard for
+// another -- a hand-rolled comparator error would be just as capable of shipping a wrong
+// remediation. Since suggestedVersion's contract is "never suggest an unproven upgrade,"
+// the conservative answer for either shape is to treat the pair as impossible to order
+// safely, so the caller skips that candidate rather than trusting Grype's relaxed result.
+func rpmSafeToCompare(a, b string) bool {
+	if strings.Contains(a, "^") || strings.Contains(b, "^") {
+		return false
+	}
+	return rpmHasExplicitEpoch(a) == rpmHasExplicitEpoch(b)
+}
+
+// rpmHasExplicitEpoch reports whether raw carries an "epoch:" prefix, mirroring how
+// Grype's own rpmVersion parser (splitEpochFromVersion) detects one: split once on ":"
+// and treat a first field present as the epoch.
+func rpmHasExplicitEpoch(raw string) bool {
+	return strings.Contains(raw, ":")
 }
 
 func parseLayersPayload(target source.ImageMetadata) (map[string]containerscan.ESLayer, error) {

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -559,6 +559,20 @@ func Test_suggestedVersion(t *testing.T) {
 			want:         "1.0-3",
 		},
 		{
+			// #961: same trailing-zero shape as above, but with a leading zero in the
+			// shared prefix ("1.01.0" vs "1.1"). Grype's own comparator trims the
+			// leading zero, judges the two versions equal, and falls through to
+			// comparing releases alone ("-2" over "-1") - exactly the relaxation
+			// rpmSafeToCompare exists to guard against. Before #961's fix to
+			// rpmVersionsDifferOnlyByTrailingZeros, the leading zero defeated the
+			// guard's own shape check, so this candidate was wrongly trusted.
+			name:         "rpm trailing-zero guard is not defeated by a leading zero in the prefix",
+			current:      "1.01.0-1",
+			versions:     []string{"1.1-2"},
+			artifactType: "rpm",
+			want:         "",
+		},
+		{
 			// #960: java-archive (Maven) versions commonly carry a non-numeric
 			// qualifier like "RELEASE" or "Final", which generic semver rejects
 			// outright. Before #960, this fell through to the unguarded semver
@@ -733,6 +747,15 @@ func Test_rpmSafeToCompare(t *testing.T) {
 		{name: "trailing zero version segment, with epoch", a: "1:1.0-1", b: "1:1-2", want: false},
 		{name: "trailing zero version segment, without epoch", a: "1.0-1", b: "1-2", want: false},
 		{name: "matching version shape is unaffected", a: "1.0-1", b: "1.0-3", want: true},
+		{
+			// #961: a leading zero in the shared prefix ("01" vs "1") used to defeat
+			// the trailing-zero shape check by comparing segments as raw strings, so
+			// this pair was (wrongly) judged safe to compare.
+			name: "trailing zero version segment hidden behind a leading zero in the prefix",
+			a:    "1.01.0-1",
+			b:    "1.1-2",
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -754,6 +777,22 @@ func Test_rpmVersionsDifferOnlyByTrailingZeros(t *testing.T) {
 		{name: "common prefix differs", a: "2", b: "1.0", want: false},
 		{name: "equal segment counts", a: "1.0", b: "1.0", want: false},
 		{name: "multiple trailing zero segments", a: "1", b: "1.0.0", want: true},
+		{
+			// A leading zero in the shared prefix ("01" vs "1") must not defeat the
+			// shape check: Grype's own tokenizer trims it and treats the two as the
+			// same digit run, so this function must recognize the shape too, or the
+			// pair slips past rpmSafeToCompare's guard as a false negative.
+			name: "leading zero in the shared prefix is recognized as equal",
+			a:    "1.01.0",
+			b:    "1.1",
+			want: true,
+		},
+		{
+			name: "extra segment with a leading zero is still recognized as zero",
+			a:    "1",
+			b:    "1.00",
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -480,19 +480,79 @@ func Test_suggestedVersion(t *testing.T) {
 			want:         "3.4.7-r10",
 		},
 		{
-			// artifactType alone doesn't force the distro path if the version itself
-			// still fails to parse under it: falls through to the generic "nothing to
-			// compare against" fallback, same as an empty current.
-			name:         "apk artifact with an unparseable current falls back to the first entry",
+			// A recognized distro artifact whose current version fails to parse under its
+			// own ecosystem's comparator must not fall through to semver and guess
+			// versions[0]: semver was never meant to parse an apk version either, and
+			// "not-a-version" gives no proof any of these candidates is actually newer.
+			name:         "apk artifact with an unparseable current returns empty, not the first entry",
 			current:      "not-a-version",
 			versions:     []string{"1.0.0", "2.0.0"},
 			artifactType: "apk",
-			want:         "1.0.0",
+			want:         "",
+		},
+		{
+			// Grype's RPM comparator only compares epochs when both sides carry one
+			// explicitly, instead of treating a missing epoch as 0 per RPM's own spec. A
+			// current version with an explicit higher epoch can therefore be judged older
+			// than a candidate that merely omits its epoch, even though the candidate is
+			// really the same or an older release: "1" compares as newer than "1:0" by
+			// version string alone once epochs are skipped. This must not be trusted as a
+			// real upgrade.
+			name:         "rpm mixed epoch presence is not trusted as an upgrade",
+			current:      "1:0",
+			versions:     []string{"1"},
+			artifactType: "rpm",
+			want:         "",
+		},
+		{
+			// Grype's RPM tokenizer has no notion of "^" (RPM's post-release/snapshot
+			// marker): the caret is dropped and the surrounding digits are compared as an
+			// ordinary numeric segment, so "1.0^20250611" ranks above "1.0.1" even though
+			// RPM itself orders a caret-tagged snapshot below the release that supersedes
+			// it. This must not be trusted as a real upgrade either.
+			name:         "rpm caret release is not trusted as an upgrade",
+			current:      "1.0.1",
+			versions:     []string{"1.0^20250611"},
+			artifactType: "rpm",
+			want:         "",
+		},
+		{
+			// The epoch/caret guards must not reject ordinary RPM comparisons: same
+			// epoch-presence on both sides, no caret, is unaffected.
+			name:         "rpm ordinary comparison is unaffected by the safety guards",
+			current:      "1:1.12.8-25.el8",
+			versions:     []string{"1:1.12.8-27.el8", "1:1.12.8-26.el8"},
+			artifactType: "rpm",
+			want:         "1:1.12.8-26.el8",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, suggestedVersion(tt.current, tt.versions, tt.artifactType))
+		})
+	}
+}
+
+// Test_rpmSafeToCompare exercises the guard in isolation, independent of
+// suggestedVersion's candidate-selection logic.
+func Test_rpmSafeToCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{name: "neither side has an epoch", a: "1.12.8-25.el8", b: "1.12.8-26.el8", want: true},
+		{name: "both sides have an epoch", a: "1:1.12.8-25.el8", b: "1:1.12.8-26.el8", want: true},
+		{name: "a has an epoch, b does not", a: "1:0", b: "1", want: false},
+		{name: "b has an epoch, a does not", a: "1", b: "1:0", want: false},
+		{name: "caret in a", a: "1.0^20250611", b: "1.0.1", want: false},
+		{name: "caret in b", a: "1.0.1", b: "1.0^20250611", want: false},
+		{name: "caret in both", a: "1.0^1", b: "1.0^2", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rpmSafeToCompare(tt.a, tt.b))
 		})
 	}
 }

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -525,6 +525,38 @@ func Test_suggestedVersion(t *testing.T) {
 			artifactType: "rpm",
 			want:         "1:1.12.8-26.el8",
 		},
+		{
+			// Grype's RPM comparator treats "1.0" and "1" as equal versions (an extra
+			// trailing "0" segment is ignored) and falls through to comparing releases
+			// alone, so it calls "1:1-2" newer than "1:1.0-1". Real RPM/librpm does not:
+			// the version with the extra segment ("1.0") outranks the shorter one
+			// regardless of release, so "1:1.0-1" is actually the newer of the two and
+			// "1:1-2" must not be suggested as an upgrade for it.
+			name:         "rpm trailing-zero version segment is not trusted as an upgrade",
+			current:      "1:1.0-1",
+			versions:     []string{"1:1-2"},
+			artifactType: "rpm",
+			want:         "",
+		},
+		{
+			// Same shape without an epoch on either side, confirming the guard applies
+			// independently of rpmHasExplicitEpoch.
+			name:         "rpm trailing-zero version segment without an epoch is not trusted",
+			current:      "1.0-1",
+			versions:     []string{"1-2"},
+			artifactType: "rpm",
+			want:         "",
+		},
+		{
+			// The trailing-zero guard must reject only the candidate with the mismatched
+			// segment count, not the whole comparison: "1.0-3" has the same version shape
+			// as current and is a real, higher release.
+			name:         "rpm trailing-zero guard skips only the mismatched candidate",
+			current:      "1.0-1",
+			versions:     []string{"1-2", "1.0-3"},
+			artifactType: "rpm",
+			want:         "1.0-3",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -549,10 +581,34 @@ func Test_rpmSafeToCompare(t *testing.T) {
 		{name: "caret in a", a: "1.0^20250611", b: "1.0.1", want: false},
 		{name: "caret in b", a: "1.0.1", b: "1.0^20250611", want: false},
 		{name: "caret in both", a: "1.0^1", b: "1.0^2", want: false},
+		{name: "trailing zero version segment, with epoch", a: "1:1.0-1", b: "1:1-2", want: false},
+		{name: "trailing zero version segment, without epoch", a: "1.0-1", b: "1-2", want: false},
+		{name: "matching version shape is unaffected", a: "1.0-1", b: "1.0-3", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, rpmSafeToCompare(tt.a, tt.b))
+		})
+	}
+}
+
+func Test_rpmVersionsDifferOnlyByTrailingZeros(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{name: "b has an extra all-zero segment", a: "1", b: "1.0", want: true},
+		{name: "a has an extra all-zero segment", a: "1.0", b: "1", want: true},
+		{name: "extra segment is non-zero", a: "1", b: "1.1", want: false},
+		{name: "common prefix differs", a: "2", b: "1.0", want: false},
+		{name: "equal segment counts", a: "1.0", b: "1.0", want: false},
+		{name: "multiple trailing zero segments", a: "1", b: "1.0.0", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rpmVersionsDifferOnlyByTrailingZeros(tt.a, tt.b))
 		})
 	}
 }

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -368,10 +368,11 @@ func TestParseImageManifest_IncompleteLayerMetadata(t *testing.T) {
 
 func Test_suggestedVersion(t *testing.T) {
 	tests := []struct {
-		name     string
-		current  string
-		versions []string
-		want     string
+		name         string
+		current      string
+		versions     []string
+		artifactType v1beta1.SyftType
+		want         string
 	}{
 		{
 			name:     "Test with empty versions",
@@ -434,10 +435,64 @@ func Test_suggestedVersion(t *testing.T) {
 			versions: []string{"not-a-version", "also-not-a-version"},
 			want:     "",
 		},
+		{
+			// #955: an epoch-prefixed dpkg/rpm version (e.g. after an epoch bump) is not
+			// valid semver, so it used to fail to parse and fall back to versions[0]
+			// unconditionally - suggesting this very downgrade. Grype's own deb comparator
+			// understands the epoch and must not suggest going backwards.
+			name:         "deb epoch: no version above current returns empty, never a downgrade",
+			current:      "1:1.2.11.dfsg-2ubuntu1.2",
+			versions:     []string{"1:1.2.11.dfsg-2ubuntu1.1"},
+			artifactType: "deb",
+			want:         "",
+		},
+		{
+			name:         "deb epoch: a real newer fix across an epoch is still found",
+			current:      "1:1.2.11.dfsg-2ubuntu1.1",
+			versions:     []string{"1:1.2.11.dfsg-2ubuntu1.3", "1:1.2.11.dfsg-2ubuntu1.2"},
+			artifactType: "deb",
+			want:         "1:1.2.11.dfsg-2ubuntu1.2",
+		},
+		{
+			// rpm versions carry the same epoch:version-release shape as deb.
+			name:         "rpm epoch: no version above current returns empty, never a downgrade",
+			current:      "1:1.12.8-26.el8",
+			versions:     []string{"1:1.12.8-25.el8"},
+			artifactType: "rpm",
+			want:         "",
+		},
+		{
+			// #955: Alpine apk release revisions ("-rN") are numeric, but generic semver
+			// treats them as prerelease identifiers and orders "-r10" before "-r9"
+			// lexically, hiding a real, newer fix. Grype's own apk comparator orders them
+			// numerically.
+			name:         "apk revision: a real newer fix at a two-digit revision is found",
+			current:      "3.4.7-r9",
+			versions:     []string{"3.4.7-r10"},
+			artifactType: "apk",
+			want:         "3.4.7-r10",
+		},
+		{
+			name:         "apk revision: nearest of several revisions is picked, not the first",
+			current:      "3.4.7-r9",
+			versions:     []string{"3.4.7-r99", "3.4.7-r10"},
+			artifactType: "apk",
+			want:         "3.4.7-r10",
+		},
+		{
+			// artifactType alone doesn't force the distro path if the version itself
+			// still fails to parse under it: falls through to the generic "nothing to
+			// compare against" fallback, same as an empty current.
+			name:         "apk artifact with an unparseable current falls back to the first entry",
+			current:      "not-a-version",
+			versions:     []string{"1.0.0", "2.0.0"},
+			artifactType: "apk",
+			want:         "1.0.0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, suggestedVersion(tt.current, tt.versions))
+			assert.Equal(t, tt.want, suggestedVersion(tt.current, tt.versions, tt.artifactType))
 		})
 	}
 }

--- a/adapters/v1/domain_to_armo_test.go
+++ b/adapters/v1/domain_to_armo_test.go
@@ -8,6 +8,7 @@ import (
 
 	containerRegistryV1 "github.com/google/go-containerregistry/pkg/v1"
 
+	grypeversion "github.com/anchore/grype/grype/version"
 	"github.com/anchore/syft/syft/source"
 	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/armoapi-go/containerscan"
@@ -557,10 +558,158 @@ func Test_suggestedVersion(t *testing.T) {
 			artifactType: "rpm",
 			want:         "1.0-3",
 		},
+		{
+			// #960: java-archive (Maven) versions commonly carry a non-numeric
+			// qualifier like "RELEASE" or "Final", which generic semver rejects
+			// outright. Before #960, this fell through to the unguarded semver
+			// fallback and returned versions[0] regardless of order - a possible
+			// downgrade. Grype's own Maven comparator understands the qualifier.
+			name:         "java-archive: a real newer fix is found despite a non-semver qualifier",
+			current:      "5.3.21.RELEASE",
+			versions:     []string{"5.3.20.RELEASE", "5.3.25.RELEASE"},
+			artifactType: "java-archive",
+			want:         "5.3.25.RELEASE",
+		},
+		{
+			name:         "java-archive: no version above current returns empty, never a downgrade",
+			current:      "5.3.25.RELEASE",
+			versions:     []string{"5.3.20.RELEASE", "5.3.21.RELEASE"},
+			artifactType: "java-archive",
+			want:         "",
+		},
+		{
+			// #960: PEP 440 pre/post-release suffixes ("rc1", ".post1") aren't valid
+			// semver either.
+			name:         "python: a real newer fix is found despite a PEP 440 pre-release suffix",
+			current:      "1.2.3rc1",
+			versions:     []string{"1.2.0", "1.2.3"},
+			artifactType: "python",
+			want:         "1.2.3",
+		},
+		{
+			name:         "python: no version above current returns empty, never a downgrade",
+			current:      "2.0.0.post1",
+			versions:     []string{"1.9.0", "2.0.0"},
+			artifactType: "python",
+			want:         "",
+		},
+		{
+			// #960: RubyGems pre-release suffixes ("pre1") aren't valid semver either.
+			name:         "gem: a real newer fix is found despite a non-semver pre-release suffix",
+			current:      "1.2.3.pre1",
+			versions:     []string{"1.2.0", "1.2.3"},
+			artifactType: "gem",
+			want:         "1.2.3",
+		},
+		{
+			// #960: Gentoo/Portage "-rN" revisions are numeric, but generic semver
+			// treats them as prerelease identifiers ordered lexically, the same
+			// class of bug #955 fixed for apk's "-rN" revisions.
+			name:         "portage: a real newer fix at a higher revision is found",
+			current:      "1.2.3-r1",
+			versions:     []string{"1.2.3-r0", "1.2.3-r2"},
+			artifactType: "portage",
+			want:         "1.2.3-r2",
+		},
+		{
+			// #960: syft reports Go modules as "go-module", which does not match
+			// grypeversion.ParseFormat's "go"/"golang" name-based cases - the exact
+			// mismatch that left this ecosystem on the unguarded semver fallback.
+			name:         "go-module: a real newer fix is found",
+			current:      "v1.2.3",
+			versions:     []string{"v1.2.0", "v1.2.4"},
+			artifactType: "go-module",
+			want:         "v1.2.4",
+		},
+		{
+			// #960: Bitnami packages append a package-only revision after the
+			// upstream version (e.g. "-1", "-2") that never addresses a
+			// vulnerability by itself, since it repackages the exact same upstream
+			// source; Grype's own Bitnami comparator deliberately ignores it, so a
+			// revision-only difference must not be suggested as a fix.
+			name:         "bitnami: a revision-only difference is not trusted as an upgrade",
+			current:      "1.2.3-1",
+			versions:     []string{"1.2.3-2"},
+			artifactType: "bitnami",
+			want:         "",
+		},
+		{
+			// #960: syft reports Windows updates as "msrc-kb", which does not match
+			// grypeversion.ParseFormat's "kb" case. Grype's own KB comparator only
+			// supports exact-match identity (KB numbers aren't sequential, so a
+			// larger number is not a "newer" one) - it can never prove a candidate
+			// is an upgrade, so no version is ever suggested for this ecosystem.
+			name:         "msrc-kb: never suggests a fix, since KB numbers cannot be ordered",
+			current:      "5028185",
+			versions:     []string{"5028184", "5028186"},
+			artifactType: "msrc-kb",
+			want:         "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, suggestedVersion(tt.current, tt.versions, tt.artifactType))
+		})
+	}
+}
+
+func Test_versionFormatForArtifact(t *testing.T) {
+	tests := []struct {
+		name         string
+		artifactType v1beta1.SyftType
+		wantFormat   grypeversion.Format
+		wantOk       bool
+	}{
+		{name: "apk", artifactType: "apk", wantFormat: grypeversion.ApkFormat, wantOk: true},
+		{name: "deb", artifactType: "deb", wantFormat: grypeversion.DebFormat, wantOk: true},
+		{name: "rpm", artifactType: "rpm", wantFormat: grypeversion.RpmFormat, wantOk: true},
+		{
+			// #960: this is the syft type string for ordinary Java library
+			// dependencies. It does not match grypeversion.ParseFormat's "maven"
+			// case, which is why routing through ParseFormat missed it entirely.
+			name:         "java-archive maps to Maven",
+			artifactType: "java-archive",
+			wantFormat:   grypeversion.MavenFormat,
+			wantOk:       true,
+		},
+		{name: "python maps to Python (PEP 440)", artifactType: "python", wantFormat: grypeversion.PythonFormat, wantOk: true},
+		{name: "gem maps to Gem", artifactType: "gem", wantFormat: grypeversion.GemFormat, wantOk: true},
+		{name: "portage maps to Portage", artifactType: "portage", wantFormat: grypeversion.PortageFormat, wantOk: true},
+		{
+			// #960: this is the syft type string for Go modules. It does not match
+			// grypeversion.ParseFormat's "go"/"golang" case either.
+			name:         "go-module maps to Golang",
+			artifactType: "go-module",
+			wantFormat:   grypeversion.GolangFormat,
+			wantOk:       true,
+		},
+		{
+			// #960: this is the syft type string for Windows updates. It does not
+			// match grypeversion.ParseFormat's "kb" case.
+			name:         "msrc-kb maps to KB",
+			artifactType: "msrc-kb",
+			wantFormat:   grypeversion.KBFormat,
+			wantOk:       true,
+		},
+		{name: "bitnami maps to Bitnami", artifactType: "bitnami", wantFormat: grypeversion.BitnamiFormat, wantOk: true},
+		{
+			name:         "an ecosystem with no dedicated Grype comparator falls back to semver",
+			artifactType: "npm",
+			wantFormat:   grypeversion.UnknownFormat,
+			wantOk:       false,
+		},
+		{
+			name:         "empty artifact type falls back to semver",
+			artifactType: "",
+			wantFormat:   grypeversion.UnknownFormat,
+			wantOk:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, ok := versionFormatForArtifact(tt.artifactType)
+			assert.Equal(t, tt.wantFormat, format)
+			assert.Equal(t, tt.wantOk, ok)
 		})
 	}
 }

--- a/adapters/v1/fixstate.go
+++ b/adapters/v1/fixstate.go
@@ -38,7 +38,7 @@ func hasKnownFix(m v1beta1.Match) (bool, string) {
 		// "no fix" one, and reporting it as "unknown" is what keeps the two meanings
 		// apart: an empty version here would say no fix is known, which is the opposite
 		// of the true this returns alongside it. See #858.
-		if v := suggestedVersion(m.Artifact.Version, m.Vulnerability.Fix.Versions); v != "" {
+		if v := suggestedVersion(m.Artifact.Version, m.Vulnerability.Fix.Versions, m.Artifact.Type); v != "" {
 			return true, v
 		}
 		return true, unknownFixVersion

--- a/adapters/v1/fixstate_test.go
+++ b/adapters/v1/fixstate_test.go
@@ -97,6 +97,30 @@ func TestHasKnownFix(t *testing.T) {
 			wantVersion: unknownFixVersion,
 		},
 		{
+			// #955: a deb package's installed version carries an epoch after a bump
+			// (e.g. util-linux, iptables), which is not valid semver. Before the fix,
+			// this fell through to an unguarded versions[0] and could suggest the very
+			// downgrade #844 was meant to prevent.
+			name: "deb epoch version reports unknown, never a downgrade",
+			match: v1beta1.Match{
+				Artifact:      v1beta1.GrypePackage{Version: "1:1.2.11.dfsg-2ubuntu1.2", Type: "deb"},
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed, Versions: []string{"1:1.2.11.dfsg-2ubuntu1.1"}}},
+			},
+			wantFixed:   true,
+			wantVersion: unknownFixVersion,
+		},
+		{
+			// #955: Alpine two-digit release revisions sort lexically under generic
+			// semver ("-r10" < "-r9"), hiding a real, newer fix.
+			name: "apk revision picks the real newer fix, not unknown",
+			match: v1beta1.Match{
+				Artifact:      v1beta1.GrypePackage{Version: "3.4.7-r9", Type: "apk"},
+				Vulnerability: v1beta1.Vulnerability{Fix: v1beta1.Fix{State: fixStateFixed, Versions: []string{"3.4.7-r10"}}},
+			},
+			wantFixed:   true,
+			wantVersion: "3.4.7-r10",
+		},
+		{
 			// The #449 shape: Grype reports no fix, but the CPE range is bounded above.
 			name: "upper-bounded CPE constraint implies a fix",
 			match: v1beta1.Match{


### PR DESCRIPTION
## Problem

`suggestedVersion` (`adapters/v1/domain_to_armo.go`) picks the nearest fix version above the installed one, using Grype's own format-aware comparator instead of generic semver for ecosystems where that matters. Before this change, that special-casing only covered apk/deb/rpm (`distroPackageVersionFormat`). Every other ecosystem Grype itself defines a dedicated, non-semver comparator for - Maven/Java, Python (PEP 440), RubyGems, Portage, Go modules, Windows KB, and Bitnami - fell through to the generic `Masterminds/semver` fallback that #845/#858/#955 already proved unsafe: a version that fails to parse as semver returns `versions[0]` unconditionally, with no check that it's actually newer than what's installed.

Real version strings from these ecosystems fail semver parsing outright (e.g. Maven `"5.3.21.RELEASE"`, Python `"1.2.3rc1"`, RubyGems `"1.2.3.pre1"`), so any vulnerable Java, Python, or Ruby package with such a version could have an older, still-vulnerable release suggested as "the fix."

## Root cause

`distroPackageVersionFormat` derived the `grypeversion.Format` by string-matching `m.Artifact.Type` (a syft package-type string) against `grypeversion.ParseFormat`'s format-name case labels. That happens to work for apk/deb/rpm/python/gem/portage/bitnami, where the syft type string and Grype's format name coincide, but not for:

- Java: syft reports `"java-archive"`, not `"maven"`.
- Go modules: syft reports `"go-module"`, not `"go"`/`"golang"`.
- Windows updates: syft reports `"msrc-kb"`, not `"kb"`.

So even adding the missing `grypeversion.Format` cases to the old switch would not have covered Java, Go, or Windows KB packages - the format still wouldn't be detected for them.

## Fix

Replace the name-based lookup with a direct mapping from the syft package type to `grypeversion.Format`, mirroring how Grype's own `grype/pkg.VersionFormat` resolves a match's comparator (switching on the same `syft/pkg.Type` constants). This is renamed to `versionFormatForArtifact` since it's no longer limited to OS-distro packages.

`nearestDistroFix` (the comparison loop that actually does the "is this really newer?" check) needed no changes - it already dispatches generically on `grypeversion.Format` via `grypeversion.New(...).Compare()`, so extending format *detection* is the whole fix.

One deliberate scope limit: JVM installations (`grypeversion.JVMFormat`) are a metadata-based sub-case of the same `java-archive` syft type used for ordinary Java library dependencies, distinguished by package metadata that isn't carried on `v1beta1.GrypePackage`. `java-archive` is mapped to `MavenFormat` unconditionally, which is Grype's own format for the large majority of `java-archive` matches; detecting the narrower JVM-installation case would require a signature this type doesn't expose today, so it's left as-is (falls back to semver, same as before this PR).

## Testing

- Added table-driven cases to `Test_suggestedVersion` for each newly-covered ecosystem (Maven/`java-archive`, Python, RubyGems, Portage, Go modules, Bitnami, Windows KB), each exercising a version string that fails generic semver parsing and confirming no downgrade is suggested when there's nothing to prove is an upgrade.
- Added `Test_versionFormatForArtifact` covering every mapped syft type - including the three that previously mismatched (`java-archive`, `go-module`, `msrc-kb`) - plus the semver-fallback case for an unmapped/empty type.
- Verified independently (outside the test suite) that Grype's own comparators for Maven/Python/Gem/Portage/Golang order these representative version strings correctly, that its Bitnami comparator intentionally ignores revision-only differences (a Bitnami package revision reuses the same upstream source, so it can't itself fix a vulnerability), and that its KB comparator only supports exact-match identity (KB numbers aren't sequential, so no ordering can be proven) - which is why the KB test case expects no suggestion rather than a guessed one.
- `go build ./adapters/...`, `go vet ./adapters/v1/...`, and `go test ./adapters/v1/...` all pass locally, including every pre-existing test in the package.

## Impact

Correct, non-downgrading fix-version suggestions for Java, Python, RubyGems, Portage, Go module, and Bitnami package matches in both the backend vulnerability report (`DomainToArmo`) and, via `hasKnownFix`, the in-cluster `VulnerabilityManifest`/`ExpiredOnFix` exception logic. Windows KB matches now correctly report "a fix exists, but no specific version can be proven" instead of a numerically-guessed KB number that has no real ordering meaning.

Fixes #960

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability fix version detection across Debian, RPM, Alpine, Maven, Python, RubyGems, Go modules, Windows updates, Bitnami, Portage, and JVM packages.
  * Correctly handles epochs, release revisions, trailing zeros, and other ecosystem-specific version formats.
  * Prevents malformed or incomparable versions from being suggested as valid fixes.
  * More reliably identifies newer Alpine revisions and reports unknown fixes when no safe comparison is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->