### PR TITLE
fix(sbomscanner): remove file catalogers from the sidecar's Syft config

### DIFF
--- a/adapters/v1/syft.go
+++ b/adapters/v1/syft.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DmitriyVTitov/size"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
-	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	sbomcataloger "github.com/anchore/syft/syft/pkg/cataloger/sbom"
 	"github.com/anchore/syft/syft/sbom"
@@ -405,16 +404,9 @@ func (s *SyftAdapter) CreateSBOM(ctx context.Context, name, imageID, imageTag st
 		// generate SBOM
 		logger.L().Debug("generating SBOM",
 			helpers.String("imageID", imageID))
-		cfg := syft.DefaultCreateSBOMConfig()
+		cfg := syftsource.NewCreateSBOMConfig()
 		cfg.ToolName = "syft"
 		cfg.ToolVersion = s.Version()
-		cfg = cfg.WithCatalogerSelection(
-			cataloging.NewSelectionRequest().WithRemovals(
-				"file-digest-cataloger",
-				"file-metadata-cataloger",
-				"file-executable-cataloger",
-			),
-		)
 		if s.scanEmbeddedSBOMs {
 			// ask Syft to also scan the image for embedded SBOMs
 			cfg.WithCatalogers(pkgcataloging.NewCatalogerReference(sbomcataloger.NewCataloger(), []string{pkgcataloging.ImageTag}))

--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -1005,6 +1005,78 @@ func Test_syftAdapter_CreateSBOM_Retry429RateLimit(t *testing.T) {
 	mu.Unlock()
 }
 
+// Test_syftAdapter_CreateSBOM_UsesSharedCatalogerSelection pins #962: the in-process adapter
+// must build its Syft config through syftsource.NewCreateSBOMConfig(), the same constructor
+// the sidecar's scannerServer uses, so the three file-walking catalogers #355 removed for
+// their peak-RSS cost stay removed on both SBOM paths.
+func Test_syftAdapter_CreateSBOM_UsesSharedCatalogerSelection(t *testing.T) {
+	layer := &bytes.Buffer{}
+	gz := gzip.NewWriter(layer)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "etc/hostname", Mode: 0o644, Size: 4}))
+	_, err := tw.Write([]byte("test"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	layerBytes := layer.Bytes()
+	layerHash := fmt.Sprintf("%x", sha256.Sum256(layerBytes))
+
+	uncompressed := &bytes.Buffer{}
+	zr, err := gzip.NewReader(bytes.NewReader(layerBytes))
+	require.NoError(t, err)
+	_, err = io.Copy(uncompressed, zr)
+	require.NoError(t, err)
+	diffID := fmt.Sprintf("%x", sha256.Sum256(uncompressed.Bytes()))
+
+	configBytes := []byte(fmt.Sprintf(
+		`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%s"]}}`, diffID))
+	configHash := fmt.Sprintf("%x", sha256.Sum256(configBytes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test-image-catalogers/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"schemaVersion": 2,
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": %d, "digest": "sha256:%s"},
+				"layers": [{"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip", "size": %d, "digest": "sha256:%s"}]
+			}`, len(configBytes), configHash, len(layerBytes), layerHash)))
+		case "/v2/test-image-catalogers/blobs/sha256:" + configHash:
+			_, _ = w.Write(configBytes)
+		case "/v2/test-image-catalogers/blobs/sha256:" + layerHash:
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	var gotCfg *syft.CreateSBOMConfig
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		gotCfg = cfg
+		return &sbom.SBOM{}, nil
+	})
+
+	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil).WithCataloger(cataloger)
+	_, err = adapter.CreateSBOM(context.Background(), "test", "", u.Host+"/test-image-catalogers:latest", domain.RegistryOptions{InsecureUseHTTP: true})
+	require.NoError(t, err)
+
+	require.NotNil(t, gotCfg)
+	assert.ElementsMatch(t, []string{
+		"file-digest-cataloger",
+		"file-metadata-cataloger",
+		"file-executable-cataloger",
+	}, gotCfg.CatalogerSelection.RemoveNamesOrTags)
+}
+
 func Test_SyftAdapter_WithCataloger(t *testing.T) {
 	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
 	assert.IsType(t, syftsource.DefaultSBOMCataloger{}, adapter.cataloger)

--- a/internal/syftsource/syftsource.go
+++ b/internal/syftsource/syftsource.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging"
 )
 
 // FormatResolvedPlatform builds an OCI-style "os/arch[/variant]" string from the platform
@@ -72,4 +73,20 @@ func GetSourceConfig(registryOptions *image.RegistryOptions, platform *image.Pla
 		WithRegistryOptions(registryOptions).
 		WithPlatform(platform).
 		WithSources("registry")
+}
+
+// NewCreateSBOMConfig builds the syft.CreateSBOMConfig both SBOM paths start from. It removes
+// file-digest-cataloger, file-metadata-cataloger and file-executable-cataloger: default-enabled
+// Syft tasks that walk and hash every file in the scanned image's filesystem, dominating
+// transient allocation, whose output is not consumed anywhere downstream of SBOM generation
+// (#355). Both paths must build their config through this helper rather than calling
+// syft.DefaultCreateSBOMConfig() directly, so they cannot silently diverge on this again (#962).
+func NewCreateSBOMConfig() *syft.CreateSBOMConfig {
+	return syft.DefaultCreateSBOMConfig().WithCatalogerSelection(
+		cataloging.NewSelectionRequest().WithRemovals(
+			"file-digest-cataloger",
+			"file-metadata-cataloger",
+			"file-executable-cataloger",
+		),
+	)
 }

--- a/internal/syftsource/syftsource_test.go
+++ b/internal/syftsource/syftsource_test.go
@@ -88,6 +88,22 @@ func TestGetSourceConfig_restrictsToRegistry(t *testing.T) {
 		"kubevuln always pulls; falling back to a local daemon or containerd socket is not wanted")
 }
 
+// TestNewCreateSBOMConfig_RemovesFileCatalogers pins the memory-reduction fix from #355
+// (~500MB peak RSS on a real workload) to the one config constructor both SBOM paths must
+// share, so the sidecar can no longer drift from the in-process adapter and reintroduce it
+// (#962). These three catalogers walk and hash every file in the scanned image and are
+// enabled by default in syft.DefaultCreateSBOMConfig(); their output is not consumed
+// anywhere downstream of SBOM generation.
+func TestNewCreateSBOMConfig_RemovesFileCatalogers(t *testing.T) {
+	cfg := NewCreateSBOMConfig()
+	require.NotNil(t, cfg)
+	assert.ElementsMatch(t, []string{
+		"file-digest-cataloger",
+		"file-metadata-cataloger",
+		"file-executable-cataloger",
+	}, cfg.CatalogerSelection.RemoveNamesOrTags)
+}
+
 // TestIsPlatformMismatch pins what counts as a platform mismatch for both SBOM paths.
 // The "unrelated error" case is the one that matters: classification is by typed error,
 // so an error that merely mentions the phrase must not be treated as one.

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -250,7 +250,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 		}(src)
 
 		logger.L().Debug("generating SBOM", helpers.String("imageID", imageID))
-		cfg := syft.DefaultCreateSBOMConfig()
+		cfg := syftsource.NewCreateSBOMConfig()
 		cfg.ToolName = "syft"
 		cfg.ToolVersion = s.version
 		if req.EnableEmbeddedSboms {

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -941,6 +941,76 @@ func TestCreateSBOM_Exhausted429RateLimitFromCataloger(t *testing.T) {
 	assert.Equal(t, domain.ReasonTooManyRequests, resp.StatusReason)
 }
 
+// TestCreateSBOM_UsesSharedCatalogerSelection pins #962: the sidecar must build its Syft
+// config through syftsource.NewCreateSBOMConfig(), the same constructor the in-process
+// SyftAdapter uses, so the three file-walking catalogers #355 removed for their peak-RSS
+// cost stay removed on both SBOM paths. It fails if server.go ever goes back to calling
+// syft.DefaultCreateSBOMConfig() directly, the way it silently diverged from the adapter
+// before this fix.
+func TestCreateSBOM_UsesSharedCatalogerSelection(t *testing.T) {
+	layerBytes, layerHash, diffId, err := makeDummyTarGz(64)
+	require.NoError(t, err)
+
+	configPayload := fmt.Sprintf(`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%s"]}}`, diffId)
+	configBytes := []byte(configPayload)
+	configHash := fmt.Sprintf("%x", sha256.Sum256(configBytes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test-image-catalogers/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"schemaVersion": 2,
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": %d, "digest": "sha256:%s"},
+				"layers": [{"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip", "size": %d, "digest": "sha256:%s"}]
+			}`, len(configBytes), configHash, len(layerBytes), layerHash)))
+		case fmt.Sprintf("/v2/test-image-catalogers/blobs/sha256:%s", configHash):
+			_, _ = w.Write(configBytes)
+		case fmt.Sprintf("/v2/test-image-catalogers/blobs/sha256:%s", layerHash):
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	var gotCfg *syft.CreateSBOMConfig
+	cataloger := syftsource.SBOMCatalogerFunc(func(_ context.Context, _ source.Source, cfg *syft.CreateSBOMConfig) (*sbom.SBOM, error) {
+		gotCfg = cfg
+		return &sbom.SBOM{}, nil
+	})
+
+	client, cleanup := startTestServer(t, WithCataloger(cataloger))
+	defer cleanup()
+
+	resp, err := client.CreateSBOM(context.Background(), &pb.CreateSBOMRequest{
+		ImageId:         u.Host + "/test-image-catalogers",
+		ImageTag:        u.Host + "/test-image-catalogers:latest",
+		Platform:        "linux/amd64",
+		MaxImageSize:    1 << 30,
+		MaxSbomSize:     1 << 30,
+		TimeoutSeconds:  30,
+		InsecureUseHttp: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Empty(t, resp.ErrorMessage)
+
+	require.NotNil(t, gotCfg)
+	assert.ElementsMatch(t, []string{
+		"file-digest-cataloger",
+		"file-metadata-cataloger",
+		"file-executable-cataloger",
+	}, gotCfg.CatalogerSelection.RemoveNamesOrTags)
+}
+
 func TestCreateSBOM_Exhausted429RateLimitFromResolveSource(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)


### PR DESCRIPTION
## Problem

kubevuln generates SBOMs through two interchangeable backends: `adapters/v1.SyftAdapter` (in-process) or `pkg/sbomscanner/v1.scannerServer` (a separate `sbom-scanner` sidecar over gRPC). They're documented as producing equivalent SBOMs.

`SyftAdapter.CreateSBOM` explicitly removes three default-enabled Syft catalogers before building the SBOM:

```go
cfg = cfg.WithCatalogerSelection(
    cataloging.NewSelectionRequest().WithRemovals(
        "file-digest-cataloger",
        "file-metadata-cataloger",
        "file-executable-cataloger",
    ),
)
```

`scannerServer.CreateSBOM` (the sidecar's equivalent) never applied the same removal — it called `syft.DefaultCreateSBOMConfig()` directly with no cataloger selection at all.

## Root cause

PR #355 added this removal to cut peak RSS (measured ~500MB reduction on a real workload; these catalogers walk and hash every file in the image and their output isn't used anywhere downstream of SBOM generation), but only touched the in-process adapter. The sidecar's `CreateSBOM` was already a separate implementation of "build a Syft config and call `CreateSBOM`" at the time, and nothing kept the two configs in sync — no shared helper, no test asserting parity — so it silently continued running all three.

## Impact

- **Undermines the sidecar's own purpose.** The sidecar exists specifically to isolate Syft's memory-hungry cataloging into a separately resource-limited container; running these catalogers there reintroduces the peak-RSS increase #355 fixed, in the exact place most likely to OOM from it.
- **Mode-dependent scan outcome for the same image.** `maxSBOMSize` compares `size.Of(syftSBOM)` against a fixed limit after generation. A sidecar-generated SBOM carries extra `files[].digests`/metadata/executable data the in-process one strips, so the same image can be classified `TooLarge` under one backend and not the other, purely based on which one ran it — breaking `maxSBOMSize`'s documented backend-independence.
- **Needlessly larger stored SBOM objects** for sidecar-mode users (inflating `SBOMSyft`/`SBOMSyftFiltered` CRD size in etcd/API server) for data that's never read back.

## Fix

Factored the cataloger removal into `syftsource.NewCreateSBOMConfig()`, alongside the other Syft config helpers both paths already share (`GetSourceConfig`, `ParsePlatform`). Both `SyftAdapter.CreateSBOM` and `scannerServer.CreateSBOM` now build their config through this one helper instead of calling `syft.DefaultCreateSBOMConfig()` directly, so they're compile-time incapable of drifting apart on this again. No change to `EnableEmbeddedSboms` handling or any other existing config option.

## Testing

- `internal/syftsource/syftsource_test.go`: `TestNewCreateSBOMConfig_RemovesFileCatalogers` pins the three removals on the shared constructor directly.
- `adapters/v1/syft_test.go`: `Test_syftAdapter_CreateSBOM_UsesSharedCatalogerSelection` runs `CreateSBOM` against a local httptest registry, captures the config actually handed to the cataloger via a stand-in `SBOMCataloger`, and asserts the removals.
- `pkg/sbomscanner/v1/server_test.go`: `TestCreateSBOM_UsesSharedCatalogerSelection` does the same for the sidecar's gRPC server.
- `go build ./...`, `go vet`, and the full test suite for all three touched packages pass. One pre-existing test (`TestCreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft`, a fixed-sleep timing test unrelated to this change) is flaky under full-suite contention on this machine but passes reliably in isolation — confirmed unaffected by this diff.

Fixes #962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - SBOM generation now consistently excludes file digest, metadata, and executable catalogers across supported scanning paths.
  - This may reduce file-level cataloging details in generated SBOMs while aligning results between integrated and sidecar-based scanning.

- **Tests**
  - Added coverage to verify that both scanning paths apply the same cataloger selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->