### PR TITLE
fix(docs): correct the multi-arch no-platform fallback claim

### DIFF
--- a/adapters/v1/syft_test.go
+++ b/adapters/v1/syft_test.go
@@ -930,6 +930,29 @@ func Test_syftAdapter_CreateSBOM_MultiArchLocalRegistry(t *testing.T) {
 	}
 }
 
+// Test_syftAdapter_CreateSBOM_MultiArchNoPlatformResolvesHostArch pins #966: with no platform
+// requested against a genuine multi-arch manifest list, stereoscope's registry provider
+// (defaultPlatformIfNil/finalizePlatform in github.com/anchore/stereoscope/pkg/image/oci)
+// silently resolves the variant matching the scanning process's own architecture - here,
+// whichever of amd64/arm64 the test happens to run on - not "whatever the manifest provides"
+// as docs/API.md incorrectly claimed before #966. This is the opposite of what an operator
+// relying on the previous documentation would expect for a pod-less scan (registry rescan,
+// periodic CRD-based rescan) that has no node context and so always leaves platform unset.
+func Test_syftAdapter_CreateSBOM_MultiArchNoPlatformResolvesHostArch(t *testing.T) {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		t.Skipf("mockMultiArchRegistry only serves amd64/arm64 variants, host is %s", runtime.GOARCH)
+	}
+	host := mockMultiArchRegistry(t)
+
+	adapter := NewSyftAdapter(10*time.Second, 100*1024*1024, 10*1024*1024, false, nil)
+	domainSBOM, err := adapter.CreateSBOM(context.Background(), "test", "", host+"/test-image:latest",
+		domain.RegistryOptions{InsecureUseHTTP: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, "linux/"+runtime.GOARCH, domainSBOM.Annotations[domain.ResolvedPlatformAnnotationKey],
+		"with no platform requested, a multi-arch manifest list resolves to the scanning host's own arch, not the manifest's default")
+}
+
 func Test_syftAdapter_CreateSBOM_Retry429RateLimit(t *testing.T) {
 	var attempts int
 	var mu sync.Mutex

--- a/core/domain/sbom.go
+++ b/core/domain/sbom.go
@@ -11,9 +11,11 @@ const (
 	ScannerMemoryLimitAnnotationKey = "kubescape.io/scanner-memory-limit"
 	// ResolvedPlatformAnnotationKey records the OCI platform ("os/arch[/variant]") that was
 	// actually used to resolve the scanned image, regardless of whether the caller requested
-	// one explicitly (RegistryOptions.Platform) or left it empty and let the adapter fall back
-	// to whatever the image manifest provides. Set by both SBOM adapters on success so a
-	// silently-wrong-arch SBOM is inspectable after the fact (see #512).
+	// one explicitly (RegistryOptions.Platform) or left it empty. Left empty against a
+	// single-arch image, resolution reflects the manifest; against a genuine multi-arch
+	// manifest list, it instead resolves to the scanning process's own architecture, silently
+	// (#966). Set by both SBOM adapters on success so a silently-wrong-arch SBOM is
+	// inspectable after the fact (see #512).
 	ResolvedPlatformAnnotationKey = "kubescape.io/resolved-platform"
 
 	ReasonImageTooLarge    = "image-too-large"

--- a/core/domain/scan.go
+++ b/core/domain/scan.go
@@ -13,8 +13,10 @@ const (
 	// ArgsPlatform lets a caller request a specific image platform (OCI "os/arch[/variant]",
 	// or a bare arch such as "arm64") for SBOM generation, e.g. an operator populating it from
 	// the scanned Pod's node architecture. Read via optionsFromWorkload into
-	// RegistryOptions.Platform. Left unset, both SBOM adapters resolve whatever platform the
-	// image manifest provides instead of forcing one (see #512).
+	// RegistryOptions.Platform. Left unset against a single-arch image, both SBOM adapters
+	// resolve whatever the manifest provides (see #512); against a genuine multi-arch
+	// manifest list, they instead resolve to the scanning process's own architecture,
+	// silently (see #966).
 	ArgsPlatform           = "platform"
 	AttributeUseHTTP       = identifiers.AttributeUseHTTP
 	AttributeSkipTLSVerify = identifiers.AttributeSkipTLSVerify

--- a/docs/API.md
+++ b/docs/API.md
@@ -656,8 +656,11 @@ curl -X POST http://localhost:8080/v1/scanRegistryImage \
 
 For multi-arch images, request a specific OS/architecture (OCI format `os/arch[/variant]`, or a
 bare arch such as `arm64`) via the `platform` arg. An operator can populate this from the scanned
-Pod's node architecture; left unset, kubevuln resolves whatever platform the image manifest
-provides instead of forcing the host's own architecture:
+Pod's node architecture. **Do not rely on leaving this unset for a multi-arch image**: kubevuln
+then silently resolves whichever platform variant matches its own scanning process's
+architecture, not the target workload's. Requesting the platform explicitly is the only way to
+get a deterministic, correct result for a multi-arch image; leaving it unset is safe only for a
+single-arch image, where there is nothing to choose between:
 
 ```bash
 curl -X POST http://localhost:8080/v1/sbomCreation \

--- a/internal/syftsource/syftsource.go
+++ b/internal/syftsource/syftsource.go
@@ -49,11 +49,15 @@ func IsPlatformMismatch(err error) bool {
 // specifier uses OCI format, "os/arch[/variant]" such as "linux/amd64", and an
 // architecture on its own is read as Linux.
 //
-// An empty specifier gives a nil platform, which leaves selection unset so Syft resolves
-// whatever the image manifest provides. That matters on the pod-less scan paths, registry
-// rescans and periodic CRD-based rescans, which have no node context to derive a platform
-// from: defaulting to the scanning process's own architecture there forced a platform
-// mismatch for single-arch images that did not happen to match it (#512).
+// An empty specifier gives a nil platform, which leaves selection unset. For a single-arch
+// image that resolves to whatever the manifest provides, fixing the platform mismatch #512
+// described for single-arch images that did not happen to match the scanning process's own
+// architecture. For a genuine multi-arch manifest list, though, stereoscope's registry
+// provider (defaultPlatformIfNil in github.com/anchore/stereoscope/pkg/image/oci) still picks
+// the variant matching the scanning process's own architecture - not the target workload's -
+// with no error and no signal that it happened (#966). That matters most on the pod-less scan
+// paths, registry rescans and periodic CRD-based rescans, which have no node context to derive
+// a platform from and so always leave this unset.
 func ParsePlatform(specifier string) (*image.Platform, error) {
 	if specifier == "" {
 		return nil, nil

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -102,11 +102,14 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	// If only an architecture is provided (e.g. "amd64"), we prepend "linux/".
 	//
 	// Only request a specific platform when the caller explicitly asked for one; otherwise
-	// leave imgPlatform nil so Syft resolves whatever platform the image manifest provides.
-	// This mirrors the in-process adapter (adapters/v1/syft.go) and matters for pod-less scan
-	// paths (registry rescans, periodic CRD-based rescans) that have no node context to derive
-	// a platform from: defaulting to runtime.GOARCH here used to force a platform mismatch for
-	// single-arch images that don't happen to match the sidecar container's own arch (see #512).
+	// leave imgPlatform nil. This mirrors the in-process adapter (adapters/v1/syft.go) and
+	// matters for pod-less scan paths (registry rescans, periodic CRD-based rescans) that have
+	// no node context to derive a platform from: defaulting to runtime.GOARCH here used to
+	// force a platform mismatch for single-arch images that don't happen to match the sidecar
+	// container's own arch (see #512). For a genuine multi-arch manifest list, though, leaving
+	// this nil does not make Syft "resolve whatever the manifest provides" - stereoscope's
+	// registry provider still defaults to the scanning process's own architecture in that case,
+	// silently and with no mismatch error (see #966).
 	imgPlatform, err := syftsource.ParsePlatform(req.Platform)
 	if err != nil {
 		return nil, fmt.Errorf("invalid platform %q: %w", req.Platform, err)


### PR DESCRIPTION
## Problem

`docs/API.md` and several code comments claimed that leaving the `platform` request arg unset makes kubevuln "resolve whatever platform the image manifest provides instead of forcing the host's own architecture." That's true for a single-arch image. It's false for a genuine multi-arch manifest list, where leaving `platform` unset silently resolves to the architecture of the machine/pod running kubevuln itself, not the target workload's, with no error and no signal that it happened.

## Root cause

kubevuln's own platform code already matches the documented intent — `internal/syftsource.ParsePlatform("")` returns `nil`, which both `adapters/v1.SyftAdapter` and `pkg/sbomscanner/v1.scannerServer` pass straight through to `syft.GetSource`. The gap is one layer down, in the pinned registry provider (`go.mod`: `replace github.com/anchore/stereoscope => github.com/matthyx/stereoscope v0.1.22-ks.1`). In that exact module, `pkg/image/oci/registry_provider.go`:

- `defaultPlatformIfNil` substitutes `linux/<runtime.GOARCH>` whenever no platform was given.
- `finalizePlatform`'s own comment states the intent: for a manifest list, that host-arch substitution is deliberately *kept* — the reset to `nil` only happens for the three single-platform media types.
- That surviving host-arch platform is what `remote.Get` uses to select which child manifest to pull, and the fetched child is then validated against that same platform — so it always matches by construction, and `image.ErrPlatformMismatch` can never fire.

PR #530 (closing #512) introduced the now-incorrect documentation when it changed kubevuln's own empty-platform default from an explicit `runtime.GOARCH` to `nil`, believing this fully closed #512's "add an explicit fallback for pod-less scan paths" sub-task (left unchecked in the issue body). It does, for single-arch images. It doesn't for genuine multi-arch ones, because `nil` just delegates the identical host-arch default one layer down into stereoscope for that case. This isn't a stereoscope bug — defaulting to the host arch for an ambiguous multi-arch pull is a reasonable choice for a general-purpose library — the bug is kubevuln's documentation asserting a guarantee the code doesn't provide.

## Solution

- Corrected `docs/API.md`'s "Requesting a Specific Image Platform" section to state plainly that leaving `platform` unset for a multi-arch image resolves to kubevuln's own scanning-process architecture, not the manifest's default, and that requesting it explicitly is the only way to get a deterministic result for a multi-arch image.
- Corrected the four code comments repeating the same claim: `internal/syftsource/syftsource.go` (`ParsePlatform`), `pkg/sbomscanner/v1/server.go`, `core/domain/sbom.go` (`ResolvedPlatformAnnotationKey`), `core/domain/scan.go` (`ArgsPlatform`).

This PR does not change runtime behavior. A real fix for the underlying gap (detecting a multi-arch manifest list and surfacing a distinct signal, or finally wiring node-architecture context through pod-less scan paths per #512's original sub-task) needs either an extra pre-fetch registry call or upstream/operator changes and is a separately-scoped follow-up; landing an incorrect guarantee in the docs in the meantime is worse than documenting the actual behavior honestly.

## Testing

Added `Test_syftAdapter_CreateSBOM_MultiArchNoPlatformResolvesHostArch` in `adapters/v1/syft_test.go`, reusing the existing `mockMultiArchRegistry` fixture that `Test_syftAdapter_CreateSBOM_MultiArchLocalRegistry` already builds (a real OCI manifest list serving distinct amd64/arm64 variants over a local `httptest` registry). It calls `CreateSBOM` with no platform requested and asserts the resolved-platform annotation equals `linux/<runtime.GOARCH>` — pinning the actual (undocumented-until-now) behavior so any future change to it shows up as a test diff, in either direction.

- `go build ./...` passes.
- `go vet ./adapters/v1/... ./internal/syftsource/... ./pkg/sbomscanner/v1/... ./core/domain/...` is clean.
- `go test` passes for all four touched packages, including the new test. Three pre-existing timing-sensitive tests (`Test_syftAdapter_CreateSBOM_TimeoutDoesNotRaceWithAbandonedSyft`, `Test_syftAdapter_CreateSBOM_SerializesWithAbandonedGoroutineAfterTimeout`, `Test_syftAdapter_CreateSBOM_GivesUpWaitingForPermanentlyStuckPullSem`) and one in the sidecar package flake under full-suite CPU contention on this machine; all four pass reliably run in isolation and are unrelated to this change (fixed-sleep/timeout-race tests, not platform-resolution logic).

## Impact

No behavior change. This stops the documentation and code comments from asserting a guarantee that silently doesn't hold for multi-arch images, and adds a regression test that makes the real behavior visible and pinned for whoever picks up the follow-up fix.

Fixes #966


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how platform selection works for single-architecture and multi-architecture images when no platform is specified.
  - Documented that multi-architecture scans resolve the variant matching the scanning process architecture.
  - Added guidance recommending explicit platform selection for deterministic multi-architecture scan results.

- **Tests**
  - Added coverage verifying that multi-architecture images without an explicit platform resolve to the scanning host architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->